### PR TITLE
Use same content markup defined on programme pages

### DIFF
--- a/assets/sass/scaffolding/content.scss
+++ b/assets/sass/scaffolding/content.scss
@@ -88,6 +88,10 @@
         @include underlined();
     }
 
+    p:empty {
+        display: none;
+    }
+
     a {
         font-weight: bold;
     }
@@ -134,5 +138,39 @@
 
     .video-container {
         margin-bottom: 1em;
+    }
+
+    table {
+        font-size: 90%;
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0;
+        border-collapse: collapse;
+        table-layout: fixed;
+        margin: 0 0 1em;
+
+        thead,
+        th {
+            font-weight: bold;
+            vertical-align: middle;
+        }
+        thead {
+            border-bottom: 3px solid palette('off-white');
+        }
+        tr {
+            border-bottom: 1px solid palette('off-white');
+        }
+        tr:last-of-type {
+            border-bottom: none;
+        }
+
+        th,
+        td {
+            padding: 10px 8px;
+            text-align: left;
+        }
+        td {
+            vertical-align: top;
+        }
     }
 }

--- a/views/pages/legacy.njk
+++ b/views/pages/legacy.njk
@@ -7,24 +7,23 @@
 {% block title %}{{ title }} | {% endblock %}
 
 {% block content %}
-
+    {% set pageAccent = 'turquoise' %}
     {% set heroContent %}
         {{ headers.overlayText('h2', title, 't2') }}
     {% endset %}
 
-    {{ hero.header('foi', heroContent, 'turquoise') }}
+    {{ hero.header('foi', heroContent, pageAccent) }}
 
-    <article role="main" class="nudge-up s-prose s-prose--full">
-        <div class="inner--wide-only accent--turquoise a--border-top content-box">
-            {% if content.subtitle %}
-                <h2 class="t2">{{ content.subtitle }}</h2>
-            {% endif %}
-            <div class="grid">
-                <div class="grid__item grid-col-8">
-                    {{ content.body | safe }}
-                </div>
+    <main role="main" class="nudge-up">
+        <article class="content-box inner--wide-only accent--turquoise a--border-top">
+            <div class="s-prose s-prose--long
+                u-constrained-content-wide accent-content--{{ pageAccent }}">
+                {% if content.subtitle %}
+                    <h2>{{ content.subtitle }}</h2>
+                {% endif %}
+                {{ content.body | safe }}
             </div>
-        </div>
-    </article>
+        </article>
+    </main>
 
 {% endblock %}

--- a/views/pages/legacy.njk
+++ b/views/pages/legacy.njk
@@ -1,18 +1,27 @@
-{% import "components/hero.njk" as hero %}
-{% import "components/headers.njk" as headers %}
-{% import "components/segment.njk" as segment %}
+{% from "components/hero.njk" import sectionHero %}
 
 {% extends "layouts/main.njk" %}
-
 {% block title %}{{ title }} | {% endblock %}
 
-{% block content %}
-    {% set pageAccent = 'turquoise' %}
-    {% set heroContent %}
-        {{ headers.overlayText('h2', title, 't2') }}
-    {% endset %}
+{% set bodyClass = "has-full-bleed-header" %}
+{% set heroImage = createHeroImage({
+    small: 'hero/jobs-small.jpg',
+    medium: 'hero/jobs-medium.jpg',
+    large: 'hero/jobs-large.jpg',
+    default: 'hero/jobs-medium.jpg',
+    caption: 'Street Dreams, Grant £9,000'
+}) %}
+{% set socialImage = heroImage %}
+{% set pageAccent = 'turquoise' %}
 
-    {{ hero.header('foi', heroContent, pageAccent) }}
+{% block content %}
+    {{
+        sectionHero(
+            accent = 'blue',
+            titleText = title,
+            image = heroImage
+        )
+    }}
 
     <main role="main" class="nudge-up">
         <article class="content-box inner--wide-only accent--turquoise a--border-top">


### PR DESCRIPTION
**Before:**

<img width="948" alt="screen shot 2017-12-14 at 12 57 04" src="https://user-images.githubusercontent.com/123386/33993405-505f112e-e0ce-11e7-8329-47a958d7e43b.png">

**After:**

<img width="952" alt="screen shot 2017-12-14 at 12 56 50" src="https://user-images.githubusercontent.com/123386/33993407-5076aed8-e0ce-11e7-8d95-af7990672c78.png">
