### PR TITLE
Add tests for viewGlobals methods

### DIFF
--- a/config/content/sass.json
+++ b/config/content/sass.json
@@ -9,6 +9,5 @@
         "xlarge": "1200px",
         "tablet": "760px",
         "desktop": "980px"
-    },
-    "themeColour": "#ec008c"
+    }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,8 @@
     "siteDomain": "www.biglotteryfund.org.uk",
     "meta": {
         "title": "The Big Lottery Fund",
-        "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery."
+        "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
+        "themeColour": "#ec008c"
     },
     "i18n": {
         "urlPrefix": {

--- a/config/locales/cy.json
+++ b/config/locales/cy.json
@@ -71,9 +71,8 @@
 	},
 	"toplevel": {
 		"home": {
-			"title": "Cronfa Loteri Fawr",
+			"title": "Hafan",
 			"description": "Mae'r Gronfa Loteri Fawr yn dosbarthu dros £600m y flwyddyn, a godir gan chwaraewyr y Loteri Genedlaethol, i gymunedau ledled y Deyrnas Unedig",
-			"home": "Hafan",
 			"hero": {
                 "intro": "Mae'r Gronfa Loteri Fawr yn dosbarthu <a href=\"/welsh/data\">dros £600m</a> y flwyddyn, a godir gan chwaraewyr y <a href=\"https://www.national-lottery.co.uk/\">Loteri Genedlaethol</a>, i gymunedau ledled y Deyrnas Unedig",
                 "under10k": {

--- a/config/locales/en.json
+++ b/config/locales/en.json
@@ -70,10 +70,9 @@
 		}
 	},
 	"toplevel": {
-		"home": {
-			"title": "Big Lottery Fund",
-			"description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
-			"home": "Home",
+        "home": {
+            "title": "Home",
+            "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
 			"hero": {
                 "intro": "The Big Lottery Fund distributes <a href=\"/data\">over £600m</a> a year to communities across the UK, raised by players of the <a href=\"https://www.national-lottery.co.uk/\">National Lottery</a>",
                 "under10k": {

--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -7,6 +7,14 @@ const { stripTrailingSlashes } = require('./urls');
 const { createHeroImage } = require('./images');
 const appData = require('./appData');
 
+function getMetaTitle(base, pageTitle) {
+    if (pageTitle) {
+        return `${pageTitle} | ${base}`;
+    } else {
+        return base;
+    }
+}
+
 function init(app) {
     const setViewGlobal = (name, value) => {
         app.get('engineEnv').addGlobal(name, value);
@@ -24,6 +32,8 @@ function init(app) {
         description: config.get('meta.description'),
         themeColour: sassConfig.themeColour
     });
+
+    setViewGlobal('getMetaTitle', getMetaTitle);
 
     setViewGlobal('getHtmlClasses', function() {
         const locale = getViewGlobal('locale');
@@ -130,5 +140,6 @@ function init(app) {
 }
 
 module.exports = {
-    init
+    init,
+    getMetaTitle
 };

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -1,0 +1,18 @@
+'use strict';
+/* global describe, it */
+const chai = require('chai');
+const expect = chai.expect;
+
+const { getMetaTitle } = require('./viewGlobals');
+
+describe('View Globals', () => {
+    describe('#getMetaTitle', () => {
+        it('should return combined meta title when page title is set', () => {
+            expect(getMetaTitle('Big Lottery Fund', 'Example')).to.equal('Example | Big Lottery Fund');
+        });
+
+        it('should return base title if no page title is set', () => {
+            expect(getMetaTitle('Big Lottery Fund')).to.equal('Big Lottery Fund');
+        });
+    });
+});

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -1,11 +1,73 @@
-'use strict';
 /* global describe, it */
+
 const chai = require('chai');
 const expect = chai.expect;
 
-const { getMetaTitle } = require('./viewGlobals');
+const httpMocks = require('node-mocks-http');
+const { buildUrl, getCurrentUrl, getHtmlClasses, getMetaTitle } = require('./viewGlobals');
 
 describe('View Globals', () => {
+    describe('#buildUrl', () => {
+        it('should build correct url based on section url and page name', () => {
+            const builderEn = buildUrl('');
+            const builderCy = buildUrl('welsh');
+
+            expect(builderEn('toplevel', 'benefits')).to.equal('/jobs/benefits');
+            expect(builderCy('toplevel', 'benefits')).to.equal('welsh/jobs/benefits');
+        });
+
+        it('should build correct url when a simple path is given', () => {
+            const testPath = 'global-content/programmes/england/awards-for-all-england';
+            expect(buildUrl('')(testPath)).to.equal(`/${testPath}`);
+            expect(buildUrl('welsh')(testPath)).to.equal(`welsh/${testPath}`);
+        });
+    });
+
+    describe('#getCurrentUrl', () => {
+        it('should return expected url for en locale', () => {
+            const req = httpMocks.createRequest({
+                method: 'GET',
+                url: '/some/example/url/',
+                headers: {
+                    Host: 'biglotteryfund.org.uk',
+                    'X-Forwarded-Proto': 'https'
+                }
+            });
+            expect(getCurrentUrl(req, 'en')).to.equal('https://biglotteryfund.org.uk/some/example/url');
+            expect(getCurrentUrl(req, 'cy')).to.equal('https://biglotteryfund.org.uk/welsh/some/example/url');
+        });
+
+        it('should correct url if in cy locale', () => {
+            expect('should return expected url for cy locale', () => {
+                const req = httpMocks.createRequest({
+                    method: 'GET',
+                    url: '/welsh/some/example/url/',
+                    headers: {
+                        Host: 'biglotteryfund.org.uk',
+                        'X-Forwarded-Proto': 'https'
+                    }
+                });
+
+                expect(getCurrentUrl(req, 'en')).to.equal('https://biglotteryfund.org.uk/some/example/url');
+                expect(getCurrentUrl(req, 'cy')).to.equal('https://biglotteryfund.org.uk/welsh/some/example/url');
+            });
+        });
+    });
+
+    describe('#getHtmlClasses', () => {
+        it('should return expected html classes based on locale', () => {
+            expect(getHtmlClasses({ locale: 'en' })).to.equal('no-js locale--en');
+            expect(getHtmlClasses({ locale: 'cy' })).to.equal('no-js locale--cy');
+        });
+
+        it('should return expected html classes if in high contrast mode', () => {
+            expect(getHtmlClasses({ locale: 'en', highContrast: true })).to.equal('no-js locale--en contrast--high');
+            expect(getHtmlClasses({ locale: 'cy', highContrast: true })).to.equal('no-js locale--cy contrast--high');
+            expect(getHtmlClasses({ locale: 'en', highContrast: false })).to.equal('no-js locale--en');
+            expect(getHtmlClasses({ locale: 'cy', highContrast: false })).to.equal('no-js locale--cy');
+        });
+    });
+
     describe('#getMetaTitle', () => {
         it('should return combined meta title when page title is set', () => {
             expect(getMetaTitle('Big Lottery Fund', 'Example')).to.equal('Example | Big Lottery Fund');

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -1,17 +1,16 @@
+{% set metaTitle = getMetaTitle(__("global.brand.title"), title) %}
 {% macro makeAbsoluteImage(path) %}{{ request.protocol }}://{{ request.headers.host }}{{ path }}{% endmacro %}
-
-<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) (Node version: {{ appData.nodeVersion }}) -->
-
+<!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
 
-<meta name="title" content="{% if title %}{{ title }} | {{ metadata.title }}{% else %}{{ metadata.title }}{% endif %}">
+<meta name="title" content="{{ metaTitle }}">
 <meta name="description" content="{% if description %}{{ description }}{% else %}{{ metadata.description }}{% endif %}">
 
 {# Open Graph data #}
 <meta property="og:type" content="website">
-<meta property="og:title" content="{% if title %}{{ title }} | {{ metadata.title }}{% else %}{{ metadata.title }}{% endif %}">
+<meta property="og:title" content="{{ metaTitle }}">
 <meta property="og:description" content="{% if description %}{{ description }}{% else %}{{ metadata.description }}{% endif %}">
 <meta property="og:url" content="{{ getCurrentUrl(request) }}">
 

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -9,7 +9,7 @@
 {% set bodyClass = "has-full-bleed-header" %}
 {% set globalFootnote = "* " + __('global.footerLinks.grantFootnote') %}
 
-{% block title %}{{ title }} | {{ copy.home }} | {% endblock %}
+{% block title %}{{ title }} | {% endblock %}
 
 {% set socialImage = heroImage.default %}
 


### PR DESCRIPTION
Adds tests for view globals methods. Particularly focussed on the complex `buildUrl` and `getCurrentUrl` methods. (Branched off `title-fix` branch).