### PR TITLE
Remove linebreaks/redundant spaces in breadcrumbs

### DIFF
--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -79,11 +79,8 @@
     <ol class="selection-trail">
         {% for crumb in trail %}
         <li class="selection-trail__item">
-            {% set showUrl = crumb.url  %}
-            {% if showUrl %}<a class="selection-trail__link" href="{{ crumb.url }}">{% endif %}
-            {{ crumb.label }}
-            {% if loop.last and itemCount %}({{ itemCount }}){% endif %}
-            {% if showUrl %}</a>{% endif %}
+            {% set showUrl = crumb.url %}
+            {% if showUrl %}<a class="selection-trail__link" href="{{ crumb.url }}">{% endif %}{{ crumb.label }}{% if loop.last and itemCount %} ({{ itemCount }}){% endif %}{% if showUrl %}</a>{% endif %}
         </li>
         {% endfor %}
     </ol>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/394376/34935978-9d5ba4f2-f9d7-11e7-825f-5a1a879c13fa.png)

After:
![image](https://user-images.githubusercontent.com/394376/34935985-a3c8dbf2-f9d7-11e7-94dd-e0cb647f6205.png)
