### PR TITLE
Reinstate 404s

### DIFF
--- a/server.js
+++ b/server.js
@@ -73,7 +73,11 @@ app.use((req, res, next) => {
 });
 
 // error handler
-app.use((err, req, res) => {
+app.use((err, req, res, next) => {
+    if (res.headersSent) {
+        return next(err);
+    }
+
     // set locals, only providing error in development
     res.locals.message = err.message;
     res.locals.error = req.app.get('env') === 'development' ? err : {};


### PR DESCRIPTION
See: http://expressjs.com/en/guide/error-handling.html#the-default-error-handler

Not affecting live thankfully. Also suggests the 404 test needs updating.