### PR TITLE
Refine funding finder redirects

### DIFF
--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -7,7 +7,8 @@
 			"england": "Lloegr",
 			"wales": "Cymru",
 			"scotland": "Yr Alban",
-			"northernIreland": "Gogledd Iwerddon"
+            "northernIreland": "Gogledd Iwerddon",
+            "ukWide": "DU gyfan"
 		},
 		"nav": {
 			"home": "Hafan",

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -7,7 +7,8 @@
 			"england": "England",
 			"wales": "Wales",
 			"scotland": "Scotland",
-			"northernIreland": "Northern Ireland"
+            "northernIreland": "Northern Ireland",
+            "ukWide": "UK-wide"
 		},
 		"nav": {
 			"home": "Home",

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -88,7 +88,8 @@ function initProgrammesList(router, config) {
                                 england: req.i18n.__('global.regions.england'),
                                 wales: req.i18n.__('global.regions.wales'),
                                 scotland: req.i18n.__('global.regions.scotland'),
-                                northernIreland: req.i18n.__('global.regions.northernIreland')
+                                northernIreland: req.i18n.__('global.regions.northernIreland'),
+                                ukWide: req.i18n.__('global.regions.ukWide')
                             };
                             return regions[key];
                         };

--- a/controllers/toplevel/legacyPages.js
+++ b/controllers/toplevel/legacyPages.js
@@ -39,9 +39,10 @@ function reformatQueryString({ originalAreaQuery, originalAmountQuery }) {
     if (originalAreaQuery) {
         newQuery.location = {
             england: 'england',
-            'northern+ireland': 'northernIreland',
+            'northern ireland': 'northernIreland',
             scotland: 'scotland',
-            wales: 'wales'
+            wales: 'wales',
+            'uk-wide': 'ukWide'
         }[originalAreaQuery];
     }
 

--- a/controllers/toplevel/legacyPages.test.js
+++ b/controllers/toplevel/legacyPages.test.js
@@ -45,7 +45,7 @@ describe('Legacy pages', () => {
 
             expect(
                 reformatQueryString({
-                    originalAreaQuery: 'Northern+Ireland',
+                    originalAreaQuery: 'Northern Ireland',
                     originalAmountQuery: null
                 })
             ).to.equal('location=northernIreland');


### PR DESCRIPTION
Ran a report of most frequently used funding finder query strings and tweaked the rules based on that.

- Correct handling of Northern Ireland query string
- Add support for UK-wide as it's frequently accessed
- Update tests