### PR TITLE
Replace addSecrets with dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TEST_URL=
+PROD_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 .css.map
 .DS_Store
+.env
 .idea
 .map
-addSecrets.sh
 always_restart.txt
 assets.json
 assets/sass/_config.scss

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ In order to do this, you'll need to do the following:
 - Obtain AWS credentials for the team's account (with permission to access EC2 Parameter Store)
 - [Configure the AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) on your machine
 - Make sure the directory `/etc/blf/` exists and is writeable (this is where application secrets will be downloaded to).
-- Rename `addSecrets.example.sh` to `addSecrets.sh` and populate it with the missing values (ask another member of the team for these). These missing values are used for deployments.
-- Run `source ./addSecrets.sh` – this will download the application secrets to `/etc/blf/parameters.json`.
+- Copy `.env.example` to `.env` and populate it with the missing values (ask another member of the team for these). These missing values are used for deployments.
+- Run `./bin/scripts/get-secrets` – this will download the application secrets to `/etc/blf/parameters.json`.
 
 #### 3. Install Dependencies:
 

--- a/addSecrets.example.sh
+++ b/addSecrets.example.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# environment endpoints (for checking statuses)
-export TEST_URL=
-export PROD_URL=
-
-# fetch latest params from EC2 parameter store
-bin/scripts/get-secrets

--- a/bin/scripts/capture-screenshots
+++ b/bin/scripts/capture-screenshots
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+require('dotenv').config();
+
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');

--- a/bin/scripts/deploy.js
+++ b/bin/scripts/deploy.js
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
+
+require('dotenv').config();
+
+const has = require('lodash/has');
+
+if (!has(process.env, 'TEST_URL') || !has(process.env, 'PROD_URL')) {
+    console.log('Error: TEST_URL and PROD_URL environment variables must be defined');
+    process.exit(1);
+}
+
 const argv = require('yargs')
     .boolean('l')
     .alias('l', 'live')
@@ -7,9 +17,9 @@ const argv = require('yargs')
     .describe('b', 'Pass a custom build number to deploy')
     .help('h')
     .alias('h', 'help').argv;
+
 const prompt = require('prompt');
 const AWS = require('aws-sdk');
-const request = require('request');
 const rp = require('request-promise');
 
 let customBuildNumber = argv.build;
@@ -221,7 +231,7 @@ function verifyCommitsToDeploy() {
 }
 
 // trigger the deploy itself
-function pushOutDeploy(env, id, commitStr) {
+function pushOutDeploy(env, id) {
     let text = `Attempting to deploy revision ${id} to environment ${env}, please wait...`;
     console.log(text);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,16 +76,6 @@
         "@types/mime": "0.0.29"
       }
     },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
-    },
     "a-sync-waterfall": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
@@ -1464,9 +1454,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
+        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1499,7 +1489,6 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1521,6 +1510,7 @@
         "https-browserify": "1.0.0",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -2854,6 +2844,12 @@
       "requires": {
         "is-obj": "1.0.1"
       }
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
     },
     "dottie": {
       "version": "2.0.0",
@@ -5594,10 +5590,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
+        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -6102,6 +6098,16 @@
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
     },
     "jsprim": {
       "version": "1.4.0",
@@ -7405,7 +7411,6 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
-        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -7413,6 +7418,7 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.2.9",
         "resolve": "1.3.3",
@@ -10394,6 +10400,14 @@
       "integrity": "sha1-Rb8dny19wJvtgfHDB8Qw5ouEz/4=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -10410,14 +10424,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-      "requires": {
-        "safe-buffer": "5.0.1"
       }
     },
     "stringify-object": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "browserify": "^14.4.0",
     "chokidar": "^1.6.1",
     "del": "^2.2.2",
+    "dotenv": "^4.0.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-babel": "^6.1.2",


### PR DESCRIPTION
Ensures that scripts that require local secrets can load them directly without needing to remember to locally source a file.

Secrets now live in `.env`. A `.env.example` file has been included for reference and the README updated to match the new steps.