### PR TITLE
Normalise content box styles

### DIFF
--- a/assets/sass/scaffolding/content.scss
+++ b/assets/sass/scaffolding/content.scss
@@ -12,17 +12,6 @@
         padding: $spacingUnit;
     }
 
-    &.content-box--pink {
-        background-color: palette('pale-pink');
-        border-right: none;
-        border-bottom: none;
-        border-left: none;
-    }
-
-    &.content-box--tint {
-        background-color: palette('pale-grey');
-    }
-
     &.content-box--narrow {
         padding: 10px;
     }
@@ -36,5 +25,12 @@
     &.content-box--frameless {
         border: none;
         background-color: transparent;
+    }
+
+    &.content-box--tinted {
+        background-color: palette('pale-pink');
+        border-right: none;
+        border-bottom: none;
+        border-left: none;
     }
 }

--- a/views/pages/toplevel/eyp.njk
+++ b/views/pages/toplevel/eyp.njk
@@ -208,7 +208,7 @@
     {{ hero.header('eyp', heroContent, 'pink', "L'Arche Belfast, Grant: £573,164") }}
 
     <article role="main" class="nudge-up">
-        <div class="inner--wide-only accent--pink a--border-top content-box content-box--pink mob--no-space">
+        <div class="inner--wide-only accent--pink a--border-top content-box content-box--tinted">
             <p>Empowering Young People is a grants programme designed to support projects in Northern Ireland that give young people aged 8 to 25 the ability to overcome the challenges they face.</p>
 
             <p><strong>Grant size</strong>: £30,000 to £500,000<br />

--- a/views/pages/toplevel/over10k.njk
+++ b/views/pages/toplevel/over10k.njk
@@ -27,7 +27,7 @@
     }}
 
     <article role="main" class="nudge-up">
-        <div class="content-box content-box--tint inner--wide-only accent--turquoise a--border-top">
+        <div class="content-box inner--wide-only accent--turquoise a--border-top">
             <p>{{ copy.intro }}</p>
             <h3 class="t1">{{ copy.callToAction }}</h3>
 

--- a/views/pages/toplevel/styleguide.njk
+++ b/views/pages/toplevel/styleguide.njk
@@ -204,4 +204,16 @@
 {% endset %}
 {{ sgBlock('Content Box', sgContent) }}
 
+{% set sgContent %}
+    <div class="content-box content-box--tinted inner--wide-only accent--pink a--border-top">
+        <p>Empowering Young People is a grants programme designed to support projects in Northern Ireland that give young people aged 8 to 25 the ability to overcome the challenges they face.</p>
+        <p><strong>Grant size</strong>: £30,000 to £500,000<br />
+        <strong>Grant duration</strong>: 2 to 5 Years</p>
+    </div>
+{% endset %}
+{% set sgNotes %}
+    <p>Tinted variant of a content box. Used to give focus to important blocks of copy on text heavy pages.</p>
+{% endset %}
+{{ sgBlock('Content Box: Tinted', sgContent, sgNotes) }}
+
 {% endblock %}

--- a/views/pages/toplevel/under10k.njk
+++ b/views/pages/toplevel/under10k.njk
@@ -26,7 +26,7 @@
     }}
 
     <article role="main" class="nudge-up">
-        <div class="content-box content-box--tint inner--wide-only accent--pink a--border-top">
+        <div class="content-box inner--wide-only accent--pink a--border-top">
             <p>{{ copy.intro }}</p>
 
             <ul class="list-bullets">


### PR DESCRIPTION
Normalise content-box colours, removes previous tinted version on over/under10k pages and standardises on regular content-box and the tinted one used on EYP. Adds tinted version to styleguide.