### PR TITLE
Content API URL

### DIFF
--- a/modules/content.js
+++ b/modules/content.js
@@ -9,13 +9,21 @@ if (!API_URL) {
     process.exit(1);
 }
 
-const getFundingProgrammes = locale => {
+function getPromotedNews(locale) {
+    return rp({
+        url: `${CMS_URL}/api/v1/${locale}/promoted-news`,
+        json: true
+    });
+}
+
+function getFundingProgrammes(locale) {
     return rp({
         url: `${API_URL}/v1/${locale}/funding-programmes`,
         json: true
     });
-};
+}
 
 module.exports = {
+    getPromotedNews,
     getFundingProgrammes
 };

--- a/modules/content.js
+++ b/modules/content.js
@@ -2,16 +2,16 @@
 const rp = require('request-promise');
 const getSecret = require('./get-secret');
 
-let CMS_URL = process.env.cmsUrl || getSecret('cms.url');
+let API_URL = process.env.cmsUrl || getSecret('content-api.url');
 
-if (!CMS_URL) {
+if (!API_URL) {
     console.log('Error: CMS_URL endpoint must be defined');
     process.exit(1);
 }
 
 const getFundingProgrammes = locale => {
     return rp({
-        url: `${CMS_URL}/api/v1/${locale}/funding-programmes`,
+        url: `${API_URL}/v1/${locale}/funding-programmes`,
         json: true
     });
 };

--- a/modules/content.js
+++ b/modules/content.js
@@ -11,7 +11,7 @@ if (!API_URL) {
 
 function getPromotedNews(locale) {
     return rp({
-        url: `${CMS_URL}/api/v1/${locale}/promoted-news`,
+        url: `${API_URL}/v1/${locale}/promoted-news`,
         json: true
     });
 }

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -10,6 +10,22 @@
 
 {% block title %}{{ title }} | {{ copy.home }} | {% endblock %}
 
+{% macro articleTeaser(article) %}
+    <article class="article-teaser">
+        <h4 class="article-teaser__title t3">
+            <a class="u-link-minimal" href="{{ article.link }}">
+                {{ article.title }}
+            </a>
+        </h4>
+        <p class="article-teaser__summary">
+            {{ article.summary }}
+            <a href="{{ article.link }}" class="accent--pink a--text u-weight-heavy">
+                {{ __('global.misc.readMore') }}&hellip;
+            </a>
+        </p>
+    </article>
+{% endmacro %}
+
 {% block content %}
 
     {% set heroContent %}
@@ -89,27 +105,18 @@
 
             {# News Posts #}
             {% if news.length %}
-                <div class="accent--blue a--border-top">
+                <section class="accent--blue a--border-top">
                     <div class="padded padded--wide-only">
                         <h3 class="t8 t--underline a--text accent--blue">{{ copy.latestNews }}</h3>
                         <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
-                            {% for n in news %}
+                            {% for article in news %}
                                 <li class="grid__item">
-                                    <h4 class="t3">
-                                        <a class="u-link-minimal" href="{{ n['link' | localeify(locale)] }}">
-                                            {{ n['title' | localeify(locale)] | safe}}
-                                        </a>
-                                    </h4>
-                                    <p>
-                                        {{ n['text' | localeify(locale)] | safe }}
-                                        <a href="{{ n['link' | localeify(locale)] }}"
-                                            class="accent--pink a--text u-weight-heavy">{{ __('global.misc.readMore') }}&hellip;</a>
-                                    </p>
+                                    {{ articleTeaser(article) }}
                                 </li>
                             {% endfor %}
                         </ul>
                     </div>
-                </div>
+                </section>
             {% endif %}
 
         </div>


### PR DESCRIPTION
Use new content api URL defined in parameter store, points to a Cloudfront cached endpoint for API methods. Reinstates news feed on homepage.