### PR TITLE
Add vanity redirects for reaching communities and awards for all scotland

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -928,6 +928,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/awardsforallscotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/contact",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -3427,6 +3486,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/prog_a4a_eng",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/prog_reaching_communities",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -928,6 +928,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/awardsforallscotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/contact",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -3427,6 +3486,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/prog_a4a_eng",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/prog_reaching_communities",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -497,18 +497,6 @@ const legacyProxiedRoutes = {
     awardsForAllEngland: withLegacyDefaults({
         path: '/global-content/programmes/england/awards-for-all-england',
         live: true
-    }),
-    awardsForAllScotland: withLegacyDefaults({
-        path: '/global-content/programmes/scotland/awards-for-all-scotland',
-        live: false
-    }),
-    awardsForAllWales: withLegacyDefaults({
-        path: '/global-content/programmes/wales/awards-for-all-wales',
-        live: false
-    }),
-    awardsForAllWalesWelsh: withLegacyDefaults({
-        path: '/welsh/global-content/programmes/wales/awards-for-all-wales',
-        live: false
     })
 };
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,6 +1,6 @@
 'use strict';
 const config = require('config');
-const _ = require('lodash');
+const { forEach, get, merge } = require('lodash');
 const anchors = config.get('anchors');
 
 const importedLegacyPages = require('../config/app/importedLegacyPages');
@@ -301,6 +301,18 @@ const routes = {
 };
 
 /**
+ * Scraped/imported pages
+ *
+ * Serve pages imported via script into the CMS
+ */
+for (let section in importedLegacyPages) {
+    if (get(routes.sections, section)) {
+        let pages = routes.sections[section].pages;
+        routes.sections[section].pages = merge(pages, importedLegacyPages[section]);
+    }
+}
+
+/**
  * Programme Migration
  *
  * Handle redirects from /global-content/programmes to /funding/programmes
@@ -317,7 +329,6 @@ function programmeMigration(from, to, isLive) {
     };
 }
 const programmeRedirects = [
-    programmeMigration('england/reaching-communities-england', 'reaching-communities-england', false),
     programmeMigration('england/parks-for-people', 'parks-for-people', false),
     programmeMigration('northern-ireland/people-and-communities', 'people-and-communities', false),
     programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants', false),
@@ -332,18 +343,6 @@ const programmeRedirects = [
     programmeMigration('uk-wide/uk-portfolio', 'uk-portfolio', false),
     programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders', false)
 ];
-
-/**
- * Scraped/imported pages
- *
- * Serve pages imported via script into the CMS
- */
-for (let section in importedLegacyPages) {
-    if (_.get(routes.sections, section)) {
-        let pages = routes.sections[section].pages;
-        routes.sections[section].pages = _.merge(pages, importedLegacyPages[section]);
-    }
-}
 
 /**
  * Vanity URLs
@@ -370,25 +369,43 @@ const vanityRedirects = [
         live: true
     },
     {
-        // this has to be here and not as an alias
-        // otherwise it won't be recognised as a welsh URL
-        name: 'Publicity (Welsh)',
-        path: '/cyhoeddusrwydd',
-        destination: '/welsh' + vanityDestinations.publicity,
-        aliasOnly: true,
+        name: 'Awards For All England',
+        path: '/prog_a4a_eng',
+        destination: '/global-content/programmes/england/awards-for-all-england',
+        live: true
+    },
+    {
+        name: 'Awards For All Scotland',
+        path: '/awardsforallscotland',
+        destination: '/global-content/programmes/scotland/awards-for-all-scotland',
+        live: true
+    },
+    {
+        name: 'Reaching Communities England',
+        path: '/prog_reaching_communities',
+        destination: '/global-content/programmes/england/reaching-communities-england',
         live: true
     },
     {
         name: 'Helping Working Families',
         path: '/helpingworkingfamilies',
-        destination: routes.sections.toplevel.pages.helpingWorkingFamilies.path,
+        destination: '/helping-working-families',
         aliasOnly: true,
         live: true
     },
     {
         name: 'Helping Working Families (Welsh)',
         path: '/helputeuluoeddgweithio',
-        destination: '/welsh' + routes.sections.toplevel.pages.helpingWorkingFamilies.path,
+        destination: '/welsh/helping-working-families',
+        aliasOnly: true,
+        live: true
+    },
+    {
+        // this has to be here and not as an alias
+        // otherwise it won't be recognised as a welsh URL
+        name: 'Publicity (Welsh)',
+        path: '/cyhoeddusrwydd',
+        destination: '/welsh' + vanityDestinations.publicity,
         aliasOnly: true,
         live: true
     },
@@ -445,30 +462,6 @@ const vanityRedirects = [
         path: '/welsh/about-big/customer-service/fraud',
         destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud,
         live: true
-    },
-    {
-        name: 'Awards For All England',
-        path: '/prog_a4a_eng',
-        destination: '/global-content/programmes/england/awards-for-all-england',
-        live: true
-    },
-    {
-        name: 'Awards For All Scotland',
-        path: '/awardsforallscotland',
-        destination: '/global-content/programmes/scotland/awards-for-all-scotland',
-        live: false // Mark as live when launching AFA test in Scotland
-    },
-    {
-        name: 'Reaching Communities England',
-        path: '/prog_reaching_communities',
-        destination: '/funding/programmes/reaching-communities-england',
-        live: false // Migration experiment
-    },
-    {
-        name: 'Parks for People',
-        path: '/prog_parks_people',
-        destination: '/funding/programmes/parks-for-people',
-        live: false // Migration experiment
     }
 ];
 

--- a/controllers/toplevel/legacyPages.js
+++ b/controllers/toplevel/legacyPages.js
@@ -99,38 +99,7 @@ function initAwardsForAll(router) {
             path: legacyProxiedRoutes.awardsForAllEngland.path,
             experimentId: 'O9FsbkKfSeOammAP0JrEyA',
             replacements: {
-                applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=en',
-                contactPhone: '0345 4 10 20 30'
-            }
-        },
-        {
-            id: 'scotland',
-            lang: 'en',
-            path: legacyProxiedRoutes.awardsForAllScotland.path,
-            experimentId: 'EcAwbF34R5mbCaWW-y_rFQ',
-            replacements: {
-                applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=sc',
-                contactPhone: '0300 123 7110'
-            }
-        },
-        {
-            id: 'wales',
-            lang: 'en',
-            path: legacyProxiedRoutes.awardsForAllWales.path,
-            experimentId: 'Ko6MLYegQfaRO1rVU1UB3w',
-            replacements: {
-                applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=wales&ln=en',
-                contactPhone: '0300 123 0735'
-            }
-        },
-        {
-            id: 'wales-welsh',
-            lang: 'cy',
-            path: legacyProxiedRoutes.awardsForAllWalesWelsh.path,
-            experimentId: 'Ko6MLYegQfaRO1rVU1UB3w',
-            replacements: {
-                applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=wales&ln=welsh',
-                contactPhone: '0300 123 0735'
+                applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=en'
             }
         }
     ];

--- a/middleware/securityHeaders.test.js
+++ b/middleware/securityHeaders.test.js
@@ -16,7 +16,7 @@ describe('securityHeaders', () => {
 
     it('should not add Content-Security-Policy header for exempt URLs', () => {
         const req = httpMocks.createRequest({
-            path: '/global-content/programmes/wales/awards-for-all-wales'
+            path: '/global-content/programmes/england/awards-for-all-england'
         });
         const res = httpMocks.createResponse();
 


### PR DESCRIPTION
Redirects to canonical `/global-content/programmes` URLs (prior to page migration).