### PR TITLE
Initial pass of improving print css

### DIFF
--- a/assets/sass/_print.common.scss
+++ b/assets/sass/_print.common.scss
@@ -1,0 +1,56 @@
+/* =========================================================================
+   Common Print Styles
+   - Component specific print styles inlined in component files
+   ========================================================================= */
+
+@page {
+    margin: 0.5in;
+}
+
+@media print {
+    *,
+    *:before,
+    *:after {
+        background: transparent !important;
+        color: #000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    a,
+    a:visited {
+        text-decoration: underline;
+    }
+
+    a[href]:after {
+        content: ' (' attr(href) ')';
+    }
+
+    abbr[title]:after {
+        content: ' (' attr(title) ')';
+    }
+
+    thead {
+        display: table-header-group;
+    }
+    tr,
+    img {
+        page-break-inside: avoid;
+    }
+
+    p,
+    h2,
+    h3 {
+        orphans: 3;
+        widows: 3;
+    }
+
+    h2,
+    h3 {
+        page-break-after: avoid;
+    }
+
+    .u-dont-print {
+        display: none !important;
+    }
+}

--- a/assets/sass/components/heroes.scss
+++ b/assets/sass/components/heroes.scss
@@ -21,22 +21,6 @@ $heroSpaceFromLeft: 20px;
     background-repeat: no-repeat;
     position: relative;
 
-    &.hero--major {
-        height: 0;
-
-        @media print {
-            display: none;
-        }
-
-        .hero__inner {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-        }
-    }
-
     // loop through each hero image set
     @each $hero, $imageset in $heroes {
         // output a default (mobile) image and aspect ratio
@@ -95,6 +79,40 @@ $heroSpaceFromLeft: 20px;
     }
 }
 
+/* =========================================================================
+   Major Heroes [DEPRECATED: To be replaced by super-hero accross site]
+   ========================================================================= */
+
+.hero.hero--major {
+    height: 0;
+
+    .hero__inner {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}
+
+@media print {
+    .hero.hero--major {
+        color: black !important;
+        background: none !important;
+        position: static;
+        padding-bottom: 0;
+        height: auto;
+
+        .hero__header,
+        .hero__inner {
+            position: static;
+        }
+    }
+}
+
+/* =========================================================================
+   Minature Heroes
+   ========================================================================= */
 .hero--miniature {
     // hacky-ish way to switch images out for miniature hero on breakpoints
     @include mq('tablet', 'max') {
@@ -122,6 +140,21 @@ $heroSpaceFromLeft: 20px;
     .hero__header {
         @include mq('tablet', 'max') {
             margin-left: $heroSpaceFromLeft;
+        }
+    }
+}
+
+@media print {
+    .hero--miniature {
+        .hero-image--mobile {
+            display: none !important;
+        }
+        .hero-image--desktop {
+            display: block !important;
+            margin-bottom: 0.5em;
+        }
+        .hero__header {
+            position: static;
         }
     }
 }
@@ -289,5 +322,25 @@ $heroSpaceFromLeft: 20px;
     &.has-image .super-hero__image,
     &.has-image .super-hero__caption {
         opacity: 1;
+    }
+}
+
+@media print {
+    .super-hero {
+        color: black !important;
+        background: none !important;
+        position: static;
+        padding-bottom: 0;
+        height: auto;
+    }
+    .super-hero__image {
+        display: none;
+    }
+    .super-hero__header {
+        text-align: left;
+    }
+    .super-hero__content,
+    .super-hero__caption {
+        position: static;
     }
 }

--- a/assets/sass/scaffolding/footer.scss
+++ b/assets/sass/scaffolding/footer.scss
@@ -23,7 +23,6 @@
         }
     }
 
-
     .footer--no-margin & {
         margin-top: 0;
     }
@@ -37,4 +36,10 @@
 }
 .footer__header {
     margin-bottom: $spacingUnit;
+}
+
+@media print {
+    .footer {
+        display: none;
+    }
 }

