### PR TITLE
Add picturefill for IE 11

### DIFF
--- a/modules/boilerplate/security.js
+++ b/modules/boilerplate/security.js
@@ -12,6 +12,7 @@ const defaultSecurityDomains = [
     "'self'",
     'fonts.gstatic.com',
     'ajax.googleapis.com',
+    'cdnjs.cloudflare.com',
     'www.google-analytics.com',
     'www.google.com',
     'maxcdn.bootstrapcdn.com',

--- a/views/includes/metaHeadJS.njk
+++ b/views/includes/metaHeadJS.njk
@@ -1,3 +1,4 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/picturefill/3.0.3/picturefill.min.js"></script>
 <script id="script-head">
 (function() {
     var AppConfig = {


### PR DESCRIPTION
Fixes display issue with homepage on IE 11. Ideally polyfills are loaded early, but not sure how you feel about using this CDN vs. self-hosting, or if you'd rather bundle it another way? 🐛 