### PR TITLE
Update funding programmes breadcrumb wording

### DIFF
--- a/assets/sass/globals/typography.scss
+++ b/assets/sass/globals/typography.scss
@@ -25,10 +25,7 @@ h2,
 .t2 {
     @include poppins();
     font-weight: 600;
-    @include font-and-leading(14px, 22px);
-    @include mq('tablet') {
-        @include font-and-leading(18px, 28px);
-    }
+    @include font-and-leading(18px, 28px);
 }
 
 // mid-page heading

--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -959,10 +959,9 @@
 		},
 		"programmes": {
 			"title": "Rhaglenni Ariannu",
-			"under10k": "Rhaglenni ariannu o dan £10,000",
-			"over10k": "Rhaglenni ariannu dros £10,000",
+			"under10k": "Grantiau dan £10,000",
+			"over10k": "Grantiau dros £10,000",
 			"breadcrumbAll": "Pob Rhaglenni",
-			"breadcrumbLocation": "Rhaglenni ariannu yn %s",
 			"details": {
 				"area": "Ardal",
 				"organisationTypes": "Math o fudiad",

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -958,10 +958,9 @@
 		},
 		"programmes": {
 			"title": "Funding Programmes",
-			"under10k": "Funding programmes under £10,000",
-			"over10k": "Funding programmes over £10,000",
+			"under10k": "Awards under £10,000",
+			"over10k": "Awards over £10,000",
 			"breadcrumbAll": "All Programmes",
-			"breadcrumbLocation": "Funding programmes in %s",
 			"details": {
 				"area": "Area",
 				"organisationTypes": "Organisation types",

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -66,6 +66,10 @@ module.exports = function(config) {
                         }
                     ];
                 } else {
+                    templateData.activeBreadcrumbs.push({
+                        label: req.i18n.__(config.lang + '.title')
+                    });
+
                     if (minAmountParam) {
                         templateData.activeBreadcrumbs.push({
                             label: req.i18n.__(config.lang + '.over10k'),
@@ -85,10 +89,7 @@ module.exports = function(config) {
                         };
 
                         templateData.activeBreadcrumbs.push({
-                            label: req.i18n.__(
-                                'funding.programmes.breadcrumbLocation',
-                                locationParamToTranslation(locationParam)
-                            )
+                            label: locationParamToTranslation(locationParam)
                         });
                     }
                 }


### PR DESCRIPTION
**Before**:

![screen shot 2017-11-06 at 17 01 28](https://user-images.githubusercontent.com/123386/32453634-ade5072c-c314-11e7-83a6-993e561e568f.png)

**After:**

![screen shot 2017-11-06 at 17 01 21](https://user-images.githubusercontent.com/123386/32453635-ae021650-c314-11e7-8939-e6c4e1ce5f6a.png)

Also normalises font-sizes for `.t2` to 18px on @ChloeAlper's request.