### PR TITLE
Add programme page redirect handlers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,10 +12,10 @@ module.exports = {
         allowImportExportEverywhere: true
     },
     rules: {
-        eqeqeq: 2,
-        semi: [2, 'always'],
-
-        'no-console': 0,
-        'no-unused-vars': 1
+        eqeqeq: 'error',
+        semi: ['error', 'always'],
+        'no-shadow': 'warn',
+        'no-console': 'off',
+        'no-unused-vars': 'warn'
     }
 };

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -4,7 +4,7 @@ const anchors = config.get('anchors');
 
 // pass some parameters onto each controller
 // so we can take route config and init all at once
-let loadController = path => {
+const loadController = path => {
     return (pages, sectionPath, sectionId) => require(path)(pages, sectionPath, sectionId);
 };
 
@@ -286,13 +286,48 @@ const routes = {
     }
 };
 
-// for the sake of brevity, define some commonly-used paths rather than repeating them below
+/**
+ * Programme Migration
+ *
+ * Handle redirects from /global-content/programmes to /funding/programmes
+ * @TODO: Consider merging into a global-content/programmes/* handler
+ *        once we decide to migrate all programme pages.
+ */
+function programmeMigration(from, to, isLive) {
+    return {
+        path: `/global-content/programmes/${from}`,
+        destination: `/funding/programmes/${to}`,
+        isPostable: false,
+        allowQueryStrings: false,
+        live: !isLive ? false : true
+    };
+}
+const programmeRedirects = [
+    programmeMigration('england/reaching-communities-england', 'reaching-communities-england', false),
+    programmeMigration('england/parks-for-people', 'parks-for-people', false),
+    programmeMigration('northern-ireland/people-and-communities', 'people-and-communities', false),
+    programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants', false),
+    programmeMigration('wales/people-and-places-large-grants', 'people-and-places-large-grants', false),
+    programmeMigration('scotland/community-assets', 'community-assets', false),
+    programmeMigration('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
+    programmeMigration('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity', false),
+    programmeMigration('scotland/grants-for-improving-lives', 'grants-for-improving-lives', false),
+    programmeMigration('scotland/our-place', 'our-place', false),
+    programmeMigration('scotland/scottish-land-fund', 'scottish-land-fund', false),
+    programmeMigration('uk-wide/forces-in-mind', 'forces-in-mind', false),
+    programmeMigration('uk-wide/uk-portfolio', 'uk-portfolio', false),
+    programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders', false)
+];
+
+/**
+ * Vanity URLs
+ *
+ * Set up some vanity URL redirects that can't be defined in the aliases on the routes above
+ */
 const vanityDestinations = {
     publicity: routes.sections.funding.path + routes.sections.funding.pages.manageFunding.path,
     contact: routes.sections.toplevel.path + routes.sections.toplevel.pages.contact.path
 };
-
-// set up some URL redirects that can't be defined in the aliases on the routes above
 const vanityRedirects = [
     {
         // this has to be here and not as an alias
@@ -380,19 +415,60 @@ const vanityRedirects = [
     {
         name: 'Awards For All Scotland',
         path: '/awardsforallscotland',
-        destination: '/funding/programmes/awards-for-all-scotland',
-        live: false // Migration experiment
+        destination: '/global-content/programmes/scotland/awards-for-all-scotland',
+        live: false // Mark as live when launching AFA test in Scotland
     },
     {
         name: 'Reaching Communities England',
         path: '/prog_reaching_communities',
         destination: '/funding/programmes/reaching-communities-england',
         live: false // Migration experiment
+    },
+    {
+        name: 'Parks for People',
+        path: '/prog_parks_people',
+        destination: '/funding/programmes/parks-for-people',
+        live: false // Migration experiment
     }
 ];
 
-// these are other paths that should be routed to this app
-// via Cloudfront but aren't explicit page routes (eg. static files, custom pages etc)
+/**
+ * Legacy proxied routes
+ * The following URLs are legacy pages that are being proxied to make small amends to them.
+ * They have not yet been redesigned or replaced so aren't ready to go into the main routes.
+ */
+function withLegacyDefaults(props) {
+    const defaults = {
+        isPostable: true,
+        allowQueryStrings: true,
+        live: false
+    };
+    return Object.assign({}, defaults, props);
+}
+const legacyProxiedRoutes = {
+    awardsForAllEngland: withLegacyDefaults({
+        path: '/global-content/programmes/england/awards-for-all-england',
+        live: true
+    }),
+    awardsForAllScotland: withLegacyDefaults({
+        path: '/global-content/programmes/scotland/awards-for-all-scotland',
+        live: false
+    }),
+    awardsForAllWales: withLegacyDefaults({
+        path: '/global-content/programmes/wales/awards-for-all-wales',
+        live: false
+    }),
+    awardsForAllWalesWelsh: withLegacyDefaults({
+        path: '/welsh/global-content/programmes/wales/awards-for-all-wales',
+        live: false
+    })
+};
+
+/**
+ * Other Routes
+ * These are other paths that should be routed to this app via Cloudfront
+ * but aren't explicit page routes (eg. static files, custom pages etc)
+ */
 const otherUrls = [
     {
         path: '/funding/funding-finder',
@@ -462,41 +538,10 @@ const otherUrls = [
     }
 ];
 
-/**
- * Legacy proxied routes
- * The following URLs are legacy pages that are being proxied to make small amends to them.
- * They have not yet been redesigned or replaced so aren't ready to go into the main routes.
- */
-const withLegacyDefaults = function(obj) {
-    const defaults = {
-        isPostable: true,
-        allowQueryStrings: true
-    };
-    return Object.assign({}, defaults, obj);
-};
-
-const legacyProxiedRoutes = {
-    awardsForAllEngland: withLegacyDefaults({
-        path: '/global-content/programmes/england/awards-for-all-england',
-        live: true
-    }),
-    awardsForAllScotland: withLegacyDefaults({
-        path: '/global-content/programmes/scotland/awards-for-all-scotland',
-        live: false
-    }),
-    awardsForAllWales: withLegacyDefaults({
-        path: '/global-content/programmes/wales/awards-for-all-wales',
-        live: false
-    }),
-    awardsForAllWalesWelsh: withLegacyDefaults({
-        path: '/welsh/global-content/programmes/wales/awards-for-all-wales',
-        live: false
-    })
-};
-
 module.exports = {
     sections: routes.sections,
+    programmeRedirects: programmeRedirects,
     vanityRedirects: vanityRedirects,
-    otherUrls: otherUrls,
-    legacyProxiedRoutes: legacyProxiedRoutes
+    legacyProxiedRoutes: legacyProxiedRoutes,
+    otherUrls: otherUrls
 };

--- a/modules/urls.test.js
+++ b/modules/urls.test.js
@@ -34,6 +34,15 @@ describe('URL Helpers', () => {
                     }
                 }
             },
+            programmeRedirects: [
+                {
+                    path: '/global-content/programmes/example',
+                    destination: '/funding/programmes/example',
+                    isPostable: false,
+                    allowQueryStrings: false,
+                    live: true
+                }
+            ],
             vanityRedirects: [
                 {
                     path: '/test',
@@ -59,7 +68,7 @@ describe('URL Helpers', () => {
 
         it('should filter out non-live routes', done => {
             let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.length).to.equal(9);
+            expect(urlList.newSite.length).to.equal(11);
             done();
         });
 


### PR DESCRIPTION
Tried a few different approaches for handling redirects from old => new programme page urls and have landed on something that feels reasonably concise.

Rather than adding loads of vanity redirects it feels like programme pages are discreet enough to warrant their own config. Focuses on handling the 80% case of redirecting `/global-content/programmes` to `/funding/programmes` equivalent + welsh versions. Short urls like `/prog_afa_england` etc. would still go in vanity urls.

I've excluded Awards For All for now to avoid conflicting with testing copy for the active A/B setup, but they should go in here too eventually.

(Also enabled `no-shadow` eslint rules as I noticed a lot of variable names were getting reused in different scopes in the routes code, e.g. `path`)

Best viewed with https://github.com/biglotteryfund/blf-alpha/pull/483/files?w=1