### PR TITLE
Add renderNotFoundWithError helper

### DIFF
--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -1,7 +1,6 @@
 'use strict';
-const Raven = require('raven');
 const { find, get, uniq } = require('lodash');
-const { renderNotFound } = require('../http-errors');
+const { renderNotFoundWithError } = require('../http-errors');
 const { createHeroImage } = require('../../modules/images');
 const contentApi = require('../../services/content-api');
 
@@ -129,10 +128,7 @@ function initProgrammesList(router, config) {
     });
 }
 
-
-
 function initProgrammeDetail(router, config) {
-
     // Allow for programmes without heroes
     const defaultHeroImage = createHeroImage({
         small: 'hero/working-families-small.jpg',
@@ -159,8 +155,7 @@ function initProgrammeDetail(router, config) {
                 }
             })
             .catch(err => {
-                Raven.captureException(err);
-                renderNotFound(req, res);
+                renderNotFoundWithError(err, req, res);
             });
     });
 }

--- a/controllers/http-errors.js
+++ b/controllers/http-errors.js
@@ -1,6 +1,7 @@
+const Raven = require('raven');
 const appData = require('../modules/appData');
 
-const renderNotFound = (req, res) => {
+function renderNotFound(req, res) {
     let err = new Error('Page not found');
     err.status = 404;
     err.friendlyText = "Sorry, we couldn't find that page / Ni allwn ddod o hyd i'r dudalen hon";
@@ -12,9 +13,14 @@ const renderNotFound = (req, res) => {
     // Render the error page
     res.status(res.locals.status);
     res.render('notfound');
-};
+}
 
-const renderError = (err, req, res) => {
+function renderNotFoundWithError(err, req, res) {
+    Raven.captureException(err);
+    renderNotFound(req, res);
+}
+
+function renderError(err, req, res) {
     // Set locals, only providing error in development
     res.locals.message = err.message;
     res.locals.error = appData.isDev ? err : {};
@@ -25,9 +31,10 @@ const renderError = (err, req, res) => {
     // Render the error page
     res.status(res.locals.status);
     res.render('error');
-};
+}
 
 module.exports = {
     renderNotFound,
+    renderNotFoundWithError,
     renderError
 };

--- a/controllers/utils/routeStatic.js
+++ b/controllers/utils/routeStatic.js
@@ -1,9 +1,7 @@
 'use strict';
 const app = require('../../server');
 const contentApi = require('../../services/content-api');
-const { renderNotFound } = require('../http-errors');
-
-const Raven = require('raven');
+const { renderNotFoundWithError } = require('../http-errors');
 
 // redirect any aliases to the canonical path
 let setupRedirects = (sectionPath, page) => {
@@ -39,7 +37,7 @@ const getCmsPath = (sectionId, pagePath) => {
     if (sectionId === 'toplevel') {
         urlPath = pagePath.replace(/^\/+/g, '');
     }
-    
+
     return urlPath;
 };
 
@@ -61,8 +59,7 @@ let serveCmsPage = (page, sectionId, router) => {
                 renderPage(content);
             })
             .catch(err => {
-                Raven.captureException(err);
-                renderNotFound(req, res);
+                renderNotFoundWithError(err, req, res);
             });
     });
 };


### PR DESCRIPTION
Extracting out some of the smaller, standalone, changes from https://github.com/biglotteryfund/blf-alpha/pull/532.

This PR adds a `renderNotFoundWithError` which handles both rendering a 404 and logging to Sentry.