### PR TITLE
Add environment and remove modules from Sentry

### DIFF
--- a/modules/boilerplate/security.js
+++ b/modules/boilerplate/security.js
@@ -33,7 +33,7 @@ const helmetSettings = helmet({
             frameSrc: childSrc,
             styleSrc: defaultSecurityDomains.concat(["'unsafe-inline'", 'fonts.googleapis.com']),
             connectSrc: defaultSecurityDomains.concat(['ws://127.0.0.1:35729/livereload']), // make dev-only?,
-            imgSrc: defaultSecurityDomains.concat(['data:']),
+            imgSrc: defaultSecurityDomains.concat(['data:', 'stats.g.doubleclick.net']),
             scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
             reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c'
         },

--- a/server.js
+++ b/server.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = secrets['sentry.dsn'];
 
 if (SENTRY_DSN) {
     Raven.config(SENTRY_DSN, {
-        environment: process.env.NODE_ENVIRONMENT || 'development',
+        environment: process.env.NODE_ENV || 'development',
         dataCallback(data) {
             delete data.modules;
             return data;

--- a/server.js
+++ b/server.js
@@ -8,7 +8,13 @@ const secrets = require('./modules/secrets');
 const SENTRY_DSN = secrets['sentry.dsn'];
 
 if (SENTRY_DSN) {
-    Raven.config(SENTRY_DSN).install();
+    Raven.config(SENTRY_DSN, {
+        environment: process.env.NODE_ENVIRONMENT || 'development',
+        dataCallback(data) {
+            delete data.modules;
+            return data;
+        }
+    }).install();
     app.use(Raven.requestHandler());
 }
 


### PR DESCRIPTION
Does two things:

1. Adds environment to sentry errors (development / test / production)
2. Removes node modules from errors

The second point is because by default node errors list all modules you have installed which seems excessive (and noisy), so this deletes them based on the solution mentioned by the core maintainers in https://github.com/getsentry/raven-node/issues/188