### PR TITLE
Update legacy homepage to proxy on post requests

### DIFF
--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -71,7 +71,7 @@ const oldHomepage = (req, res) => {
         resolveWithFullResponse: true
     }).then((response) => {
         let body = response.body;
-        // convert all links in the document to be root-relative
+        // convert all links in the document to be absolute
         // (only really useful on non-prod envs)
         body = absolution(body, 'https://www.biglotteryfund.org.uk');
 
@@ -80,6 +80,13 @@ const oldHomepage = (req, res) => {
 
         // parse the DOM
         const dom = new JSDOM(body);
+
+        const form = dom.window.document.getElementById('form1');
+        if (form) {
+            const newAction = form.getAttribute('action')
+                .replace('https://www.biglotteryfund.org.uk/', '/');
+            form.setAttribute('action', newAction);
+        }
 
         // are we in an A/B test?
         if (res.locals.ab) {
@@ -124,6 +131,27 @@ const oldHomepage = (req, res) => {
     });
 };
 
+const oldHomepagePost = ((req, res) => {
+    res.cacheControl = { maxAge: 0 };
+    rp.post({
+        uri: legacyUrl,
+        form: req.body,
+        strictSSL: false,
+        jar: true,
+        simple: true,
+        followRedirect: false,
+        resolveWithFullResponse: true,
+        followOriginalHttpMethod: true
+    }).catch((err) => {
+        const proxyResponse = err.response;
+        if (proxyResponse.statusCode === 302) {
+            res.redirect(302, proxyResponse.headers.location);
+        } else {
+            res.redirect('/');
+        }
+    });
+});
+
 module.exports = (pages, sectionPath, sectionId) => {
 
     /**
@@ -150,6 +178,8 @@ module.exports = (pages, sectionPath, sectionId) => {
     } else {
         router.get('/', newHomepage);
     }
+
+    router.post('/', oldHomepagePost);
 
     // used for tests: override A/B cohorts
     router.get('/home', newHomepage);

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "passport-local": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.15",
     "req-flash": "0.0.3",
+    "request": "^2.81.0",
     "request-promise": "^4.2.0",
     "rootbeer": "^1.0.5",
     "sequelize": "^4.8.0",
@@ -83,7 +84,6 @@
     "import-lazy": "^3.0.0",
     "node-sass": "^4.5.3",
     "prompt": "^1.0.0",
-    "request": "^2.81.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^7.1.0"


### PR DESCRIPTION
Ensures that the funding finder and global search still works on the legacy homepage when proxied through cloudfront and our express app.