### PR TITLE
Funding finder redirects

### DIFF
--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -1,10 +1,11 @@
 'use strict';
+const config = require('config');
 const express = require('express');
 const router = express.Router();
 const moment = require('moment');
 const _ = require('lodash');
 const xss = require('xss');
-const config = require('config');
+const queryString = require('query-string');
 const { body, validationResult } = require('express-validator/check');
 const { matchedData, sanitizeBody } = require('express-validator/filter');
 const cached = require('../../middleware/cached');
@@ -222,6 +223,32 @@ module.exports = (pages, sectionPath, sectionId) => {
      */
     const programmesConfig = pages.programmes;
     router.get(programmesConfig.path, programmesRoute(programmesConfig));
+
+    router.get('/funding-finder', (req, res) => {
+        const locationMapping = {
+            england: 'england',
+            'northern+ireland': 'northernIreland',
+            scotland: 'scotland',
+            wales: 'wales'
+        };
+
+        let newQuery = {};
+        if (req.query.area) {
+            newQuery.location = locationMapping[req.query.area.toLowerCase()];
+        }
+
+        if (req.query.amount && req.query.amount.toLowerCase() !== 'up to 10000') {
+            newQuery.min = '10000';
+        }
+
+        const newQueryString = queryString.stringify(newQuery);
+        let redirectUrl = programmesConfig.path;
+        if (newQueryString.length > 0) {
+            redirectUrl += `?${newQueryString}`;
+        }
+
+        res.redirect(301, redirectUrl);
+    });
 
     return router;
 };

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -348,6 +348,12 @@ const vanityRedirects = [
 // via Cloudfront but aren't explicit page routes (eg. static files, custom pages etc)
 const otherUrls = [
     {
+        path: '/funding/funding-finder',
+        isPostable: false,
+        allowQueryStrings: true,
+        live: false
+    },
+    {
         path: '/assets/*',
         isPostable: false,
         allowQueryStrings: false,


### PR DESCRIPTION
Now that we've removed the funding finder proxy code in https://github.com/biglotteryfund/blf-alpha/pull/445 it allows us to…re add that URL again. This time to experiment with https://github.com/biglotteryfund/blf-alpha/issues/318

Sets up some redirects for:

- Location. England, scotland, northern-ireland, wales all get redirected to the equivalent query string 
- If the old `amount` paramater is for anything over 10k we add `min=10000` otherwise we do nothing

That's it. Keeping it simple for now.

Based on a discussion with @TomSteinberg , the small number of programmes we have, and that we now show them all on one page there's not much value in handling more than the main sets of filters people use.

Slightly unsure what happens when someone posts to the funding finder from another page so that'd be the main thing to rule out before doing anything real with this. That and talking to Engagement.