### PR TITLE
Responsive tweaks

### DIFF
--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -5,9 +5,9 @@ $breakpoints: map-get($appConfig, 'breakpoints');
 // the main content area will have these width gutters
 // at the specified breakpoints
 $gutters: (
-    "default": 20px,
-    "tablet": 5%,
-    "desktop": 10%
+    "default": 10px,
+    "tablet": 20px,
+    "desktop": 40px
 );
 
 // at this resolution, the content area will be limited in width

--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -237,7 +237,7 @@ $btnConf: (
         }
 
         @media only screen and (min-width: 680px) {
-            margin-right: ($spacingUnit / 4);
+            margin-right: ($spacingUnit / 2);
 
             &:last-of-type {
                 margin-right: 0;

--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -3,22 +3,10 @@
    ========================================================================= */
 
 $btnConf: (
-    'default': (
-        'fontSize': 18px,
-        'desiredHeight': 59px
-    ),
-    'medium': (
-        'fontSize': 16px,
-        'desiredHeight': 42px
-    ),
-    'small': (
-        'fontSize': 16px,
-        'desiredHeight': 36px
-    ),
-    'mini': (
-        'fontSize': 13px,
-        'desiredHeight': 30px
-    )
+    'default': ('fontSize': 18px, 'desiredHeight': 59px),
+    'medium': ('fontSize': 16px, 'desiredHeight': 42px),
+    'small': ('fontSize': 16px, 'desiredHeight': 36px),
+    'mini': ('fontSize': 13px, 'desiredHeight': 30px)
 );
 
 @mixin getBtnVertPadding($conf) {
@@ -236,23 +224,24 @@ $btnConf: (
 
 .o-button-group {
     .btn {
-        margin-bottom: $spacingUnit / 2;
+        display: inline-block;
+        margin-bottom: ($spacingUnit / 2);
 
         &:last-of-type {
             margin-bottom: 0;
         }
 
-        @include mq('tablet', 'max') {
-            width: 100%;
+        @media only screen and (max-width: 680px) {
             max-width: 300px;
+            width: 100%;
         }
 
-        @include mq('desktop') {
-            margin-right: ($spacingUnit / 2);
+        @media only screen and (min-width: 680px) {
+            margin-right: ($spacingUnit / 4);
+
             &:last-of-type {
                 margin-right: 0;
             }
         }
     }
-
 }

--- a/assets/sass/components/btn.scss
+++ b/assets/sass/components/btn.scss
@@ -224,7 +224,6 @@ $btnConf: (
 
 .o-button-group {
     .btn {
-        display: inline-block;
         margin-bottom: ($spacingUnit / 2);
 
         &:last-of-type {
@@ -242,6 +241,18 @@ $btnConf: (
             &:last-of-type {
                 margin-right: 0;
             }
+        }
+    }
+}
+
+.o-button-group-block {
+    .btn {
+        display: block;
+        width: 100%;
+        margin-bottom: $spacingUnit;
+
+        &:last-of-type {
+            margin-bottom: 0;
         }
     }
 }

--- a/assets/sass/components/hero.scss
+++ b/assets/sass/components/hero.scss
@@ -199,20 +199,15 @@ $heroSpaceFromLeft: 20px;
 
     margin-bottom: $spacingUnit / 2;
 
-    // @TODO: Introduce more granular breakpoints
-    @media only screen and (min-width: 360px) {
-        margin-bottom: $spacingUnit;
-    }
-
     @include mq('tablet') {
         margin-bottom: $spacingUnit * 2;
     }
 }
 .super-hero__title {
     font-size: 14px;
-    line-height: 1.3;
+    line-height: 1.2;
     font-weight: normal;
-    margin: 0 0 ($spacingUnit / 3) 0;
+    margin: 0 0 ($spacingUnit / 2) 0;
 
     @media only screen and (min-width: 360px) {
         font-size: 18px;
@@ -224,7 +219,7 @@ $heroSpaceFromLeft: 20px;
 
     @include mq('desktop') {
         font-size: 24px;
-        margin-bottom: $spacingUnit;
+        line-height: 1.3;
     }
 
     a, a:link {

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -10,6 +10,15 @@ $nudgeAmount: 25px;
     }
 }
 
+.u-gutter {
+    margin-left: $spacingUnit;
+    margin-right: $spacingUnit;
+}
+.u-gutter-half {
+    margin-left: $spacingUnit / 2;
+    margin-right: $spacingUnit / 2;
+}
+
 .is-on-top {
     z-index: 100;
 }
@@ -24,13 +33,6 @@ $nudgeAmount: 25px;
 
 .width-natural {
     max-width: auto;
-}
-
-.gutter-mob-only {
-    @include mq('tablet', 'max') {
-        margin-left: $spacingUnit;
-        margin-right: $spacingUnit;
-    }
 }
 
 .align--center {
@@ -128,15 +130,4 @@ main {
 
 .no-space {
     margin-bottom: 0 !important;
-}
-
-.mob--no-space {
-    @include mq('tablet', 'max') {
-        margin-bottom: 0 !important;
-    }
-}
-
-.gutter-mob-only {
-    margin-left: 20px;
-    margin-right: 20px;
 }

--- a/assets/sass/scaffolding/header.scss
+++ b/assets/sass/scaffolding/header.scss
@@ -98,6 +98,9 @@ $offscreenNavWidth: 65%;
     @include mq('tablet') {
         height: 105px;
         width: 130px;
+    }
+
+    @media only screen and (min-width: $widestScreen) {
         margin-left: -20px;
     }
 
@@ -377,6 +380,8 @@ html:not(.contrast--high) .has-full-bleed-header .header {
     }
 
     .nav {
+        margin-left: $spacingUnit;
+
         @include mq('tablet') {
             align-items: initial;
         }
@@ -409,7 +414,7 @@ html:not(.contrast--high) .has-full-bleed-header .header {
 
         &:after {
             border-color: white;
-            margin: 0;
+            margin: 0 ($spacingUnit / 3);
 
             @include mq('desktop') {
                 margin: 0 $spacingUnit * 1.25;
@@ -422,6 +427,9 @@ html:not(.contrast--high) .has-full-bleed-header .header {
     .nav__search input {
         @include nav-link-style(white);
         background-color: transparent;
+        margin: 0;
+        padding: 5px 0;
+        width: 70px;
 
         @include input-placeholder {
             @include nav-link-style(white);

--- a/views/pages/toplevel/contact.njk
+++ b/views/pages/toplevel/contact.njk
@@ -14,9 +14,9 @@
 
     {{ hero.header('contact', heroContent, 'turquoise') }}
 
-    <article role="main" class="nudge-up--always">
+    <article role="main" class="nudge-up">
 
-        <div class="inner links-emphasised">
+        <div class="inner--wide-only links-emphasised">
 
             {% set applicationQuery %}
                 <h3 class="t3">{{ copy.offices.england }}</h3>

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -155,16 +155,19 @@
                     </div>
 
                     {# social buttons #}
-                    <div class="gutter-mob-only">
-                        <a href="{{ appData.config.get('social.instagram') }}" class="btn btn--small btn--outline accent--blue btn--block spaced">
+                    <div class="o-button-group-block u-gutter-half">
+                        <a class="btn btn--small btn--outline accent--blue"
+                            href="{{ appData.config.get('social.instagram') }}">
                             <span class="btn__icon">{% include "../../includes/svg/instagram.svg" %}</span>
                             {{ copy.social.followUsOn }} {{ copy.social.instagram }}
                         </a>
-                        <a href="{{ appData.config.get('social.facebookAccounts.' + locale) }}" class="btn btn--small btn--outline accent--blue btn--block spaced">
+                        <a class="btn btn--small btn--outline accent--blue"
+                            href="{{ appData.config.get('social.facebookAccounts.' + locale) }}">
                             <span class="btn__icon">{% include "../../includes/svg/facebook.svg" %}</span>
                             {{ copy.social.followUsOn }} {{ copy.social.facebook }}
                         </a>
-                        <a href="https://www.twitter.com/{{ appData.config.get('social.twitterAccounts.' + locale) }}" class="btn btn--small btn--outline accent--blue btn--block">
+                        <a class="btn btn--small btn--outline accent--blue"
+                            href="https://www.twitter.com/{{ appData.config.get('social.twitterAccounts.' + locale) }}" >
                             <span class="btn__icon">{% include "../../includes/svg/twitter.svg" %}</span>
                             {{ copy.social.followUsOn }} {{ copy.social.twitter }}
                         </a>

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -48,8 +48,8 @@
                     <span class="u-wide-only">{{ copy.callsToAction.under10k.long }}</span>
                     <span class="u-not-wide">{{ copy.callsToAction.under10k.short }}</span>
                 </span>
-            </a><!-- Fix inline-block spacing
-            --><a class="btn btn--medium
+            </a>
+            <a class="btn btn--medium
                       accent--white a--btn"
                 href="{{ buildUrl('toplevel', 'over10k') }}">
                 <span class="accent--blue a--text">

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -48,9 +48,8 @@
                     <span class="u-wide-only">{{ copy.callsToAction.under10k.long }}</span>
                     <span class="u-not-wide">{{ copy.callsToAction.under10k.short }}</span>
                 </span>
-            </a>
-
-            <a class="btn btn--medium
+            </a><!-- Fix inline-block spacing
+            --><a class="btn btn--medium
                       accent--white a--btn"
                 href="{{ buildUrl('toplevel', 'over10k') }}">
                 <span class="accent--blue a--text">


### PR DESCRIPTION
Implements a few responsive tweaks mainly focussed on the global header and heroes but also adjusting global gutters.

- Normalises gutters to pixels: 10px -> 20px -> 40px for small -> medium -> large breakpoints
- Decreases gap between logo and navigation (point 1. in annotations)
- Increases spacing between navigation items at "iPad portrait" breakpoints (point 2. in annotations)
- Decreases spacing around search icon (point 3. in annotations)
- Increases padding between buttons at "iPad portrait" breakpoints
- Prevents buttons from wrapping at "iPad  landscape" breakpoints

**~Portrait (Before)**

![ipad-portrait-before](https://user-images.githubusercontent.com/123386/31236216-71d671f4-a9eb-11e7-8938-5bbe3019d8e5.png)

**~Portrait (After)**

![ipad-portrait-after](https://user-images.githubusercontent.com/123386/31236238-7b91d4d6-a9eb-11e7-9814-bc9e7b3f5002.png)

**~Landscape (Before)**

![ipad-landscape-before](https://user-images.githubusercontent.com/123386/31236245-7f39e98e-a9eb-11e7-86c7-15cbc06f5933.png)

**~Landscape (After)**

![ipad-landscape-after](https://user-images.githubusercontent.com/123386/31236248-81ea737e-a9eb-11e7-9c1b-85afded663aa.png)

@ChloeAlper @mattandrews 