### PR TITLE
About page prep: Miniature heroes

### DIFF
--- a/assets/sass/_print.common.scss
+++ b/assets/sass/_print.common.scss
@@ -22,7 +22,7 @@
         text-decoration: underline;
     }
 
-    a[href]:after {
+    a:not(.u-dont-print-link)[href]:after {
         content: ' (' attr(href) ')';
     }
 

--- a/assets/sass/components/heroes.scss
+++ b/assets/sass/components/heroes.scss
@@ -95,70 +95,6 @@ $heroSpaceFromLeft: 20px;
     }
 }
 
-@media print {
-    .hero.hero--major {
-        color: black !important;
-        background: none !important;
-        position: static;
-        padding-bottom: 0;
-        height: auto;
-
-        .hero__header,
-        .hero__inner {
-            position: static;
-        }
-    }
-}
-
-/* =========================================================================
-   Minature Heroes
-   ========================================================================= */
-.hero--miniature {
-    // hacky-ish way to switch images out for miniature hero on breakpoints
-    @include mq('tablet', 'max') {
-        .hero-image--desktop {
-            display: none;
-        }
-        .hero-image--mobile {
-            display: block;
-        }
-    }
-
-    @include mq('tablet') {
-        .hero-image--desktop {
-            display: block;
-        }
-        .hero-image--mobile {
-            display: none;
-        }
-    }
-}
-
-.hero--miniature__content {
-    position: relative;
-
-    .hero__header {
-        @include mq('tablet', 'max') {
-            margin-left: $heroSpaceFromLeft;
-        }
-    }
-}
-
-@media print {
-    .hero--miniature {
-        .hero-image--mobile {
-            display: none !important;
-        }
-        .hero-image--desktop {
-            display: block !important;
-            margin-bottom: 0.5em;
-        }
-        .hero__header {
-            position: static;
-        }
-    }
-}
-
 /* =========================================================================
    Section Hero
    ========================================================================= */
@@ -342,5 +278,30 @@ $heroSpaceFromLeft: 20px;
     .super-hero__content,
     .super-hero__caption {
         position: static;
+    }
+}
+
+/* =========================================================================
+   Minature Heroes
+   ========================================================================= */
+/* Small feature panels (see /funding/funding-guidance/managing-your-funding or /about-big) */
+
+.miniature-hero {
+    position: relative;
+
+    .minature-hero__content {
+        position: absolute;
+        bottom: $heroSpaceFromBottomMobile;
+        padding-left: $heroSpaceFromLeft;
+
+        @include mq('tablet') {
+            bottom: $heroSpaceFromBottom;
+        }
+
+        @media print {
+            position: static;
+            padding: 0;
+            margin-bottom: 10px;
+        }
     }
 }

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -74,20 +74,33 @@
     </div>
 {% endmacro %}
 
-{% macro miniature(imagePath, imagePathMobile = false, imageCaption = false, link = false, content) %}
-    <div class="hero hero--miniature" role="complementary">
-        <section class="hero__inner">
-            {% if link %}<a href="{{ link }}">{% endif %}
-            <img src="{{ imagePath | getCachebustedPath }}" class="grid__item__poster{% if imagePathMobile %} hero-image--desktop{% endif %}" alt="{{ imageCaption }}" />
-            {% if imagePathMobile %}
-                <img src="{{ imagePathMobile | getCachebustedPath }}" class="grid__item__poster hero-image--mobile" alt="{{ imageCaption }}" />
-            {% endif %}
-            {% if link %}</a>{% endif %}
-            <div class="hero--miniature__content">
-                <div class="hero__header">
-                    {{ content | safe }}
-                </div>
+{% macro miniatureHero(titleText, imagePath, imagePathMobile = false, imageCaption = false, linkUrl = false, accent) %}
+    <div class="miniature-hero accent--{{ accent }} a--border-top--large">
+        <div class="miniature-hero__inner">
+            {% if linkUrl %}<a class="miniature-hero__link u-dont-print-link" href="{{ linkUrl }}">{% endif %}
+
+            <div class="minature-hero__image">
+                {% if imagePathMobile %}
+                    <picture>
+                        <source srcset="{{ imagePath | getCachebustedPath }}" media="(min-width: 760px)">
+                        <img src="{{ imagePathMobile | getCachebustedPath }}" alt="{{ imageCaption }}" />
+                    </picture>
+                {% else %}
+                    <img src="{{ imagePath | getCachebustedPath }}" alt="{{ imageCaption }}" />
+                {% endif %}
             </div>
-        </section>
+
+            {% if linkUrl %}</a>{% endif %}
+
+            <div class="minature-hero__content">
+                {{ headers.overlayText(
+                    tag = 'h3',
+                    text = titleText,
+                    additionalClasses = 't2 svgs-white overlay-text--wide is-opaque',
+                    link = linkUrl,
+                    showArrow = true
+                )}}
+            </div>
+        </div>
     </div>
 {% endmacro %}

