### PR TITLE
Extract clean up work related to awards for all work

### DIFF
--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -282,19 +282,22 @@ const vanityRedirects = [
         name: 'Publicity (Welsh)',
         path: '/cyhoeddusrwydd',
         destination: '/welsh' + vanityDestinations.publicity,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         name: 'Helping Working Families',
         path: '/helpingworkingfamilies',
         destination: routes.sections.toplevel.pages.helpingWorkingFamilies.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         name: 'Helping Working Families (Welsh)',
         path: '/helputeuluoeddgweithio',
         destination: '/welsh' + routes.sections.toplevel.pages.helpingWorkingFamilies.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     {
         // this stays here (and not as an alias) as express doesn't care about URL case
@@ -303,44 +306,52 @@ const vanityRedirects = [
         name: 'Logo page',
         path: '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
         destination: routes.sections.funding.path + routes.sections.funding.pages.logos.path,
-        aliasOnly: true
+        aliasOnly: true,
+        live: true
     },
     // the following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
     {
         name: 'Contact press team',
         path: '/news-and-events/contact-press-team',
-        destination: vanityDestinations.contact + '#' + anchors.contactPress
+        destination: vanityDestinations.contact + '#' + anchors.contactPress,
+        live: true
     },
     {
         name: 'Contact press team (Welsh)',
         path: '/welsh/news-and-events/contact-press-team',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress,
+        live: true
     },
     {
         name: 'Complaint page',
         path: '/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Complaint page (England)',
         path: '/england/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Complaint page (Welsh)',
         path: '/welsh/about-big/customer-service/making-a-complaint',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints,
+        live: true
     },
     {
         name: 'Fraud page',
         path: '/about-big/customer-service/fraud',
-        destination: vanityDestinations.contact + '#' + anchors.contactFraud
+        destination: vanityDestinations.contact + '#' + anchors.contactFraud,
+        live: true
     },
     {
         name: 'Fraud page (Welsh)',
         path: '/welsh/about-big/customer-service/fraud',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud
+        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud,
+        live: true
     }
 ];
 

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -1,56 +1,64 @@
 'use strict';
 const helmet = require('helmet');
 
-// these URLs won't get the helmet header protection
-// @TODO this should only affect the legacy homepage
-const pathsExemptFromHelmet = ['/', '/welsh', '/legacy'];
+module.exports = function(app) {
+    /**
+     * URLs which should be exempt from security headers
+     * Only proxied legacy URLs should be exempt.
+     */
+    const pathsExemptFromHelmet = ['/', '/welsh', '/legacy'];
 
-const defaultSecurityDomains = [
-    "'self'",
-    'cdn.polyfill.io',
-    'fonts.gstatic.com',
-    'ajax.googleapis.com',
-    'www.google-analytics.com',
-    'www.google.com',
-    'maxcdn.bootstrapcdn.com',
-    'platform.twitter.com',
-    'syndication.twitter.com',
-    'cdn.syndication.twimg.com',
-    '*.twimg.com',
-    'cdn.jsdelivr.net',
-    'sentry.io',
-    'dvmwjbtfsnnp0.cloudfront.net'
-];
+    const defaultSecurityDomains = [
+        "'self'",
+        'cdn.polyfill.io',
+        'fonts.gstatic.com',
+        'ajax.googleapis.com',
+        'www.google-analytics.com',
+        'www.google.com',
+        'maxcdn.bootstrapcdn.com',
+        'platform.twitter.com',
+        'syndication.twitter.com',
+        'cdn.syndication.twimg.com',
+        '*.twimg.com',
+        'cdn.jsdelivr.net',
+        'sentry.io',
+        'dvmwjbtfsnnp0.cloudfront.net'
+    ];
 
-const childSrc = defaultSecurityDomains.concat(['www.google.com']);
+    const directives = {
+        defaultSrc: defaultSecurityDomains,
+        childSrc: defaultSecurityDomains.concat(['www.google.com']),
+        styleSrc: defaultSecurityDomains.concat(["'unsafe-inline'", 'fonts.googleapis.com']),
+        connectSrc: defaultSecurityDomains,
+        imgSrc: defaultSecurityDomains.concat(['data:', 'localhost', 'stats.g.doubleclick.net']),
+        scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
+        reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c',
+        fontSrc: defaultSecurityDomains.concat(['data:'])
+    };
 
-const helmetSettings = helmet({
-    contentSecurityPolicy: {
-        directives: {
-            defaultSrc: defaultSecurityDomains,
-            childSrc: childSrc,
-            frameSrc: childSrc,
-            styleSrc: defaultSecurityDomains.concat(["'unsafe-inline'", 'fonts.googleapis.com']),
-            connectSrc: defaultSecurityDomains.concat(['ws://127.0.0.1:35729/livereload']), // make dev-only?,
-            imgSrc: defaultSecurityDomains.concat(['data:', 'localhost', 'stats.g.doubleclick.net']),
-            scriptSrc: defaultSecurityDomains.concat(["'unsafe-eval'", "'unsafe-inline'"]),
-            reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c',
-            fontSrc: defaultSecurityDomains.concat(['data:'])
+    if (app.get('env') === 'development') {
+        // Allow LiveReload in development
+        directives.connectSrc = directives.connectSrc.concat(['ws://127.0.0.1:35729/livereload']);
+    }
+
+    const helmetSettings = helmet({
+        contentSecurityPolicy: {
+            directives: directives,
+            browserSniff: false
         },
-        browserSniff: false
-    },
-    dnsPrefetchControl: {
-        allow: true
-    },
-    frameguard: {
-        action: 'sameorigin'
-    }
-});
+        dnsPrefetchControl: {
+            allow: true
+        },
+        frameguard: {
+            action: 'sameorigin'
+        }
+    });
 
-module.exports = (req, res, next) => {
-    if (pathsExemptFromHelmet.indexOf(req.path) !== -1) {
-        next();
-    } else {
-        helmetSettings(req, res, next);
-    }
+    return function(req, res, next) {
+        if (pathsExemptFromHelmet.indexOf(req.path) !== -1) {
+            next();
+        } else {
+            helmetSettings(req, res, next);
+        }
+    };
 };

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -83,7 +83,7 @@ const proxyLegacyPage = (req, res, domModifications, pathOverride) => {
              */
             const experimentId = get(res.locals, 'ab.id');
             const variantId = get(res.locals, 'ab.variantId');
-            if (experimentId && variantId) {
+            if (experimentId) {
                 // create GA snippet for tracking experiment
                 const gaCode = `
                 <script src="//www.google-analytics.com/cx/api.js"></script>

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -51,7 +51,7 @@ const generateUrlList = routes => {
     }
 
     // add vanity redirects too
-    routes.vanityRedirects.forEach(redirect => {
+    routes.vanityRedirects.filter(r => r.live).forEach(redirect => {
         if (redirect.paths) {
             redirect.paths.forEach(path => {
                 let page = { path: path };

--- a/modules/urls.test.js
+++ b/modules/urls.test.js
@@ -36,10 +36,12 @@ describe('URL Helpers', () => {
             },
             vanityRedirects: [
                 {
-                    path: '/test'
+                    path: '/test',
+                    live: true
                 },
                 {
-                    paths: ['/supports', '/multiple', '/redirects']
+                    paths: ['/supports', '/multiple', '/redirects'],
+                    live: true
                 }
             ],
             otherUrls: [

--- a/server.js
+++ b/server.js
@@ -46,7 +46,7 @@ viewGlobalsService.init(app);
 // Add global middlewares
 app.use(loggerMiddleware);
 app.use(cachedMiddleware.defaultHeaders);
-app.use(securityHeadersMiddleware);
+app.use(securityHeadersMiddleware(app));
 app.use(bodyParserMiddleware);
 app.use(sessionMiddleware(app));
 app.use(passportMiddleware());


### PR DESCRIPTION
(Finally) extracted from #446 to get out any tangential changes to keep the size of the awards for all PR down.

- Adds `live` flag to all vanity redirects to match other routes
- Update security middleware to only allow livereload in dev
- Only inject experiment code if we have a Google Experiments ID

Phew 😑 