### PR TITLE
Fix getCurrentUrl used for locale switcher

### DIFF
--- a/modules/urls.js
+++ b/modules/urls.js
@@ -51,17 +51,32 @@ function cymreigio(urlPath) {
     return [urlPath, makeWelsh(urlPath)];
 }
 
+function getBaseUrl(req) {
+    const headerProtocol = req.get('X-Forwarded-Proto');
+    const protocol = headerProtocol ? headerProtocol : req.protocol;
+    const baseUrl = `${protocol}://${req.get('host')}`;
+    return baseUrl;
+}
+
+/**
+ * hasTrailingSlash
+ * Does a given URL end with a trailing slash
+ */
+function hasTrailingSlash(urlPath) {
+    return urlPath[urlPath.length - 1] === '/' && urlPath.length > 1;
+}
+
 /**
  * Strip trailing slashes from a string
  * Used to strip slashes from URLs like '/welsh/' => '/welsh'
  */
-const stripTrailingSlashes = str => {
-    const hasTrailingSlash = s => s[s.length - 1] === '/' && s.length > 1;
-    if (hasTrailingSlash(str)) {
-        str = str.substring(0, str.length - 1);
+function stripTrailingSlashes(urlPath) {
+    if (hasTrailingSlash(urlPath)) {
+        urlPath = urlPath.substring(0, urlPath.length - 1);
     }
-    return str;
-};
+
+    return urlPath;
+}
 
 module.exports = {
     WELSH_REGEX,
@@ -70,5 +85,7 @@ module.exports = {
     removeWelsh,
     localify,
     cymreigio,
+    getBaseUrl,
+    hasTrailingSlash,
     stripTrailingSlashes
 };

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -38,19 +38,17 @@ describe('View Globals', () => {
         });
 
         it('should correct url if in cy locale', () => {
-            expect('should return expected url for cy locale', () => {
-                const req = httpMocks.createRequest({
-                    method: 'GET',
-                    url: '/welsh/some/example/url/',
-                    headers: {
-                        Host: 'biglotteryfund.org.uk',
-                        'X-Forwarded-Proto': 'https'
-                    }
-                });
-
-                expect(getCurrentUrl(req, 'en')).to.equal('https://biglotteryfund.org.uk/some/example/url');
-                expect(getCurrentUrl(req, 'cy')).to.equal('https://biglotteryfund.org.uk/welsh/some/example/url');
+            const req = httpMocks.createRequest({
+                method: 'GET',
+                url: '/welsh/some/example/url/',
+                headers: {
+                    Host: 'biglotteryfund.org.uk',
+                    'X-Forwarded-Proto': 'https'
+                }
             });
+
+            expect(getCurrentUrl(req, 'en')).to.equal('https://biglotteryfund.org.uk/some/example/url');
+            expect(getCurrentUrl(req, 'cy')).to.equal('https://biglotteryfund.org.uk/welsh/some/example/url');
         });
     });
 


### PR DESCRIPTION
So, it turns out I'd written tests to catch this case but made a syntax error stopping that test from running!

The main issue here was a mismatch between all our URL helpers operating on a URL path but `getCurrentUrl` working with a full URL with protocol and host.

I've reinstated the test and updated the function to work primarily on the URL path and the construct the full URL only at the end. Allows us to safely reuse shared URL helper functions.