### PR TITLE
Add sentry.io to default security domains

### DIFF
--- a/modules/boilerplate/security.js
+++ b/modules/boilerplate/security.js
@@ -19,7 +19,8 @@ const defaultSecurityDomains = [
     'syndication.twitter.com',
     'cdn.syndication.twimg.com',
     '*.twimg.com',
-    'cdn.jsdelivr.net'
+    'cdn.jsdelivr.net',
+    'sentry.io'
 ];
 
 const childSrc = defaultSecurityDomains.concat(['www.google.com']);


### PR DESCRIPTION
Fix ironic CSP warning 🥄 🥄 🥄 🥄 