### PR TITLE
SES update

### DIFF
--- a/integration-tests/user.test.js
+++ b/integration-tests/user.test.js
@@ -98,7 +98,7 @@ describe('User authentication', () => {
                 .end((err, res) => {
                     // via https://github.com/auth0/node-jsonwebtoken/issues/162
                     res.body.token.should.match(/^[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+)?$/);
-                    res.body.email.to.should.equal(formData.username);
+                    res.body.email.sendTo.should.equal(formData.username);
                     res.body.email.subject.should.equal('Activate your Big Lottery Fund website account');
                     done();
                 });

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -4,13 +4,6 @@ const config = require('config');
 const AWS = require('aws-sdk');
 const Raven = require('raven');
 
-// Use local environment AWS credentials in dev mode.
-// Otherwise, EC2 instances already have IAM instance roles
-// with valid ses:SendRawEmail permissions
-if (process.env.NODE_ENV === 'development') {
-    AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
-}
-
 // create Nodemailer SES transporter
 const transport = nodemailer.createTransport({
     SES: new AWS.SES({

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -1,19 +1,22 @@
 'use strict';
 const nodemailer = require('nodemailer');
 const config = require('config');
-const getSecret = require('../modules/get-secret');
+const AWS = require('aws-sdk');
+const Raven = require('raven');
 
-let mailConfig = {
-    user: getSecret('ses.auth.user'),
-    password: getSecret('ses.auth.password')
-};
-// create reusable transporter object using the default SMTP transport
+// Use local environment AWS credentials in dev mode.
+// Otherwise, EC2 instances already have IAM instance roles
+// with valid ses:SendRawEmail permissions
+if (process.env.NODE_ENV === 'development') {
+    AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
+}
+
+// create Nodemailer SES transporter
 const transport = nodemailer.createTransport({
-    service: 'SES-EU-WEST-1',
-    auth: {
-        user: mailConfig.user,
-        pass: mailConfig.password
-    }
+    SES: new AWS.SES({
+        apiVersion: '2010-12-01',
+        region: 'eu-west-1'
+    })
 });
 
 const send = ({ subject, text, sendTo, sendMode }) => {
@@ -41,13 +44,19 @@ const send = ({ subject, text, sendTo, sendMode }) => {
     }
 
     // send mail with defined transport object
-    transport.sendMail(mailOptions, (error, info) => {
-        if (error) {
-            // @TODO handle this better – re-send it?
-            return console.error('Error sending email via SES', error);
-        }
-        console.log('Message %s sent: %s', info.messageId, info.response);
+    let mailSend = transport.sendMail(mailOptions);
+
+    // set a generic error logger
+    mailSend.catch(error => {
+        Raven.captureMessage('Error sending email via SES', {
+            extra: error,
+            tags: {
+                feature: 'email'
+            }
+        });
     });
+
+    return mailSend;
 };
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11845,7 +11845,7 @@
     },
     "uuid": {
       "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "v8flags": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,10 @@
   },
   "nodemonConfig": {
     "verbose": true,
-    "ignore": ["assets", "public"],
+    "ignore": [
+      "assets",
+      "public"
+    ],
     "exec": "bin/www"
   },
   "dependencies": {

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -105,7 +105,7 @@
         <p>{{ copy.orderSubmitted.success.body | safe }}</p>
     {% elseif orderStatus == 'fail' %}
         <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.title }}</h2>
-        <h3 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
+        <h3 class="t2 accent--blue a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
This is to aid with my other branch ([`form-success-callback`](https://github.com/biglotteryfund/blf-alpha/tree/form-success-callback)) – updates Nodemailer to use an IAM-powered SES email transport.

This means we can send email from any SES-approved domain we own, and removes the need to pass SES secrets around via config (it just uses the IAM roles for the EC2 instances).

This also adds error tracking via Sentry and returns a Promise for email sending, allowing us to add some error handling for failed sends (if any).