### PR TITLE
Improve homepage and meta titles

### DIFF
--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -71,9 +71,8 @@
 	},
 	"toplevel": {
 		"home": {
-			"title": "Cronfa Loteri Fawr",
+			"title": "Hafan",
 			"description": "Mae'r Gronfa Loteri Fawr yn dosbarthu dros £600m y flwyddyn, a godir gan chwaraewyr y Loteri Genedlaethol, i gymunedau ledled y Deyrnas Unedig",
-			"home": "Hafan",
 			"hero": {
                 "intro": "Mae'r Gronfa Loteri Fawr yn dosbarthu <a href=\"/welsh/data\">dros £600m</a> y flwyddyn, a godir gan chwaraewyr y <a href=\"https://www.national-lottery.co.uk/\">Loteri Genedlaethol</a>, i gymunedau ledled y Deyrnas Unedig",
                 "under10k": {

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -70,10 +70,9 @@
 		}
 	},
 	"toplevel": {
-		"home": {
-			"title": "Big Lottery Fund",
-			"description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
-			"home": "Home",
+        "home": {
+            "title": "Home",
+            "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
 			"hero": {
                 "intro": "The Big Lottery Fund distributes <a href=\"/data\">over £600m</a> a year to communities across the UK, raised by players of the <a href=\"https://www.national-lottery.co.uk/\">National Lottery</a>",
                 "under10k": {

--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -7,6 +7,14 @@ const { stripTrailingSlashes } = require('./urls');
 const { createHeroImage } = require('./images');
 const appData = require('./appData');
 
+function getMetaTitle(base, pageTitle) {
+    if (pageTitle) {
+        return `${pageTitle} | ${base}`;
+    } else {
+        return base;
+    }
+}
+
 function init(app) {
     const setViewGlobal = (name, value) => {
         app.get('engineEnv').addGlobal(name, value);
@@ -24,6 +32,8 @@ function init(app) {
         description: config.get('meta.description'),
         themeColour: sassConfig.themeColour
     });
+
+    setViewGlobal('getMetaTitle', getMetaTitle);
 
     setViewGlobal('getHtmlClasses', function() {
         const locale = getViewGlobal('locale');
@@ -130,5 +140,6 @@ function init(app) {
 }
 
 module.exports = {
-    init
+    init,
+    getMetaTitle
 };

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -1,0 +1,18 @@
+'use strict';
+/* global describe, it */
+const chai = require('chai');
+const expect = chai.expect;
+
+const { getMetaTitle } = require('./viewGlobals');
+
+describe('View Globals', () => {
+    describe('#getMetaTitle', () => {
+        it('should return combined meta title when page title is set', () => {
+            expect(getMetaTitle('Big Lottery Fund', 'Example')).to.equal('Example | Big Lottery Fund');
+        });
+
+        it('should return base title if no page title is set', () => {
+            expect(getMetaTitle('Big Lottery Fund')).to.equal('Big Lottery Fund');
+        });
+    });
+});

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -1,17 +1,16 @@
+{% set metaTitle = getMetaTitle(__("global.brand.title"), title) %}
 {% macro makeAbsoluteImage(path) %}{{ request.protocol }}://{{ request.headers.host }}{{ path }}{% endmacro %}
-
-<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) (Node version: {{ appData.nodeVersion }}) -->
-
+<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
-<meta name="title" content="{% if title %}{{ title }} | {{ metadata.title }}{% else %}{{ metadata.title }}{% endif %}">
+<meta name="title" content="{{ metaTitle }}">
 <meta name="description" content="{% if description %}{{ description }}{% else %}{{ metadata.description }}{% endif %}">
 
 {# Open Graph data #}
 <meta property="og:type" content="website">
-<meta property="og:title" content="{% if title %}{{ title }} | {{ metadata.title }}{% else %}{{ metadata.title }}{% endif %}">
+<meta property="og:title" content="{{ metaTitle }}">
 <meta property="og:description" content="{% if description %}{{ description }}{% else %}{{ metadata.description }}{% endif %}">
 <meta property="og:url" content="{{ getCurrentUrl(request) }}">
 

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -9,7 +9,7 @@
 {% set bodyClass = "has-full-bleed-header" %}
 {% set globalFootnote = "* " + __('global.footerLinks.grantFootnote') %}
 
-{% block title %}{{ title }} | {{ copy.home }} | {% endblock %}
+{% block title %}{{ title }} | {% endblock %}
 
 {% set socialImage = heroImage.default %}
 


### PR DESCRIPTION
Currently there are a couple of issues with page titles:

1. The homepage title is an unwieldy "Big Lottery Fund | Home | Big Lottery Fund"
2. The meta and `og:title` properties are not fully translated

This PR:

1. Updates the homepage title to be "Home | Big Lottery Fund"
2. Adds a new `getMetaTitle` view method for getting a fully translated meta title

Before:

<img width="564" alt="screen shot 2018-01-12 at 12 25 09" src="https://user-images.githubusercontent.com/123386/34875083-b52b5096-f793-11e7-897d-651fe84ecfda.png">

After:

<img width="491" alt="screen shot 2018-01-12 at 12 25 26" src="https://user-images.githubusercontent.com/123386/34875088-b9aadee8-f793-11e7-9cdb-e1c1fa42a1b6.png">

I'd like to use this `getMetaTitle` method for the main page title too but this involves updating how the `{% block title %}` line is used on every template. A find and replace job, but want to reduce the scope of this PR.

