### PR TITLE
Update funding programmes list to use new API endpoint

### DIFF
--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -188,9 +188,8 @@ module.exports = (pages, sectionPath, sectionId) => {
 
         contentApi
             .getFundingProgrammes(req.i18n.getLocale())
-            .then(response => {
-                let programmeList = response.data;
-
+            .then(response => response.data.map(item => item.attributes))
+            .then(programmeList => {
                 // filter by location
                 if (req.query.location) {
                     // check this is a valid parameter

--- a/modules/content.js
+++ b/modules/content.js
@@ -8,11 +8,9 @@ if (!CMS_URL) {
     process.exit(1);
 }
 
-const API_URL = CMS_URL + '/content/';
-
 const getFundingProgrammes = locale => {
     return rp({
-        url: API_URL + locale + '/programs.json',
+        url: `${CMS_URL}/api/v1/${locale}/funding-programmes`,
         json: true
     });
 };


### PR DESCRIPTION
Update funding programmes list to use new API endpoint. Once this is out we can delete the old endpoint.