### PR TITLE
Programmes translations

### DIFF
--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -954,7 +954,14 @@
 			"under10k": "Funding programmes under 10k",
 			"over10k": "Funding programmes over 10k",
 			"breadcrumbAll": "All Programmes",
-			"breadcrumbLocation": "Funding programmes in %s"
+			"breadcrumbLocation": "Funding programmes in %s",
+			"details": {
+				"area": "Ardal",
+				"organisationTypes": "Math o fudiad",
+				"fundingSize": "Maint yr ariannu",
+				"totalAvailable": "Cyfanswm ar gael",
+				"applicationDeadline": "Terfyn amser ymgeisio"
+			}
 		}
 	}
 }

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -953,7 +953,14 @@
 			"under10k": "Funding programmes under 10k",
 			"over10k": "Funding programmes over 10k",
 			"breadcrumbAll": "All Programmes",
-			"breadcrumbLocation": "Funding programmes in %s"
+			"breadcrumbLocation": "Funding programmes in %s",
+			"details": {
+				"area": "Area",
+				"organisationTypes": "Organisation types",
+				"fundingSize": "Funding Size",
+				"totalAvailable": "Total Available",
+				"applicationDeadline": "Application deadline"
+			}
 		}
 	}
 }

--- a/modules/content.js
+++ b/modules/content.js
@@ -2,7 +2,8 @@
 const rp = require('request-promise');
 const getSecret = require('./get-secret');
 
-let CMS_URL = getSecret('cms.url') || process.env.cmsUrl;
+let CMS_URL = process.env.cmsUrl || getSecret('cms.url');
+
 if (!CMS_URL) {
     console.log('Error: CMS_URL endpoint must be defined');
     process.exit(1);

--- a/server.js
+++ b/server.js
@@ -5,6 +5,10 @@ const config = require('config');
 const Raven = require('raven');
 const getSecret = require('./modules/get-secret');
 
+if (app.get('env') === 'development') {
+    require('dotenv').config();
+}
+
 const SENTRY_DSN = getSecret('sentry.dsn');
 
 if (SENTRY_DSN) {

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -2,7 +2,7 @@
     £{{ minimum | numberWithCommas}}{% if maximum %} - £{{ maximum | numberWithCommas }}{% endif %}
 {% endmacro %}
 
-{% macro programmeCard(programme, accent) %}
+{% macro programmeCard(programme, accent, copy) %}
     {% set content = programme.content %}
     <article class="programme-card accent--{{ accent }} a--border-top a--border-color">
         <header class="programme-card__header">
@@ -24,28 +24,28 @@
             {% endif %}
             <dl class="programme-card__details">
                 {% if content.area %}
-                    <dt>Area</dt>
+                    <dt>{{ copy.area }}</dt>
                     <dd>{{ content.area.label }}</dd>
                 {% endif %}
                 {% if content.organisationTypes %}
-                    <dt>Organisation types</dt>
+                    <dt>{{ copy.organisationTypes }}</dt>
                     {% for orgType in content.organisationTypes %}
                         <dd>{{ orgType }}</dd>
                     {% endfor %}
                 {% endif %}
                 {% if content.fundingSize %}
-                    <dt>Funding size</dt>
+                    <dt>{{ copy.fundingSize }}</dt>
                     <dd>{{ fundingRange(
                         minimum = content.fundingSize.minimum,
                         maximum = content.fundingSize.maximum
                     ) }}</dd>
                 {% endif %}
                 {% if content.totalAvailable %}
-                    <dt>Total available</dt>
+                    <dt>{{ copy.totalAvailable }}</dt>
                     <dd>{{ content.totalAvailable }}</dd>
                 {% endif %}
                 {% if content.applicationDeadline %}
-                    <dt>Application deadline</dt>
+                    <dt>{{ copy.applicationDeadline }}</dt>
                     <dd>{{ content.applicationDeadline }}</dd>
                 {% endif %}
             </dl>
@@ -53,13 +53,14 @@
     </article>
 {% endmacro %}
 
-{% macro programmeList(programmes, accent) %}
+{% macro programmeList(programmes, accent, copy) %}
     <div class="programmes-list">
         {% for programme in programmes %}
             <div class="programmes-list__item">
                 {{ programmeCard(
                     programme = programme,
-                    accent = accent
+                    accent = accent,
+                    copy = copy
                 ) }}
             </div>
         {% endfor %}

--- a/views/pages/funding/programmes.njk
+++ b/views/pages/funding/programmes.njk
@@ -40,7 +40,11 @@
             {{ breadcrumbTrail(programmes, activeBreadcrumbs) }}
 
             {% if programmes | length > 0 %}
-                {{ programmeList(programmes = programmes, accent = 'pink') }}
+                {{ programmeList(
+                    programmes = programmes,
+                    accent = 'pink',
+                    copy = copy.details
+                ) }}
             {% else %}
                 <p>No results</p>
             {% endif %}


### PR DESCRIPTION
The other side of https://github.com/biglotteryfund/craft-dev/pull/5 🌐 

Add translations for details headings.

<img width="384" alt="screen shot 2017-11-02 at 13 10 14" src="https://user-images.githubusercontent.com/123386/32327757-96900722-bfcf-11e7-8202-e48a0ee38272.png">

In two minds as to whether this translation should come from the CMS, but this feels more like a display concern so having it in the app makes most sense for me. 💭 

Also makes a tweak to allow overriding environment variables through the `.env` file locally. Helps with switching out to use local CMS without changing any parameter files.