### PR TITLE
Remove <p> from base font-stacks

### DIFF
--- a/assets/sass/globals/typography.scss
+++ b/assets/sass/globals/typography.scss
@@ -11,7 +11,7 @@
 }
 
 // base font settings
-body, p, input, textarea, button, blockquote {
+body, input, textarea, button, blockquote {
     @include t5();
 }
 


### PR DESCRIPTION
This was bugging me: `<p>`s are currently included in the base font-stacks, this makes it harder to cascade typographic styles for blocks of text. Using `body` is enough. This is a one-line change but scoping it to a PR as it's in core styles.