### PR TITLE
Fix for IE SVG sizing in micro survey

### DIFF
--- a/assets/sass/components/survey.scss
+++ b/assets/sass/components/survey.scss
@@ -49,8 +49,8 @@ body.is-ios-editing-survey {
         svg {
             transition: all 0.3s ease-in-out;
             transform: rotate(180deg);
-            height: 100%;
-            width: 100%;
+            height: 16px;
+            width: 16px;
 
             @include on-interact() {
                 path {


### PR DESCRIPTION
Issues with intrinsic ratios for SVGs in IE meant that the micro-survey was being displayed with lots of extra padding. Setting and explicit size on the icon is the simplest fix.