### PR TITLE
Upgrade express validator

### DIFF
--- a/controllers/funding/free-materials/modifyItems.js
+++ b/controllers/funding/free-materials/modifyItems.js
@@ -3,19 +3,16 @@ const _ = require('lodash');
 const materials = require('../../../config/content/materials.json');
 
 module.exports = (req, orderKey, code) => {
-
     const validActions = ['increase', 'decrease', 'remove'];
 
-    // get form parameters
     const id = parseInt(req.params.id);
-    const action = req.sanitize('action').escape();
+    const action = req.body.action;
 
     // look up the item they're adding
     const item = materials.items.find(i => i.id === id);
 
     // is this a valid item/action?
     if (item && validActions.indexOf(action) !== -1) {
-
         let maxQuantity = item.maximum;
         let notAllowedWithItemId = item.notAllowedWithItem;
 
@@ -41,7 +38,7 @@ module.exports = (req, orderKey, code) => {
         _.set(req.session, [orderKey, code, 'name'], item.name.en);
 
         // can they add more of this item?
-        const noSpaceLeft = (currentItemQuantity === maxQuantity);
+        const noSpaceLeft = currentItemQuantity === maxQuantity;
 
         if (action === 'increase') {
             if (!noSpaceLeft && !hasBlockerItem) {

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -3,6 +3,8 @@ const express = require('express');
 const router = express.Router();
 const moment = require('moment');
 const _ = require('lodash');
+const { body, validationResult } = require('express-validator/check');
+const { matchedData, sanitizeBody } = require('express-validator/filter');
 const xss = require('xss');
 
 const routeStatic = require('../utils/routeStatic');
@@ -30,32 +32,83 @@ module.exports = (pages, sectionPath, sectionId) => {
     const freeMaterials = pages.freeMaterials;
 
     // handle adding/removing items
-    router.route(freeMaterials.path + '/item/:id').post((req, res) => {
-        // this page is dynamic so don't cache it
-        res.cacheControl = { maxAge: 0 };
+    router
+        .route(freeMaterials.path + '/item/:id')
+        .post([sanitizeBody('action').escape(), sanitizeBody('code').escape()], (req, res) => {
+            // this page is dynamic so don't cache it
+            res.cacheControl = { maxAge: 0 };
 
-        // update the session with ordered items
-        const code = req.sanitize('code').escape();
-        freeMaterialsLogic.modifyItems(req, freeMaterialsLogic.orderKey, code);
+            // update the session with ordered items
+            const code = req.body.code;
 
-        // handle ajax/standard form updates
-        res.format({
-            html: () => {
-                req.session.save(() => {
-                    res.redirect(req.baseUrl + freeMaterials.path);
-                });
-            },
-            json: () => {
-                req.session.save(() => {
-                    res.send({
-                        status: 'success',
-                        quantity: _.get(req.session, [freeMaterialsLogic.orderKey, code, 'quantity'], 0),
-                        allOrders: req.session[freeMaterialsLogic.orderKey]
+            freeMaterialsLogic.modifyItems(req, freeMaterialsLogic.orderKey, code);
+
+            // handle ajax/standard form updates
+            res.format({
+                html: () => {
+                    req.session.save(() => {
+                        res.redirect(req.baseUrl + freeMaterials.path);
                     });
-                });
+                },
+                json: () => {
+                    req.session.save(() => {
+                        res.send({
+                            status: 'success',
+                            quantity: _.get(req.session, [freeMaterialsLogic.orderKey, code, 'quantity'], 0),
+                            allOrders: req.session[freeMaterialsLogic.orderKey]
+                        });
+                    });
+                }
+            });
+        });
+
+    /**
+     * Validate fields using custom validator
+     * https://github.com/ctavan/express-validator#customvalidator
+     * @TODO: There should definitely be a better way to model error translations
+     */
+    const validators = freeMaterialsLogic.formFields.filter(field => field.required).map(field => {
+        return body(field.name)
+            .exists()
+            .custom((value, { req }) => {
+                const locale = req.i18n.getLocale();
+                // Turn 'Your name' into 'your name' (for error messages)
+                const lcfirst = str => str[0].toLowerCase() + str.substring(1);
+                // Get a translated error message
+                let fieldName = lcfirst(field.label[locale]);
+                let errorMessage = req.i18n.__('global.forms.missingFieldError', fieldName);
+                // Validate field
+                if (!value || value.length < 1) {
+                    throw new Error(errorMessage);
+                }
+
+                return true;
+            });
+    });
+
+    /**
+     * Create text for order email
+     */
+    const makeOrderText = (items, details) => {
+        let text = 'A new order has been received from the Big Lottery Fund website. The order details are below:\n\n';
+        for (let code in items) {
+            if (items[code].quantity > 0) {
+                text += `\t- x${items[code].quantity} ${code}\t (item: ${items[code].name})\n`;
+            }
+        }
+        text += "\nThe customer's personal details are below:\n\n";
+
+        freeMaterialsLogic.formFields.forEach(field => {
+            const fieldDetail = details[field.name];
+            if (fieldDetail) {
+                text += `\t${field.label['en']}: ${fieldDetail}\n\n`;
             }
         });
-    });
+
+        text += '\nThis email has been automatically generated from the Big Lottery Fund Website.';
+        text += '\nIf you have feedback, please contact matt.andrews@biglotteryfund.org.uk.';
+        return text;
+    };
 
     // PAGE: free materials form
     router
@@ -91,94 +144,64 @@ module.exports = (pages, sectionPath, sectionId) => {
                 csrfToken: ''
             });
         })
-        .post((req, res) => {
-            // turn 'Your name' into 'your name' (for error messages)
-            const lcfirst = str => str[0].toLowerCase() + str.substring(1);
-            let locale = req.i18n.getLocale();
+        .post(validators, (req, res) => {
+            // sanitise input
+            for (let key in req.body) {
+                req.body[key] = xss(req.body[key]);
+            }
 
-            freeMaterialsLogic.formFields.forEach(field => {
-                if (field.required) {
-                    // get a translated error message
-                    let fieldName = lcfirst(field.label[locale]);
-                    let errorMessage = req.i18n.__('global.forms.missingFieldError', fieldName);
-                    req.checkBody(field.name, errorMessage).notEmpty();
-                }
-            });
+            const errors = validationResult(req);
+            if (!errors.isEmpty()) {
+                req.flash('formErrors', errors.array());
+                req.flash('formValues', req.body);
 
-            const makeOrderText = (items, details) => {
-                let text =
-                    'A new order has been received from the Big Lottery Fund website. The order details are below:\n\n';
-                for (let code in items) {
-                    if (items[code].quantity > 0) {
-                        text += `\t- x${items[code].quantity} ${code}\t (item: ${items[code].name})\n`;
+                req.session.save(() => {
+                    // build a redirect URL based on the route, the language of items,
+                    // and the form anchor, so the user sees the form again via JS
+                    let returnUrl = req.baseUrl + freeMaterials.path;
+                    let formAnchor = '#your-details';
+                    let langParam = '?lang=';
+                    let redirectUrl = returnUrl;
+
+                    // add their langage choice (if valid)
+                    let langChoice = req.body.languageChoice;
+                    if (
+                        langChoice &&
+                        redirectUrl.indexOf(langParam) === -1 &&
+                        ['monolingual', 'bilingual'].indexOf(langChoice) !== -1
+                    ) {
+                        redirectUrl += langParam + langChoice;
                     }
-                }
-                text += "\nThe customer's personal details are below:\n\n";
 
-                freeMaterialsLogic.formFields.forEach(field => {
-                    if (details[field.name]) {
-                        let safeField = req.sanitize(field.name).unescape();
-                        text += `\t${field.label['en']}: ${safeField}\n\n`;
+                    // add the form anchor (if not present)
+                    if (redirectUrl.indexOf(formAnchor) === -1) {
+                        redirectUrl += formAnchor;
                     }
+
+                    res.redirect(redirectUrl);
                 });
-
-                text += '\nThis email has been automatically generated from the Big Lottery Fund Website.';
-                text += '\nIf you have feedback, please contact matt.andrews@biglotteryfund.org.uk.';
-                return text;
-            };
-
-            req.getValidationResult().then(result => {
-                // sanitise input
-                for (let key in req.body) {
-                    req.body[key] = xss(req.body[key]);
-                }
-
-                if (!result.isEmpty()) {
-                    req.flash('formErrors', result.array());
-                    req.flash('formValues', req.body);
-                    req.session.save(() => {
-                        // build a redirect URL based on the route, the language of items,
-                        // and the form anchor, so the user sees the form again via JS
-                        let returnUrl = req.baseUrl + freeMaterials.path;
-                        let formAnchor = '#your-details';
-                        let langParam = '?lang=';
-                        let redirectUrl = returnUrl;
-
-                        // add their langage choice (if valid)
-                        let langChoice = req.body.languageChoice;
-                        if (
-                            langChoice &&
-                            redirectUrl.indexOf(langParam) === -1 &&
-                            ['monolingual', 'bilingual'].indexOf(langChoice) !== -1
-                        ) {
-                            redirectUrl += langParam + langChoice;
-                        }
-
-                        // add the form anchor (if not present)
-                        if (redirectUrl.indexOf(formAnchor) === -1) {
-                            redirectUrl += formAnchor;
-                        }
-
-                        res.redirect(redirectUrl);
-                    });
+            } else {
+                /**
+                 * Allow tests to run without sending email
+                 * this is only used in tests, so we confirm the form data was correct
+                 */
+                if (req.body.skipEmail) {
+                    res.send(req.body);
                 } else {
-                    let text = makeOrderText(req.session[freeMaterialsLogic.orderKey], req.body);
-                    let dateNow = moment().format('dddd, MMMM Do YYYY, h:mm:ss a');
+                    const details = matchedData(req, { locations: ['body'] });
+                    const dateNow = moment().format('dddd, MMMM Do YYYY, h:mm:ss a');
+                    const text = makeOrderText(req.session[freeMaterialsLogic.orderKey], details);
 
-                    // allow tests to run without sending email
-                    if (!req.body.skipEmail) {
-                        email.send(text, `Order from Big Lottery Fund website - ${dateNow}`);
-                        req.flash('materialFormSuccess', true);
-                        req.flash('showOverlay', true);
-                        req.session.save(() => {
-                            res.redirect(req.baseUrl + freeMaterials.path);
-                        });
-                    } else {
-                        // this is only used in tests, so we confirm the form data was correct
-                        res.send(req.body);
-                    }
+                    email.send(text, `Order from Big Lottery Fund website - ${dateNow}`);
+
+                    req.flash('materialFormSuccess', true);
+                    req.flash('showOverlay', true);
+
+                    req.session.save(() => {
+                        res.redirect(req.baseUrl + freeMaterials.path);
+                    });
                 }
-            });
+            }
         });
 
     // funding programme list

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -177,10 +177,13 @@ module.exports = (pages, sectionPath, sectionId) => {
                 .exists()
                 .not()
                 .isEmpty(),
-            body('email', 'Please provide your email address')
+            body('email')
                 .exists()
                 .not()
-                .isEmpty(),
+                .isEmpty()
+                .withMessage('Please provide your email address')
+                .isEmail()
+                .withMessage('Please provide a valid email address'),
             body('location', 'Please choose a country newsletter')
                 .exists()
                 .not()

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -6,6 +6,8 @@ const path = require('path');
 const fs = require('fs');
 const generateSchema = require('generate-schema');
 const passport = require('passport');
+const { body, validationResult } = require('express-validator/check');
+const { matchedData } = require('express-validator/filter');
 const xss = require('xss');
 
 const globals = require('../../modules/boilerplate/globals');
@@ -216,33 +218,54 @@ router
             });
         });
     })
-    .post(isAuthenticated, (req, res) => {
-        let redirectBase = req.baseUrl + editNewsPath + '/';
+    .post(
+        isAuthenticated,
+        [
+            body('title_en', 'Please provide an English title')
+                .exists()
+                .not()
+                .isEmpty(),
+            body('title_cy', 'Please provide a Welsh title')
+                .exists()
+                .not()
+                .isEmpty(),
+            body('text_en', 'Please provide an English summary')
+                .exists()
+                .not()
+                .isEmpty(),
+            body('text_cy', 'Please provide a Welsh summary')
+                .exists()
+                .not()
+                .isEmpty(),
+            body('link_en', 'Please provide an English article link')
+                .exists()
+                .not()
+                .isEmpty(),
+            body('link_cy', 'Please provide a Welsh article link')
+                .exists()
+                .not()
+                .isEmpty()
+        ],
+        (req, res) => {
+            let redirectBase = req.baseUrl + editNewsPath + '/';
+            const errors = validationResult(req);
+            const data = matchedData(req, { locations: ['body'] });
 
-        // validate form
-        req.checkBody('title_en', 'Please provide an English title').notEmpty();
-        req.checkBody('title_cy', 'Please provide a Welsh title').notEmpty();
-        req.checkBody('text_en', 'Please provide an English summary').notEmpty();
-        req.checkBody('text_cy', 'Please provide a Welsh summary').notEmpty();
-        req.checkBody('link_en', 'Please provide an English article link').notEmpty();
-        req.checkBody('link_cy', 'Please provide a Welsh article link').notEmpty();
-
-        req.getValidationResult().then(result => {
-            if (!result.isEmpty()) {
-                req.flash('formErrors', result.array());
-                req.flash('formValues', req.body);
+            if (!errors.isEmpty()) {
+                req.flash('formErrors', errors.array());
+                req.flash('formValues', data);
                 req.session.save(() => {
                     res.redirect(redirectBase + '?error');
                 });
             } else {
                 // sanitise input
                 let rowData = {
-                    title_en: xss(req.body['title_en']),
-                    title_cy: xss(req.body['title_cy']),
-                    text_en: xss(req.body['text_en']),
-                    text_cy: xss(req.body['text_cy']),
-                    link_en: xss(req.body['link_en']),
-                    link_cy: xss(req.body['link_cy'])
+                    title_en: xss(data['title_en']),
+                    title_cy: xss(data['title_cy']),
+                    text_en: xss(data['text_en']),
+                    text_cy: xss(data['text_cy']),
+                    link_en: xss(data['link_en']),
+                    link_cy: xss(data['link_cy'])
                 };
 
                 if (req.params.id) {
@@ -263,7 +286,7 @@ router
                     res.redirect(redirectBase + '?success');
                 });
             }
-        });
-    });
+        }
+    );
 
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3762,21 +3762,19 @@
       }
     },
     "express-validator": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-3.2.1.tgz",
-      "integrity": "sha1-RWA+fu5pMYXCGY+969QUkl/9NSQ=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-4.2.1.tgz",
+      "integrity": "sha512-c2oiv3THmHdbDYV8qSXWq/yB17Gt3KopsseRqxKsn3s5xUz0G0E1hSQXeUjgL2+H9OAAGb6JMgc1Y9+7LO5XHg==",
       "requires": {
-        "@types/bluebird": "3.5.8",
         "@types/express": "4.0.35",
-        "bluebird": "3.5.0",
         "lodash": "4.17.4",
-        "validator": "6.2.1"
+        "validator": "8.2.0"
       },
       "dependencies": {
-        "@types/bluebird": {
-          "version": "3.5.8",
-          "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.8.tgz",
-          "integrity": "sha512-rBfrD56OxaqVjghtVqp2EEX0ieHkRk6IefDVrQXIVGvlhDOEBTvZff4Q02uo84ukVkH4k5eB1cPKGDM2NlFL8A=="
+        "validator": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
+          "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA=="
         }
       }
     },
@@ -10936,11 +10934,6 @@
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
-    },
-    "validator": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-6.2.1.tgz",
-      "integrity": "sha1-vFdbeNFb6y4zimZbqVMMf0Ce9mc="
     },
     "vary": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express-ab": "^0.7.1",
     "express-cache-controller": "^1.0.1",
     "express-session": "^1.15.5",
-    "express-validator": "^3.2.1",
+    "express-validator": "^4.2.1",
     "generate-schema": "^2.5.1",
     "helmet": "^3.8.1",
     "i18n-2": "^0.6.3",


### PR DESCRIPTION
This is a bit of yak shaving :why_is_there_not_a_yak_emoji: 🐮  from https://github.com/biglotteryfund/blf-alpha/pull/300 but worth doing. Upgrades `express-validator` to v4.

Forms affected are:

- Newsletter signup
- Materials form
- News Editor

There should be no changes in behaviour due to this upgrade, but as the API is quite different the are a fair few code changes so I'd appreciate a second pair of 👀  on this.

(Best viewed with https://github.com/biglotteryfund/blf-alpha/pull/301/files?w=1)