### PR TITLE
Make main funding finder route live

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -1579,6 +1579,70 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/funding-finder",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "DELETE",
+                "POST",
+                "GET",
+                "OPTIONS",
+                "PUT",
+                "PATCH"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 7
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": false
         },
         "MaxTTL": 31536000,
@@ -5109,6 +5173,70 @@
                 "Quantity": 2
             },
             "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/funding-finder",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "DELETE",
+                "POST",
+                "GET",
+                "OPTIONS",
+                "PUT",
+                "PATCH"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 7
         },
         "MinTTL": 0,
         "Compress": false

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -102,7 +102,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/Home/Funding/Funding%20Finder",
+        "PathPattern": "/Home/Funding/Funding*Finder",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -4095,7 +4095,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/welsh/Home/Funding/Funding%20Finder",
+        "PathPattern": "/welsh/Home/Funding/Funding*Finder",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -1579,6 +1579,70 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/funding-finder",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "DELETE",
+                "POST",
+                "GET",
+                "OPTIONS",
+                "PUT",
+                "PATCH"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 7
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": false
         },
         "MaxTTL": 31536000,
@@ -5109,6 +5173,70 @@
                 "Quantity": 2
             },
             "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/funding-finder",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "DELETE",
+                "POST",
+                "GET",
+                "OPTIONS",
+                "PUT",
+                "PATCH"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 7
         },
         "MinTTL": 0,
         "Compress": false

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -102,7 +102,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/Home/Funding/Funding%20Finder",
+        "PathPattern": "/Home/Funding/Funding*Finder",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -4095,7 +4095,7 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/welsh/Home/Funding/Funding%20Finder",
+        "PathPattern": "/welsh/Home/Funding/Funding*Finder",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -347,14 +347,14 @@ const vanityDestinations = {
 const vanityRedirects = [
     {
         name: 'Funding Finder Alias',
-        path: '/Home/Funding/Funding%20Finder',
+        path: '/Home/Funding/Funding*Finder',
         destination: '/funding/programmes',
         aliasOnly: true,
         live: true
     },
     {
         name: 'Funding Finder Alias (Welsh)',
-        path: '/welsh/Home/Funding/Funding%20Finder',
+        path: '/welsh/Home/Funding/Funding*Finder',
         destination: '/welsh/funding/programmes',
         aliasOnly: true,
         live: true

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -478,11 +478,11 @@ function withLegacyDefaults(props) {
 const legacyProxiedRoutes = {
     fundingFinder: withLegacyDefaults({
         path: '/funding/funding-finder',
-        live: false
+        live: true
     }),
     fundingFinderWelsh: withLegacyDefaults({
         path: '/welsh/funding/funding-finder',
-        live: false
+        live: true
     }),
     awardsForAllEngland: withLegacyDefaults({
         path: '/global-content/programmes/england/awards-for-all-england',


### PR DESCRIPTION
Second part of funding finder launch, make main funding finder URL live.