### PR TITLE
Configure eslint to run on all files and not just assets

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
-node_modules
+assets/js/libs/
+node_modules/
+public/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,16 @@
 module.exports = {
-    "rules": {
-        "semi": [
-            2,
-            "always"
-        ],
-        "no-console": 0,
-        "eqeqeq": 2,
-        "no-unused-vars": 1
+    root: true,
+    extends: 'eslint:recommended',
+    env: {
+        es6: true,
+        node: true,
+        browser: true
     },
-    "env": {
-        "es6": true,
-        "node": true,
-        "browser": true
-    },
-    "extends": "eslint:recommended"
+    rules: {
+        eqeqeq: 2,
+        semi: [2, 'always'],
+
+        'no-console': 0,
+        'no-unused-vars': 1
+    }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ const rename = importLazy('gulp-rename');
 const mochaPhantomJS = importLazy('gulp-mocha-phantomjs');
 const jsonSass = importLazy('rootbeer');
 const fs = importLazy('fs');
+const runSequence = importLazy('run-sequence');
 
 // define main directories
 const inputBase = './assets/';
@@ -241,7 +242,9 @@ gulp.task('build', ['styles', 'scripts', 'rev']);
 gulp.task('build-dev', ['styles', 'scripts']);
 
 // used on commit
-gulp.task('test', ['lint', 'mocha', 'phantomjs']);
+gulp.task('test', function(done) {
+    runSequence('lint', 'mocha', 'phantomjs', done);
+});
 
 // watch static files for changes and recompile
 gulp.task('watch', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,6 @@
-/* jshint node: true */
 'use strict';
-const importLazy = require('import-lazy')(require);
 
+const importLazy = require('import-lazy')(require);
 const browserify = importLazy('browserify');
 const envify = require('envify/custom');
 const gulp = importLazy('gulp');
@@ -19,17 +18,15 @@ const autoprefixer = importLazy('gulp-autoprefixer');
 const argv = importLazy('yargs').argv;
 const gulpif = importLazy('gulp-if');
 const eslint = importLazy('gulp-eslint');
-const babel = importLazy('gulp-babel');
 const babelify = importLazy('babelify');
 const mocha = importLazy('gulp-mocha');
-const rename = importLazy("gulp-rename");
+const rename = importLazy('gulp-rename');
 const mochaPhantomJS = importLazy('gulp-mocha-phantomjs');
 const jsonSass = importLazy('rootbeer');
 const fs = importLazy('fs');
 
-
 // define main directories
-const inputBase  = './assets/';
+const inputBase = './assets/';
 const outputBase = './public/';
 const testBase = './test/';
 const binBase = './bin/';
@@ -38,17 +35,17 @@ const binBase = './bin/';
 const DIRS = {
     in: {
         root: inputBase,
-        css:  inputBase + 'sass',
-        js:   inputBase + 'js',
-        img:  inputBase + 'images',
+        css: inputBase + 'sass',
+        js: inputBase + 'js',
+        img: inputBase + 'images',
         test: testBase,
         sassConfig: './config/content'
     },
     out: {
         root: outputBase,
-        css:  outputBase + 'stylesheets',
-        js:   outputBase + 'javascripts',
-        img:  outputBase + 'images',
+        css: outputBase + 'stylesheets',
+        js: outputBase + 'javascripts',
+        img: outputBase + 'images',
         test: outputBase + 'tests',
         manifest: binBase
     }
@@ -72,11 +69,21 @@ const FILES = {
 };
 
 // clean out folders of generated assets
-gulp.task('clean:css', function() { return del([DIRS.out.css + '/**/*']); });
-gulp.task('clean:js', function()  { return del([DIRS.out.js + '/**/*']); });
-gulp.task('clean:img', function() { return del([DIRS.out.img + '/**/*']); });
-gulp.task('clean:assets', function() { return del([DIRS.out.manifest + '/' + FILES.assets]); });
-gulp.task('clean:test', function() { return del([DIRS.out.test + '/**/*']); });
+gulp.task('clean:css', function() {
+    return del([DIRS.out.css + '/**/*']);
+});
+gulp.task('clean:js', function() {
+    return del([DIRS.out.js + '/**/*']);
+});
+gulp.task('clean:img', function() {
+    return del([DIRS.out.img + '/**/*']);
+});
+gulp.task('clean:assets', function() {
+    return del([DIRS.out.manifest + '/' + FILES.assets]);
+});
+gulp.task('clean:test', function() {
+    return del([DIRS.out.test + '/**/*']);
+});
 
 // copy images to public dir
 gulp.task('copy:img', ['clean:img'], function() {
@@ -85,7 +92,7 @@ gulp.task('copy:img', ['clean:img'], function() {
 
 // compile JS
 gulp.task('scripts', ['clean:assets', 'clean:js'], function() {
-    const nodeEnv = (argv.production) ? 'production' : 'development';
+    const nodeEnv = argv.production ? 'production' : 'development';
     return browserify({ debug: true })
         .transform(
             envify({
@@ -94,7 +101,8 @@ gulp.task('scripts', ['clean:assets', 'clean:js'], function() {
             {
                 global: true,
                 _: 'purge'
-            })
+            }
+        )
         .transform(babelify)
         .require(DIRS.in.js + '/' + FILES.in.js, { entry: true })
         .bundle()
@@ -130,9 +138,10 @@ const sassTaskDeps = sassTaskBaseDeps.concat([jsonToSassTask]);
 
 // we share sass task deps here
 // otherwise race conditions mean some images aren't copied etc
-gulp.task(jsonToSassTask, sassTaskBaseDeps, function () {
+gulp.task(jsonToSassTask, sassTaskBaseDeps, function() {
     const jsonPath = DIRS.in.sassConfig + '/' + FILES.in.sassConfig;
-    return fs.createReadStream(jsonPath)
+    return fs
+        .createReadStream(jsonPath)
         .pipe(jsonSass({ prefix: '$appConfig: ' }))
         .pipe(source(jsonPath))
         .pipe(rename(FILES.out.sassConfig))
@@ -143,15 +152,20 @@ gulp.task(jsonToSassTask, sassTaskBaseDeps, function () {
 // references to images will be replaced (on --production/LIVE)
 // with cachebusted versions
 gulp.task('styles', sassTaskDeps, function() {
-    return gulp.src(DIRS.in.css + '/' + FILES.in.css)
+    return gulp
+        .src(DIRS.in.css + '/' + FILES.in.css)
         .pipe(gulpif(!argv.production, sourcemaps.init()))
-        .pipe(sass({
-            outputStyle: 'compressed'
-        }).on('error', sass.logError))
-        .pipe(autoprefixer({
-            browsers: ['last 2 versions'],
-            cascade: false
-        }))
+        .pipe(
+            sass({
+                outputStyle: 'compressed'
+            }).on('error', sass.logError)
+        )
+        .pipe(
+            autoprefixer({
+                browsers: ['last 2 versions'],
+                cascade: false
+            })
+        )
         .pipe(sourcemaps.write())
         .pipe(rename(FILES.out.css))
         .pipe(gulp.dest(DIRS.out.css))
@@ -161,11 +175,16 @@ gulp.task('styles', sassTaskDeps, function() {
 // hash/version static files and replace image paths in CSS
 // then write an output file (only on LIVE)
 gulp.task('rev', ['styles', 'scripts'], function() {
-    return gulp.src([
-            DIRS.out.css + '/**/*',
-            DIRS.out.js + '/**/*',
-            DIRS.out.img + '/**/*'
-        ], { base: DIRS.out.root }).pipe(rev())
+    return gulp
+        .src(
+            [
+                DIRS.out.css + '/**/*',
+                DIRS.out.js + '/**/*',
+                DIRS.out.img + '/**/*'
+            ],
+            { base: DIRS.out.root }
+        )
+        .pipe(rev())
         .pipe(revcssurls())
         .pipe(revdel())
         .pipe(gulp.dest(DIRS.out.root))
@@ -174,39 +193,40 @@ gulp.task('rev', ['styles', 'scripts'], function() {
 });
 
 // run mocha tests
-gulp.task('mocha', ['build'], function () {
-   return gulp.src(testBase + '/features/**/*.js', {
-       read: false
-   }).pipe(mocha({
-       reporter: 'spec',
-       timeout: 20000,
-       bail: true,
-       exit: true
-   }));
+gulp.task('mocha', ['build'], function() {
+    return gulp
+        .src(testBase + '/features/**/*.js', {
+            read: false
+        })
+        .pipe(
+            mocha({
+                reporter: 'spec',
+                timeout: 20000,
+                bail: true,
+                exit: true
+            })
+        );
 });
 
 // run phantomjs
 // @TODO if this task fails it doesn't stop the gulp task so the build passes!
-gulp.task('phantomjs', ['test-scripts'], function () {
-    return gulp
-        .src(testBase + '/runner.html')
-        .pipe(mochaPhantomJS({
+gulp.task('phantomjs', ['test-scripts'], function() {
+    return gulp.src(testBase + '/runner.html').pipe(
+        mochaPhantomJS({
             mocha: {
                 bail: true
             }
-        }));
+        })
+    );
 });
 
 // run eslint
 gulp.task('lint', function() {
-    return gulp.src([
-        DIRS.in.js + '/**/*.js',
-        '!' + DIRS.in.js + '/libs/',
-        '!' + DIRS.in.js + '/libs/**'
-    ])
-    .pipe(eslint({}))
-    .pipe(eslint.format())
-    .pipe(eslint.failAfterError());
+    return gulp
+        .src('**/*.js')
+        .pipe(eslint({}))
+        .pipe(eslint.format())
+        .pipe(eslint.failAfterError());
 });
 
 // dev task: start the server and watch for changes
@@ -231,10 +251,10 @@ gulp.task('watch', function() {
 });
 
 gulp.task('watch-test', function() {
-    gulp.watch([
-        DIRS.in.js + '/**/*.js',
-        DIRS.in.test + '/**/*.js'
-    ], ['phantomjs']);
+    gulp.watch(
+        [DIRS.in.js + '/**/*.js', DIRS.in.test + '/**/*.js'],
+        ['phantomjs']
+    );
 });
 
 gulp.task('watch-mocha', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8307,6 +8307,16 @@
         "once": "1.4.0"
       }
     },
+    "run-sequence": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-2.2.0.tgz",
+      "integrity": "sha512-xW5DmUwdvoyYQUMPKN8UW7TZSFs7AxtT59xo1m5y91jHbvwGlGgOmdV1Yw5P68fkjf3aHUZ4G1o1mZCtNe0qtw==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8"
+      }
+    },
     "rx": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "node-sass": "^4.5.3",
     "phantomjs-prebuilt": "^2.1.15",
     "prompt": "^1.0.0",
+    "run-sequence": "^2.2.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^7.1.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node ./bin/www",
     "dev": "export DEBUG=blf-alpha:*; nodemon ./bin/www",
     "test": "gulp test",
+    "lint": "eslint .",
     "test-precommit": "gulp test; gulp build-dev",
     "test-deps": "snyk test",
     "snyk-protect": "snyk protect",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    env: {
+        mocha: true
+    }
+};

--- a/test/features/materials.test.js
+++ b/test/features/materials.test.js
@@ -1,7 +1,8 @@
 'use strict';
-/* global describe, it, beforeEach, afterEach */
 const chai = require('chai');
 chai.use(require('chai-http'));
+chai.should();
+
 const jsdom = require("jsdom");
 const {JSDOM} = jsdom;
 

--- a/test/features/materials.test.js
+++ b/test/features/materials.test.js
@@ -2,7 +2,6 @@
 /* global describe, it, beforeEach, afterEach */
 const chai = require('chai');
 chai.use(require('chai-http'));
-const should = chai.should();
 const jsdom = require("jsdom");
 const {JSDOM} = jsdom;
 

--- a/test/features/server.test.js
+++ b/test/features/server.test.js
@@ -1,9 +1,8 @@
 'use strict';
-/* global describe, it, beforeEach, afterEach */
+
 const chai = require('chai');
 const config = require('config');
 chai.use(require('chai-http'));
-const should = chai.should();
 
 const helper = require('../helper');
 

--- a/test/features/tools.test.js
+++ b/test/features/tools.test.js
@@ -2,7 +2,6 @@
 /* global describe, it, beforeEach, afterEach, after */
 const chai = require('chai');
 chai.use(require('chai-http'));
-const should = chai.should();
 const config = require("config");
 
 const helper = require('../helper');


### PR DESCRIPTION
Currently only running on client-side code. This PR expands eslint to run on all application code. Could've helped flagged unused code the code removed like https://github.com/biglotteryfund/blf-alpha/pull/225 automatically.