### PR TITLE
Make contrast buttons high-contrast

### DIFF
--- a/assets/sass/components/accessibility.scss
+++ b/assets/sass/components/accessibility.scss
@@ -15,7 +15,6 @@
         a {
             padding: 20px 30px;
             display: block;
-            background-color: palette('blue');
             color: #ffffff;
             text-decoration: none;
             position: absolute;
@@ -29,7 +28,7 @@
                 position: static;
                 width: auto;
                 height: auto;
-                background-color: #999999;
+                background-color: palette('charcoal');
             }
         }
     }


### PR DESCRIPTION
cc @ChloeAlper 

The buttons we use for switching to high contrast accessibility mode...

![image](https://user-images.githubusercontent.com/394376/31007864-e2d9debe-a4f9-11e7-801e-a9df2a37a586.png)

... fail accessibility tests for contrast!

![image](https://user-images.githubusercontent.com/394376/31007876-f1e3c6fe-a4f9-11e7-9146-f76e1a70fa2d.png)

So this change makes them dark grey:

![image](https://user-images.githubusercontent.com/394376/31007892-02036f58-a4fa-11e7-8b89-d543821f8a8b.png)

... which passes:

![image](https://user-images.githubusercontent.com/394376/31007943-2c515b12-a4fa-11e7-85e6-c451f888b8a1.png)

Let me know if this is okay @ChloeAlper.