### PR TITLE
Add referrer to logs

### DIFF
--- a/modules/boilerplate/middleware.js
+++ b/modules/boilerplate/middleware.js
@@ -24,7 +24,8 @@ require('../../modules/boilerplate/auth');
 let sessionSecret = process.env.sessionSecret || getSecret('session.secret');
 
 app.use(favicon(path.join('public', '/favicon.ico')));
-let logFormat = '[:date[clf]] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms';
+let logFormat =
+    '[:date[clf]] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms ":referrer"';
 app.use(
     morgan(logFormat, {
         skip: req => {


### PR DESCRIPTION
Should make debugging logs a little easier (eg. to determine the origins of 404s).