### PR TITLE
Fix IE issue, move margin to child

### DIFF
--- a/assets/sass/components/programmes.scss
+++ b/assets/sass/components/programmes.scss
@@ -14,8 +14,11 @@
 
     @include mq(medium-minor) {
         flex: 0 0 50%;
-        padding-left: $spacingUnit / 2;
-        padding-right: $spacingUnit / 2;
+
+        > .programme-card {
+            margin-left: $spacingUnit / 2;
+            margin-right: $spacingUnit / 2;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes an IE issue where flexbox items were wrapping. Moves margin to child element.