### PR TITLE
Update README based on initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,50 +25,58 @@ You'll need the following tools installed:
 - Git (https://help.github.com/articles/set-up-git/)
 - Some sort of terminal app (OS X comes with one)
 
-
-#### Secret configuration
-You'll also need the app secrets – config items that allow it to connect to the database (used for content), send emails (when customers order free items), etc. 
-
-In order to do this, you'll need to do the following: 
-
- - obtain AWS credentials for the team's account ()with permission to access EC2 Parameter Store)
-  
- - [Configure the AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) on your machine
- 
- - Rename `addSecrets.example.sh` to `addSecrets.sh` and populate it with the missing values (ask another member of the team for these). These missing values are used for deployments.
- 
- - Make sure the directory `/etc/blf/` exists and is writeable (this is where application secrets will be downloaded to).
- 
- You should now be able to proceed to the startup instructions below.
-
-### Startup instructions
+### Setup Instructions
 
 Run these commands in your terminal of choice:
 
-1. Clone this repository:
+#### 1. Clone this repository:
 
-        git clone git@github.com:biglotteryfund/blf-alpha.git
-    
-2. Install its dependencies:
+```
+git clone git@github.com:biglotteryfund/blf-alpha.git
+```
 
-        cd blf-alpha
-        npm install
-        
-3. Check the install worked – try to use `gulp` to build the frontend assets:
-        
-        gulp build --production
-        
-5. Run `source ./addSecrets.sh` – this will download the application secrets to `/etc/blf/parameters.json`.
-        
-6. Start the app server:
+#### 2. Configure Secrets
 
-        node bin/www
-        
-7. Visit [http://localhost:3000](http://localhost:3000) in your browser and confirm it's working. Press `Ctrl+C` to stop the server.
+You'll also need the app secrets – config items that allow it to connect to the database (used for content), send emails (when customers order free items), etc.
+
+In order to do this, you'll need to do the following:
+
+- Obtain AWS credentials for the team's account (with permission to access EC2 Parameter Store)
+- [Configure the AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) on your machine
+- Make sure the directory `/etc/blf/` exists and is writeable (this is where application secrets will be downloaded to).
+- Rename `addSecrets.example.sh` to `addSecrets.sh` and populate it with the missing values (ask another member of the team for these). These missing values are used for deployments.
+- Run `source ./addSecrets.sh` – this will download the application secrets to `/etc/blf/parameters.json`.
+
+#### 3. Install Dependencies:
+
+```
+cd blf-alpha
+npm install
+```
+
+#### 4. Run A Build
+
+Check the install worked – try to use `gulp` to build the frontend assets:
+
+```
+gulp build --production
+```
+
+#### 5. Start The App Server:
+
+```
+npm start
+```
+
+#### 6. Access The Application
+
+Visit [http://localhost:3000](http://localhost:3000) in your browser and confirm everything is working.
+
+Press `Ctrl+C` to stop the server.
 
 ## Testing
 
-The app comes with several layers of tests to ensure everything works as expected. Tests are still in-development as the app increases in size/scope, but the framework is in place for them. 
+The app comes with several layers of tests to ensure everything works as expected. Tests are still in-development as the app increases in size/scope, but the framework is in place for them.
 
 You can run them all with `gulp test` (or `npm test`) but here are the individual suites:
 
@@ -99,10 +107,10 @@ Deploys to `PRODUCTION` are manual (for now). Once a deploy has been sanity chec
 
 `./bin/scripts/deploy.js --live`
 
-The above command will begin a deployment by listing the previous 10 releases deployed to `TEST` and asking which build you wish to deploy. It will then list out the commit summaries for each change which will be deployed, then confirm if you wish to proceed. It will also post progress updates to Slack as the deployment proceeds.   
+The above command will begin a deployment by listing the previous 10 releases deployed to `TEST` and asking which build you wish to deploy. It will then list out the commit summaries for each change which will be deployed, then confirm if you wish to proceed. It will also post progress updates to Slack as the deployment proceeds.
 
 Run it without the `-l` / `--live` flag to deploy to `TEST` intead.
 
 Please speak to @mattandrews to obtain access to AWS/Jenkins to manage deployment.
 
-The app itself runs via [Phusion Passenger](https://www.phusionpassenger.com/) which is integrated into nginx web server. This is effectively a reverse proxy which adds security and manages node processes. It also allows for static assets to be served directly via nginx, bypassing node for quicker responses. On live instances, this can be monitored by running `sudo passenger-status` (`sudo` because CodeDeploy runs as root). 
+The app itself runs via [Phusion Passenger](https://www.phusionpassenger.com/) which is integrated into nginx web server. This is effectively a reverse proxy which adds security and manages node processes. It also allows for static assets to be served directly via nginx, bypassing node for quicker responses. On live instances, this can be monitored by running `sudo passenger-status` (`sudo` because CodeDeploy runs as root).


### PR DESCRIPTION
👋  First pull-request.

Adjusted the structure of the README whilst I was setting the site up locally to aid readability:

- Merged secrets step into main setup as that was being mentioned before you've checked out the repo. Updates the structure to read in the same order that steps are required in.
- Updates code samples to use code-fencing syntax rather than indentation
- Updates `node ./bin/www` command to use existing, and more standard, `npm start` alias.

All instructions worked first time so these changes are structural changes only where I noticed the steps jumping around a little bit. Good work @mattandrews 👌 