### PR TITLE
Add temporary top-level Jobs link to main nav

### DIFF
--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -8,7 +8,8 @@
 			"funding": "Ariannu",
 			"about": "Amdanom ni",
 			"search": "Chwilio",
-			"research": "Ymchwil"
+			"research": "Ymchwil",
+			"jobs": "Swyddi"
 		},
 		"contact": {
 			"city": "Llundain",

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -8,7 +8,8 @@
 			"funding": "Funding",
 			"about": "About",
 			"search": "Search",
-			"research": "Research"
+			"research": "Research",
+			"jobs": "Jobs"
 		},
 		"contact": {
 			"city": "London",

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -21,7 +21,8 @@ const sectionPaths = {
     funding: '/funding',
     about: '/about-big', // @TODO rename on launch
     aboutLegacy: '/about-big', // used on the old site
-    research: '/research'
+    research: '/research',
+    jobs: '/jobs' // temporary addition
 };
 
 // these top-level sections appear in the main site nav
@@ -208,6 +209,11 @@ const routes = {
             name: 'Research',
             langTitlePath: 'global.nav.research',
             path: sectionPaths.research
+        },
+        jobs: {
+            name: 'Jobs',
+            langTitlePath: 'global.nav.jobs',
+            path: sectionPaths.jobs
         },
         // @TODO rename this to 'about' when ready to launch /about
         'about-big': {


### PR DESCRIPTION
This is a quick fix to add a link to the nav.

It doesn't mark the actual jobs page as currently-selected – this would entail moving the `job` page object into this new top-level "section" and I'm wary of accidentally breaking things by doing this for something that doesn't feel super important. 

Thoughts, @davidrapson ?