### PR TITLE
Migrate awards for all a/b test

### DIFF
--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -67,7 +67,10 @@
 			},
 			"genericQuestion": "How could we have made this page better?",
 			"genericPrompt": "Tell us how we could improve this page..."
-		}
+        },
+        "abTests": {
+            "awardsForAllEngland": "<p>There are currently two ways to apply: via PDF application form or via online application form.</p><h2>Applying using the online form</h2><p>We are trialling a new application process where you can submit an application via a web form, rather than downloading a PDF.</p><p><a href=\"https://apply.biglotteryfund.org.uk/?cn=en\" class=\"btn\">Apply Online</a></p><p>This new form is a trial, and only open to a limited number of applicants. We’d love your feedback on how you find the experience.</p><h2><strong>Applying via email or post</strong></h2><p>You are also welcome to apply via email or post using our PDF form. To apply this way, follow the instructions below.</p><ol><li><p>Please <a href=\"https://www.biglotteryfund.org.uk/-/media/Files/Programme%20Documents/Awards%20for%20All%20England/NLA4A_guide_england.pdf\">read this guidance document first</a> (PDF 650KB).</p></li><li><p><a href=\"https://www.biglotteryfund.org.uk/-/media/Files/Programme%20Documents/Awards%20for%20All%20England/NLA4A_app_england.pdf\">Save the application form</a> (PDF 700KB) to your computer and open it with the latest version of Adobe Reader. Do not use Preview or any other application. <strong>Please note we are no longer able to accept older versions of the application form.</strong></p></li><li><p>The easiest way is to fill in the form within the file itself – you don’t need to print it off, unless you prefer to send it by post.</p></li><li><p>Email or post the completed application form to us.</p></li></ol><p>We’ll let you know our decision in about ten weeks.</p><p>If you need more information, please contact us at <a href=\"mailto:general.enquiries@awardsforall.org.uk\">general.enquiries@awardsforall.org.uk</a> or call our advice team on <strong>0345 4 10 20 30</strong>. Text Relay users, please use <strong>18001</strong> plus <strong>0345 4 10 20 30</strong>.</p>"
+        }
 	},
 	"toplevel": {
         "home": {

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -27,9 +27,10 @@ module.exports = (pages, sectionPath, sectionId) => {
      */
     programmesRoute.init({
         router: router,
-        config: {
-            listing: pages.programmes,
-            detail: pages.programmeDetail
+        routeConfig: {
+            programmes: pages.programmes,
+            programmeDetail: pages.programmeDetail,
+            programmeDetailAfaEngland: pages.programmeDetailAfaEngland
         }
     });
 

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -185,7 +185,7 @@ function initProgrammeDetailAfaEngland(router, options) {
         }
     });
 
-    // const percentageForTest = config.get('abTests.tests.awardsForAll.percentage');
+    // @TODO use config.get('abTests.tests.awardsForAll.percentage') when launching;
     const percentages = splitPercentages(50);
 
     const getSlug = urlPath => last(urlPath.split('/'));
@@ -194,7 +194,7 @@ function initProgrammeDetailAfaEngland(router, options) {
         handleProgrammeDetail(getSlug(req.path))(req, res);
     });
 
-    router.get(options.path, testFn(null, percentages.A), (req, res) => {
+    router.get(options.path, testFn(null, percentages.B), (req, res) => {
         const locale = req.i18n.getLocale();
         const slug = getSlug(req.path);
         contentApi
@@ -207,10 +207,11 @@ function initProgrammeDetailAfaEngland(router, options) {
 
                     if (applyTabIdx !== -1) {
                         const replacementText = req.i18n.__('global.abTests.awardsForAllEngland');
-                        const newBody = assign({}, entry.contentSections[applyTabIdx], {
-                            body: replacementText[locale]
+                        const newContentSection = assign({}, entry.contentSections[applyTabIdx], {
+                            body: replacementText
                         });
-                        entry.contentSections[applyTabIdx] = newBody;
+
+                        entry.contentSections[applyTabIdx] = newContentSection;
                     } else {
                         Raven.captureMessage('Failed to modify Awards For All page');
                     }
@@ -231,7 +232,9 @@ function initProgrammeDetailAfaEngland(router, options) {
 
 function init({ router, routeConfig }) {
     initProgrammesList(router, routeConfig.programmes);
-    initProgrammeDetailAfaEngland(router, routeConfig.programmeDetailAfaEngland);
+    if (config.get('abTests.enabled')) {
+        initProgrammeDetailAfaEngland(router, routeConfig.programmeDetailAfaEngland);
+    }
     initProgrammeDetail(router);
 }
 

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -1,6 +1,13 @@
 'use strict';
-const { find, get, uniq } = require('lodash');
+
+const ab = require('express-ab');
+const config = require('config');
+const moment = require('moment');
+const Raven = require('raven');
+const { assign, find, findIndex, get, last, uniq } = require('lodash');
+
 const { renderNotFoundWithError } = require('../http-errors');
+const { splitPercentages } = require('../../modules/ab');
 const { createHeroImage } = require('../../modules/images');
 const contentApi = require('../../services/content-api');
 
@@ -50,9 +57,9 @@ const programmeFilters = {
     }
 };
 
-function initProgrammesList(router, config) {
-    router.get(config.path, (req, res, next) => {
-        const lang = req.i18n.__(config.lang);
+function initProgrammesList(router, options) {
+    router.get(options.path, (req, res, next) => {
+        const lang = req.i18n.__(options.lang);
         const templateData = {
             copy: lang,
             title: lang.title,
@@ -78,25 +85,25 @@ function initProgrammesList(router, config) {
                 if (!minAmountParam && !maxAmountParam && !locationParam) {
                     templateData.activeBreadcrumbs = [
                         {
-                            label: req.i18n.__(config.lang + '.breadcrumbAll')
+                            label: req.i18n.__(options.lang + '.breadcrumbAll')
                         }
                     ];
                 } else {
                     templateData.activeBreadcrumbs.push({
-                        label: req.i18n.__(config.lang + '.title'),
+                        label: req.i18n.__(options.lang + '.title'),
                         url: req.originalUrl.split('?').shift()
                     });
 
                     if (parseInt(minAmountParam, 10) === 10000) {
                         templateData.activeBreadcrumbs.push({
-                            label: req.i18n.__(config.lang + '.over10k'),
+                            label: req.i18n.__(options.lang + '.over10k'),
                             url: '/over10k'
                         });
                     }
 
                     if (parseInt(maxAmountParam, 10) === 10000) {
                         templateData.activeBreadcrumbs.push({
-                            label: req.i18n.__(config.lang + '.under10k'),
+                            label: req.i18n.__(options.lang + '.under10k'),
                             url: '/under10k'
                         });
                     }
@@ -119,7 +126,7 @@ function initProgrammesList(router, config) {
                     }
                 }
 
-                res.render(config.template, templateData);
+                res.render(options.template, templateData);
             })
             .catch(err => {
                 err.friendlyText = 'Unable to load funding programmes';
@@ -128,27 +135,89 @@ function initProgrammesList(router, config) {
     });
 }
 
-function initProgrammeDetail(router, config) {
-    // Allow for programmes without heroes
-    const defaultHeroImage = createHeroImage({
+function renderProgrammeDetail({ res, entry }) {
+    /**
+     * Allow for programmes without heroes
+     */
+    const defaultProgrammeHeroImage = createHeroImage({
         small: 'hero/working-families-small.jpg',
         medium: 'hero/working-families-medium.jpg',
         large: 'hero/working-families-large.jpg',
         default: 'hero/working-families-medium.jpg'
     });
 
-    router.get('/programmes/:slug', function(req, res) {
+    res.render('pages/funding/programme-detail', {
+        entry: entry,
+        title: entry.title,
+        heroImage: entry.hero || defaultProgrammeHeroImage
+    });
+}
+
+function handleProgrammeDetail(slug) {
+    return function(req, res) {
+        const locale = req.i18n.getLocale();
         contentApi
-            .getFundingProgramme({
-                locale: req.i18n.getLocale(),
-                slug: req.params.slug
-            })
+            .getFundingProgramme({ locale, slug })
             .then(entry => {
                 if (entry.contentSections.length > 0) {
-                    res.render(config.template, {
-                        entry: entry,
-                        title: entry.title,
-                        heroImage: entry.hero || defaultHeroImage
+                    renderProgrammeDetail({ res, entry });
+                } else {
+                    throw new Error('NoContent');
+                }
+            })
+            .catch(err => {
+                renderNotFoundWithError(err, req, res);
+            });
+    };
+}
+
+function initProgrammeDetail(router) {
+    router.get('/programmes/:slug', (req, res) => {
+        handleProgrammeDetail(req.params.slug)(req, res);
+    });
+}
+
+function initProgrammeDetailAfaEngland(router, options) {
+    const testFn = ab.test('blf-afa-rollout-england', {
+        cookie: {
+            name: config.get('cookies.abTestAwardsForAll'),
+            maxAge: moment.duration(4, 'weeks').asMilliseconds()
+        }
+    });
+
+    // const percentageForTest = config.get('abTests.tests.awardsForAll.percentage');
+    const percentages = splitPercentages(50);
+
+    const getSlug = urlPath => last(urlPath.split('/'));
+
+    router.get(options.path, testFn(null, percentages.A), (req, res) => {
+        handleProgrammeDetail(getSlug(req.path))(req, res);
+    });
+
+    router.get(options.path, testFn(null, percentages.A), (req, res) => {
+        const locale = req.i18n.getLocale();
+        const slug = getSlug(req.path);
+        contentApi
+            .getFundingProgramme({ locale, slug })
+            .then(entry => {
+                if (entry.contentSections.length > 0) {
+                    const applyTabIdx = findIndex(entry.contentSections, section => {
+                        return section.title.match(/How do you apply/);
+                    });
+
+                    if (applyTabIdx !== -1) {
+                        const replacementText = req.i18n.__('global.abTests.awardsForAllEngland');
+                        const newBody = assign({}, entry.contentSections[applyTabIdx], {
+                            body: replacementText[locale]
+                        });
+                        entry.contentSections[applyTabIdx] = newBody;
+                    } else {
+                        Raven.captureMessage('Failed to modify Awards For All page');
+                    }
+
+                    renderProgrammeDetail({
+                        res,
+                        entry
                     });
                 } else {
                     throw new Error('NoContent');
@@ -160,9 +229,10 @@ function initProgrammeDetail(router, config) {
     });
 }
 
-function init({ router, config }) {
-    initProgrammesList(router, config.listing);
-    initProgrammeDetail(router, config.detail);
+function init({ router, routeConfig }) {
+    initProgrammesList(router, routeConfig.programmes);
+    initProgrammeDetailAfaEngland(router, routeConfig.programmeDetailAfaEngland);
+    initProgrammeDetail(router);
 }
 
 module.exports = {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -234,8 +234,12 @@ const routes = {
                 programmeDetail: {
                     name: 'Funding programme details',
                     path: '/programmes/*',
-                    template: 'pages/funding/programme-detail',
-                    allowQueryStrings: false,
+                    static: false,
+                    live: false
+                },
+                programmeDetailAfaEngland: {
+                    name: 'Awards For All England',
+                    path: '/programmes/national-lottery-awards-for-all-england',
                     static: false,
                     live: false
                 }


### PR DESCRIPTION
This PR trials an approach for migrating the Awards For All A/B test to the new pages. ~The general plumbing should be uncontroversial, but the main considerations is **where should the text come from** I'm currently assuming a similar approach to the legacy site where the A variant comes from the CMS and then the B variant being hardcoded in the app.~

Edit: Updated this so that the A variant (where applications are offline primarily) is the text that comes from the CMS and that the B variant text is hard-coded. This is the same model as the previous A/B test.

### Tasks 

- [x] Reimplement test
- [ ] Add Welsh copy
- [ ] Create a new Google Experiment, update ID
- [ ] Launch changes, restart test 