### PR TITLE
Update latest news to match designs

### DIFF
--- a/assets/sass/globals/typography.scss
+++ b/assets/sass/globals/typography.scss
@@ -197,3 +197,8 @@ h6,
 .heavier {
     font-weight: bold;
 }
+
+.u-unstyled-link {
+    color: inherit;
+    text-decoration: none;
+}

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -92,16 +92,29 @@
 
             {# news posts #}
             {% if news.length %}
-                <div class="accent--blue a--border-top">
-                    <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only expanded">
+            <div class="accent--blue a--border-top">
+                <div class="padded">
+                    <h3 class="t3 t3--a">
+                        Latest News
+                    </h3>
+                    <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                         {% for n in news %}
-                            <li class="grid__item">
-                                <h4 class="t3">{{ n['title' | localeify(locale)] | safe}}</h4>
-                                <p>{{ n['text' | localeify(locale)] | safe }} <a href="{{ n['link' | localeify(locale)] }}" class="accent--pink a--text">Read more...</a></p>
-                            </li>
+                        <li class="grid__item">
+                            <h4 class="t3">
+                                <a class="u-unstyled-link" href="{{ n['link' | localeify(locale)] }}">
+                                    {{ n['title' | localeify(locale)] | safe}}
+                                </a>
+                            </h4>
+                            <p>
+                                {{ n['text' | localeify(locale)] | safe }}
+                                <a href="{{ n['link' | localeify(locale)] }}"
+                                    class="accent--pink a--text heavier">Read more&hellip;</a>
+                            </p>
+                        </li>
                         {% endfor %}
                     </ul>
                 </div>
+            </div>
             {% endif %}
 
             {# funding finder #}


### PR DESCRIPTION
Updates the latest news section match the designs

- Add title to block
- Update "Read more" links to be bold and use a real ellipsis…
- Added a `.u-unstyled-link` utility class to allow unobtrusively linking the titles to the news article

**Before**

![screen shot 2017-09-28 at 10 43 39](https://user-images.githubusercontent.com/123386/30960113-f6c868f2-a439-11e7-9913-79d5dc855f75.png)

**After**

![screen shot 2017-09-28 at 10 43 26](https://user-images.githubusercontent.com/123386/30960114-f6c8cedc-a439-11e7-928d-4ffaa7f06290.png)
