### PR TITLE
Remove jsonStringify in favour of built-in dump

### DIFF
--- a/modules/boilerplate/viewEngine.js
+++ b/modules/boilerplate/viewEngine.js
@@ -72,13 +72,5 @@ templateEnv.addFilter('lowercaseFirst', str => {
     return str[0].toLowerCase() + str.substring(1);
 });
 
-templateEnv.addFilter('jsonStringify', val => {
-    let ret;
-    try {
-        ret = JSON.stringify(val);
-    } catch (e) {} // eslint-disable-line no-empty
-    return ret || val;
-});
-
 app.set('view engine', 'njk');
 app.set('engineEnv', templateEnv);

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -1,7 +1,7 @@
 {% import "./headers.njk" as headers %}
 
 {% macro superHero(title, content, imageDefault, imageCandidates) %}
-    <div class="super-hero js-random-hero" data-image-candidates='{{ imageCandidates | jsonStringify | safe }}'>
+    <div class="super-hero js-random-hero" data-image-candidates='{{ imageCandidates | dump | safe }}'>
         <div class="super-hero__image js-random-hero__image">
             <picture>
                 <source srcset="{{ imageDefault.large }}" media="(min-width: 980px)">


### PR DESCRIPTION
Whilst working on some form exploration for #295 I spotted that nunjucks has a built-in stringify filter under the elegant name of `dump` so we can use that instead of writing our own.

https://mozilla.github.io/nunjucks/templating.html#dump
https://github.com/mozilla/nunjucks/blob/master/src/filters.js#L112-L114