--- a/views/pages/funding/guidance/managing-your-funding.njk
+++ b/views/pages/funding/guidance/managing-your-funding.njk
@@ -20,89 +20,43 @@
         </div>
 
         <div class="inner">
-
             <ul class="unstyled grid grid--2-up grid--padded grid--equal grid--wide-only">
-
                 <li class="grid__item">
-                    <div class="accent--pink-mid a--border-top--large">
-                        {% set miniHeroContent %}
-                            {{ headers.overlayText(
-                                tag = 'h4',
-                                text = copy.body.actions.social,
-                                additionalClasses = 't2 svgs-white',
-                                link = buildUrl('funding', 'helpWithPublicity'),
-                                showArrow = true
-                            )}}
-                        {% endset %}
-                        {{ hero.miniature(
-                            imagePath = 'images/funding/tell-the-world.jpg',
-                            imageCaption = 'Three people working together on laptops',
-                            link = buildUrl('funding', 'helpWithPublicity'),
-                            content = miniHeroContent
-                        )}}
-                    </div>
+                    {{ hero.miniatureHero(
+                        titleText = copy.body.actions.social,
+                        imagePath = 'images/funding/tell-the-world.jpg',
+                        imageCaption = 'Three people working together on laptops',
+                        linkUrl = buildUrl('funding', 'helpWithPublicity'),
+                        accent = 'pink-mid'
+                    )}}
                 </li>
-
                 <li class="grid__item">
-                    <div class="accent--blue a--border-top--large">
-                        {% set miniHeroContent %}
-                            {{ headers.overlayText(
-                                tag = 'h4',
-                                text = copy.body.actions.press,
-                                additionalClasses = 't2 svgs-white',
-                                link = buildUrl('funding', 'pressCoverage'),
-                                showArrow = true
-                            )}}
-                        {% endset %}
-                        {{ hero.miniature(
-                            imagePath = 'images/funding/local-press.jpg',
-                            imageCaption = 'Two cooks in chefs\' clothing with another man smiling',
-                            link = buildUrl('funding', 'pressCoverage'),
-                            content = miniHeroContent
-                        )}}
-                    </div>
+                    {{ hero.miniatureHero(
+                        titleText = copy.body.actions.press,
+                        imagePath = 'images/funding/local-press.jpg',
+                        imageCaption = 'Two cooks in chefs\' clothing with another man smiling',
+                        linkUrl = buildUrl('funding', 'pressCoverage'),
+                        accent = 'blue'
+                    )}}
                 </li>
-
                 <li class="grid__item">
-                    <div class="accent--turquoise a--border-top--large">
-                        {% set miniHeroContent %}
-                            {{ headers.overlayText(
-                                tag = 'h4',
-                                text = copy.body.actions.logo,
-                                additionalClasses = 't2 svgs-white',
-                                link = buildUrl('funding', 'logos'),
-                                showArrow = true
-                            )}}
-                        {% endset %}
-                        {{ hero.miniature(
-                            imagePath = 'images/funding/display-the-logo.jpg',
-                            imageCaption = 'A man smiling outside the entrance to a bike shop',
-                            link = buildUrl('funding', 'logos'),
-                            content = miniHeroContent
-                        )}}
-                    </div>
+                    {{ hero.miniatureHero(
+                        titleText = copy.body.actions.logo,
+                        imagePath = 'images/funding/display-the-logo.jpg',
+                        imageCaption = 'A man smiling outside the entrance to a bike shop',
+                        linkUrl = buildUrl('funding', 'logos'),
+                        accent = 'turquoise'
+                    )}}
                 </li>
-
                 <li class="grid__item">
-                    <div class="accent--orange a--border-top--large">
-                        {% set miniHeroContent %}
-                            {{ headers.overlayText(
-                                tag = 'h4',
-                                text = copy.body.actions.freeMaterial,
-                                additionalClasses = 't2 svgs-white',
-                                link = buildUrl('funding', 'freeMaterials'),
-                                showArrow = true
-                            )}}
-                        {% endset %}
-                        {{ hero.miniature(
-                            imagePath = 'images/funding/free-branded-materials.jpg',
-                            imageCaption = 'Two people crouching down outdoors in an allotment surrounded by plants',
-                            link = buildUrl('funding', 'freeMaterials'),
-                            content = miniHeroContent
-                        )}}
-                    </div>
+                    {{ hero.miniatureHero(
+                        titleText = copy.body.actions.freeMaterial,
+                        imagePath = 'images/funding/free-branded-materials.jpg',
+                        imageCaption = 'Two people crouching down outdoors in an allotment surrounded by plants',
+                        linkUrl = buildUrl('funding', 'freeMaterials'),
+                        accent = 'orange'
+                    )}}
                 </li>
-
             </ul>
         </div>
 

