### PR TITLE
Update routes to make funding programmes live

### DIFF
--- a/bin/cloudfront/live.json
+++ b/bin/cloudfront/live.json
@@ -2061,6 +2061,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/programmes",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-1-50"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": false
         },
         "MaxTTL": 31536000,
@@ -4863,6 +4922,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/social-media",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-1-50"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/programmes",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/bin/cloudfront/test.json
+++ b/bin/cloudfront/test.json
@@ -2061,6 +2061,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/programmes",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-1-50"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": false
         },
         "MaxTTL": 31536000,
@@ -4863,6 +4922,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/social-media",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-1-50"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/programmes",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -200,8 +200,9 @@ const routes = {
                     path: '/programmes',
                     template: 'pages/funding/programmes',
                     lang: 'funding.programmes',
+                    allowQueryStrings: true,
                     static: false,
-                    live: false
+                    live: true
                 }
             }
         },

--- a/views/pages/toplevel/over10k.njk
+++ b/views/pages/toplevel/over10k.njk
@@ -33,19 +33,19 @@
 
             <ul class="unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
                <li class="grid__item">
-                   <a href="{{ buildUrl('funding/programmes?min=10000&location=england') }}"
+                   <a href="{{ buildUrl('funding/funding-finder?area=England&over=10k') }}"
                       class="btn accent--turquoise a--btn btn--block btn--small">{{ copy.locations.england }}</a>
                </li>
                <li class="grid__item">
-                   <a href="{{ buildUrl('funding/programmes?min=10000&location=scotland') }}"
+                   <a href="{{ buildUrl('funding/funding-finder?area=Scotland&over=10k') }}"
                       class="btn accent--turquoise a--btn btn--block btn--small">{{ copy.locations.scotland }}</a>
                </li>
                <li class="grid__item">
-                   <a href="{{ buildUrl('funding/programmes?min=10000&location=wales') }}"
+                   <a href="{{ buildUrl('funding/funding-finder?area=Wales&over=10k') }}"
                       class="btn accent--turquoise a--btn btn--block btn--small">{{ copy.locations.wales }}</a>
                </li>
                <li class="grid__item">
-                   <a href="{{ buildUrl('funding/programmes?min=10000&location=northernIreland') }}"
+                   <a href="{{ buildUrl('funding/funding-finder?area=Northern+Ireland&over=10k') }}"
                       class="btn accent--turquoise a--btn btn--block btn--small">{{ copy.locations.northernIreland }}</a>
                </li>
             </ul>


### PR DESCRIPTION
- Update routes to make funding programmes live
- Revert over10k URL change so we can make the funding pages live **before** we link to the new pages.