### PR TITLE
Track contrast

### DIFF
--- a/views/includes/accessibility.njk
+++ b/views/includes/accessibility.njk
@@ -1,7 +1,18 @@
+{% macro makeContrastLink(mode) %}
+    <a id="js-contrast-{{ mode }}"
+       href="/contrast/{{ mode }}?url={{ getCurrentUrl(request) | urlencode}}"
+       class="js-track-clicks"
+       data-category="Change contrast"
+       data-action="Click"
+       data-label="{{ mode }}">
+        {{ __("global.accessibility.contrast." + mode ) | safe }}
+    </a>
+{% endmacro %}
+
 <nav class="accessibility__nav">
     <ul>
         <li><a tabindex="0" href="#content">{{ __("global.accessibility.skipToContent") | safe }}</a></li>
-        <li><a id="js-contrast-standard" href="/contrast/standard?url={{ getCurrentUrl(request) | urlencode}}">{{ __("global.accessibility.contrast.standard") | safe }}</a></li>
-        <li><a id="js-contrast-high" href="/contrast/high?url={{ getCurrentUrl(request) | urlencode}}">{{ __("global.accessibility.contrast.high") | safe }}</a></li>
+        <li>{{ makeContrastLink('standard') }}</li>
+        <li>{{ makeContrastLink('high') }}</li>
     </ul>
 </nav>


### PR DESCRIPTION
Quick fix as suggested by @davidrapson – add a bit of Google Analytics tracking to the contrast switcher so we can see who's using it.