### PR TITLE
Set session cookie as httpOnly, sameSite and secure

### DIFF
--- a/modules/boilerplate/middleware.js
+++ b/modules/boilerplate/middleware.js
@@ -37,15 +37,20 @@ app.use(cookieParser());
 
 // add session
 const sessionConfig = {
-    secret: secrets['session.secret'] || process.env.sessionSecret,
     name: config.get('cookies.session'),
+    secret: process.env.sessionSecret || secrets['session.secret'],
+    cookie: { sameSite: true },
     resave: false,
     saveUninitialized: false,
-    cookie: { secure: false, httpOnly: false },
     store: new SequelizeStore({
         db: models.sequelize
     })
 };
+
+if (app.get('env') === 'production') {
+    app.set('trust proxy', 1); // trust first proxy
+    sessionConfig.cookie.secure = true; // serve secure cookies
+}
 
 // create sessions table
 sessionConfig.store.sync();


### PR DESCRIPTION
Spotted whilst updating the homepage percentage. Slightly unsure why we weren't setting the session cookie to HttpOnly and Secure so raising a PR to fix this.