### PR TITLE
Workaround iOS bug with surveys and normalise styling 🐛 🐛🐛

### DIFF
--- a/assets/js/modules/surveys.js
+++ b/assets/js/modules/surveys.js
@@ -71,12 +71,11 @@ const showSurvey = survey => {
             }
         },
         methods: {
+            localeify: function(obj, field, locale) {
+                return obj[field + '_' + locale];
+            },
             toggleSurvey: function() {
                 this.isActivated = !this.isActivated;
-
-                if (hasiOSBug()) {
-                    $('body').toggleClass('is-ios-editing-survey');
-                }
             },
             blockSurvey: function() {
                 logSurveyTaken(this.survey.id);
@@ -89,11 +88,18 @@ const showSurvey = survey => {
                     this.formData.choice = choice.id;
                 }
             },
+            messageOnFocus: function() {
+                if (hasiOSBug()) {
+                    $('body').addClass('is-ios-editing-survey');
+                }
+            },
+            messageOnBlur: function() {
+                if (hasiOSBug()) {
+                    $('body').removeClass('is-ios-editing-survey');
+                }
+            },
             updateChoice: function(choice) {
                 this.formData.choice = choice.id;
-            },
-            localeify: function(obj, field, locale) {
-                return obj[field + '_' + locale];
             },
             submitSurvey: function(e) {
                 let self = this;

--- a/assets/js/modules/surveys.js
+++ b/assets/js/modules/surveys.js
@@ -37,6 +37,19 @@ let hasTakenSurvey = surveyId => {
     }
 };
 
+/**
+ * iOS 11 has a bug where if an input is inside a position fixed element the
+ * cursor will disapear of the screen when entering text. Why???
+ * https://stackoverflow.com/questions/46339063/ios-11-safari-bootstrap-modal-text-area-outside-of-cursor/46954486#46954486
+ * https://bugs.webkit.org/show_bug.cgi?id=176896
+ */
+function hasiOSBug() {
+    return (
+        /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+        /OS 11_0_1|OS 11_0_2|OS 11_0_3|OS 11_1/.test(navigator.userAgent)
+    );
+}
+
 const showSurvey = survey => {
     const mountEl = document.getElementById('js-survey-container');
 
@@ -60,6 +73,10 @@ const showSurvey = survey => {
         methods: {
             toggleSurvey: function() {
                 this.isActivated = !this.isActivated;
+
+                if (hasiOSBug()) {
+                    $('body').toggleClass('is-ios-editing-survey');
+                }
             },
             blockSurvey: function() {
                 logSurveyTaken(this.survey.id);

--- a/assets/sass/components/survey.scss
+++ b/assets/sass/components/survey.scss
@@ -1,12 +1,33 @@
+// /* =========================================================================
+//    Micro-Surveys
+//    ========================================================================= */
+
+/**
+ * iOS 11 has a bug where if an input is inside a position fixed element the
+ * cursor will disapear of the screen when entering text. Why???
+ * https://stackoverflow.com/questions/46339063/ios-11-safari-bootstrap-modal-text-area-outside-of-cursor/46954486#46954486
+ * https://bugs.webkit.org/show_bug.cgi?id=176896
+ */
+body.is-ios-editing-survey {
+    position: fixed;
+    width: 100%;
+}
+
 .survey {
+    color: #ffffff;
+    background-color: #4a4a4a;
+
+    width: 100%;
     position: fixed;
     bottom: 0;
     right: 0;
     z-index: 100;
-    background-color: #4a4a4a;
-    color: #ffffff;
-    padding: $spacingUnit / 2 $spacingUnit;
-    width: 100%;
+    padding: $spacingUnit / 2;
+
+    @include mq(small) {
+        padding-left: $spacingUnit;
+        padding-right: $spacingUnit;
+    }
 
     @include mq('tablet') {
         width: 60%;
@@ -16,12 +37,6 @@
         margin-bottom: 0;
         text-decoration: underline;
         cursor: pointer;
-    }
-
-    &.is-active {
-        .survey__arrow svg {
-            transform: rotate(0deg);
-        }
     }
 
     .survey__arrow {
@@ -36,6 +51,11 @@
             transform: rotate(180deg);
             height: 100%;
             width: 100%;
+        }
+    }
+    &.is-active {
+        .survey__arrow svg {
+            transform: rotate(0deg);
         }
     }
 
@@ -82,19 +102,26 @@
     }
 
     .survey__form-items {
-        margin-top: 10px;
+        margin-top: $spacingUnit / 2;
     }
 
     .survey__extra {
+        display: flex;
         align-items: flex-end;
-        .grid__item {
-            margin-bottom: 0;
-        }
+    }
+    .survey__extra-message,
+    .survey__extra-submit {
+        flex: 1 1 auto;
+        margin-bottom: 0;
+    }
 
-        .survey__submit {
-            flex-grow: 0;
-            margin-bottom: 10px; // fixes weird alignment issue
-        }
+    .survey__extra-message {
+        padding-right: $spacingUnit / 2;
+    }
+
+    .survey__extra-submit {
+        flex-grow: 0;
+        margin-bottom: ($spacingUnit / 2); // fixes weird alignment issue
     }
 
     .survey__label {
@@ -105,9 +132,12 @@
     }
 
     .survey__textbox {
-        width: 100%;
-        font-size: 15px;
         padding: 5px;
+        width: 100%;
+        /* 16px minimum to avoid scaling on iOS */
+        font-size: 16px;
+        height: 100%;
+        border-radius: 0;
     }
 
     .survey__response {

--- a/views/components/surveys.njk
+++ b/views/components/surveys.njk
@@ -52,7 +52,10 @@
                             class="survey__textbox"
                             id="survey-extra-msg"
                             placeholder="{{ __('global.surveys.genericPrompt') }}"
-                            v-model="formData.message">
+                            v-model="formData.message"
+                            v-on:focus="messageOnFocus"
+                            v-on:blur="messageOnBlur"
+                        >
                         </textarea>
                     </div>
                     {# submit the survey as a "no" #}

--- a/views/components/surveys.njk
+++ b/views/components/surveys.njk
@@ -1,66 +1,72 @@
 {% import "./forms.njk" as forms %}
 
 {% macro showSurvey() %}
-    <form id="js-survey-container"
-          class="survey"
-          v-bind:class="{ 'is-active': isActivated }"
-          method="post"
-          :action="'/survey/' + survey.id"
-          v-on:submit.prevent="submitSurvey"
-          v-if="!surveyBlocked"
-          v-cloak>
-        <h6 class="survey__header"
-            v-on:click="toggleSurvey()">
-            <% localeify(survey, 'question', '{{ locale }}') %><span class="survey__arrow js-survey-arrow">{% include "../includes/svg/arrow-down.svg" %}</span>
-        </h6>
+    <div class="survey"
+        v-bind:class="{ 'is-active': isActivated }"
+        id="js-survey-container"
+        v-if="!surveyBlocked"
+        v-cloak>
+        <form
+            class="survey__form"
+            method="post"
+            :action="'/survey/' + survey.id"
+            v-on:submit.prevent="submitSurvey"
+        >
+            <h6 class="survey__header"
+                v-on:click="toggleSurvey()">
+                <% localeify(survey, 'question', '{{ locale }}') %><span class="survey__arrow js-survey-arrow">{% include "../includes/svg/arrow-down.svg" %}</span>
+            </h6>
 
-        <span class="survey__close-icon"
-              v-on:click="blockSurvey()">
-            {% include "../includes/svg/close.svg" %}
-        </span>
+            <span class="survey__close-icon"
+                v-on:click="blockSurvey()">
+                {% include "../includes/svg/close.svg" %}
+            </span>
 
-        <p class="survey__response"
-               v-if="isComplete">
-            <span v-if="isComplete == 'success'">{{ __('global.surveys.response.success') }}</span>
-            <span v-if="isComplete == 'error'">{{ __('global.surveys.response.error') }}</span>
-        </p>
+            <p class="survey__response"
+                v-if="isComplete">
+                <span v-if="isComplete == 'success'">{{ __('global.surveys.response.success') }}</span>
+                <span v-if="isComplete == 'error'">{{ __('global.surveys.response.error') }}</span>
+            </p>
 
-        <fieldset v-if="isActivated && !isComplete"
-                  class="survey__form-items">
-            <button v-for="choice in survey.choices"
+            <fieldset class="survey__form-items" v-if="isActivated && !isComplete">
+                <button
+                    v-for="choice in survey.choices"
                     class="btn btn--small survey__btn survey__btn--choice"
                     :type="(choice.allow_message) ? 'button' : 'submit'"
                     v-on:click="toggleMessage(choice)"
-                    v-if="!showMessageBox">
-                <% localeify(choice, 'title', '{{ locale }}') %>
-            </button>
+                    v-if="!showMessageBox"
+                >
+                    <% localeify(choice, 'title', '{{ locale }}') %>
+                </button>
 
-            <div v-for="choice in survey.choices"
-                 v-if="choice.allow_message && showMessageBox">
-                <div class="grid grid--padded survey__extra">
-                    {# prompt for more info #}
-                    <div class="grid__item">
+                <div class="survey__extra"
+                    v-for="choice in survey.choices"
+                    v-if="choice.allow_message && showMessageBox"
+                >
+                    <div class="survey__extra-message">
                         <label for="survey-extra-msg"
-                               class="survey__label">
+                            class="survey__label">
                             {{ __('global.surveys.genericQuestion') }}
                         </label>
-                        <textarea placeholder="{{ __('global.surveys.genericPrompt') }}"
-                                  class="survey__textbox"
-                                  id="survey-extra-msg"
-                                  v-model="formData.message">
+                        <textarea
+                            class="survey__textbox"
+                            id="survey-extra-msg"
+                            placeholder="{{ __('global.surveys.genericPrompt') }}"
+                            v-model="formData.message">
                         </textarea>
                     </div>
                     {# submit the survey as a "no" #}
-                    <div class="grid__item survey__submit">
+                    <div class="survey__extra-submit">
                         <button type="submit"
-                                class="btn btn--small survey__btn"
-                                v-on:click="updateChoice(choice)">
+                            class="btn btn--small survey__btn"
+                            v-on:click="updateChoice(choice)"
+                        >
                             {{ __('global.forms.submit') }}
                         </button>
                     </div>
                 </div>
-            </div>
 
-        </fieldset>
-    </form>
+            </fieldset>
+        </form>
+    </div>
 {% endmacro %}


### PR DESCRIPTION
Fixes iOS font-size scaling (inputs need to be a minimum of 16px otherwise iOS will scale up the viewport to help with entering text, this is an accessibility thing)

Attempts to workaround another exciting bug in iOS 11 where if an text field is in a position fixed container the input cursor will appear offscreen. The fix is…messy…so thoughts welcome.

Normalises markup and styles to be more self contained, removes fragments of `.grid` classes being dotted around.


