### PR TITLE
Display an admin panel with edit link if authed

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,6 +24,7 @@ require('./modules/heroImages').init();
 require('./modules/logos').init();
 require('./modules/materials').init();
 require('./modules/forms').init();
+require('./modules/adminPanel').init();
 
 /**
  * If we are in the live environment then load analytics

--- a/assets/js/modules/adminPanel.js
+++ b/assets/js/modules/adminPanel.js
@@ -1,0 +1,30 @@
+const $ = require('jquery');
+
+function init() {
+    if (window.AppConfig.adminEndpoint) {
+        $.ajax({
+            url: window.AppConfig.adminEndpoint,
+            dataType: 'json',
+            xhrFields: {
+                withCredentials: true
+            }
+        })
+            .then(response => response.data.attributes)
+            .then(attributes => {
+                var div = document.createElement('div');
+                div.className = 'admin-panel';
+                div.innerHTML = `<ul class="admin-panel__list">
+                    <li class="admin-panel__item">
+                        <a class="admin-panel__link" href="${attributes.editUrl}">Edit Page</a>
+                    </li>
+                </ul>`;
+                var bodyEl = document.querySelector('body');
+                bodyEl.appendChild(div);
+            })
+            .catch(function() {});
+    }
+}
+
+module.exports = {
+    init
+};

--- a/assets/sass/components/admin-panel.scss
+++ b/assets/sass/components/admin-panel.scss
@@ -1,0 +1,41 @@
+/* =========================================================================
+   Admin Panel
+   ========================================================================= */
+
+.admin-panel {
+    display: inline-block;
+    position: fixed;
+    z-index: 999;
+    bottom: 0;
+    right: 0;
+    width: auto;
+    font-size: 14px;
+    font-weight: normal;
+    color: white;
+    background-color: #28282f;
+    box-shadow: -3px 0 6px rgba(0, 0, 0, 0.2);
+}
+.admin-panel__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.admin-panel__item,
+.admin-panel__link {
+    display: block;
+    float: left;
+    margin: 0;
+}
+.admin-panel__link,
+.admin-panel__link:link,
+.admin-panel__link:visited,
+.admin-panel__link:hover,
+.admin-panel__link:active {
+    color: inherit;
+    padding: 8px 10px;
+    text-decoration: none;
+}
+.admin-panel__link:hover {
+    color: white;
+    background-color: black;
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -53,6 +53,7 @@
 @import 'components/case-studies';
 @import 'components/heroes';
 @import 'components/survey';
+@import 'components/admin-panel';
 
 // =========================================================================
 // Third-party / Vendor styles

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -173,15 +173,20 @@ function getHeroImage(entry) {
 
 function initProgrammeDetail(router, config) {
     router.get('/programmes/:slug', function(req, res) {
+        const currentLocale = req.i18n.getLocale();
         contentApi
             .getFundingProgramme({
-                locale: req.i18n.getLocale(),
+                locale: currentLocale,
                 slug: req.params.slug
             })
             .then(entry => {
                 if (entry.contentSections.length > 0) {
                     res.render(config.template, {
                         entry: entry,
+                        adminEndpoint: contentApi.getAdminLinkEndpont({
+                            locale: currentLocale,
+                            contentId: parseInt(entry.contentId, 10)
+                        }),
                         title: entry.title,
                         heroImage: getHeroImage(entry)
                     });

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -26,7 +26,8 @@ module.exports = function(environment) {
         'cdn.jsdelivr.net',
         'sentry.io',
         'dvmwjbtfsnnp0.cloudfront.net',
-        '*.biglotteryfund.org.uk'
+        '*.biglotteryfund.org.uk',
+        '*.biglotteryfund.local'
     ];
 
     const directives = {

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -1,7 +1,9 @@
 'use strict';
+const { URL } = require('url');
 const helmet = require('helmet');
 const { map } = require('lodash');
 const { legacyProxiedRoutes } = require('../controllers/routes');
+const { apiEndpoint } = require('../services/content-api');
 
 module.exports = function(environment) {
     /**
@@ -26,8 +28,7 @@ module.exports = function(environment) {
         'cdn.jsdelivr.net',
         'sentry.io',
         'dvmwjbtfsnnp0.cloudfront.net',
-        '*.biglotteryfund.org.uk',
-        '*.biglotteryfund.local'
+        new URL(apiEndpoint).hostname
     ];
 
     const directives = {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,10 @@ const path = require('path');
 const config = require('config');
 const Raven = require('raven');
 
+if (app.get('env') === 'development') {
+    require('dotenv').config();
+}
+
 const viewEngineService = require('./modules/viewEngine');
 const viewGlobalsService = require('./modules/viewGlobals');
 
@@ -21,10 +25,6 @@ const favicon = require('serve-favicon');
 const getSecret = require('./modules/get-secret');
 const routes = require('./controllers/routes');
 const { renderError, renderNotFound } = require('./controllers/http-errors');
-
-if (app.get('env') === 'development') {
-    require('dotenv').config();
-}
 
 const SENTRY_DSN = getSecret('sentry.dsn');
 if (SENTRY_DSN) {

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -9,6 +9,10 @@ if (!API_URL) {
     process.exit(1);
 }
 
+function getAdminLinkEndpont({ locale, contentId }) {
+    return `${API_URL}/v1/${locale}/admin-links/${contentId}`;
+}
+
 function getPromotedNews({ locale, limit }) {
     return request({
         url: `${API_URL}/v1/${locale}/promoted-news`,
@@ -53,6 +57,7 @@ function getLegacyPage({ locale, path }) {
 }
 
 module.exports = {
+    getAdminLinkEndpont,
     getPromotedNews,
     getFundingProgrammes,
     getFundingProgramme,

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -2,20 +2,20 @@ const { get, take } = require('lodash');
 const request = require('request-promise-native');
 const getSecret = require('../modules/get-secret');
 
-const API_URL = process.env.cmsUrl || getSecret('content-api.url');
+const apiEndpoint = process.env.cmsUrl || getSecret('content-api.url');
 
-if (!API_URL) {
+if (!apiEndpoint) {
     console.log('Error: CMS_URL endpoint must be defined');
     process.exit(1);
 }
 
 function getAdminLinkEndpont({ locale, contentId }) {
-    return `${API_URL}/v1/${locale}/admin-links/${contentId}`;
+    return `${apiEndpoint}/v1/${locale}/admin-links/${contentId}`;
 }
 
 function getPromotedNews({ locale, limit }) {
     return request({
-        url: `${API_URL}/v1/${locale}/promoted-news`,
+        url: `${apiEndpoint}/v1/${locale}/promoted-news`,
         json: true
     }).then(response => {
         const data = get(response, 'data', []);
@@ -26,7 +26,7 @@ function getPromotedNews({ locale, limit }) {
 
 function getFundingProgrammes({ locale }) {
     return request({
-        url: `${API_URL}/v1/${locale}/funding-programmes`,
+        url: `${apiEndpoint}/v1/${locale}/funding-programmes`,
         json: true
     }).then(response => {
         const programmes = response.data.map(item => item.attributes);
@@ -36,7 +36,7 @@ function getFundingProgrammes({ locale }) {
 
 function getFundingProgramme({ locale, slug }) {
     return request({
-        url: `${API_URL}/v1/${locale}/funding-programme/${slug}`,
+        url: `${apiEndpoint}/v1/${locale}/funding-programme/${slug}`,
         json: true
     }).then(response => {
         const entry = get(response, 'data.attributes');
@@ -46,7 +46,7 @@ function getFundingProgramme({ locale, slug }) {
 
 function getLegacyPage({ locale, path }) {
     return request({
-        url: `${API_URL}/v1/${locale}/legacy`,
+        url: `${apiEndpoint}/v1/${locale}/legacy`,
         qs: {
             path: path
         },
@@ -57,6 +57,7 @@ function getLegacyPage({ locale, path }) {
 }
 
 module.exports = {
+    apiEndpoint,
     getAdminLinkEndpont,
     getPromotedNews,
     getFundingProgrammes,

--- a/views/includes/metaHeadJS.njk
+++ b/views/includes/metaHeadJS.njk
@@ -2,6 +2,10 @@
 <script id="script-head">
 (function() {
     var AppConfig = {
+        adminEndpoint: (function() {
+            var shouldReturn = window.location.hostname !== "{{ appData.config.get('siteDomain') }}";
+            return shouldReturn && {% if adminEndpoint %}"{{ adminEndpoint }}"{% else %}null{% endif %};
+        }()),
         isModernBrowser:
             'querySelector' in document &&
             'addEventListener' in window &&


### PR DESCRIPTION
Re-do of #485 this time by requesting an authenticated endpoint from the CMS to get details about an entry. Requires configuring cookie sharing. Although the real need for this is on a non-test domain the `test.blf.digital` domain is in a position where we could trial this.