### PR TITLE
Updates to how legacy proxied pages are handled

### DIFF
--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -282,19 +282,22 @@ const vanityRedirects = [
         name: 'Publicity (Welsh)',
         path: '/cyhoeddusrwydd',
         destination: '/welsh' + vanityDestinations.publicity,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         name: 'Helping Working Families',
         path: '/helpingworkingfamilies',
         destination: routes.sections.toplevel.pages.helpingWorkingFamilies.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         name: 'Helping Working Families (Welsh)',
         path: '/helputeuluoeddgweithio',
         destination: '/welsh' + routes.sections.toplevel.pages.helpingWorkingFamilies.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         // this stays here (and not as an alias) as express doesn't care about URL case
@@ -303,44 +306,52 @@ const vanityRedirects = [
         name: 'Logo page',
         path: '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
         destination: routes.sections.funding.path + routes.sections.funding.pages.logos.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     // the following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
     {
         name: 'Contact press team',
         path: '/news-and-events/contact-press-team',
-        destination: vanityDestinations.contact + '#' + anchors.contactPress
+        destination: vanityDestinations.contact + '#' + anchors.contactPress,
+        live: true
     },
     {
         name: 'Contact press team (Welsh)',
         path: '/welsh/news-and-events/contact-press-team',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress,
+        live: true
     },
     {
         name: 'Complaint page',
         path: '/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Complaint page (England)',
         path: '/england/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Complaint page (Welsh)',
         path: '/welsh/about-big/customer-service/making-a-complaint',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Fraud page',
         path: '/about-big/customer-service/fraud',
-        destination: vanityDestinations.contact + '#' + anchors.contactFraud
+        destination: vanityDestinations.contact + '#' + anchors.contactFraud,
+        live: true
     },
     {
         name: 'Fraud page (Welsh)',
         path: '/welsh/about-big/customer-service/fraud',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud,
+        live: true
     }
 ];
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -407,12 +407,6 @@ const otherUrls = [
         live: true
     },
     {
-        path: '/funding/funding-finder',
-        isPostable: true,
-        allowQueryStrings: true,
-        live: true
-    },
-    {
         path: '/surveys',
         isPostable: false,
         allowQueryStrings: true,
@@ -432,8 +426,29 @@ const otherUrls = [
     }
 ];
 
+/**
+ * Legacy proxies routes
+ * The following URLs are legacy pages that are being proxied to make small amends to them.
+ * They have not yet been redesigned or replaced so aren't ready to go into the main routes.
+ */
+const withLegacyDefaults = function(obj) {
+    const defaults = {
+        isPostable: true,
+        allowQueryStrings: true
+    };
+    return Object.assign({}, defaults, obj);
+};
+
+const legacyProxiedRoutes = {
+    fundingFinder: withLegacyDefaults({
+        path: '/funding/funding-finder',
+        live: true
+    })
+};
+
 module.exports = {
     sections: routes.sections,
     vanityRedirects: vanityRedirects,
-    otherUrls: otherUrls
+    otherUrls: otherUrls,
+    legacyProxiedRoutes: legacyProxiedRoutes
 };

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -16,12 +16,13 @@ const routeStatic = require('../utils/routeStatic');
 const regions = require('../../config/content/regions.json');
 const models = require('../../models/index');
 const proxyLegacy = require('../../modules/proxy');
-const utilities = require('../../modules/utilities');
 const getSecret = require('../../modules/get-secret');
 const analytics = require('../../modules/analytics');
 const contentApi = require('../../modules/content');
 const cached = require('../../middleware/cached');
 const { heroImages } = require('../../modules/images');
+
+const legacyPages = require('./legacyPages');
 
 const robots = require('../../config/app/robots.json');
 // block everything on non-prod envs
@@ -62,43 +63,6 @@ const oldHomepage = (req, res) => {
     return proxyLegacy.proxyLegacyPage(req, res);
 };
 
-// serve the legacy site funding finder (via proxy)
-router.get('/funding/funding-finder', (req, res) => {
-    // rewrite HTML to remove invalid funding programs
-    return proxyLegacy.proxyLegacyPage(req, res, dom => {
-        // should we filter out programs under 10k?
-        if (req.query.over && req.query.over === '10k') {
-            // get the list of program elements
-            let programs = dom.window.document.querySelectorAll('article.programmeList');
-            if (programs.length > 0) {
-                [].forEach.call(programs, p => {
-                    // find the key facts block (which contains the funding size)
-                    let keyFacts = p.querySelectorAll('.taxonomy-keyFacts dt');
-                    if (keyFacts.length > 0) {
-                        [].forEach.call(keyFacts, k => {
-                            // find the node with the funding size info (if it exists)
-                            let textValue = k.textContent.toLowerCase();
-                            // english/welsh version
-                            if (['funding size:', 'maint yr ariannu:'].indexOf(textValue) !== -1) {
-                                // convert string into number
-                                let programUpperLimit = utilities.parseValueFromString(k.nextSibling.textContent);
-                                // remove the element if it's below our threshold
-                                if (programUpperLimit <= 10000) {
-                                    p.parentNode.removeChild(p);
-                                }
-                            }
-                        });
-                    }
-                });
-            }
-        }
-        return dom;
-    });
-});
-
-// allow form submissions on funding finder to pass through to proxy
-router.post('/funding/funding-finder', proxyLegacy.postToLegacyForm);
-
 module.exports = (pages, sectionPath, sectionId) => {
     /**
      * 1. Populate static pages
@@ -133,6 +97,8 @@ module.exports = (pages, sectionPath, sectionId) => {
     router.get('/legacy', (req, res) => {
         return proxyLegacy.proxyLegacyPage(req, res, null, '/');
     });
+
+    legacyPages.init(router);
 
     // send form data to the (third party) email newsletter provider
     router.post(

--- a/controllers/toplevel/legacyPages.js
+++ b/controllers/toplevel/legacyPages.js
@@ -1,0 +1,51 @@
+const { parseValueFromString } = require('../../modules/utilities');
+const { proxyLegacyPage, postToLegacyForm } = require('../../modules/proxy');
+const { legacyProxiedRoutes } = require('../routes');
+
+function initFundingFinder(router) {
+    function proxyFundingFinder(req, res) {
+        // rewrite HTML to remove invalid funding programs
+        return proxyLegacyPage(req, res, dom => {
+            // should we filter out programs under 10k?
+            if (req.query.over && req.query.over === '10k') {
+                // get the list of program elements
+                let programs = dom.window.document.querySelectorAll('article.programmeList');
+                if (programs.length > 0) {
+                    [].forEach.call(programs, p => {
+                        // find the key facts block (which contains the funding size)
+                        let keyFacts = p.querySelectorAll('.taxonomy-keyFacts dt');
+                        if (keyFacts.length > 0) {
+                            [].forEach.call(keyFacts, k => {
+                                // find the node with the funding size info (if it exists)
+                                let textValue = k.textContent.toLowerCase();
+                                // english/welsh version
+                                if (['funding size:', 'maint yr ariannu:'].indexOf(textValue) !== -1) {
+                                    // convert string into number
+                                    let programUpperLimit = parseValueFromString(k.nextSibling.textContent);
+                                    // remove the element if it's below our threshold
+                                    if (programUpperLimit <= 10000) {
+                                        p.parentNode.removeChild(p);
+                                    }
+                                }
+                            });
+                        }
+                    });
+                }
+            }
+            return dom;
+        });
+    }
+
+    router
+        .route(legacyProxiedRoutes.fundingFinder.path)
+        .get(proxyFundingFinder)
+        .post(postToLegacyForm);
+}
+
+function init(router) {
+    initFundingFinder(router);
+}
+
+module.exports = {
+    init
+};

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -1,56 +1,67 @@
 'use strict';
 const helmet = require('helmet');
+const { map } = require('lodash');
+const { legacyProxiedRoutes } = require('../controllers/routes');
 
-// these URLs won't get the helmet header protection
-// @TODO this should only affect the legacy homepage
-const pathsExemptFromHelmet = ['/', '/welsh', '/legacy', '/funding/funding-finder', '/welsh/funding/funding-finder'];
+module.exports = function(app) {
+    /**
+     * URLs which should be exempt from security headers
+     * Only proxied legacy URLs should be exempt.
+     */
+    const exemptLegacyUrls = map(legacyProxiedRoutes, _ => _.path);
+    const pathsExemptFromHelmet = ['/', '/welsh', '/legacy'].concat(exemptLegacyUrls);
 
-const defaultSecurityDomains = [
-    "'self'",
-    'cdn.polyfill.io',
-    'fonts.gstatic.com',
-    'ajax.googleapis.com',
-    'www.google-analytics.com',
-    'www.google.com',
-    'maxcdn.bootstrapcdn.com',
-    'platform.twitter.com',
-    'syndication.twitter.com',
-    'cdn.syndication.twimg.com',
-    '*.twimg.com',
-    'cdn.jsdelivr.net',
-    'sentry.io',
-    'dvmwjbtfsnnp0.cloudfront.net'
-];
+    const defaultSecurityDomains = [
+        "'self'",
+        'cdn.polyfill.io',
+        'fonts.gstatic.com',
+        'ajax.googleapis.com',
+        'www.google-analytics.com',
+        'www.google.com',
+        'maxcdn.bootstrapcdn.com',
+        'platform.twitter.com',
+        'syndication.twitter.com',
+        'cdn.syndication.twimg.com',
+        '*.twimg.com',
+        'cdn.jsdelivr.net',
+        'sentry.io',
+        'dvmwjbtfsnnp0.cloudfront.net'
+    ];
 
-const childSrc = defaultSecurityDomains.concat(['www.google.com']);
+    const directives = {
+        defaultSrc: defaultSecurityDomains,
+        childSrc: defaultSecurityDomains.concat(['www.google.com']),
+        styleSrc: defaultSecurityDomains.concat(["'unsafe-inline'", 'fonts.googleapis.com']),
+        connectSrc: defaultSecurityDomains,
+        imgSrc: defaultSecurityDomains.concat(['data:', 'localhost', 'stats.g.doubleclick.net']),
+        scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
+        reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c',
+        fontSrc: defaultSecurityDomains.concat(['data:'])
+    };
 
-const helmetSettings = helmet({
-    contentSecurityPolicy: {
-        directives: {
-            defaultSrc: defaultSecurityDomains,
-            childSrc: childSrc,
-            frameSrc: childSrc,
-            styleSrc: defaultSecurityDomains.concat(["'unsafe-inline'", 'fonts.googleapis.com']),
-            connectSrc: defaultSecurityDomains.concat(['ws://127.0.0.1:35729/livereload']), // make dev-only?,
-            imgSrc: defaultSecurityDomains.concat(['data:', 'localhost', 'stats.g.doubleclick.net']),
-            scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
-            reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c',
-            fontSrc: defaultSecurityDomains.concat(['data:'])
+    if (app.get('env') === 'development') {
+        // Allow LiveReload in development
+        directives.connectSrc = directives.connectSrc.concat(['ws://127.0.0.1:35729/livereload']);
+    }
+
+    const helmetSettings = helmet({
+        contentSecurityPolicy: {
+            directives: directives,
+            browserSniff: false
         },
-        browserSniff: false
-    },
-    dnsPrefetchControl: {
-        allow: true
-    },
-    frameguard: {
-        action: 'sameorigin'
-    }
-});
+        dnsPrefetchControl: {
+            allow: true
+        },
+        frameguard: {
+            action: 'sameorigin'
+        }
+    });
 
-module.exports = (req, res, next) => {
-    if (pathsExemptFromHelmet.indexOf(req.path) !== -1) {
-        next();
-    } else {
-        helmetSettings(req, res, next);
-    }
+    return function(req, res, next) {
+        if (pathsExemptFromHelmet.indexOf(req.path) !== -1) {
+            next();
+        } else {
+            helmetSettings(req, res, next);
+        }
+    };
 };

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -51,7 +51,7 @@ const generateUrlList = routes => {
     }
 
     // add vanity redirects too
-    routes.vanityRedirects.forEach(redirect => {
+    routes.vanityRedirects.filter(r => r.live).forEach(redirect => {
         if (redirect.paths) {
             redirect.paths.forEach(path => {
                 let page = { path: path };

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -1,3 +1,5 @@
+const { filter, forEach } = require('lodash');
+
 // take a route config and format it for cloudfront
 const makeUrlObject = (page, customPath) => {
     return {
@@ -63,8 +65,14 @@ const generateUrlList = routes => {
         }
     });
 
-    // finally add the miscellaneous routes for static files etc
+    // Add the miscellaneous routes
     routes.otherUrls.filter(r => r.live).forEach(routeConfig => {
+        urlList.newSite.push(makeUrlObject(routeConfig));
+    });
+
+    // Legacy proxied routes
+    const liveLegacyRoutes = filter(routes.legacyProxiedRoutes, _ => _.live);
+    forEach(liveLegacyRoutes, routeConfig => {
         urlList.newSite.push(makeUrlObject(routeConfig));
     });
 

--- a/modules/urls.test.js
+++ b/modules/urls.test.js
@@ -22,10 +22,12 @@ const testRoutes = {
     },
     vanityRedirects: [
         {
-            path: '/test'
+            path: '/test',
+            live: true
         },
         {
-            paths: ['/supports', '/multiple', '/redirects']
+            paths: ['/supports', '/multiple', '/redirects'],
+            live: true
         }
     ],
     otherUrls: [

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ viewGlobalsService.init(app);
 // Add global middlewares
 app.use(loggerMiddleware);
 app.use(cachedMiddleware.defaultHeaders);
-app.use(securityHeadersMiddleware);
+app.use(securityHeadersMiddleware(app));
 app.use(bodyParserMiddleware);
 app.use(sessionMiddleware(app));
 app.use(passportMiddleware());


### PR DESCRIPTION
Extract the parts of https://github.com/biglotteryfund/blf-alpha/pull/437 that are suitable to go live now.

- Adds `live` flag to vanity URLs to allow dark-launching of vanity redirects in the same way we do other URLs
- Extract legacy proxied URLs into their own config, allowing us to share paths around the app in an isolated way rather than duplicating URLs
- Update security headers middleware to share legacy routes config