### PR TITLE
Add social images

### DIFF
--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -1,4 +1,4 @@
-{% macro makeAbsoluteImage(path) %}{{ request.protocol }}://{{ request.headers.host }}{{ path | getImagePath }}{% endmacro %}
+{% macro makeAbsoluteImage(path) %}{{ request.protocol }}://{{ request.headers.host }}{{ path }}{% endmacro %}
 
 <!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) (Node version: {{ appData.nodeVersion }}) -->
 
@@ -17,8 +17,16 @@
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@{{ appData.config.get('social.twitterAccounts.' + locale) }}" />
-<meta property="twitter:image" content="{{ makeAbsoluteImage("social/twitter.jpg") }}">
-<meta property="og:image" content="{{ makeAbsoluteImage("social/facebook.jpg") }}">
+
+{% if socialImage %}
+<meta property="twitter:image" content="{{ makeAbsoluteImage(socialImage.default) }}">
+<meta property="og:image" content="{{ makeAbsoluteImage(socialImage.default) }}">
+{% else %}
+<meta property="twitter:image" content="{{ makeAbsoluteImage("social/twitter.jpg" | getImagePath) }}">
+<meta property="og:image" content="{{ makeAbsoluteImage("social/facebook.jpg" | getImagePath) }}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+{% endif %}
 
 {# tiles/themes #}
 <meta name="apple-mobile-web-app-title" content="{{ metadata.title }}">

--- a/views/pages/funding/programmes.njk
+++ b/views/pages/funding/programmes.njk
@@ -6,17 +6,20 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
+{% set heroImage = createHeroImage({
+    small: 'hero/young-foundation-small.jpg',
+    medium: 'hero/young-foundation-medium.jpg',
+    large: 'hero/young-foundation-large.jpg',
+    default: 'hero/young-foundation-medium.jpg',
+    caption: 'The Young Foundation - Amplify, Grant £1.06M'
+}) %}
+{% set socialImage = heroImage %}
+
 {% block content %}
     <main role="main">
         {{ sectionHero(
             titleText = title,
-            image = createHeroImage({
-                small: 'hero/young-foundation-small.jpg',
-                medium: 'hero/young-foundation-medium.jpg',
-                large: 'hero/young-foundation-large.jpg',
-                default: 'hero/young-foundation-medium.jpg',
-                caption: 'The Young Foundation - Amplify, Grant £1.06M'
-            }),
+            image = heroImage,
             accent = 'green'
         ) }}
 

--- a/views/pages/toplevel/benefits.njk
+++ b/views/pages/toplevel/benefits.njk
@@ -8,15 +8,16 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
-{% block content %}
+{% set heroImage = createHeroImage({
+    small: 'hero/jobs-small.jpg',
+    medium: 'hero/jobs-medium.jpg',
+    large: 'hero/jobs-large.jpg',
+    default: 'hero/jobs-medium.jpg',
+    caption: 'Street Dreams, Grant £9,000'
+}) %}
+{% set socialImage = heroImage %}
 
-    {% set heroImage = createHeroImage({
-        small: 'hero/jobs-small.jpg',
-        medium: 'hero/jobs-medium.jpg',
-        large: 'hero/jobs-large.jpg',
-        default: 'hero/jobs-medium.jpg',
-        caption: 'Street Dreams, Grant £9,000'
-    }) %}
+{% block content %}
 
     {{
         sectionHero(

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -11,6 +11,8 @@
 
 {% block title %}{{ title }} | {{ copy.home }} | {% endblock %}
 
+{% set socialImage = heroImage.default %}
+
 {% block content %}
     {{
         homepageSuperHero(

--- a/views/pages/toplevel/jobs.njk
+++ b/views/pages/toplevel/jobs.njk
@@ -8,18 +8,22 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
+{% set heroImage = createHeroImage({
+    small: 'hero/jobs-small.jpg',
+    medium: 'hero/jobs-medium.jpg',
+    large: 'hero/jobs-large.jpg',
+    default: 'hero/jobs-medium.jpg',
+    caption: 'Street Dreams, Grant £9,000'
+}) %}
+
+{% set socialImage = heroImage %}
+
 {% block content %}
     {{
         sectionHero(
             accent = 'blue',
             titleText = title,
-            image = createHeroImage({
-                small: 'hero/jobs-small.jpg',
-                medium: 'hero/jobs-medium.jpg',
-                large: 'hero/jobs-large.jpg',
-                default: 'hero/jobs-medium.jpg',
-                caption: 'Street Dreams, Grant £9,000'
-            })
+            image = heroImage
         )
     }}
 

--- a/views/pages/toplevel/over10k.njk
+++ b/views/pages/toplevel/over10k.njk
@@ -7,17 +7,16 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
+{% set heroImage = createHeroImage({
+    small: 'hero/over-10k-small.jpg',
+    medium: 'hero/over-10k-medium.jpg',
+    large: 'hero/over-10k-large.jpg',
+    default: 'hero/over-10k-medium.jpg',
+    caption: 'Passion4Fusion, Grant £36,700'
+}) %}
+{% set socialImage = heroImage %}
+
 {% block content %}
-
-
-    {% set heroImage = createHeroImage({
-        small: 'hero/over-10k-small.jpg',
-        medium: 'hero/over-10k-medium.jpg',
-        large: 'hero/over-10k-large.jpg',
-        default: 'hero/over-10k-medium.jpg',
-        caption: 'Passion4Fusion, Grant £36,700'
-    }) %}
-
     {{
         sectionHero(
             titleText = copy.title,

--- a/views/pages/toplevel/under10k.njk
+++ b/views/pages/toplevel/under10k.njk
@@ -7,16 +7,16 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
+{% set heroImage = createHeroImage({
+    small: 'hero/under-10k-small.jpg',
+    medium: 'hero/under-10k-medium.jpg',
+    large: 'hero/under-10k-large.jpg',
+    default: 'hero/under-10k-medium.jpg',
+    caption: 'Friends of Greenwich Peninsula Ecology Park, Grant £5,350'
+}) %}
+{% set socialImage = heroImage %}
+
 {% block content %}
-
-    {% set heroImage = createHeroImage({
-        small: 'hero/under-10k-small.jpg',
-        medium: 'hero/under-10k-medium.jpg',
-        large: 'hero/under-10k-large.jpg',
-        default: 'hero/under-10k-medium.jpg',
-        caption: 'Friends of Greenwich Peninsula Ecology Park, Grant £5,350'
-    }) %}
-
     {{
         sectionHero(
             titleText = copy.title,

--- a/views/pages/toplevel/working-families.njk
+++ b/views/pages/toplevel/working-families.njk
@@ -6,18 +6,21 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
+{% set heroImage = createHeroImage({
+    small: 'hero/working-families-small.jpg',
+    medium: 'hero/working-families-medium.jpg',
+    large: 'hero/working-families-large.jpg',
+    default: 'hero/working-families-medium.jpg',
+    caption: 'Grassroots, Grant £455,268'
+}) %}
+{% set socialImage = heroImage %}
+
 {% block content %}
     {{
         sectionHero(
             accent = 'pink',
             titleText = title,
-            image = createHeroImage({
-                small: 'hero/working-families-small.jpg',
-                medium: 'hero/working-families-medium.jpg',
-                large: 'hero/working-families-large.jpg',
-                default: 'hero/working-families-medium.jpg',
-                caption: 'Grassroots, Grant £455,268'
-            })
+            image = heroImage
         )
     }}
 


### PR DESCRIPTION
For new-style hero headers, this PR uses their imagery as a social image (eg. for Facebook/Twitter open graph tags). Otherwise it falls back to the existing generic image (which itself may end up being updated soon).