### PR TITLE
Improve test flaking

### DIFF
--- a/integration-tests/1-server-integration.test.js
+++ b/integration-tests/1-server-integration.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const config = require('config');
 const helper = require('./helper');
 
-describe('Express application', () => {
+describe('Basic server tests', () => {
     let server;
 
     before(done => {
@@ -19,7 +19,7 @@ describe('Express application', () => {
 
     after(() => helper.after(server));
 
-    it('responds to /', () => {
+    it('should respond to /', () => {
         return chai
             .request(server)
             .get('/')
@@ -32,7 +32,7 @@ describe('Express application', () => {
             });
     });
 
-    it('serves static files', () => {
+    it('should serve static files', () => {
         const assets = require('../modules/assets');
         const CSS_PATH = assets.getCachebustedPath('stylesheets/style.css');
         return chai
@@ -44,7 +44,7 @@ describe('Express application', () => {
             });
     });
 
-    it('can set contrast preferences', () => {
+    it('should set contrast preferences', () => {
         let redirectUrl = 'http://www.google.com';
         return chai
             .request(server)
@@ -61,7 +61,7 @@ describe('Express application', () => {
             });
     });
 
-    it('404s everything else', () => {
+    it('should 404 everything else', () => {
         return chai
             .request(server)
             .get('/foo/bar')

--- a/integration-tests/2-locale-integration.test.js
+++ b/integration-tests/2-locale-integration.test.js
@@ -10,7 +10,7 @@ const expect = chai.expect;
 
 const helper = require('./helper');
 
-describe('locale integration tests', () => {
+describe('Locale integration tests', () => {
     let server;
 
     before(done => {
@@ -22,8 +22,8 @@ describe('locale integration tests', () => {
 
     after(() => helper.after(server));
 
-    describe('welsh translation', () => {
-        it('serves welsh content', () => {
+    describe('Welsh translation', () => {
+        it('should serve welsh content', () => {
             return chai
                 .request(server)
                 .get('/welsh')
@@ -44,31 +44,32 @@ describe('locale integration tests', () => {
         });
     });
 
-    describe('language switcher', () => {
-        function langSwitherHref(res) {
-            const { document } = new JSDOM(res.text).window;
-            const langSwitcherHref = document.getElementById('qa-lang-switcher').href;
-            const urlPath = new URL(langSwitcherHref).pathname;
-            return urlPath;
-        }
-
-        it('has correct language for en locale', () => {
-            chai
+    describe('Language switcher', () => {
+        it('should include correct language switcher for en locale', () => {
+            return chai
                 .request(server)
                 .get('/funding/programmes')
                 .then(res => {
-                    const urlPath = langSwitherHref(res);
+                    const { document } = new JSDOM(res.text).window;
+                    const langSwitcherHref = document.getElementById('qa-lang-switcher').href;
+                    const urlPath = new URL(langSwitcherHref).pathname;
                     expect(urlPath).to.equal('/welsh/funding/programmes');
+                }).catch(err => {
+                    console.log(err);
                 });
         });
 
-        it('has correct language switcher for cy locale', () => {
-            chai
+        it('should include correct language switcher for cy locale', () => {
+            return chai
                 .request(server)
                 .get('/welsh/funding/programmes')
                 .then(res => {
-                    const urlPath = langSwitherHref(res);
+                    const { document } = new JSDOM(res.text).window;
+                    const langSwitcherHref = document.getElementById('qa-lang-switcher').href;
+                    const urlPath = new URL(langSwitcherHref).pathname;
                     expect(urlPath).to.equal('/funding/programmes');
+                }).catch(err => {
+                    console.log(err);
                 });
         });
     });

--- a/integration-tests/2-locale-integration.test.js
+++ b/integration-tests/2-locale-integration.test.js
@@ -48,28 +48,24 @@ describe('Locale integration tests', () => {
         it('should include correct language switcher for en locale', () => {
             return chai
                 .request(server)
-                .get('/funding/programmes')
+                .get('/over10k')
                 .then(res => {
                     const { document } = new JSDOM(res.text).window;
                     const langSwitcherHref = document.getElementById('qa-lang-switcher').href;
                     const urlPath = new URL(langSwitcherHref).pathname;
-                    expect(urlPath).to.equal('/welsh/funding/programmes');
-                }).catch(err => {
-                    console.log(err);
+                    expect(urlPath).to.equal('/welsh/over10k');
                 });
         });
 
         it('should include correct language switcher for cy locale', () => {
             return chai
                 .request(server)
-                .get('/welsh/funding/programmes')
+                .get('/welsh/over10k')
                 .then(res => {
                     const { document } = new JSDOM(res.text).window;
                     const langSwitcherHref = document.getElementById('qa-lang-switcher').href;
                     const urlPath = new URL(langSwitcherHref).pathname;
-                    expect(urlPath).to.equal('/funding/programmes');
-                }).catch(err => {
-                    console.log(err);
+                    expect(urlPath).to.equal('/over10k');
                 });
         });
     });

--- a/integration-tests/helper.js
+++ b/integration-tests/helper.js
@@ -12,6 +12,8 @@ process.env.PORT = 8090;
 process.env.USE_LOCAL_DATABASE = true;
 // never send emails in test mode (instead capture their content)
 process.env.DONT_SEND_EMAIL = true;
+// Skip morgan logs
+process.env.SKIP_LOGS = true;
 
 const userService = require('../services/user');
 

--- a/integration-tests/survey.test.js
+++ b/integration-tests/survey.test.js
@@ -71,7 +71,6 @@ describe('Survey tool', () => {
             .set('Accept', 'application/json')
             .send(surveyData)
             .end((err, res) => {
-                console.log(err);
                 res.should.have.status(200);
                 res.should.have.header('content-type', /^application\/json/);
                 res.body.should.have.property('status');

--- a/middleware/logger.js
+++ b/middleware/logger.js
@@ -5,8 +5,8 @@ const morgan = require('morgan');
 const logFormat =
     '[:date[clf]] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms ":referrer"';
 
+const skipLogs = process.env.SKIP_LOGS;
+
 module.exports = morgan(logFormat, {
-    skip: req => {
-        return req.originalUrl === '/status';
-    }
+    skip: req => skipLogs || req.originalUrl === '/status'
 });


### PR DESCRIPTION
This PR update the URLs used for the locale switcher tests, along with pulling over some of the smaller debugging improvements from https://github.com/biglotteryfund/blf-alpha/pull/569.

This raises an interesting challenge with is that testing the `/funding/programmes` route is flaky because the entire page is reliant on the CMS and sometimes Travis has networking problems causing these tests to fail. Rerunning the build usually fixes the tests, causing it to be something of a hiesenbug.

Don't really want to have network dependant tests, so for now I'm updating the test to use a different page.

Longer term we may want to decide:

- a. if we want to just avoid testing any pages that are network dependant
- b. test the pages using some kind of mock / interceptor for the content api
- c. accept the reliance on the network but move the integration/functional tests into a separate repo and run the tests on a schedule outside of the critical path. Might make sense if we were more in the realm of WebDriver tests, but I'd like to avoid that.

---

Log changes.

Before:

<img width="798" alt="screen shot 2018-01-18 at 15 23 24" src="https://user-images.githubusercontent.com/123386/35105727-50a88e74-fc64-11e7-8366-69dd1c2d5c66.png">

After:

<img width="676" alt="screen shot 2018-01-18 at 15 28 00" src="https://user-images.githubusercontent.com/123386/35105728-510e31e8-fc64-11e7-9c11-acfb382ebdeb.png">
