### PR TITLE
Update hero images to only randomise after first view

### DIFF
--- a/assets/js/modules/heroImages.js
+++ b/assets/js/modules/heroImages.js
@@ -27,23 +27,25 @@ function replaceCaption($captionEl, caption) {
 }
 
 function init() {
-    $(SELECTORS.parent).each(function() {
-        const $heroEl = $(this);
-        const imageCandidates = $heroEl.data('imageCandidates');
-        const $imageEl = $heroEl.find(SELECTORS.image);
-        const $captionEl = $heroEl.find(SELECTORS.caption);
+    if ($('html').hasClass('is-repeat-visitor')) {
+        $(SELECTORS.parent).each(function() {
+            const $heroEl = $(this);
+            const imageCandidates = $heroEl.data('imageCandidates');
+            const $imageEl = $heroEl.find(SELECTORS.image);
+            const $captionEl = $heroEl.find(SELECTORS.caption);
 
-        if (imageCandidates.length > 1 && $imageEl.length > 0) {
-            const randomImage = rand(imageCandidates);
+            if (imageCandidates.length > 1 && $imageEl.length > 0) {
+                const randomImage = rand(imageCandidates);
 
-            if (randomImage) {
-                replaceImage($imageEl, randomImage);
-                replaceCaption($captionEl, randomImage.caption);
+                if (randomImage) {
+                    replaceImage($imageEl, randomImage);
+                    replaceCaption($captionEl, randomImage.caption);
 
-                $heroEl.addClass('has-image');
+                    $heroEl.addClass('has-image');
+                }
             }
-        }
-    });
+        });
+    }
 }
 
 module.exports = {

--- a/assets/sass/components/hero.scss
+++ b/assets/sass/components/hero.scss
@@ -243,7 +243,7 @@ $heroSpaceFromLeft: 20px;
     }
 }
 
-.js-on .super-hero {
+.js-on.is-repeat-visitor .super-hero {
     background-color: palette('charcoal');
 
     .super-hero__image,

--- a/views/includes/metaHeadJS.njk
+++ b/views/includes/metaHeadJS.njk
@@ -1,19 +1,34 @@
 <script id="script-head">
 (function() {
-    var docEl = document.documentElement;
-    var docClass = docEl.className;
-    var classes = ['js-on'];
-
     var AppConfig = {
         isModernBrowser:
             'querySelector' in document &&
             'addEventListener' in window &&
             'localStorage' in window &&
             'bind' in Function,
-        isOldIE:
-            navigator.userAgent.indexOf('MSIE') !== -1 ||
-            navigator.appVersion.indexOf('Trident/') > 0
+        isOldIE: navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0,
+        hasSeenPageBefore: (function() {
+            var hasSeenPageBefore = false;
+            try {
+                hasSeenPageBefore = !!window.sessionStorage.getItem('app.hasSeenPageBefore');
+            } catch (e) {} // eslint-disable-line no-empty
+
+            if (!hasSeenPageBefore) {
+                try {
+                    window.sessionStorage.setItem('app.hasSeenPageBefore', true);
+                } catch (e) {} // eslint-disable-line no-empty
+            }
+
+            return hasSeenPageBefore;
+        })()
     };
+
+    /**
+     * Add state classes to document
+     */
+    var docEl = document.documentElement;
+    var docClass = docEl.className;
+    var classes = ['js-on'];
 
     if (AppConfig.isModernBrowser) {
         classes.push('is-modern');
@@ -21,6 +36,10 @@
 
     if (AppConfig.isOldIE) {
         classes.push('is-ie');
+    }
+
+    if (AppConfig.hasSeenPageBefore) {
+        classes.push('is-repeat-visitor');
     }
 
     docEl.className = docClass.replace('no-js', '') + ' ' + classes.join(' ');


### PR DESCRIPTION
Updates homepage hero so that the default image is shown on first page load (currently "Cloughmills Community Action") and then only on subsequent page views do we randomise the image.

- Adds a `sessionStorage` flag to mark if the person visiting has seen the page before and adds a `is-return-visitor` class to the page.
- Updates the hero randomisation code to look for this class on the body before running.