### PR TITLE
Add legacy page support

### DIFF
--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -280,6 +280,12 @@ const routes = {
                         // sectionPaths.aboutLegacy + "/customer-service/data-protection",
                         '/data-protection'
                     ]
+                },
+                peopleInTheLead: {
+                    name: 'People in the Lead',
+                    path: '/helping-millions-change-their-lives',
+                    cms: true,
+                    live: false
                 }
             }
         }

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -284,7 +284,7 @@ const routes = {
                 peopleInTheLead: {
                     name: 'People in the Lead',
                     path: '/helping-millions-change-their-lives',
-                    cms: true,
+                    isLegacyPage: true,
                     live: false
                 }
             }

--- a/controllers/utils/routeStatic.js
+++ b/controllers/utils/routeStatic.js
@@ -3,7 +3,6 @@ const app = require('../../server');
 const contentApi = require('../../services/content-api');
 const { renderNotFound } = require('../http-errors');
 
-const { get } = require('lodash');
 const Raven = require('raven');
 
 // redirect any aliases to the canonical path
@@ -43,8 +42,10 @@ let serveCmsPage = (page, sectionId, router) => {
         };
 
         contentApi
-            .getLegacyPage(req.i18n.getLocale(), sectionId + page.path)
-            .then(response => get(response, 'data.attributes', []))
+            .getLegacyPage({
+                locale: req.i18n.getLocale(),
+                path: sectionId + page.path
+            })
             .then(content => {
                 renderPage(content);
             })
@@ -88,7 +89,7 @@ let initRouting = (pages, router, sectionPath, sectionId) => {
         // redirect any aliases to the canonical path
         setupRedirects(sectionPath, page);
 
-        if (page.cms) {
+        if (page.isLegacyPage) {
             // serve a static template with CMS-loaded content
             serveCmsPage(page, sectionId, router);
         } else if (page.static) {

--- a/controllers/utils/routeStatic.js
+++ b/controllers/utils/routeStatic.js
@@ -34,10 +34,8 @@ let servePage = (page, router) => {
 };
 
 let serveCmsPage = (page, sectionId, router) => {
-
     router.get(page.path, (req, res) => {
-
-        const renderPage = (content) => {
+        const renderPage = content => {
             res.render('pages/legacy', {
                 title: content.title,
                 content: content
@@ -55,7 +53,6 @@ let serveCmsPage = (page, sectionId, router) => {
                 renderNotFound(req, res);
             });
     });
-
 };
 
 // map this section ID (for all routes in this path)

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -25,7 +25,8 @@ module.exports = function(environment) {
         '*.youtube.com',
         'cdn.jsdelivr.net',
         'sentry.io',
-        'dvmwjbtfsnnp0.cloudfront.net'
+        'dvmwjbtfsnnp0.cloudfront.net',
+        '*.biglotteryfund.org.uk'
     ];
 
     const directives = {

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -40,13 +40,15 @@ function getFundingProgramme({ locale, slug }) {
     });
 }
 
-function getLegacyPage(locale, path) {
+function getLegacyPage({ locale, path }) {
     return request({
         url: `${API_URL}/v1/${locale}/legacy`,
         qs: {
             path: path
         },
         json: true
+    }).then(response => {
+        return get(response, 'data.attributes');
     });
 }
 

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -40,8 +40,19 @@ function getFundingProgramme({ locale, slug }) {
     });
 }
 
+function getLegacyPage(locale, path) {
+    return request({
+        url: `${API_URL}/v1/${locale}/legacy`,
+        qs: {
+            path: path
+        },
+        json: true
+    });
+}
+
 module.exports = {
     getPromotedNews,
     getFundingProgrammes,
-    getFundingProgramme
+    getFundingProgramme,
+    getLegacyPage
 };

--- a/views/pages/legacy.njk
+++ b/views/pages/legacy.njk
@@ -14,7 +14,7 @@
 
     {{ hero.header('foi', heroContent, 'turquoise') }}
 
-    <article role="main" class="nudge-up s-prose">
+    <article role="main" class="nudge-up s-prose s-prose--full">
         <div class="inner--wide-only accent--turquoise a--border-top content-box">
             {{ content.body | safe }}
         </div>

--- a/views/pages/legacy.njk
+++ b/views/pages/legacy.njk
@@ -1,0 +1,23 @@
+{% import "components/hero.njk" as hero %}
+{% import "components/headers.njk" as headers %}
+{% import "components/segment.njk" as segment %}
+
+{% extends "layouts/main.njk" %}
+
+{% block title %}{{ title }} | {% endblock %}
+
+{% block content %}
+
+    {% set heroContent %}
+        {{ headers.overlayText('h2', title, 't2') }}
+    {% endset %}
+
+    {{ hero.header('foi', heroContent, 'turquoise') }}
+
+    <article role="main" class="nudge-up s-prose">
+        <div class="inner--wide-only accent--turquoise a--border-top content-box">
+            {{ content.body | safe }}
+        </div>
+    </article>
+
+{% endblock %}


### PR DESCRIPTION
Open to discussion about the paradigm here.

Essentially, the workflow for importing legacy pages will be:

- Run the scraper (see https://github.com/biglotteryfund/blf-alpha/pull/468)
- Add its cleaned HTML output to the CMS*, specifying a `legacyPath` for the content
- Add the legacy path to the routes file

(this is more of a manual process than the funding programme tool as the URLs we're exploring importing for this aren't in any specific section).



* this could be via automated means, or done manually as I've been doing for now.