### PR TITLE
Model database queries in services

### DIFF
--- a/assets/js/modules/surveys.js
+++ b/assets/js/modules/surveys.js
@@ -138,8 +138,8 @@ module.exports = {
     init: () => {
         // does this page have any surveys?
         $.get(`/surveys?path=${window.location.pathname}`).then(response => {
-            if (response.status === 'success' && response.survey) {
-                showSurvey(response.survey);
+            if (response.status === 'success' && response.surveys.length > 0) {
+                showSurvey(response.surveys[0]);
             }
         });
     }

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -7,10 +7,10 @@ const fs = require('fs');
 const generateSchema = require('generate-schema');
 
 const routes = require('../routes');
-const models = require('../../models/index');
 const auth = require('../../middleware/authed');
 const cached = require('../../middleware/cached');
 const appData = require('../../modules/appData');
+const surveysService = require('../../services/surveys');
 
 const LAUNCH_DATE = moment();
 
@@ -67,22 +67,8 @@ router.get('/status/pages', (req, res) => {
 });
 
 router.route('/tools/survey-results/').get(auth.requireAuthedLevel(USER_LEVEL_REQUIRED), cached.noCache, (req, res) => {
-    models.Survey.findAll({
-        include: [
-            {
-                model: models.SurveyChoice,
-                as: 'choices',
-                required: true,
-                include: [
-                    {
-                        model: models.SurveyResponse,
-                        as: 'responses',
-                        required: true
-                    }
-                ]
-            }
-        ]
-    })
+    surveysService
+        .findAll()
         .then(surveys => {
             res.render('pages/tools/surveys', {
                 surveys: surveys

--- a/integration-tests/helper.js
+++ b/integration-tests/helper.js
@@ -13,7 +13,7 @@ process.env.USE_LOCAL_DATABASE = true;
 // never send emails in test mode (instead capture their content)
 process.env.DONT_SEND_EMAIL = true;
 
-const models = require('../models/index');
+const userService = require('../services/user');
 
 let hook;
 
@@ -35,13 +35,9 @@ let captureStream = stream => {
     };
 };
 
-const createTestUser = userData => {
-    return models.Users.create(userData);
-};
+const createTestUser = userData => userService.createUser(userData);
 
-const truncateUsers = () => {
-    return models.Users.destroy({ where: {} });
-};
+const truncateUsers = () => userService.__destroyAll();
 
 function getCsrfToken(agent, urlPath) {
     return new Promise(resolve => {

--- a/integration-tests/survey.test.js
+++ b/integration-tests/survey.test.js
@@ -6,7 +6,7 @@ chai.use(require('chai-http'));
 chai.should();
 
 const helper = require('./helper');
-const models = require('../models/index');
+const surveyService = require('../services/surveys');
 
 let testSurveyData = {
     name: 'Test Survey',
@@ -36,15 +36,8 @@ describe('Survey tool', () => {
             server = serverInstance;
 
             // create initial survey for testing
-            models.Survey
-                .create(testSurveyData, {
-                    include: [
-                        {
-                            model: models.SurveyChoice,
-                            as: 'choices'
-                        }
-                    ]
-                })
+            surveyService
+                .createWithChoices(testSurveyData)
                 .then(data => {
                     // store our survey data to test against
                     storedSurveyData = data;

--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -1,11 +1,12 @@
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
-const models = require('../models');
+const userService = require('../services/user');
 
 module.exports = function() {
     passport.use(
         new LocalStrategy((username, password, done) => {
-            models.Users.findOne({ where: { username: username } })
+            userService
+                .findByUsername(username)
                 .then(user => {
                     // use generic error messages here to avoid exposing existing accounts
                     let genericError = 'Your username and password combination is invalid';
@@ -28,7 +29,8 @@ module.exports = function() {
     });
 
     passport.deserializeUser((id, cb) => {
-        models.Users.findById(id)
+        userService
+            .findById(id)
             .then(user => {
                 cb(null, user);
             })

--- a/models/index.js
+++ b/models/index.js
@@ -21,6 +21,8 @@ if (dbCredentials.host) {
         host: dbCredentials.host,
         logging: false,
         dialect: 'mysql',
+        // http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-security
+        operatorsAliases: false,
         pool: {
             max: 5,
             min: 1,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "assets/**/*.scss": [
       "prettier --write"
     ],
-    "{assets,controllers,integration-tests,lambda,middleware,models,modules}/**/*.js": [
+    "{assets,controllers,integration-tests,lambda,middleware,models,modules,services}/**/*.js": [
       "prettier --write",
       "eslint"
     ],

--- a/services/surveys.js
+++ b/services/surveys.js
@@ -1,0 +1,64 @@
+const xss = require('xss');
+const { Survey, SurveyChoice, SurveyResponse } = require('../models');
+
+function findAll() {
+    return Survey.findAll({
+        include: [
+            {
+                model: SurveyChoice,
+                as: 'choices',
+                required: true,
+                include: [
+                    {
+                        model: SurveyResponse,
+                        as: 'responses',
+                        required: true
+                    }
+                ]
+            }
+        ]
+    });
+}
+
+function findActiveWithChoices({ filterByPath }) {
+    return Survey.findAll({
+        where: {
+            active: true
+        },
+        include: [
+            {
+                model: SurveyChoice,
+                as: 'choices',
+                required: true
+            }
+        ]
+    }).then(surveys => {
+        if (filterByPath) {
+            return surveys.filter(s => s.activePath === filterByPath);
+        } else {
+            return surveys;
+        }
+    });
+}
+
+function createWithChoices(data) {
+    return Survey.create(data, {
+        include: [
+            {
+                model: SurveyChoice,
+                as: 'choices'
+            }
+        ]
+    });
+}
+
+function createResponse(response) {
+    return SurveyResponse.create(response);
+}
+
+module.exports = {
+    findAll,
+    findActiveWithChoices,
+    createWithChoices,
+    createResponse
+};

--- a/services/user.js
+++ b/services/user.js
@@ -1,0 +1,105 @@
+const xss = require('xss');
+const { Op } = require('sequelize');
+const { Users } = require('../models');
+
+function getSanitizedUser({ username, password, level }) {
+    return {
+        username: xss(username),
+        password: xss(password),
+        level: level || 0
+    };
+}
+
+function findById(id) {
+    return Users.findById(id);
+}
+
+function findByUsername(username) {
+    return Users.findOne({
+        where: {
+            username: {
+                [Op.eq]: xss(username)
+            }
+        }
+    });
+}
+
+function findWithActivePasswordReset({ id }) {
+    return Users.findOne({
+        where: {
+            id: {
+                [Op.eq]: id
+            },
+            is_password_reset: true
+        }
+    });
+}
+
+function updateIsInPasswordReset({ id }) {
+    return Users.update(
+        {
+            is_password_reset: true
+        },
+        {
+            where: {
+                id: {
+                    [Op.eq]: id
+                }
+            }
+        }
+    );
+}
+
+function updateNewPassword({ newPassword, id }) {
+    return Users.update(
+        {
+            password: newPassword,
+            is_password_reset: false
+        },
+        {
+            where: {
+                id: {
+                    [Op.eq]: id
+                }
+            }
+        }
+    );
+}
+
+function updateActivateUser({ id }) {
+    return Users.update(
+        {
+            is_active: true
+        },
+        {
+            where: {
+                [Op.eq]: id
+            }
+        }
+    );
+}
+
+function createUser({ username, password, level }) {
+    return Users.create(
+        getSanitizedUser({
+            username,
+            password,
+            level
+        })
+    );
+}
+
+function __destroyAll() {
+    return Users.destroy({ where: {} });
+}
+
+module.exports = {
+    findById,
+    findByUsername,
+    findWithActivePasswordReset,
+    updateIsInPasswordReset,
+    updateNewPassword,
+    updateActivateUser,
+    createUser,
+    __destroyAll
+};


### PR DESCRIPTION
This helps with https://github.com/biglotteryfund/blf-alpha/issues/467

- Centralise related database calls into dedicated files (e.g, all user queries) to avoid spreading sequelize syntax around the app
- Updates `where` clauses to use `Op` calls
- Disables `operatorsAliases`

Deprecation warning is gone and tests still pass. Note: The one part I've not updated to this style is the material orders.

The Sequelize docs aren't particularly well written here. So I'm not 100% sure I follow 
exactly to what extent the `Op` calls are needed, but I think it makes sense. http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-security
