### PR TITLE
Design amends

### DIFF
--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -154,8 +154,8 @@ $btnConf: (
 
     .icon--arrow-left,
     .icon--arrow-right {
-        width: 24px;
-        height: 40px;
+        width: 22px;
+        height: 22px;
         fill: #1a44a1;
     }
 
@@ -182,7 +182,19 @@ $btnConf: (
         .icon--arrow-right {
             fill: #ffffff;
             text-align: center;
-            height: 36px;
+        }
+
+        /**
+         * Optically align icons
+         */
+        .icon--arrow-left {
+            position: relative;
+            right: 1px;
+        }
+
+        .icon--arrow-right {
+            position: relative;
+            left: 1px;
         }
     }
 }

--- a/assets/sass/components/hero.scss
+++ b/assets/sass/components/hero.scss
@@ -134,7 +134,7 @@ $heroSpaceFromLeft: 20px;
         width: 100%;
 
         @include mq('tablet') {
-            max-width: 18em;
+            max-width: 20em;
         }
     }
 

--- a/assets/sass/components/overlay-text.scss
+++ b/assets/sass/components/overlay-text.scss
@@ -1,4 +1,8 @@
+/* =========================================================================
+   Overlay Text
+   ========================================================================= */
 // blocked-out colourised background
+
 .overlay-text {
     width: 60%;
     line-height: 1.4;
@@ -48,6 +52,12 @@
         height: 18px;
         vertical-align: middle;
     }
+}
 
+.overlay-text--deep {
+    line-height: 1.7;
 
+    > span {
+        padding: 5px;
+    }
 }

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -22,7 +22,7 @@
         <section class="hero__inner">
             <div class="hero__content inner">
                 <div class="hero__header" id="content">
-                    {{ headers.overlayText('h1', titleText, 'accent--' + accent) }}
+                    {{ headers.overlayText('h1', titleText, 'hero__title overlay-text--deep t2 accent--' + accent) }}
                 </div>
                 {% if caption %}
                     <span class="hero__caption u-caption u-desktop-only">{{ caption }}</span>

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -107,7 +107,7 @@
             {% if news.length %}
                 <div class="accent--blue a--border-top">
                     <div class="padded padded--wide-only">
-                        <h3 class="t3 t3--a">{{ copy.latestNews }}</h3>
+                        <h3 class="t3 t3--a accent--blue">{{ copy.latestNews }}</h3>
                         <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                             {% for n in news %}
                                 <li class="grid__item">

--- a/views/pages/toplevel/under10k.njk
+++ b/views/pages/toplevel/under10k.njk
@@ -15,7 +15,6 @@
         hero.sectionHero(
             name = 'under10k',
             titleText = copy.title,
-            caption = 'Somewhere To',
             accent = 'pink'
         )
     }}


### PR DESCRIPTION
A few design amends based on feedback from @ChloeAlper 

- Fixes alignment of carousel controls
- Adds blue accent to latest news header
- Switches section heroes (under10k / over10k titles) to use T2 font-size
- Removes caption from Somewhere To image

<img width="996" alt="screen shot 2017-10-02 at 11 06 57" src="https://user-images.githubusercontent.com/123386/31073685-dfc4e18e-a764-11e7-8ca6-783f2c4c77da.png">
