### PR TITLE
Strip trailing slashes

### DIFF
--- a/integration-tests/1-server-integration.test.js
+++ b/integration-tests/1-server-integration.test.js
@@ -32,6 +32,39 @@ describe('Basic server tests', () => {
             });
     });
 
+    it('should redirect trailing slashes', () => {
+        function redirectRequest({ originalPath, redirectedPath }) {
+            return chai
+                .request(server)
+                .get(originalPath)
+                .redirects(0)
+                .catch(err => err.response)
+                .then(res => {
+                    return {
+                        res,
+                        originalPath,
+                        redirectedPath
+                    };
+                });
+        }
+
+        return Promise.all([
+            redirectRequest({
+                originalPath: '/funding/',
+                redirectedPath: '/funding'
+            }),
+            redirectRequest({
+                originalPath: '/funding/programmes/?location=wales',
+                redirectedPath: '/funding/programmes?location=wales'
+            })
+        ]).then(results => {
+            results.forEach(result => {
+                expect(result.res.status).to.equal(301);
+                expect(result.res).to.redirectTo(result.redirectedPath);
+            });
+        });
+    });
+
     it('should serve static files', () => {
         const assets = require('../modules/assets');
         const CSS_PATH = assets.getCachebustedPath('stylesheets/style.css');
@@ -44,7 +77,7 @@ describe('Basic server tests', () => {
             });
     });
 
-    it('should set contrast preferences', () => {
+    it('should allow contrast preferences to be set', () => {
         let redirectUrl = 'http://www.google.com';
         return chai
             .request(server)

--- a/integration-tests/tools.test.js
+++ b/integration-tests/tools.test.js
@@ -58,7 +58,7 @@ describe('CMS Tools', function() {
 
         it('should block access to staff-only tools', done => {
             agent
-                .get('/tools/survey-results/')
+                .get('/tools/survey-results')
                 .redirects(0)
                 .end((err, res) => {
                     res.should.redirectTo('/user/login');
@@ -76,11 +76,9 @@ describe('CMS Tools', function() {
                     password: 'wrong'
                 })
                 .end((postErr, postRes) => {
-                    postRes.text.should.match(
-                        /(.*)Your username and password combination is invalid(.*)/
-                    );
+                    postRes.text.should.match(/(.*)Your username and password combination is invalid(.*)/);
                     return agent
-                        .get('/tools/survey-results/')
+                        .get('/tools/survey-results')
                         .redirects(0)
                         .end((err, res) => {
                             res.should.have.status(302);
@@ -96,18 +94,16 @@ describe('CMS Tools', function() {
                     _csrf: csrfToken,
                     username: validUser.username,
                     password: validUser.password,
-                    redirectUrl: '/tools/survey-results/'
+                    redirectUrl: '/tools/survey-results'
                 })
                 .redirects(0)
                 .end((postErr, postRes) => {
                     postRes.should.have.status(302);
-                    postRes.should.redirectTo('/tools/survey-results/');
-                    return agent
-                        .get('/tools/survey-results/')
-                        .end((err, res) => {
-                            res.should.have.status(200);
-                            done();
-                        });
+                    postRes.should.redirectTo('/tools/survey-results');
+                    return agent.get('/tools/survey-results/').end((err, res) => {
+                        res.should.have.status(200);
+                        done();
+                    });
                 });
         });
     });

--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,16 +1,21 @@
 'use strict';
+const slashes = require('connect-slashes');
 
 function redirectNonWww(req, res, next) {
-    let host = req.headers.host;
-    let domainProd = 'biglotteryfund.org.uk';
+    const host = req.headers.host;
+    const domainProd = 'biglotteryfund.org.uk';
     if (host === domainProd) {
-        return res.redirect(301, req.protocol + '://www.' + domainProd + req.originalUrl);
+        const redirectUrl = `${req.protocol}://www.${domainProd}${req.originalUrl}`;
+        return res.redirect(301, redirectUrl);
     } else {
         return next();
     }
 }
 
+const removeTrailingSlashes = slashes(false);
+
 module.exports = {
-    all: [redirectNonWww],
-    redirectNonWww
+    all: [redirectNonWww, removeTrailingSlashes],
+    redirectNonWww,
+    removeTrailingSlashes
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2692,6 +2692,11 @@
         "deep-equal": "1.0.1"
       }
     },
+    "connect-slashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/connect-slashes/-/connect-slashes-1.3.1.tgz",
+      "integrity": "sha1-ldYYMND51YU8hojwtfQ5iLGGrDc="
+    },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "chai-http": "^3.0.0",
     "config": "^1.26.2",
     "connect-session-sequelize": "^4.1.0",
+    "connect-slashes": "^1.3.1",
     "cookie-parser": "~1.4.3",
     "csurf": "^1.9.0",
     "debug": "~2.6.0",


### PR DESCRIPTION
Adds [`connect-slashes`](https://www.npmjs.com/package/connect-slashes) middleware to strip trailing slashes from URLs. The middleware supports either adding or removing trailing slashes. Aesthetically I prefer no trailing slashes, but not a strong preference as long as we're consistent. Includes a basic integration test to confirm the middleware is working.