### PR TITLE
Allow data sources for fonts to fix Sentry errors

### DIFF
--- a/modules/boilerplate/security.js
+++ b/modules/boilerplate/security.js
@@ -37,7 +37,8 @@ const helmetSettings = helmet({
             connectSrc: defaultSecurityDomains.concat(['ws://127.0.0.1:35729/livereload']), // make dev-only?,
             imgSrc: defaultSecurityDomains.concat(['data:', 'localhost', 'stats.g.doubleclick.net']),
             scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
-            reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c'
+            reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c',
+            fontSrc: defaultSecurityDomains.concat(['data:'])
         },
         browserSniff: false
     },


### PR DESCRIPTION
Should fix this: https://sentry.io/big-lottery-fund/biglotteryfund/issues/367637560/