### PR TITLE
Rename type classes

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -2,14 +2,6 @@
    Mixins
    ========================================================================= */
 
-// Standard body text
-@mixin t5() {
-    @include roboto();
-    @include font-and-leading(20px, 27px);
-    font-weight: 400;
-    color: palette('charcoal');
-}
-
 @mixin mq($width, $type: min) {
     @if map_has_key($breakpoints, $width) {
         $width: unquote(map_get($breakpoints, $width));

--- a/assets/sass/components/data.scss
+++ b/assets/sass/components/data.scss
@@ -148,7 +148,7 @@
             width: 160px;
             position: absolute;
             z-index: 10;
-            right: -$spacingUnit;
+            right: 0;
             top: 20px;
             display: none;
 
@@ -160,6 +160,9 @@
         @include mq('desktop') {
             width: 250px;
             top: $spacingUnit * 4;
+        }
+
+        @media only screen and (min-width: $widestScreen) {
             right: -$spacingUnit * 4;
         }
     }

--- a/assets/sass/globals/base.scss
+++ b/assets/sass/globals/base.scss
@@ -44,7 +44,10 @@ input,
 textarea,
 button,
 blockquote {
-    @include t5();
+    @include roboto();
+    @include font-and-leading(20px, 27px);
+    font-weight: 400;
+    color: palette('charcoal');
 }
 
 h1,

--- a/assets/sass/globals/typography.scss
+++ b/assets/sass/globals/typography.scss
@@ -2,65 +2,47 @@
    Typographic Scale
    ========================================================================== */
 
-// very important headings, short word length.
-// often paired with overlay-text
 h1,
 .t1 {
     @include poppins();
+    @include font-and-leading(22px, 28px);
     font-weight: 600;
-    @include font-and-leading(18px, 26px);
-
-    @include mq('xsmall') {
-        @include font-and-leading(20px, 30px);
-    }
-
-    @include mq('tablet') {
-        @include font-and-leading(28px, 44px);
-    }
 }
 
-// smaller variant of the above, for longer sentences
-// often paired with overlay-text
 h2,
 .t2 {
     @include poppins();
     font-weight: 600;
-    @include font-and-leading(18px, 28px);
+    font-size: 20px;
 }
 
-// mid-page heading
 h3,
 .t3 {
-    @include poppins();
-    font-weight: 600;
-    @include font-and-leading(16px, 22px);
-    @include mq('tablet') {
-        @include font-and-leading(20px, 28px);
-    }
+    @include roboto();
+    @include font-and-leading(20px, 27px);
+    font-weight: 400;
 }
-
-// minor headings
 h4,
 .t4 {
     @include poppins();
+    @include font-and-leading(18px, 27px);
+    font-weight: 600;
+}
+
+h5,
+.t5 {
+    @include poppins();
     font-weight: 600;
     @include font-and-leading(16px, 22px);
 }
 
-// standard body text
-.t5 {
-    @include t5();
-}
-
-// yep, the numerical discrepancy is deliberate here
-h5,
-.t6 {
-    @include roboto();
-    font-weight: 400;
-    @include font-and-leading(13px, 20px);
-}
-
 h6,
+.t6 {
+    @include poppins();
+    font-weight: 600;
+    @include font-and-leading(14px, 22px);
+}
+
 .t7 {
     @include roboto();
     font-weight: 400;
@@ -68,15 +50,9 @@ h6,
 }
 
 .t8 {
-    @include font-and-leading(18px, 20px);
-
-    @include mq(small) {
-        @include font-and-leading(20px, 28px);
-    }
-
-    @include mq(large) {
-        @include font-and-leading(22px, 28px);
-    }
+    @include roboto();
+    font-weight: 400;
+    @include font-and-leading(13px, 20px);
 }
 
 /**

--- a/views/components/blocks.njk
+++ b/views/components/blocks.njk
@@ -10,7 +10,7 @@
             {% if project.link %}</a>{% endif %}
         </div>
         <div class="project-card__body">
-            <h4 class="project-card__header t4">{{ project.name }}</h4>
+            <h4 class="project-card__header t5">{{ project.name }}</h4>
 
             {% if project.amount %}
             <p class="project-card__subheader t7 accent--blue a--text">

--- a/views/components/caseStudy.njk
+++ b/views/components/caseStudy.njk
@@ -15,13 +15,13 @@
                         <p>{{ quoteText }}</p>
                     </div>
                     <div class="pullquote__meta">
-                        <cite class="pullquote__citation t3 t--tracking">{{ quoteName }}</cite>
+                        <cite class="pullquote__citation t2 t--tracking">{{ quoteName }}</cite>
                         <div class="pullquote__aside">
                             {% if quoteNameCaption %}
-                                <p class="t6 u-weight-normal">{{ quoteNameCaption }}</p>
+                                <p class="t8 u-weight-normal">{{ quoteNameCaption }}</p>
                             {% endif %}
                             {% if link %}<a href="{{ buildUrl(link) }}">{% endif %}
-                                <p class="t6 u-weight-normal">{{ projectName | safe }}</p>
+                                <p class="t8 u-weight-normal">{{ projectName | safe }}</p>
                             {% if link %}</a>{% endif %}
                         </div>
                     </div>

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -44,7 +44,7 @@
                     {{ headers.overlayText(
                         tag = 'h1',
                         text = titleText,
-                        additionalClasses = 'section-hero__title overlay-text--deep t2 accent--' + accent)
+                        additionalClasses = 'section-hero__title overlay-text--deep t4 accent--' + accent)
                     }}
                 </div>
             </div>
@@ -96,7 +96,7 @@
                 {{ headers.overlayText(
                     tag = 'h3',
                     text = titleText,
-                    additionalClasses = 't2 svgs-white overlay-text--wide is-opaque',
+                    additionalClasses = 't4 svgs-white overlay-text--wide is-opaque',
                     link = linkUrl,
                     showArrow = true
                 )}}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -6,7 +6,7 @@
     {% set content = programme.content %}
     <article class="programme-card accent--{{ accent }} a--border-top a--border-color">
         <header class="programme-card__header">
-            <h3 class="programme-card__title t8">
+            <h3 class="programme-card__title t1">
                 <a class="u-link-minimal accent--{{ accent }} a--text" href="{{ content.linkUrl }}">
                     {{ content.title }}
                 </a>

--- a/views/error.njk
+++ b/views/error.njk
@@ -15,11 +15,11 @@
 
     <article role="main" class="nudge-up">
         <div class="inner--wide-only accent--pink a--border-top content-box">
-            <h3 class="t3">Error {{ status }} &ndash; {{ message }}</h3>
+            <h3 class="t2">Error {{ status }} &ndash; {{ message }}</h3>
             <p>We're sorry, we are unable to show you this page at the moment. You can <a href="/">return to our homepage</a>, or visit us on <a href="https://www.facebook.com/BigLotteryFund">Facebook</a> or <a href="https://twitter.com/BigLotteryFund">Twitter</a>.</p>
             <p>If you keep encountering problems accessing our pages, please <a href="mailto:webmaster@biglotteryfund.org.uk">let us know</a>.</p>
 
-            <h3 class="t3">Gwall {{ status }} &ndash; {{ message }}</h3>
+            <h3 class="t2">Gwall {{ status }} &ndash; {{ message }}</h3>
             <p>Yn anffodus ni allwn ddangos y dudalen hon ar hyn o bryd. Gallwch ddychwelyd i’r hafan neu ymweld â ni ar <a href="http://facebook.com/biglotteryfundwales">Facebook</a> neu <a href="http://twitter.com/loterifawrcymru">Twitter</a>. Os byddwch yn profi anhawster o hyd wrth gyrchu ein tudalennau, <a href="mailto:webmaster@biglotteryfund.org.uk">rhowch wybod i ni</a>.</p>
 
             {% if sentry %}

--- a/views/includes/footer.njk
+++ b/views/includes/footer.njk
@@ -10,7 +10,7 @@
                 </ul>
             </li>
             <li class="grid__item">
-                <h4 class="footer__header t2 u-desktop-only u-uppercase">{{ __("global.footerLinks.title") | safe }}</h4>
+                <h4 class="footer__header t6 u-desktop-only u-uppercase">{{ __("global.footerLinks.title") | safe }}</h4>
                 <div class="grid grid--wide-only grid--top list-spaced">
                     <ul class="grid__item">
                         <li><a href="{{ buildUrl('about-big/customer-service/freedom-of-information') }}">{{ __("global.footerLinks.foi") | safe }}</a></li>

--- a/views/pages/about/data-protection.njk
+++ b/views/pages/about/data-protection.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('dataProtection', heroContent, 'blue') }}

--- a/views/pages/about/freedom-of-information.njk
+++ b/views/pages/about/freedom-of-information.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('foi', heroContent, 'turquoise') }}
@@ -22,21 +22,21 @@
 
         {% if copy.sections.howToRequest.body %}
             <div class="inner--wide-only accent--pink a--border-top content-box">
-                <h3 class="t3">{{ copy.sections.howToRequest.title }}</h3>
+                <h3 class="t2">{{ copy.sections.howToRequest.title }}</h3>
                 {{ copy.sections.howToRequest.body | safe }}
             </div>
         {% endif %}
 
         {% if copy.sections.forCustomers.body %}
             <div class="inner--wide-only accent--blue a--border-top content-box">
-                <h3 class="t3">{{ copy.sections.forCustomers.title }}</h3>
+                <h3 class="t2">{{ copy.sections.forCustomers.title }}</h3>
                 {{ copy.sections.forCustomers.body | safe }}
             </div>
         {% endif %}
 
         {% if copy.sections.publicationScheme.body %}
             <div class="inner--wide-only accent--orange a--border-top content-box">
-                <h3 class="t3">{{ copy.sections.publicationScheme.title }}</h3>
+                <h3 class="t2">{{ copy.sections.publicationScheme.title }}</h3>
                 {{ copy.sections.publicationScheme.body | safe }}
             </div>
         {% endif %}

--- a/views/pages/experimental/apply/example-startpage.njk
+++ b/views/pages/experimental/apply/example-startpage.njk
@@ -3,7 +3,7 @@
 {% block content %}
     <div class="content-box inner inner--wide-only accent--pink a--border-top">
         <h1>Example Application Form</h1>
-        <h2 class="t2 t--underline accent--pink">Eligibility</h2>
+        <h2 class="t6 t--underline accent--pink">Eligibility</h2>
         <p>If you are a voluntary or community group such as a charity, co-operative, social enterprise or community interest company, a not for profit company limited by guarantee or a statutory organisation such as a local authority or school then you can apply for this funding. When setting up your management committee please make sure it has at least three unrelated members.</p>
         <p>Partnerships are also welcome to apply as long as they are led by a voluntary, community or social enterprise (VCSE) organisation. However, we are unable to fund individuals or sole traders, profit making groups or those not established in the UK.</p>
         <a class="btn" href="{{ startUrl }}">Apply Now</a>

--- a/views/pages/experimental/apply/form.njk
+++ b/views/pages/experimental/apply/form.njk
@@ -63,7 +63,7 @@
             {% if prevStepUrl %}
                 <a href="{{ prevStepUrl }}">← Back</a>
             {% endif %}
-            <h1 class="form-header__title t1">{{ form.title }}</h1>
+            <h1 class="form-header__title t2">{{ form.title }}</h1>
             <h2 class="form-header__subtitle">
                 Step {{ currentStepNumber }} of {{ totalSteps }}: {{ step.name }}
             </h2>
@@ -80,7 +80,7 @@
 
         {% for fieldset in step.fieldsets %}
             <fieldset class="form-fieldset u-constrained-content">
-                <legend class="form-fieldset__legend t2 t--underline accent--pink">{{ fieldset.legend }}</legend>
+                <legend class="form-fieldset__legend t6 t--underline accent--pink">{{ fieldset.legend }}</legend>
                 <div class="form-fieldset__fields">
                     {% for field in fieldset.fields %}
                         {% set fieldErrors = errorsForField(field) %}

--- a/views/pages/experimental/apply/review.njk
+++ b/views/pages/experimental/apply/review.njk
@@ -5,7 +5,7 @@
         <div class="u-constrained-content">
             <h1>Check Your Answers Before Sending Your Application</h1>
             {% for step in summary %}
-                <h2 class="t3 t--underline">
+                <h2 class="t2 t--underline">
                     {{ step.name }}
                     [<a href="{{ baseUrl }}/{{ loop.index }}">Edit</a>]
                 </h2>

--- a/views/pages/funding/guidance/getting-press-coverage.njk
+++ b/views/pages/funding/guidance/getting-press-coverage.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('press', heroContent, 'turquoise') }}

--- a/views/pages/funding/guidance/help-with-publicity.njk
+++ b/views/pages/funding/guidance/help-with-publicity.njk
@@ -8,7 +8,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 'accent--turquoise t1') }}
+        {{ headers.overlayText('h2', title, 'accent--turquoise t2') }}
     {% endset %}
 
     {{ hero.header('social', heroContent, 'blue') }}
@@ -17,9 +17,9 @@
         <div class="inner--wide-only accent--turquoise a--border-top content-box">
             {{ copy.body.part1 | safe }}
 
-            <h3 class="t3">{{ copy.body.actions[1] | safe }}</h3>
-            <h3 class="t3">{{ copy.body.actions[2] | safe }}</h3>
-            <h3 class="t3">{{ copy.body.actions[3] | safe }}</h3>
+            <h3 class="t2">{{ copy.body.actions[1] | safe }}</h3>
+            <h3 class="t2">{{ copy.body.actions[2] | safe }}</h3>
+            <h3 class="t2">{{ copy.body.actions[3] | safe }}</h3>
 
             {{ copy.body.part2 | safe }}
 

--- a/views/pages/funding/guidance/logos.njk
+++ b/views/pages/funding/guidance/logos.njk
@@ -13,16 +13,16 @@
         {% set logoExamplePath = 'logos/examples-cy.png' %}
     {% endif %}
 
-    <h3 class="t4">{{ copy.howToUseLogo.sections.freeKit.title | safe }}</h3>
+    <h3 class="t5">{{ copy.howToUseLogo.sections.freeKit.title | safe }}</h3>
     <p>{{ copy.howToUseLogo.sections.freeKit.body | safe}}</p>
 
-    <h3 class="t4">{{ copy.howToUseLogo.sections.brandGuidance.title | safe }}</h3>
+    <h3 class="t5">{{ copy.howToUseLogo.sections.brandGuidance.title | safe }}</h3>
     <p>{{ copy.howToUseLogo.sections.brandGuidance.body | safe }}</p>
 
-    <h3 class="t4">{{ copy.howToUseLogo.sections.format.title | safe }}</h3>
+    <h3 class="t5">{{ copy.howToUseLogo.sections.format.title | safe }}</h3>
     <p>{{ copy.howToUseLogo.sections.format.body | safe }}</p>
 
-    <h3 class="t4">{{ copy.howToUseLogo.sections.options.title | safe }}</h3>
+    <h3 class="t5">{{ copy.howToUseLogo.sections.options.title | safe }}</h3>
     <p>{{ copy.howToUseLogo.sections.options.body | safe }}</p>
 
     <div class="central-gap">
@@ -51,8 +51,8 @@
     {% if copy.successMessages[type] %}
         <div class="u-hidden js-success js-success--{{ type }}">
             <h3>{{ copy.successMessages.success }}</h3>
-            <h4 class="t4">{{ copy.successMessages[type].title }}</h4>
-            <h4 class="t6">{{ copy.successMessages[type].body }}</h4>
+            <h4 class="t5">{{ copy.successMessages[type].title }}</h4>
+            <h4 class="t8">{{ copy.successMessages[type].body }}</h4>
         </div>
     {% endif %}
 {% endmacro %}
@@ -213,7 +213,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', copy.heroText, 't1') }}
+        {{ headers.overlayText('h2', copy.heroText, 't2') }}
     {% endset %}
 
     {{ hero.header('logo', heroContent, 'blue') }}
@@ -222,7 +222,7 @@
 
         <div class="inner--wide-only accent--blue a--border-top content-box">
 
-            <h3 class="t3">{{ copy.subtitle }}</h3>
+            <h3 class="t2">{{ copy.subtitle }}</h3>
             <p>{{ copy.body | safe }}</p>
             <p><strong>{{ copy.locationPrompt }}</strong></p>
 

--- a/views/pages/funding/guidance/managing-your-funding.njk
+++ b/views/pages/funding/guidance/managing-your-funding.njk
@@ -8,14 +8,14 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', copy.title, 't1') }}
+        {{ headers.overlayText('h2', copy.title, 't2') }}
     {% endset %}
 
     {{ hero.header('managing-grants', heroContent, 'blue') }}
 
     <article role="main" class="nudge-up">
         <div class="inner--wide-only accent--blue a--border-top content-box">
-            <h3 class="t3">{{ copy.body.header1 }}</h3>
+            <h3 class="t2">{{ copy.body.header1 }}</h3>
             {{ copy.body.block1 | safe }}
         </div>
 
@@ -61,7 +61,7 @@
         </div>
 
         <div class="inner--wide-only accent--turquoise a--border-top content-box">
-            <h3 class="t3">{{ copy.body.header2 }}</h3>
+            <h3 class="t2">{{ copy.body.header2 }}</h3>
             {{ copy.body.block2 | safe }}
         </div>
     </article>

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -17,8 +17,8 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="material-item__controls">
             <label class="material-item__label">
-                <strong class="t4">{% if product.name[locale] %}{{ product.name[locale] }}{% else %}{{ item.name[locale] }}{% endif %}</strong>
-                {% if item.description %} <span class="t6">({{ item.description[locale] or item.description }}){% endif %}</span>
+                <strong class="t5">{% if product.name[locale] %}{{ product.name[locale] }}{% else %}{{ item.name[locale] }}{% endif %}</strong>
+                {% if item.description %} <span class="t8">({{ item.description[locale] or item.description }}){% endif %}</span>
             </label>
             <div class="material-item__buttons">
                 {% if not item.outOfStock %}
@@ -76,7 +76,7 @@
             <li class="grid__item">
                 <div class="grid__item__inner accent--blue a--border-top--large material-item card card--padded card--title">
 
-                    <h6 class="t4 card__title">{{ item.name[locale] }}</h6>
+                    <h6 class="t5 card__title">{{ item.name[locale] }}</h6>
 
                     <div class="card__media">
                         {% set imgPath = 'materials/' + imageLocale + '/' + item.image %}
@@ -100,19 +100,19 @@
 
 {% block overlay %}
     {% if orderStatus == 'success' %}
-        <h2 class="t3 accent--pink a--text">{{ copy.orderSubmitted.success.title }}</h2>
-        <h3 class="t3 accent--blue a--text">{{ copy.orderSubmitted.success.subtitle }}</h3>
+        <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.success.title }}</h2>
+        <h3 class="t2 accent--blue a--text">{{ copy.orderSubmitted.success.subtitle }}</h3>
         <p>{{ copy.orderSubmitted.success.body | safe }}</p>
     {% elseif orderStatus == 'fail' %}
-        <h2 class="t3 accent--pink a--text">{{ copy.orderSubmitted.failure.title }}</h2>
-        <h3 class="t3 accent--pink a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
+        <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.title }}</h2>
+        <h3 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
     {% endif %}
 {% endblock %}
 
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('logo', heroContent, 'blue') }}
@@ -149,13 +149,13 @@
 
                 {# monolingual items #}
                 <div v-if="itemLanguage === 'monolingual'" id="monolingual">
-                    <h3 class="t3">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.monolingual }})</noscript></h3>
+                    <h3 class="t2">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.monolingual }})</noscript></h3>
                     {{ listProducts('monolingual') }}
                 </div>
 
                 {# bilingual items #}
                 <div v-if="itemLanguage === 'bilingual'" id="bilingual">
-                    <h3 class="t3">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.bilingual }})</noscript></h3>
+                    <h3 class="t2">{{ copy.chooseItems }} <noscript>({{ copy.languageOptions.bilingual }})</noscript></h3>
                     {{ listProducts('bilingual') }}
                 </div>
 
@@ -163,7 +163,7 @@
 
             <div class="inner accent--blue a--border-top p" id="your-details">
                 <div class="padded">
-                    <h3 class="t3">{{ copy.enterDeliveryAddress }}</h3>
+                    <h3 class="t2">{{ copy.enterDeliveryAddress }}</h3>
 
                     <form class="inline-form order-form" method="post">
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/views/pages/grants.njk
+++ b/views/pages/grants.njk
@@ -16,7 +16,7 @@
 
     <article role="main" class="accent--pink">
         <div class="inner a--border-top content-box">
-            <h3 class="t3">We awarded {{ grants.length }} grants near you:</h3>
+            <h3 class="t2">We awarded {{ grants.length }} grants near you:</h3>
 
             <ul class="grant-list">
                 {% for g in grants %}

--- a/views/pages/toplevel/about.njk
+++ b/views/pages/toplevel/about.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('about', heroContent, 'blue', 'Castlehaven Community Centre, Grant: £14,000') }}
@@ -58,7 +58,7 @@
                 <div class="grid__item column--second">
                     <div class="spaced--x-l column__item">
                         <aside class="accent--green d-expanded--l">
-                            {{ headers.overlayText('h4', 'In 2016/17 we awarded over £700 million, including 10,000 grants under £10,000', 't1 overlay-text--wide') }}
+                            {{ headers.overlayText('h4', 'In 2016/17 we awarded over £700 million, including 10,000 grants under £10,000', 't2 overlay-text--wide') }}
                         </aside>
                     </div>
 
@@ -69,7 +69,7 @@
 
                     <div class="spaced--x-l column__item">
                         <aside class="accent--green">
-                            {{ headers.overlayText('h4', 'We reached nearly 10 million people with our funding last year', 't1 overlay-text--wide') }}
+                            {{ headers.overlayText('h4', 'We reached nearly 10 million people with our funding last year', 't2 overlay-text--wide') }}
                         </aside>
                     </div>
 

--- a/views/pages/toplevel/benefits.njk
+++ b/views/pages/toplevel/benefits.njk
@@ -35,7 +35,7 @@
             </div>
 
             {% for benefit in copy.benefits %}
-                <h3 class="t3">{{ benefit.title }}</h3>
+                <h3 class="t2">{{ benefit.title }}</h3>
                 {{ benefit.text | safe }}
             {% endfor %}
 

--- a/views/pages/toplevel/contact.njk
+++ b/views/pages/toplevel/contact.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't1') }}
+        {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
     {{ hero.header('contact', heroContent, 'turquoise') }}
@@ -19,7 +19,7 @@
         <div class="inner--wide-only links-emphasised">
 
             {% set applicationQuery %}
-                <h3 class="t3">{{ copy.offices.england }}</h3>
+                <h3 class="t2">{{ copy.offices.england }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '0345 4 10 20 30' | makePhoneLink | safe }}<br />
                     <strong class="highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0345 4 10 20 30 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -27,7 +27,7 @@
                     <strong class="highlight">{{ copy.methods.address }}</strong>: 1 Plough Place, {{ copy.offices.london }}, EC4A 1DE
                 </p>
 
-                <h3 class="t3">{{ copy.offices.ni }}</h3>
+                <h3 class="t2">{{ copy.offices.ni }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '028 9055 1455' | makePhoneLink | safe }}<br />
                     <strong class="highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 028 9055 1431 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -36,7 +36,7 @@
                     <strong class="highlight">{{ copy.methods.address }}</strong>: 1 Cromac Quay, Belfast, BT7 2JD
                 </p>
 
-                <h3 class="t3">{{ copy.offices.scotland }}</h3>
+                <h3 class="t2">{{ copy.offices.scotland }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '0300 123 7110' | makePhoneLink | safe }}<br />
                     <strong class="highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 0300 123 7110 ({{ copy['hearing-speech-impairment']}})<br />
@@ -46,7 +46,7 @@
                     <strong class="highlight">{{ copy.methods.address }}</strong>: Pacific House, 70 Wellington Street, Glasgow, G2 6UA
                 </p>
 
-                <h3 class="t3">{{ copy.offices.wales }}</h3>
+                <h3 class="t2">{{ copy.offices.wales }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '0300 123 0735' | makePhoneLink | safe }}<br />
                     <strong class="highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0300 123 0735 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -55,7 +55,7 @@
                     <strong class="highlight">{{ copy.methods.address }}</strong>: {{ copy.wales.address2 }}<br />
                 </p>
 
-                <h3 class="t3">{{ copy.ukPortfolio.title }}</h3>
+                <h3 class="t2">{{ copy.ukPortfolio.title }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '0345 4 10 20 30' | makePhoneLink | safe }}<br />
                     <strong class="highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0300 123 4567 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -73,7 +73,7 @@
             {% endset %}
 
             {% set other %}
-                <h3 class="t3">{{ copy.offices.corporate }}</h3>
+                <h3 class="t2">{{ copy.offices.corporate }}</h3>
 
                 <p>
                     1 Plough Place<br />
@@ -89,26 +89,26 @@
             {% endset %}
 
             {% set pressQuery %}
-                <h3 class="t3">{{ copy.offices.england }}/{{ copy.offices.uk }}</h3>
+                <h3 class="t2">{{ copy.offices.england }}/{{ copy.offices.uk }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '020 7211 1888' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: 07867 500572)<br />
                     <strong class="highlight">Email:</strong> <a href="mailto:pressoffice@biglotteryfund.org.uk">pressoffice@biglotteryfund.org.uk</a>
                 </p>
 
-                <h3 class="t3">{{ copy.offices.ni }}</h3>
+                <h3 class="t2">{{ copy.offices.ni }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '02890 551 432' | makePhoneLink | safe }} {{ __('global.misc.or') }} {{ '02890 551 450' | makePhoneLink | safe }} <br />
                     ({{ copy['out-of-hours'] }}: {{ '07580 811 135' | makePhoneLink | safe }})
                 </p>
 
-                <h3 class="t3">{{ copy.offices.scotland }}</h3>
+                <h3 class="t2">{{ copy.offices.scotland }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '0141 242 1458' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: {{ '07880 737 157' | makePhoneLink | safe }})
                 </p>
 
-                <h3 class="t3">{{ copy.offices.wales }}</h3>
+                <h3 class="t2">{{ copy.offices.wales }}</h3>
                 <p>
                     <strong class="highlight">{{ copy.methods.phone }}</strong>: {{ '029 2067 8236' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: {{ '07870 566 867' | makePhoneLink | safe }})

--- a/views/pages/toplevel/data.njk
+++ b/views/pages/toplevel/data.njk
@@ -30,14 +30,14 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', copy.title, 't2') }}
+        {{ headers.overlayText('h2', copy.title) }}
     {% endset %}
 
     {{ hero.header('data', heroContent, 'blue') }}
 
     <article role="main" class="nudge-up">
         <div class="inner accent--pink a--border-top stats-holder content-box content-box--borderless">
-            <h3 class="t3 t--underline accent--pink">{{ copy.keyStats }}</h3>
+            <h3 class="t2 t--underline accent--pink">{{ copy.keyStats }}</h3>
 
             <ul class="unstyled grid grid--3-up grid--bordered grid--equal grid--wide-only stats">
                 {% for stats in copy.data %}
@@ -56,7 +56,7 @@
 
     <aside class="accent--blue a--border-top map-holder">
         <div class="inner--wide-only expanded map-holder__inner content-box content-box--frameless no-space">
-            <h3 class="t3 t--underline accent--blue">{{ copy.map.title }}</h3>
+            <h3 class="t2 t--underline accent--blue">{{ copy.map.title }}</h3>
 
             <div class="map-wrapper">
                 {% include "../../includes/uk-svg.njk" %}
@@ -66,16 +66,16 @@
                 {% for region in grants %}
                     <section id="region-{{ region.id }}" class="tab__pane{% if loop.first %} pane--active{% endif %}">
                         <article class="map-info accent--blue a--border-top padded region--{{ region.id }}--b-t">
-                            <h4 class="t3 t--underline region--{{ region.id }}--b-b">{{ copy.regions[region.id] }}</h4>
+                            <h4 class="t2 t--underline region--{{ region.id }}--b-b">{{ copy.regions[region.id] }}</h4>
 
-                            <h5 class="map-info__stat t3 accent--blue a--text">{{ region.population | numberWithCommas }}</h5>
-                            <h6 class="t6"><strong>{{ copy.map.population }}</strong></h6>
+                            <h5 class="map-info__stat t2 accent--blue a--text">{{ region.population | numberWithCommas }}</h5>
+                            <h6 class="t8"><strong>{{ copy.map.population }}</strong></h6>
 
-                            <h5 class="map-info__stat t3 accent--blue a--text">{{ region.totalAwarded }}</h5>
-                            <h6 class="t6"><strong>{{ copy.map.totalAwarded }}</strong></h6>
+                            <h5 class="map-info__stat t2 accent--blue a--text">{{ region.totalAwarded }}</h5>
+                            <h6 class="t8"><strong>{{ copy.map.totalAwarded }}</strong></h6>
 
-                            <h5 class="map-info__stat t3 accent--blue a--text">{{ region.beneficiaries | numberWithCommas }}</h5>
-                            <h6 class="t6"><strong>{{ copy.map.totalBeneficiaries }}</strong></h6>
+                            <h5 class="map-info__stat t2 accent--blue a--text">{{ region.beneficiaries | numberWithCommas }}</h5>
+                            <h6 class="t8"><strong>{{ copy.map.totalBeneficiaries }}</strong></h6>
                         </article>
                     </section>
                 {% endfor %}

--- a/views/pages/toplevel/eyp.njk
+++ b/views/pages/toplevel/eyp.njk
@@ -98,7 +98,7 @@
         <p class="links-emphasised">People get in touch with us every day to discuss their ideas, their communities and what matters most to them. Call us on {{ '02890 551455' | makePhoneLink | safe }} Monday to Friday, 9.00am to 5.00pm (not including public holidays).</p>
 
         {% for item in beforeApplyContents %}
-            <h3 id="before-{{ item.id }}" class="t3 t--underline accent--pink a--text">{{ loop.index }}. {{ item.title }}</h3>
+            <h3 id="before-{{ item.id }}" class="t2 t--underline accent--pink a--text">{{ loop.index }}. {{ item.title }}</h3>
             {{ item.content | safe }}
         {% endfor %}
 
@@ -202,7 +202,7 @@
 {% block content %}
 
     {% set heroContent %}
-        {{ headers.overlayText('h2', "Empowering Young People", 't1') }}
+        {{ headers.overlayText('h2', "Empowering Young People", 't2') }}
     {% endset %}
 
     {{ hero.header('eyp', heroContent, 'pink', "L'Arche Belfast, Grant: £573,164") }}
@@ -244,7 +244,7 @@
         </div>
 
         <div class="inner">
-            <h3 class="t3">Examples of projects that have been funded</h3>
+            <h3 class="t2">Examples of projects that have been funded</h3>
             <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                 {% for project in exampleProjects %}
                     <li class="grid__item">{{ projectBlock(project, 'accent--pink') }}</li>

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -12,7 +12,7 @@
 
 {% macro articleTeaser(article) %}
     <article class="article-teaser">
-        <h4 class="article-teaser__title t3">
+        <h4 class="article-teaser__title t2">
             <a class="u-link-minimal" href="{{ article.link }}">
                 {{ article.title }}
             </a>
@@ -107,7 +107,7 @@
             {% if news.length %}
                 <section class="accent--blue a--border-top">
                     <div class="padded padded--wide-only">
-                        <h3 class="t8 t--underline a--text accent--blue">{{ copy.latestNews }}</h3>
+                        <h3 class="t1 t--underline a--text accent--blue">{{ copy.latestNews }}</h3>
                         <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                             {% for article in news %}
                                 <li class="grid__item">
@@ -130,14 +130,14 @@
                 </li>
                 <li class="grid__item accent--pink a--border-top">
                     <form class="form-ebulletin padded spaced" id="{{ anchors.ebulletin }}" method="post" action="/ebulletin">
-                        <h3 class="t8 t--underline accent--pink a--text">{{ copy.ebulletin.title }}</h3>
+                        <h3 class="t1 t--underline accent--pink a--text">{{ copy.ebulletin.title }}</h3>
                         {% if request.flash and request.flash('ebulletinStatus') %}
                             {% if request.flash('ebulletinStatus') === 'success' %}
-                                <h5 class="t4">{{ copy.ebulletin.responses.success.title }}</h5>
-                                <p class="t6">{{ copy.ebulletin.responses.success.body | safe }}</p>
+                                <h5 class="t5">{{ copy.ebulletin.responses.success.title }}</h5>
+                                <p class="t8">{{ copy.ebulletin.responses.success.body | safe }}</p>
                             {% else %}
-                                <h5 class="t4">{{ copy.ebulletin.responses.error.title }}</h5>
-                                <p class="t6">{{ copy.ebulletin.responses.error.body }}</p>
+                                <h5 class="t5">{{ copy.ebulletin.responses.error.title }}</h5>
+                                <p class="t8">{{ copy.ebulletin.responses.error.body }}</p>
                             {% endif %}
                         {% else %}
                             <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/views/pages/toplevel/jobs.njk
+++ b/views/pages/toplevel/jobs.njk
@@ -31,13 +31,13 @@
                 <a class="btn accent--pink a--btn central-gap spaced--l" href="https://atsv7.wcn.co.uk/search_engine/jobs.cgi?owner=5031783&ownertype=fair&submitSearchForm=1&submitSearchForm=Search&vac_xtra5031783.30_5031783=&posting_code=53">{{ copy['call-to-action'] }}</a>
             </div>
 
-            <h3 class="t3">{{ copy.sections.whyWork.title }}</h3>
+            <h3 class="t2">{{ copy.sections.whyWork.title }}</h3>
             {{ copy.sections.whyWork.body | safe }}
 
         </div>
 
         <div class="inner--wide-only accent--green a--border-top content-box">
-            <h3 class="t3">{{ copy.sections.benefits.title }}</h3>
+            <h3 class="t2">{{ copy.sections.benefits.title }}</h3>
             {{ copy.sections.benefits.body | safe }}
             <ul class="list-bullets highlight">
                 {% for benefit in copy.sections.benefits.list %}
@@ -48,14 +48,14 @@
         </div>
 
         <div class="inner--wide-only accent--turquoise a--border-top content-box">
-            <h3 class="t3">{{ copy.sections.offices.title }}</h3>
+            <h3 class="t2">{{ copy.sections.offices.title }}</h3>
             <div class="google-map">
                 <iframe src="https://www.google.com/maps/d/embed?mid=1ANUmJnn8RObMDFvo50elNW58F7A&hl=en" width="100%" height="480" frameborder="0"></iframe>
             </div>
         </div>
 
         <div class="inner--wide-only accent--orange a--border-top content-box">
-            <h3 class="t3">{{ copy.sections.equalities.title }}</h3>
+            <h3 class="t2">{{ copy.sections.equalities.title }}</h3>
             {{ copy.sections.equalities.body | safe }}
         </div>
 

--- a/views/pages/toplevel/over10k.njk
+++ b/views/pages/toplevel/over10k.njk
@@ -29,7 +29,7 @@
     <article role="main" class="nudge-up">
         <div class="content-box content-box--tint inner--wide-only accent--turquoise a--border-top">
             <p>{{ copy.intro }}</p>
-            <h3 class="t8">{{ copy.callToAction }}</h3>
+            <h3 class="t1">{{ copy.callToAction }}</h3>
 
             <ul class="unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
                <li class="grid__item">
@@ -59,7 +59,7 @@
         </div>
 
         <div class="inner">
-            <h3 class="t8">{{ copy.projectExamples }}</h3>
+            <h3 class="t1">{{ copy.projectExamples }}</h3>
             <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                 {% for project in copy.projects %}
                     <li class="grid__item">{{ projectBlock(project, 'accent--turquoise') }}</li>

--- a/views/pages/toplevel/styleguide.njk
+++ b/views/pages/toplevel/styleguide.njk
@@ -6,7 +6,7 @@
 {% macro styleguideSectionHeader(title) %}
     <div class="sg-section-header">
         <div class="sg-section-header__inner inner">
-            <h2 class="sg-section-header__title t1">{{ title }}</h2>
+            <h2 class="sg-section-header__title t2">{{ title }}</h2>
         </div>
     </div>
 {% endmacro %}
@@ -14,7 +14,7 @@
 {% macro styleguideBlock(title, content, notes) %}
     <div class="sg-block">
         <div class="sg-block-content__inner inner">
-            <h3 class="sg-block__title accent--soft-grey t2 t--underline">{{ title }}</h3>
+            <h3 class="sg-block__title accent--soft-grey t6 t--underline">{{ title }}</h3>
             <div class="sg-block__content">
                 {{ content | safe }}
             </div>
@@ -36,26 +36,26 @@
 
 {{ styleguideSectionHeader('Typography') }}
 {% set sgContent %}
-    <h2 class="t1">T1 Typographic Style</h2>
-    <h2 class="t2">T2 Typographic Style</h2>
-    <h2 class="t2 t--underline accent--pink a--text">T2 Typographic Style (with underline)</h2>
-    <h2 class="t3">T3 Typographic Style</h2>
-    <h2 class="t3 t--tracking">T3b Typographic Style</h2>
-    <h2 class="t4">T4 Typographic Style</h2>
-    <h2 class="t5">T5 Typographic Style</h2>
-    <h2 class="t6">T6 Typographic Style</h2>
-    <h2 class="t7">T7 Typographic Style</h2>
-    <h2 class="t8">T8 Typographic Style</h2>
+    {% for n in range(1, 9) %}
+        <h2 class="t{{ n }}">T{{ n }} Typographic Style</h2>
+    {% endfor %}
 {% endset %}
 {{ styleguideBlock('Titles', sgContent) }}
 
 {% set sgContent %}
-    <h2 class="t1 accent--cyan overlay-text">
-        <span>T1 typographic style with overlay text</span>
-    </h2>
-    <br />{# TODO: Should overlay-text have some default margin? #}
+    <h2 class="t2 t--underline accent--pink a--text">Title with underline</h2>
+    <h2 class="t3 t--tracking">Title with tracking</h2>
+{% endset %}
+
+{{ styleguideBlock('Modifiers', sgContent) }}
+
+{% set sgContent %}
     <h2 class="t2 accent--cyan overlay-text">
         <span>T2 typographic style with overlay text</span>
+    </h2>
+    <br />{# TODO: Should overlay-text have some default margin? #}
+    <h2 class="t6 accent--cyan overlay-text">
+        <span>T6 typographic style with overlay text</span>
     </h2>
 {% endset %}
 {{ styleguideBlock('Overlay text', sgContent) }}

--- a/views/pages/toplevel/under10k.njk
+++ b/views/pages/toplevel/under10k.njk
@@ -35,7 +35,7 @@
                 {% endfor %}
             </ul>
 
-            <h3 class="accent--pink t8 t--underline">{{ copy.callToAction }}</h3>
+            <h3 class="accent--pink t1 t--underline">{{ copy.callToAction }}</h3>
 
             <ul class="unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
                <li class="grid__item">
@@ -68,7 +68,7 @@
         </div>
 
         <div class="inner">
-            <h3 class="t8">{{ copy.projectExamples }}</h3>
+            <h3 class="t1">{{ copy.projectExamples }}</h3>
             <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
                 {% for project in copy.projects %}
                     <li class="grid__item">{{ projectBlock(project, 'accent--pink') }}</li>


### PR DESCRIPTION
This is complicated but has been confirmed by @ChloeAlper.

| Old type class name | New type class name  |
|:--|:--|
| t1 | t2 |
| t2 | t6 |
| t3 | t2 |
| t4 | t5 |
| t5 | t4 |
| t6 | t8 |
| t7 | t7 |
| t8 | t1 |

(note some `.t2`s become `.t4`s to aid readability)

... the easiest thing to do would be to look at the updated styleguide:

![image](https://user-images.githubusercontent.com/394376/32790198-b108e9f4-c955-11e7-99da-5b7705d35c92.png)

First I search/replaced the classnames to reflect the changes, then added a few manual tweaks with @ChloeAlper.

Hero headers now use the same font size regardless of content:

### (this change versus the existing styles)

![image](https://user-images.githubusercontent.com/394376/32790299-facdecc4-c955-11e7-81bf-5158fd058849.png)

![image](https://user-images.githubusercontent.com/394376/32790346-1a3fd6bc-c956-11e7-89f2-b7ecc48974ba.png)
