### PR TITLE
Batch getParameters calls to avoid hitting max 10 limit

### DIFF
--- a/bin/scripts/get-secrets
+++ b/bin/scripts/get-secrets
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const assert = require('assert');
 const AWS = require('aws-sdk');
+const { chunk, flatten } = require('lodash');
 
 AWS.config.update({ region: 'eu-west-1' });
 
@@ -13,33 +14,68 @@ var ssm = new AWS.SSM();
 const etcDir = '/etc/blf';
 const parametersDest = etcDir + '/parameters.json';
 
-ssm.describeParameters(function(err, data) {
-    if (err) {
-        console.log(err, err.stack);
-        process.exit(1);
-    }
 
-    const names = data.Parameters.map(_ => _.Name);
+/**
+ * Amazon Weird Services:
+ * `describeParameters` returns up to **50** items but `getParameters`
+ * will only return **10** items at a time so to get everything we
+ * need we'll must chunk up our list of parameters and fetch them
+ * in batches of 10 parameters at a time.
+ */
+//  https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeParameters.html#EC2-DescribeParameters-request-MaxResults
+const DESCRIBE_PARAMETERS_LIMIT = 50;
+// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html#API_GetParameters_RequestSyntax
+const GET_PARAMETERS_LIMIT = 10;
 
-    ssm.getParameters(
-        {
-            Names: names,
-            WithDecryption: true
-        },
-        function(err, data) {
-            if (err) {
-                console.log(err, err.stack);
-                process.exit(1);
+ssm.describeParameters(
+    {
+        MaxResults: DESCRIBE_PARAMETERS_LIMIT
+    },
+    function(err, data) {
+        if (err) {
+            console.log(err, err.stack);
+            process.exit(1);
+        }
+
+        const parameterNames = data.Parameters.map(_ => _.Name);
+
+        const parameterChunks = chunk(parameterNames, GET_PARAMETERS_LIMIT);
+
+        const promises = parameterChunks.map(names => {
+            return new Promise((resolve, reject) => {
+                ssm.getParameters(
+                    {
+                        Names: names,
+                        WithDecryption: true
+                    },
+                    function(err, data) {
+                        if (err) {
+                            reject(err);
+                        }
+                        resolve(data.Parameters);
+                    }
+                );
+            });
+        });
+
+        Promise.all(
+            promises
+        )
+        .then(results => flatten(results))
+        .then(allParameters => {
+            if (parameterNames.length !== allParameters.length) {
+                throw new Error('Number of results doesn\'t match the amount requested');
             }
-
-            const parameters = data.Parameters;
 
             if (!fs.existsSync(etcDir)) {
                 fs.mkdirSync(etcDir);
             }
 
-            fs.writeFileSync(parametersDest, JSON.stringify(parameters, null, 4));
+            fs.writeFileSync(parametersDest, JSON.stringify(allParameters, null, 4));
             assert(fs.existsSync(parametersDest));
-        }
-    );
-});
+        }, function(err) {
+            console.log(err, err.stack);
+            process.exit(1);
+        });
+    }
+);


### PR DESCRIPTION
Like #305 but just the batch changes.

`describeParameters` returns up to **50** items but `getParameters` will only return **10** items at a time so to get everything we need we'll must chunk up our list of parameters and fetch them in batches of 10 parameters at a time.
