### PR TITLE
Prevent the i18n module from re-reading JSON locale files

### DIFF
--- a/modules/boilerplate/middleware.js
+++ b/modules/boilerplate/middleware.js
@@ -67,7 +67,8 @@ i18n.expressBind(app, {
     locales: ['en', 'cy'],
     cookieName: 'locale',
     extension: '.json',
-    directory: './config/locales'
+    directory: './config/locales',
+    devMode: app.get('env') === 'development'
 });
 
 // handle overlays


### PR DESCRIPTION
The [i18n module](https://github.com/jeresig/i18n-node-2) has the following setting:

>When your server is in production mode it will read [your locale files] only once and then cache the result. It will not write any updated strings when in production mode.

This is fine for `development` environments where you may be changing these files and want to see changes right away, but on non-dev environments we see log errors like [this](https://sentry.io/big-lottery-fund/biglotteryfund/issues/396043097/):

`Error: ENOENT: no such file or directory, mkdir './config/locales'`

(this also pollutes the raw nginx/Express logs)

This change means this behaviour will only be enabled in `development` environments. I can't see a time where we'd want to enable this outside of dev anyway.