### PR TITLE
Normalise how environment is determined, use appData

### DIFF
--- a/controllers/http-errors.js
+++ b/controllers/http-errors.js
@@ -1,3 +1,5 @@
+const appData = require('../modules/appData');
+
 const renderNotFound = (req, res) => {
     let err = new Error('Page not found');
     err.status = 404;
@@ -15,7 +17,7 @@ const renderNotFound = (req, res) => {
 const renderError = (err, req, res) => {
     // Set locals, only providing error in development
     res.locals.message = err.message;
-    res.locals.error = req.app.get('env') === 'development' ? err : {};
+    res.locals.error = appData.isDev ? err : {};
     res.locals.status = err.status || 500;
     res.locals.errorTitle = err.friendlyText ? err.friendlyText : 'Error: ' + err.message;
     res.locals.sentry = res.sentry;

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -11,20 +11,20 @@ const moment = require('moment');
 
 const router = express.Router();
 
-const app = require('../../server');
-const contentApi = require('../../services/content-api');
-const surveyService = require('../../services/surveys');
-const routeStatic = require('../utils/routeStatic');
+const appData = require('../../modules/appData');
 const getSecret = require('../../modules/get-secret');
 const analytics = require('../../modules/analytics');
 const { heroImages } = require('../../modules/images');
+const contentApi = require('../../services/content-api');
+const surveyService = require('../../services/surveys');
+const routeStatic = require('../utils/routeStatic');
 const regions = require('../../config/content/regions.json');
 
 const legacyPages = require('./legacyPages');
 
 const robots = require('../../config/app/robots.json');
 // block everything on non-prod envs
-if (app.get('env') !== 'production') {
+if (appData.isNotProduction) {
     robots.push('/');
 }
 

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -28,7 +28,7 @@ router.get('/status', cached.noCache, (req, res) => {
     res.setHeader('Content-Type', 'application/json');
 
     res.send({
-        APP_ENV: process.env.NODE_ENV,
+        APP_ENV: appData.environment,
         DEPLOY_ID: appData.deployId,
         COMMIT_ID: appData.commitId,
         BUILD_NUMBER: appData.buildNumber,

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -2,8 +2,9 @@
 const helmet = require('helmet');
 const { map } = require('lodash');
 const { legacyProxiedRoutes } = require('../controllers/routes');
+const appData = require('../modules/appData');
 
-module.exports = function(environment) {
+module.exports = function() {
     /**
      * URLs which should be exempt from security headers
      * Only proxied legacy URLs should be exempt.
@@ -40,7 +41,7 @@ module.exports = function(environment) {
         fontSrc: defaultSecurityDomains.concat(['data:'])
     };
 
-    if (environment === 'development') {
+    if (appData.isDev) {
         // Allow LiveReload in development
         directives.connectSrc = directives.connectSrc.concat(['ws://127.0.0.1:35729/livereload']);
     }

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -1,11 +1,12 @@
 'use strict';
+const Raven = require('raven');
 const config = require('config');
+const { get } = require('lodash');
 const rp = require('request-promise-native');
 const absolution = require('absolution');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
-const { get } = require('lodash');
-const Raven = require('raven');
+const appData = require('../modules/appData');
 
 const legacyUrl = config.get('legacyDomain');
 
@@ -67,7 +68,7 @@ const proxyLegacyPage = (req, res, domModifications, pathOverride) => {
             // parse the DOM
             let dom = new JSDOM(body);
 
-            if (req.app.get('env') === 'development') {
+            if (appData.isDev) {
                 let titleText = dom.window.document.title;
                 dom.window.document.title = '[PROXIED] ' + titleText;
             }

--- a/modules/viewEngine.js
+++ b/modules/viewEngine.js
@@ -4,15 +4,14 @@ const nunjucks = require('nunjucks');
 const moment = require('moment');
 const slugify = require('slugify');
 const assets = require('./assets');
+const appData = require('./appData');
 
 function init(app) {
-    const IS_DEV = (process.env.NODE_ENV || 'development') === 'development';
-
     const templateEnv = nunjucks.configure('views', {
         autoescape: true,
         express: app,
-        noCache: IS_DEV,
-        watch: IS_DEV
+        noCache: appData.isDev,
+        watch: appData.isDev
     });
 
     // register template filters first

--- a/views/error.njk
+++ b/views/error.njk
@@ -26,7 +26,7 @@
                 <small><strong>Error ID:</strong> <code>{{ sentry }}</code></small>
             {% endif %}
 
-            {% if appData.IS_DEV and error.stack %}
+            {% if appData.isDev and error.stack %}
                 <h4>Stack trace:</h4>
                 <pre>{{ error.stack }}</pre>
             {% endif %}


### PR DESCRIPTION
Noticed we had a few different ways of determining current the node environment. This PR tidies things up so that we always get it from `appData` (which in turn uses whatever `node-config` thinks, defaulting to `development` if nothing is set).