### PR TITLE
Design amends (continued)

### DIFF
--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -7,6 +7,10 @@ $btnConf: (
         'fontSize': 18px,
         'desiredHeight': 59px
     ),
+    'medium': (
+        'fontSize': 16px,
+        'desiredHeight': 42px
+    ),
     'small': (
         'fontSize': 16px,
         'desiredHeight': 36px
@@ -84,6 +88,27 @@ $btnConf: (
     @media only screen and (min-width: 360px) {
         @include getBtnVertPadding(map-get($btnConf, 'small'));
         font-size: map-deep-get($btnConf, 'small', 'fontSize');
+    }
+
+    @include on-interact {
+        background-color: darken(palette('pink'), 15%);
+        outline: none;
+    }
+}
+
+.btn--medium {
+    @include getBtnVertPadding(map-get($btnConf, 'mini'));
+    font-size: map-deep-get($btnConf, 'mini', 'fontSize');
+    background-color: palette('pink');
+
+    @media only screen and (min-width: 360px) {
+        @include getBtnVertPadding(map-get($btnConf, 'small'));
+        font-size: map-deep-get($btnConf, 'small', 'fontSize');
+    }
+
+    @include mq('tablet') {
+        @include getBtnVertPadding(map-get($btnConf, 'medium'));
+        font-size: map-deep-get($btnConf, 'medium', 'fontSize');
     }
 
     @include on-interact {

--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -232,8 +232,14 @@ $btnConf: (
 .o-button-group {
     .btn {
         margin-bottom: $spacingUnit / 2;
+
         &:last-of-type {
             margin-bottom: 0;
+        }
+
+        @include mq('tablet', 'max') {
+            width: 100%;
+            max-width: 300px;
         }
 
         @include mq('desktop') {

--- a/assets/sass/components/case-studies.scss
+++ b/assets/sass/components/case-studies.scss
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 .case-study {
-    background-color: palette('blue-bg');
+    background-color: palette('pale-grey');
 
     @media screen and (min-width: 640px) {
         display: flex;
@@ -29,7 +29,7 @@
 }
 .case-study__content {
     padding: ($spacingUnit / 2) $spacingUnit;
-    border: 1px solid darken(palette('blue-bg'), 10%);
+    border: 1px solid darken(palette('pale-grey'), 10%);
 
     @media screen and (min-width: 640px) {
         border: none;

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -16,13 +16,10 @@ $nudgeAmount: 25px;
 
 // @TODO better name
 .central-gap {
-    $gap: 20%;
-    @include mq('tablet', 'max') {
-        margin-left: $gap / 2;
-        margin-right: $gap / 2;
+    @include mq('tablet') {
+        margin-left: 20%;
+        margin-right: 20%;
     }
-    margin-left: $gap;
-    margin-right: $gap;
 }
 
 .width-natural {

--- a/assets/sass/scaffolding/header.scss
+++ b/assets/sass/scaffolding/header.scss
@@ -330,6 +330,12 @@ html:not(.contrast--high) .has-full-bleed-header .header {
     width: 100%;
 
     .header__inner {
+        padding: 10px 0;
+
+        @media only screen and (min-width: 420px) {
+            padding: 15px 0;
+        }
+
         @include mq('tablet') {
             padding: 0;
         }
@@ -350,13 +356,24 @@ html:not(.contrast--high) .has-full-bleed-header .header {
             margin-top: 0;
         }
     }
+    .header__hamburger {
+        top: 25px;
+
+        @media only screen and (min-width: 420px) {
+            top: 40px;
+        }
+    }
     .header__hamburger a svg,
     .header__hamburger a path {
         fill: white;
     }
 
     .logo {
-        margin-top: ($spacingUnit / 2);
+        margin-top: 0;
+
+        @media only screen and (min-width: 420px) {
+            margin-top: 10px;
+        }
     }
 
     .nav {

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -34,7 +34,7 @@
 
     {% set heroContent %}
         <div class="o-button-group">
-            <a class="btn btn--small
+            <a class="btn btn--medium
                       accent--white a--btn"
                 href="{{ buildUrl('toplevel', 'under10k') }}">
                 <span class="accent--pink a--text">
@@ -43,7 +43,7 @@
                 </span>
             </a>
 
-            <a class="btn btn--small
+            <a class="btn btn--medium
                       accent--white a--btn"
                 href="{{ buildUrl('toplevel', 'over10k') }}">
                 <span class="accent--blue a--text">


### PR DESCRIPTION
- Use pale-grey for case study background
- Define medium button size (displays in steps mini -> small -> large)
- Tighten up header spacing on small screens
- Lock buttons to max-width on small screens within button group
- Scope central-gap to tablet and above (needs better name?)

Note: I'm using a lot of in-betweener breakpoints so points to a need to better define some more granular breakpoints at some point.