### PR TITLE
Don't auto-stage files after running prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,19 +24,16 @@
     "prepush": "npm test"
   },
   "lint-staged": {
+    "assets/**/*.scss": [
+      "prettier --write"
+    ],
     "{assets,controllers,integration-tests,lambda,middleware,models,modules}/**/*.js": [
       "prettier --write",
-      "eslint",
-      "git add"
+      "eslint"
     ],
     "{gulpfile.js,server.js}": [
       "prettier --write",
-      "eslint",
-      "git add"
-    ],
-    "assets/**/*.scss": [
-      "prettier --write",
-      "git add"
+      "eslint"
     ],
     "controllers/routes.js": [
       "./bin/generate-cloudfront-config"


### PR DESCRIPTION
The fact that `lint-staged` can't handle partially staged changes has been nagging at me. There's an ongoing issue where where it looks like they are working towards an approach https://github.com/okonet/lint-staged/issues/62 but in the meantime it feels like the least-magic thing to do is to not re-add files and only format.

Not quite as invisible, but I'm erring towards patching in partial changes being more important than some auto-formatting.