### PR TITLE
Fix flex-container bug with homepage case-studies

### DIFF
--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -12,13 +12,15 @@
 {% macro caseStudy(projectName, quoteName, quoteText, imageUrl, imageSmallUrl, link = false) %}
 
     <div class="case-study">
-        {% if link %}<a href="{{ buildUrl(link) }}">{% endif %}
-            <picture class="case-study__image">
-                <source srcset="{{ imageUrl | getCachebustedPath }}" media="(min-width: 600px)">
-                <source srcset="{{ imageSmallUrl | getCachebustedPath }}">
-                <img src="{{ imageSmallUrl | getCachebustedPath }}" alt="{{ quoteName }} {{ projectName }}" />
-            </picture>
-        {% if link %}</a>{% endif %}
+        <div class="case-study__image">
+            {% if link %}<a href="{{ buildUrl(link) }}">{% endif %}
+                <picture>
+                    <source srcset="{{ imageUrl | getCachebustedPath }}" media="(min-width: 600px)">
+                    <source srcset="{{ imageSmallUrl | getCachebustedPath }}">
+                    <img src="{{ imageSmallUrl | getCachebustedPath }}" alt="{{ quoteName }} {{ projectName }}" />
+                </picture>
+            {% if link %}</a>{% endif %}
+        </div>
         <div class="case-study__content">
                 <blockquote class="pullquote">
                     <div class="pullquote__text">


### PR DESCRIPTION
Fixes a layout bug with the homepage case-studies. The addition of the link around the image created a new flex-child and so breaks the desired flexbox behaviour. This moves the markup around to correct that.

**Before**

![screen shot 2017-10-03 at 14 32 41](https://user-images.githubusercontent.com/123386/31127797-c834f2c8-a847-11e7-8135-8ce4bf8113d7.png)

**After**
![screen shot 2017-10-03 at 14 32 45](https://user-images.githubusercontent.com/123386/31127798-c83573a6-a847-11e7-8c1a-47ee5f9609c3.png)
