### PR TITLE
Fix high contrast mode to only initialise server-side

### DIFF
--- a/assets/js/modules/common.js
+++ b/assets/js/modules/common.js
@@ -2,11 +2,6 @@
 
 const $ = require('jquery');
 
-const getCookieValue = a => {
-    let b = document.cookie.match('(^|;)\\s*' + a + '\\s*=\\s*([^;]+)');
-    return b ? b.pop() : '';
-};
-
 function initToggleMobileNav() {
     // bind mobile nav show/hidew button
     const $html = $('html');
@@ -14,20 +9,6 @@ function initToggleMobileNav() {
         e.preventDefault();
         $html.toggleClass('show-off-canvas');
     });
-}
-
-function initHighContrastMode() {
-    // toggle contrast mode (we do this in JS to avoid breaking caching)
-    const $html = $('html');
-    const isHighContrast = getCookieValue('contrastMode'); // @TODO get from config
-    if (isHighContrast === 'high') {
-        $html.addClass('contrast--high');
-        $('#js-contrast-standard').show();
-        $('#js-contrast-high').hide();
-    } else {
-        $('#js-contrast-standard').hide();
-        $('#js-contrast-high').show();
-    }
 }
 
 function initOverlays() {
@@ -39,7 +20,6 @@ function initOverlays() {
 
 function init() {
     initToggleMobileNav();
-    initHighContrastMode();
     initOverlays();
 }
 

--- a/assets/sass/components/accessibility.scss
+++ b/assets/sass/components/accessibility.scss
@@ -1,4 +1,8 @@
-.accessibility__nav {
+/* =========================================================================
+   Accessibility
+   ========================================================================= */
+
+.accessibility-nav {
     position: absolute;
     top: $spacingUnit;
     left: $spacingUnit;

--- a/modules/boilerplate/globals.js
+++ b/modules/boilerplate/globals.js
@@ -51,7 +51,7 @@ setGlobal('getHtmlClasses', function() {
     let parts = ['no-js', 'locale--' + locale];
 
     if (highContrast) {
-        parts.push('contrast--hight');
+        parts.push('contrast--high');
     }
 
     return parts.join(' ');

--- a/views/includes/accessibility.njk
+++ b/views/includes/accessibility.njk
@@ -1,6 +1,5 @@
 {% macro makeContrastLink(mode) %}
-    <a id="js-contrast-{{ mode }}"
-       href="/contrast/{{ mode }}?url={{ getCurrentUrl(request) | urlencode}}"
+    <a href="/contrast/{{ mode }}?url={{ getCurrentUrl(request) | urlencode}}"
        class="js-track-clicks"
        data-category="Change contrast"
        data-action="Click"
@@ -9,10 +8,13 @@
     </a>
 {% endmacro %}
 
-<nav class="accessibility__nav">
+<nav class="accessibility-nav">
     <ul>
         <li><a tabindex="0" href="#content">{{ __("global.accessibility.skipToContent") | safe }}</a></li>
-        <li>{{ makeContrastLink('standard') }}</li>
-        <li>{{ makeContrastLink('high') }}</li>
+        {% if highContrast %}
+            <li>{{ makeContrastLink('standard') }}</li>
+        {% else %}
+            <li>{{ makeContrastLink('high') }}</li>
+        {% endif %}
     </ul>
 </nav>


### PR DESCRIPTION
Spotted by @mattandrews whilst reviewing https://github.com/biglotteryfund/blf-alpha/pull/423

We are currently handling adding high-contrast mode classes both client-side and server-side. One with a typo, one without. The client-side code is there to "to avoid breaking caching", but we already vary the cache based on the contrast cookie so that's not technically true.

Personally I'm happy for high contrast mode to be supported server side so this PR reworks things so that high contrast logic only happens in one place.