### PR TITLE
Programmes translation tweaks

### DIFF
--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -951,8 +951,8 @@
 		},
 		"programmes": {
 			"title": "Rhaglenni Ariannu",
-			"under10k": "Rhaglenni ariannu o dan 10k",
-			"over10k": "Rhaglenni ariannu dros 10k",
+			"under10k": "Rhaglenni ariannu o dan £10,000",
+			"over10k": "Rhaglenni ariannu dros £10,000",
 			"breadcrumbAll": "Pob Rhaglenni",
 			"breadcrumbLocation": "Rhaglenni ariannu yn %s",
 			"details": {

--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -950,11 +950,11 @@
 			}
 		},
 		"programmes": {
-			"title": "Funding Programmes",
-			"under10k": "Funding programmes under 10k",
-			"over10k": "Funding programmes over 10k",
-			"breadcrumbAll": "All Programmes",
-			"breadcrumbLocation": "Funding programmes in %s",
+			"title": "Rhaglenni Ariannu",
+			"under10k": "Rhaglenni ariannu o dan 10k",
+			"over10k": "Rhaglenni ariannu dros 10k",
+			"breadcrumbAll": "Pob Rhaglenni",
+			"breadcrumbLocation": "Rhaglenni ariannu yn %s",
 			"details": {
 				"area": "Ardal",
 				"organisationTypes": "Math o fudiad",

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -950,8 +950,8 @@
 		},
 		"programmes": {
 			"title": "Funding Programmes",
-			"under10k": "Funding programmes under 10k",
-			"over10k": "Funding programmes over 10k",
+			"under10k": "Funding programmes under £10,000",
+			"over10k": "Funding programmes over £10,000",
 			"breadcrumbAll": "All Programmes",
 			"breadcrumbLocation": "Funding programmes in %s",
 			"details": {

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -7,7 +7,9 @@
     <article class="programme-card accent--{{ accent }} a--border-top a--border-color">
         <header class="programme-card__header">
             <h3 class="programme-card__title t8">
-                <a class="u-link-minimal accent--{{ accent }} a--text" href="{{ programme.url }}">{{ programme.title }}</a>
+                <a class="u-link-minimal accent--{{ accent }} a--text" href="{{ programme.url }}">
+                    {{ content.title }}
+                </a>
             </h3>
             {% if content.photo %}
                 <div class="programme-card__media">

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -7,7 +7,7 @@
     <article class="programme-card accent--{{ accent }} a--border-top a--border-color">
         <header class="programme-card__header">
             <h3 class="programme-card__title t8">
-                <a class="u-link-minimal accent--{{ accent }} a--text" href="{{ programme.url }}">
+                <a class="u-link-minimal accent--{{ accent }} a--text" href="{{ content.linkUrl }}">
                     {{ content.title }}
                 </a>
             </h3>


### PR DESCRIPTION
Add UI translations. Most of this language was already used on the legacy site. Making the assumption that is accurate but will double check.

Also updates the programme card template to use the `programmeTitle` field rather than the top-level title.

<img width="757" alt="screen shot 2017-11-02 at 15 13 36" src="https://user-images.githubusercontent.com/123386/32333716-7ae411e2-bfe0-11e7-8f58-7a7cedb73e9f.png">