--- a/assets/sass/scaffolding/grid.scss
+++ b/assets/sass/scaffolding/grid.scss
@@ -83,7 +83,6 @@
             }
 
             &.grid--bordered {
-
                 $borderColour: #94aee5;
 
                 @include mq('tablet', 'max') {
@@ -97,10 +96,18 @@
                         border-right: 1px solid $borderColour;
 
                         // some magic to alternate border colours
-                        &:nth-child(odd) { &:after { border-left-color: palette('blue'); } }
-                        &:nth-child(even) { &:after { border-left-color: palette('pink'); } }
+                        &:nth-child(odd) {
+                            &:after {
+                                border-left-color: palette('blue');
+                            }
+                        }
+                        &:nth-child(even) {
+                            &:after {
+                                border-left-color: palette('pink');
+                            }
+                        }
 
-                        &:nth-child(-n+#{$i}) {
+                        &:nth-child(-n + #{$i}) {
                             border-top: none;
                         }
 
@@ -109,7 +116,7 @@
                         }
 
                         // internal border
-                        &:nth-child(#{$i}n+1) {
+                        &:nth-child(#{$i}n + 1) {
                             $desiredHeight: 50%;
                             &:after {
                                 position: relative;
@@ -133,7 +140,6 @@
                     }
                 }
             }
-
         }
     }
 }
@@ -187,5 +193,18 @@
         .column__item {
             padding-left: $spacingUnit * 2;
         }
+    }
+}
+
+@media print {
+    .grid {
+        display: block !important;
+        margin: 0 !important;
+    }
+    .grid__item {
+        display: block !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        margin: 0 !important;
     }
 }

--- a/assets/sass/scaffolding/header.scss
+++ b/assets/sass/scaffolding/header.scss
@@ -72,7 +72,6 @@ $offscreenNavWidth: 65%;
     }
 }
 
-
 /* =========================================================================
    Global Header: Logo
    ========================================================================= */
@@ -467,4 +466,10 @@ html:not(.contrast--high).is-ie .has-full-bleed-header .logo {
 }
 html:not(.contrast--high).locale--cy.is-ie .has-full-bleed-header .logo {
     background-image: url(../images/logo-new--welsh.png);
+}
+
+@media print {
+    .header {
+        position: static !important;
+    }
 }

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -54,3 +54,8 @@
  * 6. Overrides / Utilities
  */
 @import 'utilities/utilities';
+
+/**
+ * 7. Common Print Styles
+ */
+@import '_print.common';

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -61,7 +61,7 @@
     <div class="hero hero--major {% if name %}hero--{{ name }}{% endif %}{% if extraClasses %} {{ extraClasses }}{% endif %}" role="complementary">
         <section class="hero__inner">
             {% if caption %}
-                <div class="inner hero__caption u-desktop-only">
+                <div class="inner hero__caption u-desktop-only u-dont-print">
                     <span class="hero__caption-text">{{ caption }}</span>
                 </div>
             {% endif %}

--- a/views/includes/header.njk
+++ b/views/includes/header.njk
@@ -8,12 +8,12 @@
                     <span class="u-visually-hidden">{{ __("global.brand.title") }}</span>
                 </h1>
             </a>
-            <nav class="header__hamburger u-mobile-only" id="js-mobile-nav-toggle">
+            <nav class="header__hamburger u-mobile-only u-dont-print" id="js-mobile-nav-toggle">
                 <a href="#nav">
                     {% include "../includes/svg/hamburger.svg" %}
                 </a>
             </nav>
-            <nav role="navigation" class="header__nav header__content-item u-desktop-only">
+            <nav role="navigation" class="header__nav header__content-item u-desktop-only u-dont-print">
                 <ul class="nav grid">
                     {{ navlinks('nav__link') }}
                 </ul>


### PR DESCRIPTION
Pass of a print stylesheet, using the WIP about page as a test:

**Before**
![screen shot 2017-10-18 at 10 44 13](https://user-images.githubusercontent.com/123386/31711954-a18a09b4-b3f1-11e7-90ba-c4c5d70fb1f4.png)

**After**
![screen shot 2017-10-18 at 10 43 47](https://user-images.githubusercontent.com/123386/31711955-a19de34e-b3f1-11e7-9933-2cf7f32194dc.png)

Continues with the rough approach that had already been started

- Adds a common print stylesheet inline with some global resets
- All other print styles are inlined in components
- Adds a `u-dont-print` utility for contextually opting parts out of printing

(Highlighted the fact that the miniature hero styles could definitely stand to be refactored ahead of any about page work so I might try and do that next)