### PR TITLE
Order form validation fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@ These are chores, refactoring tasks or simply reminders of code that needs to be
 - [ ] homepage: data/application base64 JS is violating CSP (google cx api)
 - [ ] homepage: google tag manager / experiment for homepage – verify working
 - [ ] log material orders (need legal signoff)
-- [ ] form errors on order form return users to unselected tab
 
 ## To think about
 - [ ] CSRF: how to approach when pages are cached?

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -13,6 +13,7 @@ Vue.options.delimiters = ['<%', '%>'];
 require('./modules/carousel').init();
 require('./modules/tabs').init();
 const analytics = require('./modules/analytics');
+const utils = require('./utils');
 
 // enable JS-only features
 const $html = $('html');
@@ -128,14 +129,30 @@ let fundingPagePath = /\/funding\/funding-guidance\/managing-your-funding\/order
 router.get(fundingPagePath, () => {
 
     let allOrderData = {};
+    let langParam = 'lang';
+    let isValidLangParam = (param) => ['monolingual', 'bilingual'].indexOf(param) !== -1;
 
     new Vue({
         el: '#js-vue',
         data: {
             orderData: allOrderData,
-            showMonolingual: null
+            itemLanguage: null
+        },
+        created: function () {
+            let params = utils.parseQueryString();
+            if (params[langParam] && isValidLangParam(params[langParam])) {
+                this.itemLanguage = params[langParam];
+            }
         },
         methods: {
+            toggleItemLanguage: function (newState) {
+                if (isValidLangParam(newState)) {
+                    this.itemLanguage = newState;
+                    if (history.replaceState) {
+                        history.replaceState(null, null, `?${langParam}=${newState}`);
+                    }
+                }
+            },
             getQuantity: function (code, valueAtPageload) {
                 if (this.orderData[code]) {
                     return this.orderData[code].quantity;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -130,7 +130,11 @@ router.get(fundingPagePath, () => {
 
     let allOrderData = {};
     let langParam = 'lang';
+    // make sure we only allow valid language options
     let isValidLangParam = (param) => ['monolingual', 'bilingual'].indexOf(param) !== -1;
+
+    // save the language preference in the form so we can redirect to it
+    let storeLangPrefInForm = (newState) => $('#js-language-choice').val(newState);
 
     new Vue({
         el: '#js-vue',
@@ -139,20 +143,27 @@ router.get(fundingPagePath, () => {
             itemLanguage: null
         },
         created: function () {
+            // check for a ?lang param and show the relevant products (if valid)
             let params = utils.parseQueryString();
             if (params[langParam] && isValidLangParam(params[langParam])) {
+                storeLangPrefInForm(params[langParam]);
                 this.itemLanguage = params[langParam];
             }
         },
         methods: {
+            // swap between languages for product list
             toggleItemLanguage: function (newState) {
                 if (isValidLangParam(newState)) {
                     this.itemLanguage = newState;
+                    storeLangPrefInForm(newState);
+                    // add this to the URL
                     if (history.replaceState) {
                         history.replaceState(null, null, `?${langParam}=${newState}`);
                     }
                 }
             },
+            // look up the quantity of a given item, defaulting to its
+            // value when the page was loaded (eg. from session cookie)
             getQuantity: function (code, valueAtPageload) {
                 if (this.orderData[code]) {
                     return this.orderData[code].quantity;
@@ -160,6 +171,8 @@ router.get(fundingPagePath, () => {
                     return valueAtPageload;
                 }
             },
+            // work out if the user has anything in their "basket"
+            // eg. should the data form be disabled or not
             isEmpty: function () {
                 let quantity = 0;
                 for (let o in this.orderData) {
@@ -167,13 +180,13 @@ router.get(fundingPagePath, () => {
                 }
                 return (quantity === 0);
             },
+            // increment/decrement a product in the user's basket via AJAX
             changeQuantity: function (e) {
-                // this is a bit ugly: use jquery to make AJAX call
-                // @TODO refactor this and commit fully to vue!
                 let $elm = $(e.currentTarget);
                 const $form = $elm.parents('form');
                 const url = $form.attr('action');
                 let data = $form.serialize();
+                // is this an increase or decrease button?
                 data += '&action=' + $elm.val();
                 $.ajax({
                     url: url,
@@ -181,7 +194,9 @@ router.get(fundingPagePath, () => {
                     data: data,
                     dataType: 'json',
                     success: (response) => {
+                        // update the basket data from the session
                         allOrderData = response.allOrders;
+                        // this triggers a Vue update (and needs a babel plugin to work in IE)
                         this.orderData = Object.assign({}, this.orderData, response.allOrders);
                     }
                 });

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -54,7 +54,19 @@ let numberWithCommas = (x) => {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 };
 
+let parseQueryString = () => {
+    let qstr = window.location.search;
+    let query = {};
+    let items = (qstr[0] === '?' ? qstr.substr(1) : qstr).split('&');
+    items.forEach(item => {
+        let b = item.split('=');
+        query[decodeURIComponent(b[0])] = decodeURIComponent(b[1] || '');
+    });
+    return query;
+};
+
 module.exports = {
     formatCurrency,
-    numberWithCommas
+    numberWithCommas,
+    parseQueryString
 };

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -146,7 +146,7 @@ module.exports = (pages, sectionPath, sectionId) => {
                         let redirectUrl = returnUrl;
 
                         // add their langage choice (if valid)
-                        let langChoice = req.body['languageChoice'];
+                        let langChoice = req.body.languageChoice;
                         if (langChoice && redirectUrl.indexOf(langParam) === -1 &&
                             ['monolingual', 'bilingual'].indexOf(langChoice) !== -1) {
                             redirectUrl += langParam + langChoice;

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -138,21 +138,30 @@ module.exports = (pages, sectionPath, sectionId) => {
                     req.flash('formErrors', result.array());
                     req.flash('formValues', req.body);
                     req.session.save(() => {
-                        // get the referring URL so we can capture the language selected
-                        // (eg. mono/bilingual) and show the user the page with this
-                        // already selected and the form onscreen
-                        let referrer = req.get('Referrer') || req.baseUrl + freeMaterials.path;
+                        // build a redirect URL based on the route, the language of items,
+                        // and the form anchor, so the user sees the form again via JS
+                        let returnUrl = req.baseUrl + freeMaterials.path;
                         let formAnchor = '#your-details';
-                        let redirectUrl = referrer;
-                        if (referrer.indexOf(formAnchor) === -1) {
+                        let langParam = '?lang=';
+                        let redirectUrl = returnUrl;
+
+                        // add their langage choice (if valid)
+                        let langChoice = req.body['languageChoice'];
+                        if (langChoice && redirectUrl.indexOf(langParam) === -1 &&
+                            ['monolingual', 'bilingual'].indexOf(langChoice) !== -1) {
+                            redirectUrl += langParam + langChoice;
+                        }
+
+                        // add the form anchor (if not present)
+                        if (redirectUrl.indexOf(formAnchor) === -1) {
                             redirectUrl += formAnchor;
                         }
+
                         res.redirect(redirectUrl);
                     });
                 } else {
                     let text = makeOrderText(req.session[freeMaterialsLogic.orderKey], req.body);
                     let dateNow = moment().format("dddd, MMMM Do YYYY, h:mm:ss a");
-
 
                     // allow tests to run without sending email
                     if (!req.body.skipEmail) {

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -141,7 +141,7 @@ module.exports = (pages, sectionPath, sectionId) => {
                         // get the referring URL so we can capture the language selected
                         // (eg. mono/bilingual) and show the user the page with this
                         // already selected and the form onscreen
-                        let referrer = req.get('Referrer');
+                        let referrer = req.get('Referrer') || req.baseUrl + freeMaterials.path;
                         let formAnchor = '#your-details';
                         let redirectUrl = referrer;
                         if (referrer.indexOf(formAnchor) === -1) {

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -138,7 +138,16 @@ module.exports = (pages, sectionPath, sectionId) => {
                     req.flash('formErrors', result.array());
                     req.flash('formValues', req.body);
                     req.session.save(() => {
-                        res.redirect(req.baseUrl + freeMaterials.path + '#your-details');
+                        // get the referring URL so we can capture the language selected
+                        // (eg. mono/bilingual) and show the user the page with this
+                        // already selected and the form onscreen
+                        let referrer = req.get('Referrer');
+                        let formAnchor = '#your-details';
+                        let redirectUrl = referrer;
+                        if (referrer.indexOf(formAnchor) === -1) {
+                            redirectUrl += formAnchor;
+                        }
+                        res.redirect(redirectUrl);
                     });
                 } else {
                     let text = makeOrderText(req.session[freeMaterialsLogic.orderKey], req.body);

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -128,14 +128,14 @@
                     <li class="grid__item">
                         <a href="#monolingual"
                            class="btn btn--block btn--small accent--blue a--btn"
-                           v-on:click.prevent="showMonolingual = true">
+                           v-on:click.prevent="toggleItemLanguage('monolingual')">
                             {{ copy.locations.monolingual }}
                         </a>
                     </li>
                     <li class="grid__item">
                         <a href="#bilingual"
                            class="btn btn--block btn--small accent--blue a--btn"
-                           v-on:click.prevent="showMonolingual = false">
+                           v-on:click.prevent="toggleItemLanguage('bilingual')">
                             {{ copy.locations.bilingual }}
                         </a>
                     </li>
@@ -143,18 +143,18 @@
             </div>
         </div>
 
-        <div v-if="showMonolingual !== null">
+        <div v-if="itemLanguage !== null">
 
             <div class="inner">
 
                 {# monolingual items #}
-                <div v-if="showMonolingual" id="monolingual">
+                <div v-if="itemLanguage === 'monolingual'" id="monolingual">
                     <h3 class="t3">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.monolingual }})</noscript></h3>
                     {{ listProducts('monolingual') }}
                 </div>
 
                 {# bilingual items #}
-                <div v-if="!showMonolingual" id="bilingual">
+                <div v-if="itemLanguage === 'bilingual'" id="bilingual">
                     <h3 class="t3">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.bilingual }})</noscript></h3>
                     {{ listProducts('bilingual') }}
                 </div>

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -167,6 +167,7 @@
 
                     <form class="inline-form order-form" method="post">
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                        <input type="hidden" name="languageChoice" value="" id="js-language-choice">
                         <ul class="grid grid--wide-only grid--3-up grid--padded--large unstyled">
                             {% for field in formFields %}
                                 <li class="grid__item">{{ input(field.name, field.label[locale], inputType = field.type, required = field.required) }}</li>


### PR DESCRIPTION
This is an edge case, but has bothered me for a while, so here comes the fix.

Basically: when you order something from the [free materials form](http://www.biglotteryfund.org.uk/funding/funding-guidance/managing-your-funding/ordering-free-materials?lang=bilingual#your-details), it's possible to fail server-side validation and be returned to the form. 

Sadly, when this happens, the page's content is then hidden via JavaScript (eg. to make you choose monolingual/bilingual), so the form you're being returned to is hidden from you.

In practice this is unlikely to happen often, as the form has client-side validation (for required fields, and email fields), so the only users who will experience this bug are people in older browsers that don't support HTML5 form validation, or people who edit the form HTML to remove the validation(!).

This change adds two things: it updates the URL when a language preference is made for products (so sharing/reloading that URL will now show the correct products), and also passes this preference through the form, so when a validation error happens, the user is returned to the correct product page *and* shown their invalid form to correct.