### PR TITLE
Redirect ugly links (PENDING)

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -8426,5 +8426,64 @@
         },
         "MinTTL": 0,
         "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/~/link.aspx",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
     }
 ]

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -8426,5 +8426,64 @@
         },
         "MinTTL": 0,
         "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": true
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/~/link.aspx",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
     }
 ]

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -581,6 +581,12 @@ const otherUrls = [
         isPostable: true,
         allowQueryStrings: true,
         live: true
+    },
+    {
+        path: '/~/link.aspx',
+        isPostable: false,
+        allowQueryStrings: true,
+        live: true
     }
 ];
 

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -136,7 +136,7 @@ const proxyLegacyPage = (req, res, domModifications, pathOverride) => {
 };
 
 const redirectUglyLink = (req, res) => {
-    let handleError = () =>  res.redirect('/');
+    let handleError = () => res.redirect('/');
     const livePagePath = `https://${config.get('siteDomain')}${req.originalUrl}`;
     rp({
         url: livePagePath,
@@ -144,14 +144,16 @@ const redirectUglyLink = (req, res) => {
         jar: true,
         resolveWithFullResponse: false,
         maxRedirects: 1
-    }).then(response => {
-        const $ = cheerio.load(response);
-        let canonicalUrl = $('meta[name="identifier"]').attr('content');
-        if (!canonicalUrl) {
-            return handleError();
-        }
-        res.redirect(301, canonicalUrl);
-    }).catch(handleError);
+    })
+        .then(response => {
+            const $ = cheerio.load(response);
+            let canonicalUrl = $('meta[name="identifier"]').attr('content');
+            if (!canonicalUrl) {
+                return handleError();
+            }
+            res.redirect(301, canonicalUrl);
+        })
+        .catch(handleError);
 };
 
 module.exports = {

--- a/modules/proxy.js
+++ b/modules/proxy.js
@@ -7,7 +7,6 @@ const absolution = require('absolution');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
 const appData = require('../modules/appData');
-const cheerio = require('cheerio');
 
 const legacyUrl = config.get('legacyDomain');
 
@@ -146,12 +145,13 @@ const redirectUglyLink = (req, res) => {
         maxRedirects: 1
     })
         .then(response => {
-            const $ = cheerio.load(response);
-            let canonicalUrl = $('meta[name="identifier"]').attr('content');
-            if (!canonicalUrl) {
+            let dom = new JSDOM(response);
+            let metaIdentifier = dom.window.document.querySelector('meta[name="identifier"]');
+            let intendedUrl = metaIdentifier.getAttribute('content');
+            if (!metaIdentifier || !intendedUrl) {
                 return handleError();
             }
-            res.redirect(301, canonicalUrl);
+            res.redirect(301, intendedUrl);
         })
         .catch(handleError);
 };

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const Raven = require('raven');
 const appData = require('./modules/appData');
 const viewEngineService = require('./modules/viewEngine');
 const viewGlobalsService = require('./modules/viewGlobals');
+const { redirectUglyLink } = require('./modules/proxy');
 
 const bodyParserMiddleware = require('./middleware/bodyParser');
 const cachedMiddleware = require('./middleware/cached');
@@ -137,6 +138,10 @@ routes.vanityRedirects.forEach(route => {
         });
     }
 });
+
+// redirect all bad link aliases to their canonical equivalents
+// (you're welcome, Sitecore)
+app.get('/~/link.aspx', redirectUglyLink);
 
 // alias for error pages for old site -> new
 app.get('/error', (req, res) => {


### PR DESCRIPTION
Turns this:
https://www.biglotteryfund.org.uk/~/link.aspx?_id=50FAB7D4B5A248F8A8C8F5D4D33F9E0F&_z=z

Into this:

https://www.biglotteryfund.org.uk/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding

This is fairly straightforward but could do with another pair of eyes on it.

Note that merging this will make it live.