### PR TITLE
Fix lint warnings

### DIFF
--- a/bin/scripts/cloudfront.js
+++ b/bin/scripts/cloudfront.js
@@ -38,8 +38,7 @@ const CF_CONFIGS = {
     test: {
         distributionId: 'E3D5QJTWAG3GDP',
         origins: {
-            legacy: 'ELB-TEST',
-            newSite: 'ELB-LIVE'
+            newSite: 'ELB-TEST'
         }
     },
     live: {
@@ -68,6 +67,8 @@ const makeUrlObject = (url, isPostable, allowQueryStrings) => {
 // or are manual legacy links
 // keys here are mapped to origin servers in config above
 let URLs = {
+    // if anything is added here, the TEST Cloudfront distribution will fail
+    // as it doesn't have a legacy origin.
     legacy: [],
     newSite: [
         makeUrlObject('/assets/*'),

--- a/bin/scripts/cloudfront.js
+++ b/bin/scripts/cloudfront.js
@@ -7,8 +7,7 @@ const argv = require('yargs')
     .alias('f', 'file')
     .describe('f', 'Pass an existing config to apply (eg. restore a backup)')
     .help('h')
-    .alias('h', 'help')
-    .argv;
+    .alias('h', 'help').argv;
 const prompt = require('prompt');
 const routes = require('../../controllers/routes');
 const utilities = require('../../modules/utilities');
@@ -40,25 +39,21 @@ const CF_CONFIGS = {
         distributionId: 'E3D5QJTWAG3GDP',
         origins: {
             legacy: 'ELB-TEST',
-            newSite: 'ELB-LIVE',
-            smallGrants: 'ELB-TEST',
-            smallGrantsTest: 'ELB-TEST'
+            newSite: 'ELB-LIVE'
         }
     },
     live: {
         distributionId: 'E2WYWBLMWIN5U1',
         origins: {
             legacy: 'Custom-www.biglotteryfund.org.uk',
-            newSite: 'ELB_LIVE',
-            smallGrants: 'small-grants',
-            smallGrantsTest: 'small-grants-test'
+            newSite: 'ELB_LIVE'
         }
     }
 };
 
 // decide which config to use (pass --live to this script to use live)
 const IS_LIVE = argv.l;
-const CF = (IS_LIVE) ? CF_CONFIGS.live : CF_CONFIGS.test;
+const CF = IS_LIVE ? CF_CONFIGS.live : CF_CONFIGS.test;
 
 // create a URL object to mark whether a URL is POST-able or not
 const makeUrlObject = (url, isPostable, allowQueryStrings) => {
@@ -69,26 +64,11 @@ const makeUrlObject = (url, isPostable, allowQueryStrings) => {
     };
 };
 
-// load secret hashes for SGO form
-const SGO_HASH = process.env.SGO_HASH;
-const SGO_HASH_TEST = process.env.SGO_HASH_TEST;
-
-if(!SGO_HASH || !SGO_HASH_TEST) {
-    console.error('Error: could not find SGO hashes. Exiting.');
-    process.exit(1);
-}
-
 // populate other app URLs that aren't in the router
 // or are manual legacy links
 // keys here are mapped to origin servers in config above
 let URLs = {
     legacy: [],
-    smallGrants: [
-        // makeUrlObject('/apply-' + SGO_HASH + '/*')
-    ],
-    smallGrantsTest: [
-        // makeUrlObject('/testapply-' + SGO_HASH_TEST + '/*')
-    ],
     newSite: [
         makeUrlObject('/assets/*'),
         makeUrlObject('/contrast/*', false, true),
@@ -102,7 +82,7 @@ let URLs = {
 
 // lookup cookies from app config
 const cookies = config.get('cookies');
-const cookiesInUse = Object.keys(cookies).map((k) => cookies[k]);
+const cookiesInUse = Object.keys(cookies).map(k => cookies[k]);
 
 // configure headers, cookies and origin servers for paths
 const BehaviourConfig = {
@@ -122,17 +102,17 @@ const BehaviourConfig = {
     newSite: {
         headersToKeep: ['Accept', 'Host'],
         cookies: {
-            "Forward": "whitelist",
-            "WhitelistedNames": {
-                "Items": cookiesInUse,
-                "Quantity": cookiesInUse.length
+            Forward: 'whitelist',
+            WhitelistedNames: {
+                Items: cookiesInUse,
+                Quantity: cookiesInUse.length
             }
         }
     },
     legacy: {
         headersToKeep: ['*'],
         cookies: {
-           "Forward": "all"
+            Forward: 'all'
         }
     }
 };
@@ -142,7 +122,7 @@ const makeBehaviourItem = (origin, path, isPostable, allowQueryStrings, originSe
     // the new site is properly cached, the legacy is not
     // so anything legacy should not cache cookies, headers, etc
     const isLegacy = origin !== 'newSite';
-    const cacheConfig = (isLegacy) ? BehaviourConfig['legacy'] : BehaviourConfig['newSite'];
+    const cacheConfig = isLegacy ? BehaviourConfig['legacy'] : BehaviourConfig['newSite'];
 
     // strip trailing slashes
     // fixes /welsh => /welsh/ homepage confusion
@@ -150,51 +130,49 @@ const makeBehaviourItem = (origin, path, isPostable, allowQueryStrings, originSe
     path = utilities.stripTrailingSlashes(path);
 
     // use all HTTP methods for legacy
-    const allowedHttpMethods = (isLegacy || isPostable) ? BehaviourConfig.httpMethods.getAndPost : BehaviourConfig.httpMethods.getOnly;
+    const allowedHttpMethods =
+        isLegacy || isPostable ? BehaviourConfig.httpMethods.getAndPost : BehaviourConfig.httpMethods.getOnly;
     // allow any protocol for legacy, redirect to HTTPS for new
-    const protocol = (isLegacy) ? BehaviourConfig.protocols.allowAll : BehaviourConfig.protocols.redirectToHttps;
+    const protocol = isLegacy ? BehaviourConfig.protocols.allowAll : BehaviourConfig.protocols.redirectToHttps;
 
     return {
-        "TrustedSigners": {
-            "Enabled": false,
-            "Items": [],
-            "Quantity": 0
+        TrustedSigners: {
+            Enabled: false,
+            Items: [],
+            Quantity: 0
         },
-        "LambdaFunctionAssociations": {
-            "Items": [],
-            "Quantity": 0
+        LambdaFunctionAssociations: {
+            Items: [],
+            Quantity: 0
         },
-        "TargetOriginId": originServer,
-        "ViewerProtocolPolicy": protocol,
-        "ForwardedValues": {
-            "Headers": {
-                "Items": cacheConfig.headersToKeep,
-                "Quantity": cacheConfig.headersToKeep.length
+        TargetOriginId: originServer,
+        ViewerProtocolPolicy: protocol,
+        ForwardedValues: {
+            Headers: {
+                Items: cacheConfig.headersToKeep,
+                Quantity: cacheConfig.headersToKeep.length
             },
-            "Cookies": cacheConfig.cookies,
-            "QueryStringCacheKeys": {
-                "Items": [],
-                "Quantity": 0
+            Cookies: cacheConfig.cookies,
+            QueryStringCacheKeys: {
+                Items: [],
+                Quantity: 0
             },
-            "QueryString": (isLegacy || allowQueryStrings)
+            QueryString: isLegacy || allowQueryStrings
         },
-        "MaxTTL": BehaviourConfig.TTLs.max,
-        "PathPattern": path,
-        "SmoothStreaming": false,
-        "DefaultTTL": BehaviourConfig.TTLs.default,
-        "AllowedMethods": {
-            "Items": allowedHttpMethods,
-            "CachedMethods": {
-                "Items": [
-                    "HEAD",
-                    "GET"
-                ],
-                "Quantity": 2
+        MaxTTL: BehaviourConfig.TTLs.max,
+        PathPattern: path,
+        SmoothStreaming: false,
+        DefaultTTL: BehaviourConfig.TTLs.default,
+        AllowedMethods: {
+            Items: allowedHttpMethods,
+            CachedMethods: {
+                Items: ['HEAD', 'GET'],
+                Quantity: 2
             },
-            "Quantity": allowedHttpMethods.length,
+            Quantity: allowedHttpMethods.length
         },
-        "MinTTL": BehaviourConfig.TTLs.min,
-        "Compress": false
+        MinTTL: BehaviourConfig.TTLs.min,
+        Compress: false
     };
 };
 
@@ -229,7 +207,7 @@ for (let s in routes.sections) {
 // add vanity redirects too
 routes.vanityRedirects.forEach(redirect => {
     if (redirect.paths) {
-        redirect.paths.forEach((path) => {
+        redirect.paths.forEach(path => {
             URLs.newSite.push(makeUrlObject(path));
         });
     } else {
@@ -250,120 +228,134 @@ for (let origin in URLs) {
 }
 
 // get existing cloudfront config
-let getDistributionConfig = cloudfront.getDistribution({
-    Id: CF.distributionId
-}).promise();
+let getDistributionConfig = cloudfront
+    .getDistribution({
+        Id: CF.distributionId
+    })
+    .promise();
 
 // handle response from fetching config
-getDistributionConfig.then((data) => { // fetching the config worked
+getDistributionConfig
+    .then(data => {
+        // fetching the config worked
 
-    // store the old config before changing it, just in case...
-    const clone = _.cloneDeep(data);
-    const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
-    const confPath = path.join(__dirname, `../cloudfront/${timestamp}.json`);
-    const confData = JSON.stringify(clone, null, 4);
+        // store the old config before changing it, just in case...
+        const clone = _.cloneDeep(data);
+        const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
+        const confPath = path.join(__dirname, `../cloudfront/${timestamp}.json`);
+        const confData = JSON.stringify(clone, null, 4);
 
-    // write config to file for backup
-    try {
-        fs.writeFileSync(confPath, confData);
-        console.log("A copy of the existing config was saved in " + confPath);
-    } catch (err) {
-        return console.error('Error saving old config', err);
-    }
-
-    // store etag for later update
-    const etag = data.ETag;
-
-    // are we using a custom config (eg. a backup file)?
-    if (customConfig) {
-        data = customConfig;
-    } else { // assign new behaviours from config here instead
-        data.Distribution.DistributionConfig.CacheBehaviors.Items = behaviours;
-        data.Distribution.DistributionConfig.CacheBehaviors.Quantity = behaviours.length;
-    }
-
-    // store just the distro config for update
-    const conf = data.Distribution.DistributionConfig;
-
-    const getUrls = (item) => {
-        // add a leading slash for comparison's sake
-        let path = item.PathPattern;
-        if (path[0] !== '/') {
-            path = '/' + path;
+        // write config to file for backup
+        try {
+            fs.writeFileSync(confPath, confData);
+            console.log('A copy of the existing config was saved in ' + confPath);
+        } catch (err) {
+            return console.error('Error saving old config', err);
         }
-        return {
-            path: path,
-            origin: item.TargetOriginId
-        };
-    };
 
-    // record the proposed config change
-    console.log(JSON.stringify(data));
+        // store etag for later update
+        const etag = data.ETag;
 
-    // verify what's being changed
-    const paths = {
-        before: clone.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls),
-        after: data.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls)
-    };
-    const pathsAdded = _.filter(paths.after, (obj) => !_.find(paths.before, obj));
-    const pathsRemoved = _.filter(paths.before, (obj) => !_.find(paths.after, obj));
-
-    // warn users about changes
-    console.log('There are currently ' + clone.Distribution.DistributionConfig.CacheBehaviors.Quantity + ' items in the existing behaviours, and ' + data.Distribution.DistributionConfig.CacheBehaviors.Quantity + ' in this one.');
-
-    if (pathsRemoved.length) {
-        console.log('The following paths will be removed from Cloudfront:', {
-            paths: pathsRemoved
-        });
-    }
-
-    if (pathsAdded.length) {
-        console.log('The following paths will be added to Cloudfront:', {
-            paths: pathsAdded
-        });
-    }
-
-    // prompt to confirm change
-    let promptSchema =   {
-        description: `Are you sure you want to make this change to ${CF.distributionId}?`,
-        name: 'yesno',
-        type: 'string',
-        pattern: /y[es]*|n[o]?/,
-        message: 'Please answer the question properly',
-        required: true
-    };
-
-    prompt.start();
-
-    prompt.get(promptSchema, (err, result) => {
-        if (['y', 'yes'].indexOf(result.yesno) !== -1) {
-            console.log('Starting update...');
-
-            // try to update the distribution
-            let updateDistributionConfig = cloudfront.updateDistribution({
-                DistributionConfig: conf,
-                Id: CF.distributionId,
-                IfMatch: etag
-            }).promise();
-
-            // respond to update change
-            updateDistributionConfig.then((data) => { // the update worked
-                console.log(data);
-                console.log('CloudFront was successfully updated with the new configuration!');
-            }).catch((err) => { // failed to update config
-                console.log(JSON.stringify(conf));
-                console.error('There was an error uploading this config', {
-                    error: err
-                });
-            });
-
+        // are we using a custom config (eg. a backup file)?
+        if (customConfig) {
+            data = customConfig;
         } else {
-            console.log('Bailing out!');
+            // assign new behaviours from config here instead
+            data.Distribution.DistributionConfig.CacheBehaviors.Items = behaviours;
+            data.Distribution.DistributionConfig.CacheBehaviors.Quantity = behaviours.length;
         }
-    });
 
-}).catch((err) => { // failed to get config
-    console.error('There was an error fetching the config', {
-        error: err
+        // store just the distro config for update
+        const conf = data.Distribution.DistributionConfig;
+
+        const getUrls = item => {
+            // add a leading slash for comparison's sake
+            let path = item.PathPattern;
+            if (path[0] !== '/') {
+                path = '/' + path;
+            }
+            return {
+                path: path,
+                origin: item.TargetOriginId
+            };
+        };
+
+        // verify what's being changed
+        const paths = {
+            before: clone.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls),
+            after: data.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls)
+        };
+        const pathsAdded = _.filter(paths.after, obj => !_.find(paths.before, obj));
+        const pathsRemoved = _.filter(paths.before, obj => !_.find(paths.after, obj));
+
+        // warn users about changes
+        console.log(
+            'There are currently ' +
+                clone.Distribution.DistributionConfig.CacheBehaviors.Quantity +
+                ' items in the existing behaviours, and ' +
+                data.Distribution.DistributionConfig.CacheBehaviors.Quantity +
+                ' in this one.'
+        );
+
+        if (pathsRemoved.length) {
+            console.log('The following paths will be removed from Cloudfront:', {
+                paths: pathsRemoved
+            });
+        }
+
+        if (pathsAdded.length) {
+            console.log('The following paths will be added to Cloudfront:', {
+                paths: pathsAdded
+            });
+        }
+
+        // prompt to confirm change
+        let promptSchema = {
+            description: `Are you sure you want to make this change to ${CF.distributionId}?`,
+            name: 'yesno',
+            type: 'string',
+            pattern: /y[es]*|n[o]?/,
+            message: 'Please answer the question properly',
+            required: true
+        };
+
+        prompt.start();
+
+        prompt.get(promptSchema, (err, result) => {
+            if (['y', 'yes'].indexOf(result.yesno) !== -1) {
+                console.log('Starting update...');
+
+                // try to update the distribution
+                let updateDistributionConfig = cloudfront
+                    .updateDistribution({
+                        DistributionConfig: conf,
+                        Id: CF.distributionId,
+                        IfMatch: etag
+                    })
+                    .promise();
+
+                // respond to update change
+                updateDistributionConfig
+                    .then(data => {
+                        // the update worked
+                        console.log(data);
+                        console.log('CloudFront was successfully updated with the new configuration!');
+                    })
+                    .catch(err => {
+                        // failed to update config
+                        console.log(JSON.stringify(conf));
+                        console.error('There was an error uploading this config', {
+                            error: err
+                        });
+                    });
+            } else {
+                console.log('Bailing out!');
+            }
+        });
+    })
+    .catch(err => {
+        // failed to get config
+        console.error('There was an error fetching the config', {
+            error: err
+        });
     });
-});

--- a/bin/scripts/deploy.js
+++ b/bin/scripts/deploy.js
@@ -6,8 +6,7 @@ const argv = require('yargs')
     .alias('b', 'build')
     .describe('b', 'Pass a custom build number to deploy')
     .help('h')
-    .alias('h', 'help')
-    .argv;
+    .alias('h', 'help').argv;
 const prompt = require('prompt');
 const AWS = require('aws-sdk');
 const request = require('request');
@@ -37,79 +36,81 @@ const codeDeployEnvs = {
 const CONF = {
     s3Bucket: 'blf-travis-test',
     filenamePattern: /build-(\d+).zip/,
-    codedeploy: (argv.l) ? codeDeployEnvs.live : codeDeployEnvs.test,
+    codedeploy: argv.l ? codeDeployEnvs.live : codeDeployEnvs.test,
     githubAccount: 'biglotteryfund',
     githubRepo: 'blf-alpha'
 };
 
 // create AWS SDK instance
 const credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
-AWS.config.update({region:'eu-west-1'});
+AWS.config.update({ region: 'eu-west-1' });
 AWS.config.credentials = credentials;
 const codedeploy = new AWS.CodeDeploy();
 
 // do we have a build number?
 if (customBuildNumber) {
-    
     lookupRevisionAndDeploy(customBuildNumber); // try to deploy it!
-
-} else { // ask for one instead
+} else {
+    // ask for one instead
 
     // fetch recent revisions from TEST (eg. to promote to live or re-deploy)
-    let getRevisions = codedeploy.listApplicationRevisions({
-        applicationName: codeDeployEnvs.test.applicationName,
-        deployed: 'ignore',
-        s3Bucket: CONF.s3Bucket,
-        sortBy: 'registerTime',
-        sortOrder: 'descending'
-    }).promise();
+    let getRevisions = codedeploy
+        .listApplicationRevisions({
+            applicationName: codeDeployEnvs.test.applicationName,
+            deployed: 'ignore',
+            s3Bucket: CONF.s3Bucket,
+            sortBy: 'registerTime',
+            sortOrder: 'descending'
+        })
+        .promise();
 
     // present past revisions to the user
-    getRevisions.then((data) => {
-        console.log('Listing the most recent revisions on TEST:\n');
-        let revisions = data.revisions.slice(0, 10);
-        let validDeploys = [];
-        revisions.forEach(r => {
-            let id = r.s3Location.key;
-            let number = id.match(CONF.filenamePattern);
-            if (number && number[1]) {
-                validDeploys.push(parseInt(number[1]));
-                console.log(`\t• Build #${number[1]}`);
-            }
+    getRevisions
+        .then(data => {
+            console.log('Listing the most recent revisions on TEST:\n');
+            let revisions = data.revisions.slice(0, 10);
+            let validDeploys = [];
+            revisions.forEach(r => {
+                let id = r.s3Location.key;
+                let number = id.match(CONF.filenamePattern);
+                if (number && number[1]) {
+                    validDeploys.push(parseInt(number[1]));
+                    console.log(`\t• Build #${number[1]}`);
+                }
+            });
+
+            // prompt to ask which revision to deploy
+            let promptSchema = {
+                description: `\nWhich revision would you like to deploy to ${CONF.codedeploy.applicationName}?`,
+                name: 'revisionId',
+                type: 'integer',
+                message: 'Please supply a valid deploy ID',
+                required: true
+            };
+
+            prompt.start();
+
+            // deploy a known revision
+            prompt.get(promptSchema, (err, result) => {
+                let typedId = result.revisionId;
+                if (validDeploys.indexOf(typedId) !== -1) {
+                    // we know this is valid
+                    deployRevision(typedId);
+                } else {
+                    // not sure about this, look it up
+                    console.log("That ID wasn't in the list, looking it up...");
+                    lookupRevisionAndDeploy(typedId);
+                }
+            });
+        })
+        .catch(err => {
+            console.error('Error fetching revisions', {
+                error: err
+            });
         });
-
-        // prompt to ask which revision to deploy
-        let promptSchema = {
-            description: `\nWhich revision would you like to deploy to ${CONF.codedeploy.applicationName}?`,
-            name: 'revisionId',
-            type: 'integer',
-            message: 'Please supply a valid deploy ID',
-            required: true
-        };
-
-        prompt.start();
-
-        // deploy a known revision
-        prompt.get(promptSchema, (err, result) => {
-            let typedId = result.revisionId;
-            if (validDeploys.indexOf(typedId) !== -1) {
-                // we know this is valid
-                deployRevision(typedId);
-            } else {
-                // not sure about this, look it up
-                console.log('That ID wasn\'t in the list, looking it up...');
-                lookupRevisionAndDeploy(typedId);
-            }
-        });
-
-    }).catch((err) => {
-        console.error('Error fetching revisions', {
-            error: err
-        });
-    });
 }
 
-function getEnvStatus (env) {
+function getEnvStatus(env) {
     const URLs = {
         test: process.env.ELB_TEST,
         production: process.env.ELB_PROD
@@ -117,19 +118,16 @@ function getEnvStatus (env) {
 
     return rp({
         url: URLs[env]
-    }).then((response) => {
+    }).then(response => {
         return JSON.parse(response);
     });
 }
 
-function getCommitsToBeDeployed () {
-    let lookups = [
-        getEnvStatus('test'),
-        getEnvStatus('production')
-    ];
+function getCommitsToBeDeployed() {
+    let lookups = [getEnvStatus('test'), getEnvStatus('production')];
 
     // get server statuses
-    return Promise.all(lookups).then((responses) => {
+    return Promise.all(lookups).then(responses => {
         let test = responses[0];
         let prod = responses[1];
 
@@ -144,51 +142,57 @@ function getCommitsToBeDeployed () {
         let commitList = `https://api.github.com/repos/${CONF.githubAccount}/${CONF.githubRepo}/commits?sha=${ids.test}&per_page=100`;
 
         // now get commits made before the one currently on TEST
-        return rp.get({
-            url: commitList,
-            headers: {
-                'User-Agent': 'BLF-Deploy-Tool'
-            }
-        }).then(response => {
-            let commits = JSON.parse(response);
-            let commitsToAdd = [];
-            // filter out commits made before the last PROD deploy
-            for (let i = 0; i < commits.length; i++) {
-                if (commits[i].sha === ids.prod) { break; }
-                commitsToAdd.push(commits[i]);
-            }
-            return commitsToAdd;
-        });
-
+        return rp
+            .get({
+                url: commitList,
+                headers: {
+                    'User-Agent': 'BLF-Deploy-Tool'
+                }
+            })
+            .then(response => {
+                let commits = JSON.parse(response);
+                let commitsToAdd = [];
+                // filter out commits made before the last PROD deploy
+                for (let i = 0; i < commits.length; i++) {
+                    if (commits[i].sha === ids.prod) {
+                        break;
+                    }
+                    commitsToAdd.push(commits[i]);
+                }
+                return commitsToAdd;
+            });
     });
 }
 
-function postMessageToSlack (title, subtitle, color) {
-    request({
-        url: SLACK_URL,
-        method: 'POST',
-        json: {
-            "text": title,
-            "attachments": [
-                {
-                    "text": subtitle,
-                    "color": color
-                }
-            ]
+function postMessageToSlack(title, subtitle, color) {
+    request(
+        {
+            url: SLACK_URL,
+            method: 'POST',
+            json: {
+                text: title,
+                attachments: [
+                    {
+                        text: subtitle,
+                        color: color
+                    }
+                ]
+            }
+        },
+        error => {
+            if (error) {
+                console.error('Error sending Slack message', {
+                    error: error
+                });
+            } else {
+                console.log('Sent message to Slack!');
+            }
         }
-    }, (error, response) => {
-        if (error){
-            console.error('Error sending Slack message', {
-                error: error
-            });
-        } else {
-            console.log('Sent message to Slack!');
-        }
-    });
+    );
 }
 
 // make JSON data for deploy config
-function createDeploymentConf (id) {
+function createDeploymentConf(id) {
     return {
         applicationName: CONF.codedeploy.applicationName,
         autoRollbackConfiguration: {
@@ -212,119 +216,130 @@ function createDeploymentConf (id) {
     };
 }
 
-function verifyCommitsToDeploy () {
+function verifyCommitsToDeploy() {
     return new Promise((resolve, reject) => {
+        return getCommitsToBeDeployed()
+            .then(commits => {
+                // list the commits
+                let commitStr = '';
+                console.log('This deployment will push the following commits live:');
+                commits.forEach(c => {
+                    let line = ` - ${c.commit.message} \n`;
+                    commitStr += line;
+                    console.log('\t' + line);
+                });
 
-        return getCommitsToBeDeployed().then(commits => {
+                // make sure the user is happy to push these commits
+                let promptSchema = {
+                    description: `Are you sure you want to push the above commits live?`,
+                    name: 'yesno',
+                    type: 'string',
+                    pattern: /y[es]*|n[o]?/,
+                    message: 'Please answer the question properly',
+                    required: true
+                };
 
-            // list the commits
-            let commitStr = '';
-            console.log('This deployment will push the following commits live:');
-            commits.forEach((c) => {
-                let line = ` - ${c.commit.message} \n`;
-                commitStr += line;
-                console.log('\t' + line);
+                prompt.start();
+
+                prompt.get(promptSchema, (err, result) => {
+                    if (['y', 'yes'].indexOf(result.yesno) !== -1) {
+                        resolve('\nThe following commits will be deployed: \n' + commitStr);
+                    } else {
+                        reject('Bailing out!');
+                    }
+                });
+            })
+            .catch(err => {
+                reject(err);
             });
-
-            // make sure the user is happy to push these commits
-            let promptSchema = {
-                description: `Are you sure you want to push the above commits live?`,
-                name: 'yesno',
-                type: 'string',
-                pattern: /y[es]*|n[o]?/,
-                message: 'Please answer the question properly',
-                required: true
-            };
-
-            prompt.start();
-
-            prompt.get(promptSchema, (err, result) => {
-                if (['y', 'yes'].indexOf(result.yesno) !== -1) {
-                    resolve('\nThe following commits will be deployed: \n' + commitStr);
-                } else {
-                    reject("Bailing out!");
-                }
-            });
-
-        }).catch((err) => {
-            reject(err);
-        });
-
     });
 }
 
 // trigger the deploy itself
-function pushOutDeploy (env, id, commitStr) {
+function pushOutDeploy(env, id, commitStr) {
     let text = `Attempting to deploy revision ${id} to environment ${env}, please wait...`;
 
-    postMessageToSlack(`Attempting to deploy build \`#${id}\` to BLF Alpha on the \`${env}\` environment:`, commitStr, 'warning');
+    postMessageToSlack(
+        `Attempting to deploy build \`#${id}\` to BLF Alpha on the \`${env}\` environment:`,
+        commitStr,
+        'warning'
+    );
     console.log(text);
     const deployParams = createDeploymentConf(id);
     let attemptDeploy = codedeploy.createDeployment(deployParams).promise();
-    attemptDeploy.then((data) => {
-        let status = 'Deployment started, monitoring...';
-        console.log(status);
-        postMessageToSlack('Deployment has begun', 'Monitoring...', 'warning');
-        let deployCheck = codedeploy.waitFor('deploymentSuccessful', { deploymentId: data.deploymentId }).promise();
-        deployCheck.then((data) => {
-            let status = 'Deployment succeeded!';
-            postMessageToSlack('Deployment succeeded!', ':cool:', 'good');
+    attemptDeploy
+        .then(data => {
+            let status = 'Deployment started, monitoring...';
             console.log(status);
-        }).catch((err) => {
-            postMessageToSlack('Deployment failed!', '```' + JSON.stringify(err) + '```', 'danger');
-            console.error('Error deploying revision', {
-                deploymentId: data.deploymentId,
+            postMessageToSlack('Deployment has begun', 'Monitoring...', 'warning');
+            let deployCheck = codedeploy.waitFor('deploymentSuccessful', { deploymentId: data.deploymentId }).promise();
+            deployCheck
+                .then(() => {
+                    let status = 'Deployment succeeded!';
+                    postMessageToSlack('Deployment succeeded!', ':cool:', 'good');
+                    console.log(status);
+                })
+                .catch(err => {
+                    postMessageToSlack('Deployment failed!', '```' + JSON.stringify(err) + '```', 'danger');
+                    console.error('Error deploying revision', {
+                        deploymentId: data.deploymentId,
+                        error: err
+                    });
+                });
+        })
+        .catch(err => {
+            postMessageToSlack('Could not create deployment!', '```' + JSON.stringify(err) + '```', 'danger');
+            console.error('Error creating deployment', {
+                buildId: id,
                 error: err
             });
         });
-    }).catch((err) => {
-        postMessageToSlack('Could not create deployment!', '```' + JSON.stringify(err) + '```', 'danger');
-        console.error('Error creating deployment', {
-            buildId: id,
-            error: err
-        });
-    });
 }
 
 // do a final check about commits
-function deployRevision (id) {
-    let env = (argv.l) ? 'PRODUCTION' : 'TEST';
+function deployRevision(id) {
+    let env = argv.l ? 'PRODUCTION' : 'TEST';
 
     // if we're deploying to PROD, look up the commits this will push live
     if (env === 'PRODUCTION') {
-        verifyCommitsToDeploy().then(commitStr => {
-            pushOutDeploy(env, id, commitStr);
-        }).catch(err => {
-            console.log(err);
-            process.exit(1);
-        });
-    } else { // it's a non-prod deploy, no need to verify commits
+        verifyCommitsToDeploy()
+            .then(commitStr => {
+                pushOutDeploy(env, id, commitStr);
+            })
+            .catch(err => {
+                console.log(err);
+                process.exit(1);
+            });
+    } else {
+        // it's a non-prod deploy, no need to verify commits
         pushOutDeploy(env, id);
     }
 }
 
 // lookup a known revision on TEST
-function getRevision (id) {
-    return codedeploy.getApplicationRevision({
-        applicationName: codeDeployEnvs.test.applicationName,
-        revision: {
-            revisionType: 'S3',
-            s3Location: {
-                bucket: CONF.s3Bucket,
-                bundleType: 'zip',
-                key: `build-${id}.zip`
+function getRevision(id) {
+    return codedeploy
+        .getApplicationRevision({
+            applicationName: codeDeployEnvs.test.applicationName,
+            revision: {
+                revisionType: 'S3',
+                s3Location: {
+                    bucket: CONF.s3Bucket,
+                    bundleType: 'zip',
+                    key: `build-${id}.zip`
+                }
             }
-        }
-    }).promise();
-
+        })
+        .promise();
 }
 
-function lookupRevisionAndDeploy (id) {
-    getRevision(id).then((response) => {
-        console.log('Found your revision ID! Deploying it now...');
-        deployRevision(id);
-    }).catch((err) => {
-        console.error('Error! That ID didn\'t exist. Sorry :(');
-    });
+function lookupRevisionAndDeploy(id) {
+    getRevision(id)
+        .then(() => {
+            console.log('Found your revision ID! Deploying it now...');
+            deployRevision(id);
+        })
+        .catch(() => {
+            console.error("Error! That ID didn't exist. Sorry :(");
+        });
 }
-

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -16,7 +16,6 @@ const freeMaterialsLogic = {
 };
 
 module.exports = (pages, sectionPath, sectionId) => {
-
     /**
      * 1. Populate static pages
      */
@@ -30,9 +29,9 @@ module.exports = (pages, sectionPath, sectionId) => {
     const freeMaterials = pages.freeMaterials;
 
     // handle adding/removing items
-    router.route(freeMaterials.path + '/item/:id').post((req, res, next) => {
+    router.route(freeMaterials.path + '/item/:id').post((req, res) => {
         // this page is dynamic so don't cache it
-        res.cacheControl = {maxAge: 0};
+        res.cacheControl = { maxAge: 0 };
 
         // update the session with ordered items
         const code = req.sanitize('code').escape();
@@ -55,15 +54,14 @@ module.exports = (pages, sectionPath, sectionId) => {
                 });
             }
         });
-
     });
 
     // PAGE: free materials form
-    router.route([freeMaterials.path])
-        .get((req, res, next) => {
-
+    router
+        .route([freeMaterials.path])
+        .get((req, res) => {
             // this page is dynamic so don't cache it
-            res.cacheControl = {maxAge: 0};
+            res.cacheControl = { maxAge: 0 };
 
             let orderStatus;
             // clear order details if it succeeded
@@ -83,7 +81,7 @@ module.exports = (pages, sectionPath, sectionId) => {
             res.render(freeMaterials.template, {
                 title: lang.title,
                 copy: lang,
-                description: "Order items free of charge to acknowledge your grant",
+                description: 'Order items free of charge to acknowledge your grant',
                 materials: freeMaterialsLogic.materials.items,
                 formFields: freeMaterialsLogic.formFields,
                 orders: orders,
@@ -92,10 +90,9 @@ module.exports = (pages, sectionPath, sectionId) => {
                 csrfToken: ''
             });
         })
-        .post((req, res, next) => {
-
+        .post((req, res) => {
             // turn 'Your name' into 'your name' (for error messages)
-            const lcfirst = (str) => str[0].toLowerCase() + str.substring(1);
+            const lcfirst = str => str[0].toLowerCase() + str.substring(1);
             let locale = req.i18n.getLocale();
 
             freeMaterialsLogic.formFields.forEach(field => {
@@ -108,7 +105,8 @@ module.exports = (pages, sectionPath, sectionId) => {
             });
 
             const makeOrderText = (items, details) => {
-                let text = "A new order has been received from the Big Lottery Fund website. The order details are below:\n\n";
+                let text =
+                    'A new order has been received from the Big Lottery Fund website. The order details are below:\n\n';
                 for (let code in items) {
                     if (items[code].quantity > 0) {
                         text += `\t- x${items[code].quantity} ${code}\t (item: ${items[code].name})\n`;
@@ -123,12 +121,12 @@ module.exports = (pages, sectionPath, sectionId) => {
                     }
                 });
 
-                text += "\nThis email has been automatically generated from the Big Lottery Fund Website.";
-                text += "\nIf you have feedback, please contact matt.andrews@biglotteryfund.org.uk.";
+                text += '\nThis email has been automatically generated from the Big Lottery Fund Website.';
+                text += '\nIf you have feedback, please contact matt.andrews@biglotteryfund.org.uk.';
                 return text;
             };
 
-            req.getValidationResult().then((result) => {
+            req.getValidationResult().then(result => {
                 // sanitise input
                 for (let key in req.body) {
                     req.body[key] = xss(req.body[key]);
@@ -147,8 +145,11 @@ module.exports = (pages, sectionPath, sectionId) => {
 
                         // add their langage choice (if valid)
                         let langChoice = req.body.languageChoice;
-                        if (langChoice && redirectUrl.indexOf(langParam) === -1 &&
-                            ['monolingual', 'bilingual'].indexOf(langChoice) !== -1) {
+                        if (
+                            langChoice &&
+                            redirectUrl.indexOf(langParam) === -1 &&
+                            ['monolingual', 'bilingual'].indexOf(langChoice) !== -1
+                        ) {
                             redirectUrl += langParam + langChoice;
                         }
 
@@ -161,7 +162,7 @@ module.exports = (pages, sectionPath, sectionId) => {
                     });
                 } else {
                     let text = makeOrderText(req.session[freeMaterialsLogic.orderKey], req.body);
-                    let dateNow = moment().format("dddd, MMMM Do YYYY, h:mm:ss a");
+                    let dateNow = moment().format('dddd, MMMM Do YYYY, h:mm:ss a');
 
                     // allow tests to run without sending email
                     if (!req.body.skipEmail) {
@@ -175,7 +176,6 @@ module.exports = (pages, sectionPath, sectionId) => {
                         // this is only used in tests, so we confirm the form data was correct
                         res.send(req.body);
                     }
-
                 }
             });
         });

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,14 +1,12 @@
-'use strict';
+"use strict";
 const config = require('config');
 const anchors = config.get('anchors');
 
 // pass some parameters onto each controller
 // so we can take route config and init all at once
-let loadController = path => {
+let loadController = (path) => {
     return (pages, sectionPath, sectionId) => require(path)(pages, sectionPath, sectionId);
 };
-
-console.log('hello');
 
 // define top-level controllers for the site
 const controllers = {
@@ -19,11 +17,11 @@ const controllers = {
 
 // configure base paths for site sections
 const sectionPaths = {
-    toplevel: '',
-    funding: '/funding',
-    about: '/about-big', // @TODO rename on launch
-    aboutLegacy: '/about-big', // used on the old site
-    research: '/research'
+    toplevel: "",
+    funding: "/funding",
+    about: "/about-big", // @TODO rename on launch
+    aboutLegacy: "/about-big", // used on the old site
+    research: "/research"
 };
 
 // these top-level sections appear in the main site nav
@@ -31,51 +29,51 @@ const sectionPaths = {
 const routes = {
     sections: {
         toplevel: {
-            name: 'Top-level pages',
-            langTitlePath: 'global.nav.home',
+            name: "Top-level pages",
+            langTitlePath: "global.nav.home",
             path: sectionPaths.toplevel,
             controller: controllers.toplevel,
             pages: {
                 home: {
-                    name: 'Home',
-                    path: '/',
-                    template: 'pages/toplevel/home',
-                    lang: 'toplevel.home',
+                    name: "Home",
+                    path: "/",
+                    template: "pages/toplevel/home",
+                    lang: "toplevel.home",
                     code: 0,
                     static: false,
                     live: true,
                     isPostable: true
                 },
                 contact: {
-                    name: 'Contact',
-                    path: '/contact',
-                    template: 'pages/toplevel/contact',
-                    lang: 'toplevel.contact',
+                    name: "Contact",
+                    path: "/contact",
+                    template: "pages/toplevel/contact",
+                    lang: "toplevel.contact",
                     code: 4,
                     static: true,
                     live: true,
                     aliases: [
-                        sectionPaths.toplevel + '/about-big/contact-us',
-                        sectionPaths.toplevel + '/help-and-support',
-                        sectionPaths.toplevel + '/england/about-big/contact-us',
-                        sectionPaths.toplevel + '/wales/about-big/contact-us',
-                        sectionPaths.toplevel + '/scotland/about-big/contact-us',
-                        sectionPaths.toplevel + '/northernireland/about-big/contact-us'
+                        sectionPaths.toplevel + "/about-big/contact-us",
+                        sectionPaths.toplevel + "/help-and-support",
+                        sectionPaths.toplevel + "/england/about-big/contact-us",
+                        sectionPaths.toplevel + "/wales/about-big/contact-us",
+                        sectionPaths.toplevel + "/scotland/about-big/contact-us",
+                        sectionPaths.toplevel + "/northernireland/about-big/contact-us"
                     ]
                 },
                 data: {
-                    name: 'Data',
-                    path: '/data',
-                    template: 'pages/toplevel/data',
-                    lang: 'toplevel.data',
+                    name: "Data",
+                    path: "/data",
+                    template: "pages/toplevel/data",
+                    lang: "toplevel.data",
                     static: false,
                     live: true
                 },
                 jobs: {
-                    name: 'Jobs',
-                    path: '/jobs',
-                    template: 'pages/toplevel/jobs',
-                    lang: 'toplevel.jobs',
+                    name: "Jobs",
+                    path: "/jobs",
+                    template: "pages/toplevel/jobs",
+                    lang: "toplevel.jobs",
                     code: 7,
                     static: true,
                     live: true,
@@ -86,37 +84,39 @@ const routes = {
                     ]
                 },
                 benefits: {
-                    name: 'Benefits',
-                    path: '/jobs/benefits',
-                    template: 'pages/toplevel/benefits',
-                    lang: 'toplevel.benefits',
+                    name: "Benefits",
+                    path: "/jobs/benefits",
+                    template: "pages/toplevel/benefits",
+                    lang: "toplevel.benefits",
                     static: true,
                     live: true,
-                    aliases: [sectionPaths.toplevel + '/about-big/jobs/benefits']
+                    aliases: [
+                        sectionPaths.toplevel + '/about-big/jobs/benefits',
+                    ]
                 },
                 under10k: {
-                    name: 'Under 10k',
-                    path: '/under10k',
-                    template: 'pages/toplevel/under10k',
-                    lang: 'toplevel.under10k',
+                    name: "Under 10k",
+                    path: "/under10k",
+                    template: "pages/toplevel/under10k",
+                    lang: "toplevel.under10k",
                     code: 29,
                     static: true,
                     live: true
                 },
                 over10k: {
-                    name: 'Over 10k',
-                    path: '/over10k',
-                    template: 'pages/toplevel/over10k',
-                    lang: 'toplevel.over10k',
+                    name: "Over 10k",
+                    path: "/over10k",
+                    template: "pages/toplevel/over10k",
+                    lang: "toplevel.over10k",
                     code: 30,
                     static: true,
                     live: true
                 },
                 eyp: {
-                    name: 'Empowering Young People',
-                    path: '/empowering-young-people',
-                    template: 'pages/toplevel/eyp',
-                    lang: 'toplevel.eyp',
+                    name: "Empowering Young People",
+                    path: "/empowering-young-people",
+                    template: "pages/toplevel/eyp",
+                    lang: "toplevel.eyp",
                     code: 0,
                     static: true,
                     live: true,
@@ -127,51 +127,49 @@ const routes = {
             }
         },
         funding: {
-            name: 'Funding',
-            langTitlePath: 'global.nav.funding',
+            name: "Funding",
+            langTitlePath: "global.nav.funding",
             path: sectionPaths.funding,
             controller: controllers.funding,
             pages: {
                 logos: {
-                    name: 'Logos',
-                    path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
-                    template: 'pages/funding/guidance/logos',
-                    lang: 'funding.guidance.logos',
+                    name: "Logos",
+                    path: "/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+                    template: "pages/funding/guidance/logos",
+                    lang: "funding.guidance.logos",
                     code: 1,
                     static: true,
                     live: true,
                     aliases: [
-                        sectionPaths.funding +
-                            '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
-                        sectionPaths.funding + '/funding-guidance/managing-your-funding/logodownloads'
+                        sectionPaths.funding + "/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+                        sectionPaths.funding + "/funding-guidance/managing-your-funding/logodownloads"
                     ]
                 },
                 manageFunding: {
-                    name: 'Managing your funding',
-                    path: '/funding-guidance/managing-your-funding',
-                    template: 'pages/funding/guidance/managing-your-funding',
-                    lang: 'funding.guidance.managing-your-funding',
+                    name: "Managing your funding",
+                    path: "/funding-guidance/managing-your-funding",
+                    template: "pages/funding/guidance/managing-your-funding",
+                    lang: "funding.guidance.managing-your-funding",
                     code: 2,
                     static: true,
                     live: true,
                     aliases: [
                         sectionPaths.funding + '/funding-guidance/managing-your-funding/help-with-publicity',
-                        '/welcome',
-                        '/publicity'
+                        "/welcome",
+                        "/publicity"
                     ]
                 },
                 freeMaterials: {
-                    name: 'Ordering free materials',
-                    path: '/funding-guidance/managing-your-funding/ordering-free-materials',
-                    template: 'pages/funding/guidance/order-free-materials',
-                    lang: 'funding.guidance.order-free-materials',
+                    name: "Ordering free materials",
+                    path: "/funding-guidance/managing-your-funding/ordering-free-materials",
+                    template: "pages/funding/guidance/order-free-materials",
+                    lang: "funding.guidance.order-free-materials",
                     code: 3,
                     live: true,
                     isPostable: true,
                     isWildcard: true,
                     aliases: [
-                        sectionPaths.funding +
-                            '/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
+                        sectionPaths.funding + '/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
                         '/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials',
                         '/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials',
                         '/england/funding/funding-guidance/managing-your-funding/ordering-free-materials',
@@ -179,19 +177,19 @@ const routes = {
                     ]
                 },
                 helpWithPublicity: {
-                    name: 'Help with publicity',
-                    path: '/funding-guidance/managing-your-funding/social-media',
-                    template: 'pages/funding/guidance/help-with-publicity',
-                    lang: 'funding.guidance.help-with-publicity',
+                    name: "Help with publicity",
+                    path: "/funding-guidance/managing-your-funding/social-media",
+                    template: "pages/funding/guidance/help-with-publicity",
+                    lang: "funding.guidance.help-with-publicity",
                     code: 12,
                     static: true,
                     live: true
                 },
                 pressCoverage: {
-                    name: 'Getting press coverage',
-                    path: '/funding-guidance/managing-your-funding/press',
-                    template: 'pages/funding/guidance/getting-press-coverage',
-                    lang: 'funding.guidance.getting-press-coverage',
+                    name: "Getting press coverage",
+                    path: "/funding-guidance/managing-your-funding/press",
+                    template: "pages/funding/guidance/getting-press-coverage",
+                    lang: "funding.guidance.getting-press-coverage",
                     code: 18,
                     static: true,
                     live: true
@@ -199,22 +197,22 @@ const routes = {
             }
         },
         research: {
-            name: 'Research',
-            langTitlePath: 'global.nav.research',
+            name: "Research",
+            langTitlePath: "global.nav.research",
             path: sectionPaths.research
         },
         // @TODO rename this to 'about' when ready to launch /about
-        'about-big': {
-            name: 'About',
-            langTitlePath: 'global.nav.about',
+        "about-big": {
+            name: "About",
+            langTitlePath: "global.nav.about",
             path: sectionPaths.about,
             controller: controllers.about,
             pages: {
                 root: {
-                    name: 'About',
-                    path: '/',
-                    template: 'pages/toplevel/about',
-                    lang: 'toplevel.about',
+                    name: "About",
+                    path: "/",
+                    template: "pages/toplevel/about",
+                    lang: "toplevel.about",
                     code: 0,
                     static: true,
                     live: false,
@@ -223,29 +221,29 @@ const routes = {
                     ]
                 },
                 freedomOfInformation: {
-                    name: 'Freedom of Information',
-                    path: '/customer-service/freedom-of-information',
-                    template: 'pages/about/freedom-of-information',
-                    lang: 'about.foi',
+                    name: "Freedom of Information",
+                    path: "/customer-service/freedom-of-information",
+                    template: "pages/about/freedom-of-information",
+                    lang: "about.foi",
                     code: 85,
                     static: true,
                     live: true,
                     aliases: [
                         // sectionPaths.aboutLegacy + "/customer-service/freedom-of-information",
-                        '/freedom-of-information'
+                        "/freedom-of-information"
                     ]
                 },
                 dataProtection: {
-                    name: 'Data Protection',
-                    path: '/customer-service/data-protection',
-                    template: 'pages/about/data-protection',
-                    lang: 'about.dataProtection',
+                    name: "Data Protection",
+                    path: "/customer-service/data-protection",
+                    template: "pages/about/data-protection",
+                    lang: "about.dataProtection",
                     code: 84,
                     static: true,
                     live: true,
                     aliases: [
                         // sectionPaths.aboutLegacy + "/customer-service/data-protection",
-                        '/data-protection'
+                        "/data-protection"
                     ]
                 }
             }
@@ -264,8 +262,8 @@ const vanityRedirects = [
     {
         // this has to be here and not as an alias
         // otherwise it won't be recognised as a welsh URL
-        name: 'Publicity (Welsh)',
-        path: '/cyhoeddusrwydd',
+        name: "Publicity (Welsh)",
+        path: "/cyhoeddusrwydd",
         destination: '/welsh' + vanityDestinations.publicity,
         aliasOnly: true
     },
@@ -273,45 +271,45 @@ const vanityRedirects = [
         // this stays here (and not as an alias) as express doesn't care about URL case
         // and this link is the same (besides case) as an existing alias
         // (annoyingly, the Title Case version of this link persists on the web... for now.)
-        name: 'Logo page',
-        path: '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
+        name: "Logo page",
+        path: "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
         destination: routes.sections.funding.path + routes.sections.funding.pages.logos.path,
         aliasOnly: true
     },
     // the following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
     {
-        name: 'Contact press team',
-        path: '/news-and-events/contact-press-team',
+        name: "Contact press team",
+        path: "/news-and-events/contact-press-team",
         destination: vanityDestinations.contact + '#' + anchors.contactPress
     },
     {
-        name: 'Contact press team (Welsh)',
-        path: '/welsh/news-and-events/contact-press-team',
+        name: "Contact press team (Welsh)",
+        path: "/welsh/news-and-events/contact-press-team",
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress
     },
     {
-        name: 'Complaint page',
+        name: "Complaint page",
         path: '/about-big/customer-service/making-a-complaint',
         destination: vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: 'Complaint page (England)',
+        name: "Complaint page (England)",
         path: '/england/about-big/customer-service/making-a-complaint',
         destination: vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: 'Complaint page (Welsh)',
+        name: "Complaint page (Welsh)",
         path: '/welsh/about-big/customer-service/making-a-complaint',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: 'Fraud page',
+        name: "Fraud page",
         path: '/about-big/customer-service/fraud',
         destination: vanityDestinations.contact + '#' + anchors.contactFraud
     },
     {
-        name: 'Fraud page (Welsh)',
+        name: "Fraud page (Welsh)",
         path: '/welsh/about-big/customer-service/fraud',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud
     }

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,12 +1,14 @@
-"use strict";
+'use strict';
 const config = require('config');
 const anchors = config.get('anchors');
 
 // pass some parameters onto each controller
 // so we can take route config and init all at once
-let loadController = (path) => {
+let loadController = path => {
     return (pages, sectionPath, sectionId) => require(path)(pages, sectionPath, sectionId);
 };
+
+console.log('hello');
 
 // define top-level controllers for the site
 const controllers = {
@@ -17,11 +19,11 @@ const controllers = {
 
 // configure base paths for site sections
 const sectionPaths = {
-    toplevel: "",
-    funding: "/funding",
-    about: "/about-big", // @TODO rename on launch
-    aboutLegacy: "/about-big", // used on the old site
-    research: "/research"
+    toplevel: '',
+    funding: '/funding',
+    about: '/about-big', // @TODO rename on launch
+    aboutLegacy: '/about-big', // used on the old site
+    research: '/research'
 };
 
 // these top-level sections appear in the main site nav
@@ -29,51 +31,51 @@ const sectionPaths = {
 const routes = {
     sections: {
         toplevel: {
-            name: "Top-level pages",
-            langTitlePath: "global.nav.home",
+            name: 'Top-level pages',
+            langTitlePath: 'global.nav.home',
             path: sectionPaths.toplevel,
             controller: controllers.toplevel,
             pages: {
                 home: {
-                    name: "Home",
-                    path: "/",
-                    template: "pages/toplevel/home",
-                    lang: "toplevel.home",
+                    name: 'Home',
+                    path: '/',
+                    template: 'pages/toplevel/home',
+                    lang: 'toplevel.home',
                     code: 0,
                     static: false,
                     live: true,
                     isPostable: true
                 },
                 contact: {
-                    name: "Contact",
-                    path: "/contact",
-                    template: "pages/toplevel/contact",
-                    lang: "toplevel.contact",
+                    name: 'Contact',
+                    path: '/contact',
+                    template: 'pages/toplevel/contact',
+                    lang: 'toplevel.contact',
                     code: 4,
                     static: true,
                     live: true,
                     aliases: [
-                        sectionPaths.toplevel + "/about-big/contact-us",
-                        sectionPaths.toplevel + "/help-and-support",
-                        sectionPaths.toplevel + "/england/about-big/contact-us",
-                        sectionPaths.toplevel + "/wales/about-big/contact-us",
-                        sectionPaths.toplevel + "/scotland/about-big/contact-us",
-                        sectionPaths.toplevel + "/northernireland/about-big/contact-us"
+                        sectionPaths.toplevel + '/about-big/contact-us',
+                        sectionPaths.toplevel + '/help-and-support',
+                        sectionPaths.toplevel + '/england/about-big/contact-us',
+                        sectionPaths.toplevel + '/wales/about-big/contact-us',
+                        sectionPaths.toplevel + '/scotland/about-big/contact-us',
+                        sectionPaths.toplevel + '/northernireland/about-big/contact-us'
                     ]
                 },
                 data: {
-                    name: "Data",
-                    path: "/data",
-                    template: "pages/toplevel/data",
-                    lang: "toplevel.data",
+                    name: 'Data',
+                    path: '/data',
+                    template: 'pages/toplevel/data',
+                    lang: 'toplevel.data',
                     static: false,
                     live: true
                 },
                 jobs: {
-                    name: "Jobs",
-                    path: "/jobs",
-                    template: "pages/toplevel/jobs",
-                    lang: "toplevel.jobs",
+                    name: 'Jobs',
+                    path: '/jobs',
+                    template: 'pages/toplevel/jobs',
+                    lang: 'toplevel.jobs',
                     code: 7,
                     static: true,
                     live: true,
@@ -84,39 +86,37 @@ const routes = {
                     ]
                 },
                 benefits: {
-                    name: "Benefits",
-                    path: "/jobs/benefits",
-                    template: "pages/toplevel/benefits",
-                    lang: "toplevel.benefits",
+                    name: 'Benefits',
+                    path: '/jobs/benefits',
+                    template: 'pages/toplevel/benefits',
+                    lang: 'toplevel.benefits',
                     static: true,
                     live: true,
-                    aliases: [
-                        sectionPaths.toplevel + '/about-big/jobs/benefits',
-                    ]
+                    aliases: [sectionPaths.toplevel + '/about-big/jobs/benefits']
                 },
                 under10k: {
-                    name: "Under 10k",
-                    path: "/under10k",
-                    template: "pages/toplevel/under10k",
-                    lang: "toplevel.under10k",
+                    name: 'Under 10k',
+                    path: '/under10k',
+                    template: 'pages/toplevel/under10k',
+                    lang: 'toplevel.under10k',
                     code: 29,
                     static: true,
                     live: true
                 },
                 over10k: {
-                    name: "Over 10k",
-                    path: "/over10k",
-                    template: "pages/toplevel/over10k",
-                    lang: "toplevel.over10k",
+                    name: 'Over 10k',
+                    path: '/over10k',
+                    template: 'pages/toplevel/over10k',
+                    lang: 'toplevel.over10k',
                     code: 30,
                     static: true,
                     live: true
                 },
                 eyp: {
-                    name: "Empowering Young People",
-                    path: "/empowering-young-people",
-                    template: "pages/toplevel/eyp",
-                    lang: "toplevel.eyp",
+                    name: 'Empowering Young People',
+                    path: '/empowering-young-people',
+                    template: 'pages/toplevel/eyp',
+                    lang: 'toplevel.eyp',
                     code: 0,
                     static: true,
                     live: true,
@@ -127,49 +127,51 @@ const routes = {
             }
         },
         funding: {
-            name: "Funding",
-            langTitlePath: "global.nav.funding",
+            name: 'Funding',
+            langTitlePath: 'global.nav.funding',
             path: sectionPaths.funding,
             controller: controllers.funding,
             pages: {
                 logos: {
-                    name: "Logos",
-                    path: "/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
-                    template: "pages/funding/guidance/logos",
-                    lang: "funding.guidance.logos",
+                    name: 'Logos',
+                    path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
+                    template: 'pages/funding/guidance/logos',
+                    lang: 'funding.guidance.logos',
                     code: 1,
                     static: true,
                     live: true,
                     aliases: [
-                        sectionPaths.funding + "/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
-                        sectionPaths.funding + "/funding-guidance/managing-your-funding/logodownloads"
+                        sectionPaths.funding +
+                            '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
+                        sectionPaths.funding + '/funding-guidance/managing-your-funding/logodownloads'
                     ]
                 },
                 manageFunding: {
-                    name: "Managing your funding",
-                    path: "/funding-guidance/managing-your-funding",
-                    template: "pages/funding/guidance/managing-your-funding",
-                    lang: "funding.guidance.managing-your-funding",
+                    name: 'Managing your funding',
+                    path: '/funding-guidance/managing-your-funding',
+                    template: 'pages/funding/guidance/managing-your-funding',
+                    lang: 'funding.guidance.managing-your-funding',
                     code: 2,
                     static: true,
                     live: true,
                     aliases: [
                         sectionPaths.funding + '/funding-guidance/managing-your-funding/help-with-publicity',
-                        "/welcome",
-                        "/publicity"
+                        '/welcome',
+                        '/publicity'
                     ]
                 },
                 freeMaterials: {
-                    name: "Ordering free materials",
-                    path: "/funding-guidance/managing-your-funding/ordering-free-materials",
-                    template: "pages/funding/guidance/order-free-materials",
-                    lang: "funding.guidance.order-free-materials",
+                    name: 'Ordering free materials',
+                    path: '/funding-guidance/managing-your-funding/ordering-free-materials',
+                    template: 'pages/funding/guidance/order-free-materials',
+                    lang: 'funding.guidance.order-free-materials',
                     code: 3,
                     live: true,
                     isPostable: true,
                     isWildcard: true,
                     aliases: [
-                        sectionPaths.funding + '/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
+                        sectionPaths.funding +
+                            '/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
                         '/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials',
                         '/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials',
                         '/england/funding/funding-guidance/managing-your-funding/ordering-free-materials',
@@ -177,19 +179,19 @@ const routes = {
                     ]
                 },
                 helpWithPublicity: {
-                    name: "Help with publicity",
-                    path: "/funding-guidance/managing-your-funding/social-media",
-                    template: "pages/funding/guidance/help-with-publicity",
-                    lang: "funding.guidance.help-with-publicity",
+                    name: 'Help with publicity',
+                    path: '/funding-guidance/managing-your-funding/social-media',
+                    template: 'pages/funding/guidance/help-with-publicity',
+                    lang: 'funding.guidance.help-with-publicity',
                     code: 12,
                     static: true,
                     live: true
                 },
                 pressCoverage: {
-                    name: "Getting press coverage",
-                    path: "/funding-guidance/managing-your-funding/press",
-                    template: "pages/funding/guidance/getting-press-coverage",
-                    lang: "funding.guidance.getting-press-coverage",
+                    name: 'Getting press coverage',
+                    path: '/funding-guidance/managing-your-funding/press',
+                    template: 'pages/funding/guidance/getting-press-coverage',
+                    lang: 'funding.guidance.getting-press-coverage',
                     code: 18,
                     static: true,
                     live: true
@@ -197,22 +199,22 @@ const routes = {
             }
         },
         research: {
-            name: "Research",
-            langTitlePath: "global.nav.research",
+            name: 'Research',
+            langTitlePath: 'global.nav.research',
             path: sectionPaths.research
         },
         // @TODO rename this to 'about' when ready to launch /about
-        "about-big": {
-            name: "About",
-            langTitlePath: "global.nav.about",
+        'about-big': {
+            name: 'About',
+            langTitlePath: 'global.nav.about',
             path: sectionPaths.about,
             controller: controllers.about,
             pages: {
                 root: {
-                    name: "About",
-                    path: "/",
-                    template: "pages/toplevel/about",
-                    lang: "toplevel.about",
+                    name: 'About',
+                    path: '/',
+                    template: 'pages/toplevel/about',
+                    lang: 'toplevel.about',
                     code: 0,
                     static: true,
                     live: false,
@@ -221,29 +223,29 @@ const routes = {
                     ]
                 },
                 freedomOfInformation: {
-                    name: "Freedom of Information",
-                    path: "/customer-service/freedom-of-information",
-                    template: "pages/about/freedom-of-information",
-                    lang: "about.foi",
+                    name: 'Freedom of Information',
+                    path: '/customer-service/freedom-of-information',
+                    template: 'pages/about/freedom-of-information',
+                    lang: 'about.foi',
                     code: 85,
                     static: true,
                     live: true,
                     aliases: [
                         // sectionPaths.aboutLegacy + "/customer-service/freedom-of-information",
-                        "/freedom-of-information"
+                        '/freedom-of-information'
                     ]
                 },
                 dataProtection: {
-                    name: "Data Protection",
-                    path: "/customer-service/data-protection",
-                    template: "pages/about/data-protection",
-                    lang: "about.dataProtection",
+                    name: 'Data Protection',
+                    path: '/customer-service/data-protection',
+                    template: 'pages/about/data-protection',
+                    lang: 'about.dataProtection',
                     code: 84,
                     static: true,
                     live: true,
                     aliases: [
                         // sectionPaths.aboutLegacy + "/customer-service/data-protection",
-                        "/data-protection"
+                        '/data-protection'
                     ]
                 }
             }
@@ -262,8 +264,8 @@ const vanityRedirects = [
     {
         // this has to be here and not as an alias
         // otherwise it won't be recognised as a welsh URL
-        name: "Publicity (Welsh)",
-        path: "/cyhoeddusrwydd",
+        name: 'Publicity (Welsh)',
+        path: '/cyhoeddusrwydd',
         destination: '/welsh' + vanityDestinations.publicity,
         aliasOnly: true
     },
@@ -271,45 +273,45 @@ const vanityRedirects = [
         // this stays here (and not as an alias) as express doesn't care about URL case
         // and this link is the same (besides case) as an existing alias
         // (annoyingly, the Title Case version of this link persists on the web... for now.)
-        name: "Logo page",
-        path: "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+        name: 'Logo page',
+        path: '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
         destination: routes.sections.funding.path + routes.sections.funding.pages.logos.path,
         aliasOnly: true
     },
     // the following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
     {
-        name: "Contact press team",
-        path: "/news-and-events/contact-press-team",
+        name: 'Contact press team',
+        path: '/news-and-events/contact-press-team',
         destination: vanityDestinations.contact + '#' + anchors.contactPress
     },
     {
-        name: "Contact press team (Welsh)",
-        path: "/welsh/news-and-events/contact-press-team",
+        name: 'Contact press team (Welsh)',
+        path: '/welsh/news-and-events/contact-press-team',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress
     },
     {
-        name: "Complaint page",
+        name: 'Complaint page',
         path: '/about-big/customer-service/making-a-complaint',
         destination: vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: "Complaint page (England)",
+        name: 'Complaint page (England)',
         path: '/england/about-big/customer-service/making-a-complaint',
         destination: vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: "Complaint page (Welsh)",
+        name: 'Complaint page (Welsh)',
         path: '/welsh/about-big/customer-service/making-a-complaint',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints
     },
     {
-        name: "Fraud page",
+        name: 'Fraud page',
         path: '/about-big/customer-service/fraud',
         destination: vanityDestinations.contact + '#' + anchors.contactFraud
     },
     {
-        name: "Fraud page (Welsh)",
+        name: 'Fraud page (Welsh)',
         path: '/welsh/about-big/customer-service/fraud',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud
     }

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -22,7 +22,7 @@ const localeFiles = {
 };
 
 // status page used by load balancer
-router.get('/status', (req, res, next) => {
+router.get('/status', (req, res) => {
     // don't cache this page!
     res.cacheControl = { maxAge: 0 };
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -40,7 +40,7 @@ router.get('/status', (req, res, next) => {
 });
 
 // pagelist
-router.get('/status/pages', (req, res, next) => {
+router.get('/status/pages', (req, res) => {
     const totals = {
         canonical: [],
         aliases: [],
@@ -71,7 +71,7 @@ router.get('/status/pages', (req, res, next) => {
 // login auth
 const loginPath = '/tools/login';
 routeStatic.injectUrlRequest(router, loginPath);
-router.get(loginPath, (req, res, next) => {
+router.get(loginPath, (req, res) => {
     // don't cache this page!
     res.cacheControl = { maxAge: 0 };
     res.render('pages/tools/login', {
@@ -126,14 +126,14 @@ let localeEditorPath = '/tools/locales/';
 routeStatic.injectUrlRequest(router, localeEditorPath);
 router
     .route(localeEditorPath)
-    .get(isAuthenticated, (req, res, next) => {
+    .get(isAuthenticated, (req, res) => {
         // don't cache this page!
         res.cacheControl = { maxAge: 0 };
         res.render('pages/tools/langEditor', {
             user: req.user
         });
     })
-    .post(isAuthenticated, (req, res, next) => {
+    .post(isAuthenticated, (req, res) => {
         // fetch these each time
         const locales = {
             en: JSON.parse(fs.readFileSync(path.join(__dirname, localeFiles.en), 'utf8')),
@@ -158,7 +158,7 @@ router
     });
 
 // update a language file
-router.post('/tools/locales/update/', isAuthenticated, (req, res, next) => {
+router.post('/tools/locales/update/', isAuthenticated, (req, res) => {
     const json = req.body;
     let validKeys = ['en', 'cy'];
     let failedUpdates = [];
@@ -216,7 +216,7 @@ router
             });
         });
     })
-    .post(isAuthenticated, (req, res, next) => {
+    .post(isAuthenticated, (req, res) => {
         let redirectBase = req.baseUrl + editNewsPath + '/';
 
         // validate form

--- a/controllers/utils/routeStatic.js
+++ b/controllers/utils/routeStatic.js
@@ -7,7 +7,7 @@ let setupRedirects = (sectionPath, page) => {
     if (page.aliases && page.aliases.length > 0) {
         localePaths.forEach(localePath => {
             page.aliases.forEach(pagePath => {
-                app.get(localePath + pagePath, (req, res, next) => {
+                app.get(localePath + pagePath, (req, res) => {
                     res.redirect(localePath + sectionPath + page.path);
                 });
             });
@@ -18,7 +18,7 @@ let setupRedirects = (sectionPath, page) => {
 // serve a static page (eg. no special dependencies)
 let servePage = (page, router) => {
     // serve the canonical path with the supplied template
-    router.get(page.path, (req, res, next) => {
+    router.get(page.path, (req, res) => {
         let lang = req.i18n.__(page.lang);
         res.render(page.template, {
             title: lang.title,
@@ -58,7 +58,6 @@ let injectUrlRequest = (router, path) => {
 
 // set up path routing for a list of (static) pages
 let initRouting = (pages, router, sectionPath, sectionId) => {
-
     // first inject the section middleware
     injectSection(router, sectionId);
 

--- a/models/user.js
+++ b/models/user.js
@@ -15,11 +15,10 @@ module.exports = (sequelize, DataTypes) => {
     });
 
     User.prototype.isValidPassword = (storedHash, typedPass) => {
-        const salt = bcrypt.genSaltSync(10);
-        const hash = bcrypt.hashSync(typedPass, salt);
+        // const salt = bcrypt.genSaltSync(10);
+        // const hash = bcrypt.hashSync(typedPass, salt);
         return bcrypt.compareSync(typedPass, storedHash);
     };
 
     return User;
-
 };

--- a/modules/boilerplate/middleware.js
+++ b/modules/boilerplate/middleware.js
@@ -24,14 +24,16 @@ require('../../modules/boilerplate/auth');
 
 app.use(favicon(path.join('public', '/favicon.ico')));
 let logFormat = '[:date[clf]] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms';
-app.use(morgan(logFormat, {
-    skip: (req, res) => {
-        // don't log status messages
-        return (req.originalUrl === '/status');
-    }
-}));
+app.use(
+    morgan(logFormat, {
+        skip: req => {
+            // don't log status messages
+            return req.originalUrl === '/status';
+        }
+    })
+);
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: false}));
+app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 
 // add session
@@ -91,7 +93,7 @@ app.use((req, res, next) => {
 app.use((req, res, next) => {
     const WELSH_LOCALE = 'cy';
     const CYMRU_URL = /^\/welsh(\/|$)/;
-    const IS_WELSH = (req.url.match(CYMRU_URL) !== null);
+    const IS_WELSH = req.url.match(CYMRU_URL) !== null;
     let localePrefix = '';
 
     if (IS_WELSH) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepush": "npm test"
   },
   "lint-staged": {
-    "{gulpfile.js,server.js,controllers/**/*.js,models/**/*.js,modules/**/*.js,test/**/*.js}": [
+    "{gulpfile.js,server.js,controllers/**/*.js,models/**/*.js,modules/**/*.js,test/**/*.js,bin/scripts/**/*.js}": [
       "prettier --write",
       "eslint",
       "git add"

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 'use strict';
 const express = require('express');
-const app = module.exports = express();
+const app = (module.exports = express());
 const config = require('config');
 
 // load the app routing list
@@ -18,7 +18,7 @@ require('./modules/boilerplate/middleware');
 app.use('/', require('./controllers/toplevel/tools'));
 
 // aka welshify - create an array of paths: default (english) and welsh variant
-const cymreigio = (mountPath) => {
+const cymreigio = mountPath => {
     let welshPath = config.get('i18n.urlPrefix.cy') + mountPath;
     return [mountPath, welshPath];
 };
@@ -41,13 +41,13 @@ for (let sectionId in routes.sections) {
 
 // add vanity redirects
 routes.vanityRedirects.forEach(r => {
-    let servePath = (path, destination) => {
-        app.get(path, (req, res, next) => {
+    let servePath = path => {
+        app.get(path, (req, res) => {
             res.redirect(r.destination);
         });
     };
     if (r.paths) {
-        r.paths.forEach((path) => {
+        r.paths.forEach(path => {
             servePath(path, r.destination);
         });
     } else {
@@ -73,12 +73,12 @@ app.use((req, res, next) => {
 });
 
 // error handler
-app.use((err, req, res, next) => {
+app.use((err, req, res) => {
     // set locals, only providing error in development
     res.locals.message = err.message;
     res.locals.error = req.app.get('env') === 'development' ? err : {};
     res.locals.status = err.status || 500;
-    res.locals.errorTitle = (err.friendlyText) ? err.friendlyText : 'Error: ' + err.message;
+    res.locals.errorTitle = err.friendlyText ? err.friendlyText : 'Error: ' + err.message;
 
     // render the error page
     res.status(res.locals.status);

--- a/test/features/materials.test.js
+++ b/test/features/materials.test.js
@@ -3,41 +3,40 @@ const chai = require('chai');
 chai.use(require('chai-http'));
 chai.should();
 
-const jsdom = require("jsdom");
-const {JSDOM} = jsdom;
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
 
 const helper = require('../helper');
 const routes = require('../../controllers/routes');
 
 // test the order form specifically
-describe("Material order form", () => {
-
+describe('Material order form', () => {
     let agent, csrfToken, server;
 
-    beforeEach((done) => {
+    beforeEach(done => {
         server = helper.before();
 
         // grab a valid CSRF token
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
         agent = chai.request.agent(server);
-        agent.get(path)
-            .end((err, res) => {
-                // res.should.have.cookie('_csrf');
-                const dom = new JSDOM(res.text);
-                csrfToken = dom.window.document.querySelector('input[name=_csrf]').value;
-                done();
-            });
+        agent.get(path).end((err, res) => {
+            // res.should.have.cookie('_csrf');
+            const dom = new JSDOM(res.text);
+            csrfToken = dom.window.document.querySelector('input[name=_csrf]').value;
+            done();
+        });
     });
 
     afterEach(() => {
         helper.after();
     });
 
-    it('should serve materials to order', (done) => {
+    it('should serve materials to order', done => {
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
-        chai.request(server)
+        chai
+            .request(server)
             .get(path)
             .end((err, res) => {
                 res.should.have.status(200);
@@ -45,18 +44,19 @@ describe("Material order form", () => {
             });
     });
 
-    it('should allow adding a product to an order via AJAX', (done) => {
+    it('should allow adding a product to an order via AJAX', done => {
         const itemId = 1;
         const itemCode = 'BIG-PLAQAS';
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
 
-        agent.post(path + '/item/' + itemId)
+        agent
+            .post(path + '/item/' + itemId)
             .set('Accept', 'application/json')
             .send({
-                '_csrf': csrfToken,
-                'code': itemCode,
-                'action': 'increase'
+                _csrf: csrfToken,
+                code: itemCode,
+                action: 'increase'
             })
             .end((err, res) => {
                 res.should.have.status(200);
@@ -69,25 +69,27 @@ describe("Material order form", () => {
             });
     });
 
-    it('should allow incrementing a product in an order via AJAX', (done) => {
+    it('should allow incrementing a product in an order via AJAX', done => {
         const itemId = 1;
         const itemCode = 'BIG-PLAQAS';
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
 
         const formData = {
-            '_csrf': csrfToken,
-            'code': itemCode,
-            'action': 'increase'
+            _csrf: csrfToken,
+            code: itemCode,
+            action: 'increase'
         };
 
         // add the first item
-        agent.post(path + '/item/' + itemId)
+        agent
+            .post(path + '/item/' + itemId)
             .set('Accept', 'application/json')
             .send(formData)
-            .end((err, res) => {
+            .end(() => {
                 // add the second item
-                agent.post(path + '/item/' + itemId)
+                agent
+                    .post(path + '/item/' + itemId)
                     .set('Accept', 'application/json')
                     .send(formData)
                     .end((err, res) => {
@@ -100,27 +102,26 @@ describe("Material order form", () => {
                         done();
                     });
             });
-
     });
 
-    it('should allow decrementing a product in an order via AJAX', (done) => {
+    it('should allow decrementing a product in an order via AJAX', done => {
         const itemId = 1;
         const itemCode = 'BIG-PLAQAS';
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
 
         const formData = {
-            '_csrf': csrfToken,
-            'code': itemCode,
-            'action': 'increase'
+            _csrf: csrfToken,
+            code: itemCode,
+            action: 'increase'
         };
 
         // add the first item
-        agent.post(path + '/item/' + itemId)
+        agent
+            .post(path + '/item/' + itemId)
             .set('Accept', 'application/json')
             .send(formData)
             .end((err, res) => {
-
                 // check it was added
                 res.should.have.status(200);
                 res.should.have.header('content-type', /^application\/json/);
@@ -131,7 +132,8 @@ describe("Material order form", () => {
 
                 // now remove the first item
                 formData.action = 'decrease';
-                agent.post(path + '/item/' + itemId)
+                agent
+                    .post(path + '/item/' + itemId)
                     .set('Accept', 'application/json')
                     .send(formData)
                     .end((err, res) => {
@@ -146,27 +148,28 @@ describe("Material order form", () => {
             });
     });
 
-    it('should allow ordering with personal details', (done) => {
+    it('should allow ordering with personal details', done => {
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
 
         const formData = {
-            '_csrf': csrfToken,
-            'skipEmail': true,
-            'yourName': 'Little Bobby Tables',
-            'yourEmail': 'bobby@xkcd.com',
-            'yourNumber': '123456789',
-            'yourAddress1': '123 Fake Street',
-            'yourAddress2': 'Notrealsville',
-            'yourTown': 'Madeuptown',
-            'yourCounty': 'Nonexistentland',
-            'yourPostcode': 'NW1 6XE',
-            'yourProjectName': 'White Hat Testing',
-            'yourProjectID': '666',
-            'yourGrantAmount': '£2038'
+            _csrf: csrfToken,
+            skipEmail: true,
+            yourName: 'Little Bobby Tables',
+            yourEmail: 'bobby@xkcd.com',
+            yourNumber: '123456789',
+            yourAddress1: '123 Fake Street',
+            yourAddress2: 'Notrealsville',
+            yourTown: 'Madeuptown',
+            yourCounty: 'Nonexistentland',
+            yourPostcode: 'NW1 6XE',
+            yourProjectName: 'White Hat Testing',
+            yourProjectID: '666',
+            yourGrantAmount: '£2038'
         };
 
-        agent.post(path)
+        agent
+            .post(path)
             .send(formData)
             .redirects(0)
             .end((err, res) => {
@@ -176,21 +179,24 @@ describe("Material order form", () => {
             });
     });
 
-    it('should block ordering with missing personal details', (done) => {
+    it('should block ordering with missing personal details', done => {
         const funding = routes.sections.funding;
         const path = funding.path + funding.pages.freeMaterials.path;
 
         const formData = {
-            '_csrf': csrfToken,
-            'skipEmail': true,
-            'yourName': 'Little Bobby Tables'
+            _csrf: csrfToken,
+            skipEmail: true,
+            yourName: 'Little Bobby Tables'
         };
 
-        agent.post(path)
+        agent
+            .post(path)
             .send(formData)
             .redirects(0)
             .end((err, res) => {
-                res.should.redirectTo('/funding/funding-guidance/managing-your-funding/ordering-free-materials#your-details');
+                res.should.redirectTo(
+                    '/funding/funding-guidance/managing-your-funding/ordering-free-materials#your-details'
+                );
                 res.should.have.status(302);
                 done();
             });

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,17 +1,16 @@
 'use strict';
 
 // use the test database
-const config = require("config");
+const config = require('config');
 process.env.CUSTOM_DB = config.get('database-test');
 process.env.PORT = 8090;
 
-
 let server, hook;
 
-let captureStream = (stream) => {
+let captureStream = stream => {
     let oldWrite = stream.write;
     let buf = '';
-    stream.write = function(chunk, encoding, callback) {
+    stream.write = function(chunk) {
         buf += chunk.toString(); // chunk is a String or Buffer
         oldWrite.apply(stream, arguments);
     };

--- a/test/specs/tabs.test.js
+++ b/test/specs/tabs.test.js
@@ -1,47 +1,40 @@
 /* global describe, it, expect */
-"use strict";
+'use strict';
 
 let tabs = require('../../assets/js/modules/tabs');
 
-let getClassesFromElm = (elm) => {
+let getClassesFromElm = elm => {
     let classes = [];
     if (elm && elm.classList) {
-        [].forEach.call(elm.classList, (c) => classes.push(c));
+        [].forEach.call(elm.classList, c => classes.push(c));
     }
     return classes;
 };
 
-describe("Tab module", () => {
+describe('Tab module', () => {
     // get first tab module
     let tabModule = document.getElementById('js-tab-test');
-    let paneId = tabModule.getAttribute('data-panes');
-    let paneHolder = document.getElementById(paneId);
-
-    // look up a second module to ensure no conflicts exist
-    let tabModule2 = document.getElementById('js-tab-test-2');
-    let paneId2 = tabModule2.getAttribute('data-paneset');
-    let paneHolder2 = document.getElementById(paneId2);
 
     // find a wrongly-configured tab module
     let tabModuleBroken = document.getElementById('js-tab-test-broken');
 
     tabs.init();
 
-    it("registers new tab modules", () => {
+    it('registers new tab modules', () => {
         expect(tabModule.querySelectorAll('.tab--active').length).to.equal(1);
     });
 
-    it("does not modify incorrectly configured tab modules", () => {
+    it('does not modify incorrectly configured tab modules', () => {
         expect(tabModuleBroken.querySelectorAll('.tab--active').length).to.equal(0);
     });
 
-    it("adds a class to a tab when clicked", () => {
+    it('adds a class to a tab when clicked', () => {
         let tabLink = tabModule.querySelector('a');
         tabLink.click();
         expect(getClassesFromElm(tabLink)).to.contain('tab--active');
     });
 
-    it("removes a class from other tabs when one is clicked", () => {
+    it('removes a class from other tabs when one is clicked', () => {
         let tabs = tabModule.querySelectorAll('li');
         let t1 = tabs[1].querySelector('a');
         let t2 = tabs[0].querySelector('a');
@@ -51,7 +44,7 @@ describe("Tab module", () => {
         expect(getClassesFromElm(t1)).not.to.contain('tab--active');
     });
 
-    it("adds a class to the correct pane when a tab is clicked", () => {
+    it('adds a class to the correct pane when a tab is clicked', () => {
         let tabs = tabModule.querySelectorAll('li');
         let link = tabs[1].querySelector('a');
         link.click();
@@ -59,7 +52,7 @@ describe("Tab module", () => {
         expect(getClassesFromElm(pane)).to.contain('pane--active');
     });
 
-    it("removes a class from other panes when a tab is clicked", () => {
+    it('removes a class from other panes when a tab is clicked', () => {
         let tabs = tabModule.querySelectorAll('li');
         let t1 = tabs[1].querySelector('a');
         let t2 = tabs[0].querySelector('a');
@@ -70,5 +63,4 @@ describe("Tab module", () => {
         expect(getClassesFromElm(activePane)).to.contain('pane--active');
         expect(getClassesFromElm(inactivePane)).not.to.contain('pane--active');
     });
-
 });


### PR DESCRIPTION
This is just a hygiene thing – there were a lot of warnings introduced via https://github.com/biglotteryfund/blf-alpha/pull/229 so this just aims to remove the common ones (mostly unused `next` functions in routes).