### PR TITLE
Fix order emails

### DIFF
--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -189,7 +189,8 @@ module.exports = (pages, sectionPath, sectionId) => {
                 if (req.body.skipEmail) {
                     res.send(req.body);
                 } else {
-                    const details = matchedData(req, { locations: ['body'] });
+                    // some fields are optional so matchedData misses them here
+                    const details = req.body;
                     const items = req.session[freeMaterialsLogic.orderKey];
                     const dateNow = moment().format('dddd, MMMM Do YYYY, h:mm:ss a');
                     const text = makeOrderText(items, details);

--- a/integration-tests/materials.test.js
+++ b/integration-tests/materials.test.js
@@ -174,6 +174,9 @@ describe('Material order form', () => {
             .end((err, res) => {
                 res.body.should.have.property('yourEmail');
                 res.body.yourEmail.should.equal('bobby@xkcd.com');
+                // ensure optional fields are returned too
+                res.body.should.have.property('yourAddress2');
+                res.body.yourAddress2.should.equal('Notrealsville');
                 done();
             });
     });


### PR DESCRIPTION
We had some reports that some customer address details were missing from recent orders.

Looking into this, it was dropping the optional fields (eg. address line 2, county). This was because of [this](https://github.com/biglotteryfund/blf-alpha/commit/ea35ab2c07c3a3fed6b7896990c87b6a7cd39928#diff-86d36374bce6dbc222d37bbe10885cf3R191) change which uses `matchedData` to capture `req.body` params. `matchedData` only returns things that were validated, which in this case didn't include the optional fields.

I don't think we lost anything too important in the month or so this has been live, but I've added a test just to be safe. The external suppliers have been contacting customers where data was missing so no harm done.