### PR TITLE
Upgrade to Node 8, latest LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '8'
 cache:
   directories:
     - node_modules

--- a/bin/scripts/provision.sh
+++ b/bin/scripts/provision.sh
@@ -35,7 +35,7 @@ GzipEnabled="gzip_types"
 sed -i "s|$GzipDisabled|$GzipEnabled|g" /etc/nginx/nginx.conf
 
 # install node
-curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 apt-get install -y nodejs
 
 # install aws cli (to fetch secrets from parameterstore)

--- a/modules/boilerplate/globals.js
+++ b/modules/boilerplate/globals.js
@@ -27,6 +27,7 @@ const appEnv = process.env.NODE_ENV || 'development';
 
 // store some app-wide config data
 setGlobal('appData', {
+    nodeVersion: process.version,
     deployId: deploymentData && deploymentData.deployId ? deploymentData.deployId : 'DEV',
     buildNumber: deploymentData && deploymentData.buildNumber ? deploymentData.buildNumber : 'DEV',
     commitId: deploymentData && deploymentData.commitId ? deploymentData.commitId : 'DEV',

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -1,4 +1,4 @@
-<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) -->
+<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) (Node version: {{ appData.nodeVersion }}) -->
 
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
As Node 8 is now [officially in LTS](https://nodejs.org/en/) it's a good a time as any to upgrade. I've updated the travis and provision file, but not sure what the actual process it to get codedeploy to rebuild the instances. Guessing this doesn't happen during an in-place deploy?