### PR TITLE
Remove default margin from footer

### DIFF
--- a/assets/sass/scaffolding/footer.scss
+++ b/assets/sass/scaffolding/footer.scss
@@ -3,10 +3,9 @@
    ========================================================================== */
 
 .footer {
-    background-color: palette('charcoal');
-    color: palette('off-white');
     font-size: 14px;
-    margin-top: $spacingUnit;
+    color: palette('off-white');
+    background-color: palette('charcoal');
 
     @media print {
         display: none;
@@ -15,16 +14,11 @@
     a {
         color: inherit;
         text-decoration: none;
-        //vertical-align: super; // fixes collapsing margins
 
         @include on-interact {
             color: white;
             text-decoration: underline;
         }
-    }
-
-    .footer--no-margin & {
-        margin-top: 0;
     }
 }
 .footer__inner {
@@ -36,10 +30,4 @@
 }
 .footer__header {
     margin-bottom: $spacingUnit;
-}
-
-@media print {
-    .footer {
-        display: none;
-    }
 }

--- a/views/pages/toplevel/benefits.njk
+++ b/views/pages/toplevel/benefits.njk
@@ -41,7 +41,7 @@
 
         </div>
 
-        <div class="inner">
+        <div class="inner spaced">
             <img src="{{ 'jobs/equality-sponsors.png' | getImagePath }}" alt="The logos of Positive About Disabled People, Stonewall, Investors In People, Business Disability Forum and Living Wage Employer" />
         </div>
 

--- a/views/pages/toplevel/data.njk
+++ b/views/pages/toplevel/data.njk
@@ -2,7 +2,6 @@
 {% import "components/headers.njk" as headers %}
 {% from "components/data.njk" import statsGrid %}
 
-{% set bodyClass = "footer--no-margin" %}
 {% extends "../../layouts/main.njk" %}
 
 {% block title %}{{ copy.title | striptags(true) }} | {% endblock %}

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -83,7 +83,7 @@
 
         </div>
 
-        <div class="inner--wide-only">
+        <div class="inner--wide-only spaced">
             {# tweets #}
             {% set twitterAccount = appData.config.get('social.twitterAccounts.' + locale)  %}
             <ul class="unstyled grid grid--wide-only grid--equal">

--- a/views/pages/toplevel/jobs.njk
+++ b/views/pages/toplevel/jobs.njk
@@ -59,7 +59,7 @@
             {{ copy.sections.equalities.body | safe }}
         </div>
 
-        <div class="inner">
+        <div class="inner spaced">
             <img src="{{ 'jobs/equality-sponsors.png' | getImagePath }}" alt="The logos of Positive About Disabled People, Stonewall, Investors In People, Business Disability Forum and Living Wage Employer" />
         </div>
 

--- a/views/pages/toplevel/over10k.njk
+++ b/views/pages/toplevel/over10k.njk
@@ -66,7 +66,7 @@
                 {% endfor %}
             </ul>
 
-            <div class="central-gap">
+            <div class="central-gap spaced">
                 <a href="{{ buildUrl('funding/search-past-grants') }}" class="btn btn--outline accent--turquoise btn--a btn--block btn--small">{{ copy.browseAll }}</a>
             </div>
         </div>

--- a/views/pages/toplevel/under10k.njk
+++ b/views/pages/toplevel/under10k.njk
@@ -75,7 +75,7 @@
                 {% endfor %}
             </ul>
 
-            <div class="central-gap">
+            <div class="central-gap spaced">
                 <a href="{{ buildUrl('funding/search-past-grants') }}" class="btn btn--outline accent--pink btn--block btn--small">{{ copy.browseFundedProjects }}</a>
             </div>
         </div>

--- a/views/pages/toplevel/working-families.njk
+++ b/views/pages/toplevel/working-families.njk
@@ -2,7 +2,7 @@
 {% from "../../components/hero.njk" import sectionHero %}
 {% from "../../components/tabs.njk" import tabs %}
 
-{% set bodyClass = "has-full-bleed-header has-welsh-logo footer--no-margin" %}
+{% set bodyClass = "has-full-bleed-header has-welsh-logo" %}
 {% extends "../../layouts/main.njk" %}
 
 {% block title %}{{ title }} | {% endblock %}


### PR DESCRIPTION
Bumped into this whilst building the helping working families pages. The default top margin on the footer results in slightly awkward override classes where we want things to sit flush.

The majority of our components have consistent vertical margin on them already so we can safely remove the default margin on the footer without much issue. I've added `.spaced` classes to the few pages that needed it.