### PR TITLE
Add working Cloudfront /survey endpoint

### DIFF
--- a/bin/cloudfront/live.json
+++ b/bin/cloudfront/live.json
@@ -2890,7 +2890,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/survey",
+        "PathPattern": "/survey/*",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/bin/cloudfront/test.json
+++ b/bin/cloudfront/test.json
@@ -2890,7 +2890,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/survey",
+        "PathPattern": "/survey/*",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -393,7 +393,7 @@ const otherUrls = [
         live: true
     },
     {
-        path: '/survey',
+        path: '/survey/*',
         isPostable: true,
         allowQueryStrings: false,
         live: true


### PR DESCRIPTION
This was my foolish error. The microsurveys `POST` to `/survey/<id>` but I didn't reflect this in the routes config so nobody's surveys would submit on `PRODUCTION`. D'oh.