### PR TITLE
Block Google Analytics from activating on live load balancer

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-/* global $, ga, cxApi */
+/* global $, ga, cxApi, _BLF */
 'use strict';
 
 // initialise router (eg. run conditional code for certain URLs)
@@ -53,16 +53,28 @@ $('#js-close-overlay').on('click', () => {
     $('#js-overlay').hide();
 });
 
-// setup google analytics
-const uaCode = $thisScript.data('ga-code');
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-ga('create', uaCode, {
-    'cookieDomain': 'none'
-});
+// if the env is production
+// then only load analytics
+// if the domain name is live domain
 
+// setup google analytics
+if (!_BLF.blockAnalytics) { // set in main.njk
+    const uaCode = $thisScript.data('ga-code');
+    (function (i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        i[r] = i[r] || function () {
+            (i[r].q = i[r].q || []).push(arguments);
+        }, i[r].l = 1 * new Date();
+        a = s.createElement(o),
+            m = s.getElementsByTagName(o)[0];
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+    ga('create', uaCode, {
+        'cookieDomain': 'none'
+    });
+}
 // initialise A/B tests
 let ab = {
     id: $thisScript.data('ab-id'),

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
     "staticExpiration": 1,
     "viewCacheExpiration": 300,
+    "siteDomain": "www.biglotteryfund.org.uk",
     "meta": {
         "title": "The Big Lottery Fund",
         "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery."

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -42,6 +42,14 @@
             </div>
         </div>
 
+        {# global config items #}
+        <script>
+            {# allows us to disable google analytics on live env when loaded via EC2/ELB and not the real domain #}
+            {# eg to avoid polluting data with extra domains #}
+            window._BLF = {
+                blockAnalytics: ({{ appData.environment == 'production' }} && window.location.hostname !== "{{ appData.config.get('siteDomain') }}")
+            };
+        </script>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
         <script src="//www.google-analytics.com/cx/api.js"></script>
         <script src="{{ 'javascripts/app.js' | getCachebustedPath }}"


### PR DESCRIPTION
Some of our analytics data is including traffic from the load balancer domain rather than www.biglotteryfund.org.uk – this PR checks that on the live environment, the domain matches the expected value. If it doesn't, analytics aren't loaded.