--- a/views/pages/toplevel/about.njk
+++ b/views/pages/toplevel/about.njk
@@ -28,24 +28,14 @@
                     </div>
 
                     <div class="spaced--x-l">
-                        <div class="accent--pink a--border-top--large">
-                            {% set miniHeroContent %}
-                                {{ headers.overlayText(
-                                tag = 'h3',
-                                text = 'Read our annual report 2016/17',
-                                additionalClasses = 't3 overlay-text--wide svgs-white is-opaque',
-                                link = '#',
-                                showArrow = true
-                                )}}
-                            {% endset %}
-                            {{ hero.miniature(
-                                imagePath = 'images/about/pennine-lancashire.jpg',
-                                imagePathMobile = 'images/about/pennine-lancashire--mobile.jpg',
-                                imageCaption = 'Three people working together on laptops',
-                                link = '#',
-                                content = miniHeroContent
-                            )}}
-                        </div>
+                        {{ hero.miniatureHero(
+                            titleText = 'Read our annual report 2016/17',
+                            imagePath = 'images/about/pennine-lancashire.jpg',
+                            imagePathMobile = 'images/about/pennine-lancashire--mobile.jpg',
+                            imageCaption = 'Three people working together on laptops',
+                            linkUrl = '#',
+                            accent = 'pink'
+                        )}}
                     </div>
 
                     <div class="spaced--x-l">
@@ -54,24 +44,14 @@
                     </div>
 
                     <div class="spaced--x-l">
-                        <div class="accent--turquoise a--border-top--large">
-                            {% set miniHeroContent %}
-                                {{ headers.overlayText(
-                                tag = 'h3',
-                                text = '&ldquo;Putting people in the lead&rdquo;: Discover the strategic framework that guides our work',
-                                additionalClasses = 't3 overlay-text--wide svgs-white is-opaque',
-                                link = '#',
-                                showArrow = true
-                                )}}
-                            {% endset %}
-                            {{ hero.miniature(
+                        {{ hero.miniatureHero(
+                            titleText = '&ldquo;Putting people in the lead&rdquo;: Discover the strategic framework that guides our work',
                             imagePath = 'images/about/dawn.jpg',
                             imagePathMobile = 'images/about/dawn--mobile.jpg',
                             imageCaption = 'Dawn Austwick, Chief Executive',
-                            link = '#',
-                            content = miniHeroContent
-                            )}}
-                        </div>
+                            linkUrl = '#',
+                            accent = 'turquoise'
+                        )}}
                     </div>
                 </div>
 

--- a/views/pages/toplevel/styleguide.njk
+++ b/views/pages/toplevel/styleguide.njk
@@ -1,6 +1,6 @@
 {% extends "../../layouts/styleguide.njk" %}
 
-{% from "../../components/hero.njk" import sectionHero %}
+{% import "../../components/hero.njk" as hero %}
 {% from "../../components/caseStudy.njk" import caseStudy %}
 
 {% macro styleguideSectionHeader(title) %}
@@ -128,5 +128,28 @@
     }}
 {% endset %}
 {{ styleguideBlock('Case Studies', sgContent) }}
+{% set sgContent %}
+    <ul class="unstyled grid grid--2-up grid--padded grid--equal grid--wide-only">
+        <li class="grid__item">
+            {{ hero.miniatureHero(
+                titleText = 'Example Miniature Hero',
+                imagePath = 'images/funding/tell-the-world.jpg',
+                imageCaption = 'Three people working together on laptops',
+                linkUrl = '#',
+                accent = 'pink-mid'
+            )}}
+        </li>
+        <li class="grid__item">
+            {{ hero.miniatureHero(
+                titleText = 'Example Miniature Hero',
+                imagePath = 'images/funding/local-press.jpg',
+                imageCaption = 'Two cooks in chefs\' clothing with another man smiling',
+                linkUrl = '#',
+                accent = 'blue'
+            )}}
+        </li>
+    </ul>
+{% endset %}
+{{ styleguideBlock('Miniature Heroes', sgContent) }}
 
 {% endblock %}


### PR DESCRIPTION
This is some prep work for the about page. 

Decouples miniature heroes into their own standalone classname. Normalises the style of overlay text between about page and "managing your funding" to avoid needing compose and pass so much disparate information in. Now a single macro.

![screen shot 2017-10-18 at 12 05 00](https://user-images.githubusercontent.com/123386/31716434-ac72661a-b3ff-11e7-8c5d-f00591c57f58.png)
![screen shot 2017-10-18 at 12 05 12](https://user-images.githubusercontent.com/123386/31716435-ac88de22-b3ff-11e7-9a29-44b1f186b35b.png)
![screen shot 2017-10-18 at 12 16 22](https://user-images.githubusercontent.com/123386/31716437-ac9e3cb8-b3ff-11e7-96db-daeee9d6b9b6.png)
