### PR TITLE
Update information page to support BBO page

### DIFF
--- a/assets/js/helpers/urls.js
+++ b/assets/js/helpers/urls.js
@@ -3,8 +3,8 @@ function isDownloadLink(href) {
     return documentRegex.test(href);
 }
 
-function isExternalLink(linkEl) {
-    return !(location.hostname === linkEl.hostname || !linkEl.hostname.length);
+function isExternalLink(currentHostname, linkHostname) {
+    return !(currentHostname === linkHostname || !linkHostname.length);
 }
 
 module.exports = {

--- a/assets/js/helpers/urls.js
+++ b/assets/js/helpers/urls.js
@@ -1,8 +1,13 @@
 function isDownloadLink(href) {
-    const documentRegex = /\.(pdf|doc|docx)$/i;
+    const documentRegex = /\.(pdf|doc|docx|xls|xlsx)$/i;
     return documentRegex.test(href);
 }
 
+function isExternalLink(linkEl) {
+    return !(location.hostname === linkEl.hostname || !linkEl.hostname.length);
+}
+
 module.exports = {
-    isDownloadLink
+    isDownloadLink,
+    isExternalLink
 };

--- a/assets/js/helpers/urls.test.js
+++ b/assets/js/helpers/urls.test.js
@@ -3,9 +3,14 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { isDownloadLink } = require('./urls');
+const { isExternalLink, isDownloadLink } = require('./urls');
 
 describe('URL helpers', () => {
+    it('should determine if a link is to an external document', () => {
+        expect(isExternalLink('biglotteryfund.org.uk', 'biglotteryfund.org.uk')).to.be.false;
+        expect(isExternalLink('biglotteryfund.org.uk', 'example.com')).to.be.true;
+    });
+
     it('should determine if a link is to a document', () => {
         expect(isDownloadLink('https://example.com/path/to/url')).to.be.false;
         expect(isDownloadLink('https://example.com/path/to/some.pdf')).to.be.true;

--- a/assets/js/modules/common.js
+++ b/assets/js/modules/common.js
@@ -2,6 +2,7 @@
 
 const $ = require('jquery');
 const fitvids = require('fitvids');
+const { isDownloadLink, isExternalLink } = require('../helpers/urls');
 
 function initToggleMobileNav() {
     // bind mobile nav show/hidew button
@@ -23,10 +24,22 @@ function initFitVids() {
     fitvids('.video-container');
 }
 
+function initContentTweaks() {
+    const $contentArea = $('.s-prose');
+    $contentArea.find('a').each((idx, el) => {
+        if (isDownloadLink(el.href)) {
+            $(el).addClass('is-download-link');
+        } else if (isExternalLink(el)) {
+            $(el).addClass('is-external-link');
+        }
+    });
+}
+
 function init() {
     initToggleMobileNav();
     initOverlays();
     initFitVids();
+    initContentTweaks();
 }
 
 module.exports = {

--- a/assets/js/modules/common.js
+++ b/assets/js/modules/common.js
@@ -29,7 +29,7 @@ function initContentTweaks() {
     $contentArea.find('a').each((idx, el) => {
         if (isDownloadLink(el.href)) {
             $(el).addClass('is-download-link');
-        } else if (isExternalLink(el)) {
+        } else if (isExternalLink(location.hostname, el.hostname)) {
             $(el).addClass('is-external-link');
         }
     });

--- a/assets/js/modules/common.js
+++ b/assets/js/modules/common.js
@@ -25,7 +25,7 @@ function initFitVids() {
 }
 
 function initContentTweaks() {
-    const $contentArea = $('.s-prose');
+    const $contentArea = $('.js-annotate-links');
     $contentArea.find('a').each((idx, el) => {
         if (isDownloadLink(el.href)) {
             $(el).addClass('is-download-link');

--- a/assets/sass/scaffolding/content.scss
+++ b/assets/sass/scaffolding/content.scss
@@ -2,6 +2,44 @@
    Content
    ========================================================================= */
 
+/* =========================================================================
+   Page Section
+   ========================================================================= */
+
+.page-section {
+    @include mq('medium', 'max') {
+        border: none !important;
+    }
+
+    @include mq('medium') {
+        display: flex;
+        flex: 1;
+    }
+}
+.page-section__content,
+.page-section__supplementary {
+    @include mq('medium') {
+        border: none !important;
+    }
+}
+.page-section__content {
+    @include mq('medium') {
+        flex: 1;
+        margin-right: $spacingUnit / 2;
+    }
+}
+.page-section__supplementary {
+    font-size: 18px;
+
+    @include mq('medium') {
+        flex: 0 0 300px;
+    }
+}
+
+/* =========================================================================
+   Content Box
+   ========================================================================= */
+
 .content-box {
     @include bordered();
     background-color: palette('pale');
@@ -69,6 +107,38 @@
     ol li {
         list-style-type: decimal;
     }
+
+    a {
+        font-weight: bold;
+    }
+
+    a.is-download-link {
+        padding-left: 20px;
+        background-repeat: no-repeat;
+        background-position: center left;
+        background-size: 14px;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M27.414 19.414l-10 10a2 2 0 0 1-2.828 0l-10-10a2 2 0 1 1 2.828-2.828L14 23.172V4a2 2 0 1 1 4 0v19.172l6.586-6.586c.39-.39.902-.586 1.414-.586s1.024.195 1.414.586a2 2 0 0 1 0 2.828z" fill="#1a44a1"/></svg>');
+    }
+
+    a.is-external-link {
+        padding-right: 20px;
+        background-repeat: no-repeat;
+        background-position: center right;
+        background-size: 12px;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="32"><path d="M20 24H4V8.06L8 8V4H0v24h24V18h-4v6zM12 4l4 4-6 6 4 4 6-6 4 4V4H12z" fill="#1a44a1"/></svg>');
+    }
+}
+
+.s-prose--links {
+    a,
+    a:link {
+        font-weight: bold;
+        text-decoration: none;
+    }
+    a:hover,
+    a:active {
+        text-decoration: underline;
+    }
 }
 
 /**
@@ -90,10 +160,6 @@
 
     p:empty {
         display: none;
-    }
-
-    a {
-        font-weight: bold;
     }
 
     a[href^='mailto:'],

--- a/assets/sass/scaffolding/content.scss
+++ b/assets/sass/scaffolding/content.scss
@@ -34,6 +34,16 @@
     @include mq('medium') {
         flex: 0 0 300px;
     }
+
+    a,
+    a:link {
+        font-weight: bold;
+        text-decoration: none;
+    }
+    a:hover,
+    a:active {
+        text-decoration: underline;
+    }
 }
 
 /* =========================================================================
@@ -76,190 +86,5 @@
         border-right: none;
         border-bottom: none;
         border-left: none;
-    }
-}
-
-/* =========================================================================
-   Content: Scoped Prose Styles
-   ========================================================================= */
-/*
-    Opt-in typography:
-    https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/
-    http://css-tricks.com/opt-in-typography/
-*/
-.s-prose {
-    ul,
-    ol {
-        margin-bottom: $spacingUnit;
-    }
-
-    ul li,
-    ol li {
-        margin-left: $spacingUnit;
-        margin-bottom: 0.3em;
-        margin-top: 0;
-    }
-
-    ul li {
-        list-style-type: disc;
-    }
-
-    ol li {
-        list-style-type: decimal;
-    }
-
-    a {
-        font-weight: bold;
-    }
-
-    a.is-download-link {
-        padding-left: 20px;
-        background-repeat: no-repeat;
-        background-position: center left;
-        background-size: 14px;
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M27.414 19.414l-10 10a2 2 0 0 1-2.828 0l-10-10a2 2 0 1 1 2.828-2.828L14 23.172V4a2 2 0 1 1 4 0v19.172l6.586-6.586c.39-.39.902-.586 1.414-.586s1.024.195 1.414.586a2 2 0 0 1 0 2.828z" fill="#1a44a1"/></svg>');
-    }
-
-    a.is-external-link {
-        padding-right: 20px;
-        background-repeat: no-repeat;
-        background-position: center right;
-        background-size: 12px;
-        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="32"><path d="M20 24H4V8.06L8 8V4H0v24h24V18h-4v6zM12 4l4 4-6 6 4 4 6-6 4 4V4H12z" fill="#1a44a1"/></svg>');
-    }
-}
-
-.s-prose--links {
-    a,
-    a:link {
-        font-weight: bold;
-        text-decoration: none;
-    }
-    a:hover,
-    a:active {
-        text-decoration: underline;
-    }
-}
-
-/**
- * Expanded prose styles for long blocks of text
- */
-.s-prose--long {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        font-weight: 600;
-    }
-
-    h2::after {
-        @include underlined();
-    }
-
-    p:empty {
-        display: none;
-    }
-
-    a[href^='mailto:'],
-    a[href^='tel:'] {
-        color: palette('green');
-        font-weight: bold;
-        word-break: break-word;
-    }
-
-    a[href^='tel:'] {
-        text-decoration: none;
-    }
-
-    .contrast--high & {
-        a[href^='mailto:'],
-        a[href^='tel:'] {
-            color: palette('blue') !important;
-        }
-    }
-
-    ol li,
-    ul li {
-        margin-left: $spacingUnit * 3;
-    }
-
-    figure,
-    .inline-figure {
-        margin-left: -($spacingUnit);
-        margin-right: -($spacingUnit);
-
-        @include mq(tablet) {
-            margin: 1em 0 2em;
-        }
-
-        &.auto-width {
-            img {
-                width: auto;
-            }
-        }
-    }
-
-    .inline-figure--padded {
-        @include mq('tablet') {
-            margin-left: $spacingUnit * 3;
-            margin-right: $spacingUnit * 3;
-        }
-    }
-
-    .video-container {
-        margin-bottom: 1em;
-    }
-
-    table {
-        font-size: 90%;
-        box-sizing: border-box;
-        width: 100%;
-        padding: 0;
-        border-collapse: collapse;
-        table-layout: fixed;
-        margin: 0 0 1em;
-
-        thead,
-        th {
-            font-weight: bold;
-            vertical-align: middle;
-        }
-        thead {
-            border-bottom: 3px solid palette('off-white');
-        }
-        tr {
-            border-bottom: 1px solid palette('off-white');
-        }
-        tr:last-of-type {
-            border-bottom: none;
-        }
-
-        th,
-        td {
-            padding: 10px 8px;
-            text-align: left;
-        }
-        td {
-            vertical-align: top;
-        }
-    }
-
-    code,
-    pre {
-        overflow-x: auto;
-        white-space: pre-wrap;
-        font-family: Hack, Consolas, monospace;
-        font-size: 14px;
-        padding: 10px;
-        border-radius: 2px;
-        color: palette('pale');
-        background-color: palette('charcoal');
-    }
-
-    pre {
-        padding: 10px;
-        border-radius: 2px;
     }
 }

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -1,0 +1,205 @@
+/* =========================================================================
+   Scoped Prose Styles
+   ========================================================================= */
+/*
+    Opt-in typography:
+    https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/
+    http://css-tricks.com/opt-in-typography/
+*/
+.s-prose {
+    ul,
+    ol {
+        margin-bottom: $spacingUnit;
+    }
+
+    ul li,
+    ol li {
+        margin-left: $spacingUnit;
+        margin-bottom: 0.3em;
+        margin-top: 0;
+    }
+
+    ul li {
+        list-style-type: disc;
+    }
+
+    ol li {
+        list-style-type: decimal;
+    }
+
+    a {
+        font-weight: bold;
+    }
+
+    a[href^='mailto:'],
+    a[href^='tel:'] {
+        color: palette('green');
+        font-weight: bold;
+        word-break: break-word;
+    }
+
+    a[href^='tel:'] {
+        text-decoration: none;
+    }
+
+    .contrast--high & {
+        a[href^='mailto:'],
+        a[href^='tel:'] {
+            color: palette('blue') !important;
+        }
+    }
+
+    figure {
+        margin: 0 0 0.5em 0;
+    }
+
+    /**
+     * Download and external link styles
+     * Only applied if a class of `js-annotate-links` is added to the content area
+     */
+    a.is-download-link {
+        padding-left: 20px;
+        background-repeat: no-repeat;
+        background-position: center left;
+        background-size: 14px;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M27.414 19.414l-10 10a2 2 0 0 1-2.828 0l-10-10a2 2 0 1 1 2.828-2.828L14 23.172V4a2 2 0 1 1 4 0v19.172l6.586-6.586c.39-.39.902-.586 1.414-.586s1.024.195 1.414.586a2 2 0 0 1 0 2.828z" fill="#1a44a1"/></svg>');
+    }
+    a.is-external-link {
+        padding-right: 20px;
+        background-repeat: no-repeat;
+        background-position: center right;
+        background-size: 12px;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="32"><path d="M20 24H4V8.06L8 8V4H0v24h24V18h-4v6zM12 4l4 4-6 6 4 4 6-6 4 4V4H12z" fill="#1a44a1"/></svg>');
+    }
+}
+
+/**
+ * Common styles for longer blocks of text
+ * `long` is used for new content, e.g., programme pages
+ * `legacy` is use for legacy migrated content pages
+ */
+.s-prose--long,
+.s-prose--legacy {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-weight: 600;
+    }
+
+    ol li,
+    ul li {
+        margin-left: $spacingUnit * 3;
+    }
+
+    table {
+        font-size: 90%;
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0;
+        border-collapse: collapse;
+        table-layout: fixed;
+        margin: 0 0 1em;
+
+        thead,
+        th {
+            font-weight: bold;
+            vertical-align: middle;
+        }
+        thead {
+            border-bottom: 3px solid palette('off-white');
+        }
+        tr {
+            border-bottom: 1px solid palette('off-white');
+        }
+        tr:last-of-type {
+            border-bottom: none;
+        }
+
+        th,
+        td {
+            padding: 10px 8px;
+            text-align: left;
+        }
+        td {
+            vertical-align: top;
+        }
+    }
+
+    code,
+    pre {
+        overflow-x: auto;
+        white-space: pre-wrap;
+        font-family: Hack, Consolas, monospace;
+        font-size: 14px;
+        padding: 10px;
+        border-radius: 2px;
+        color: palette('pale');
+        background-color: palette('charcoal');
+    }
+
+    pre {
+        padding: 10px;
+        border-radius: 2px;
+    }
+}
+
+/**
+ * Expanded prose styles for long blocks of text
+ */
+.s-prose--long {
+    h2::after {
+        @include underlined();
+    }
+
+    figure,
+    .inline-figure {
+        margin-left: -($spacingUnit);
+        margin-right: -($spacingUnit);
+
+        @include mq(tablet) {
+            margin: 1em 0 2em;
+        }
+
+        &.auto-width {
+            img {
+                width: auto;
+            }
+        }
+    }
+
+    .inline-figure--padded {
+        @include mq('tablet') {
+            margin-left: $spacingUnit * 3;
+            margin-right: $spacingUnit * 3;
+        }
+    }
+
+    .video-container {
+        margin-bottom: 1em;
+    }
+}
+
+/**
+ * Expanded prose styles for legacy pages
+ */
+.s-prose--legacy {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-weight: 600;
+    }
+
+    h2 {
+        margin: 1em 0 0.5em;
+
+        &:first-of-type {
+            margin-top: 0;
+        }
+    }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -29,8 +29,9 @@
 
 @import 'scaffolding/header';
 @import 'scaffolding/footer';
-@import 'scaffolding/content';
 @import 'scaffolding/grid';
+@import 'scaffolding/scope-prose';
+@import 'scaffolding/content';
 
 // =========================================================================
 // Components

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -251,6 +251,12 @@ const routes = {
                     path: '/programmes/national-lottery-awards-for-all-england',
                     static: false,
                     live: true
+                },
+                buildingBetterOpportunites: {
+                    name: 'Building Better Opportunites',
+                    path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',
+                    useCmsContent: true,
+                    live: false
                 }
             }
         },

--- a/controllers/utils/routeStatic.js
+++ b/controllers/utils/routeStatic.js
@@ -5,6 +5,7 @@ const app = require('../../server');
 const contentApi = require('../../services/content-api');
 const { renderNotFoundWithError } = require('../http-errors');
 const { stripTrailingSlashes } = require('../../modules/urls');
+const { createHeroImage } = require('../../modules/images');
 
 /**
  * Redirect any aliases to the canonical path
@@ -49,13 +50,29 @@ function handleCmsPage(sectionId) {
                 path: contentApi.getCmsPath(sectionId, req.path)
             })
             .then(content => {
+                /**
+                 * Allow for pages without heroes
+                 * @TODO: Define better default hero image.
+                 */
+                const defaultHeroImage = createHeroImage({
+                    small: 'hero/jobs-small.jpg',
+                    medium: 'hero/jobs-medium.jpg',
+                    large: 'hero/jobs-large.jpg',
+                    default: 'hero/jobs-medium.jpg',
+                    caption: 'Street Dreams, Grant £9,000'
+                });
+
                 if (content.children) {
                     res.render('pages/listings/listingPage', {
-                        content
+                        title: content.title,
+                        content: content,
+                        heroImage: content.hero || defaultHeroImage
                     });
                 } else {
                     res.render('pages/listings/informationPage', {
-                        content
+                        title: content.title,
+                        content: content,
+                        heroImage: content.hero || defaultHeroImage
                     });
                 }
             })

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -4,52 +4,43 @@
 {% extends "layouts/main.njk" %}
 
 {% set bodyClass = "has-full-bleed-header" %}
-
-{% block title %}{{ content.title }} | {% endblock %}
-
-{% set heroImage = createHeroImage({
-    small: 'hero/jobs-small.jpg',
-    medium: 'hero/jobs-medium.jpg',
-    large: 'hero/jobs-large.jpg',
-    default: 'hero/jobs-medium.jpg',
-    caption: 'Street Dreams, Grant £9,000'
-}) %}
-
 {% set socialImage = heroImage %}
 
+{% block title %}{{ title }} | {% endblock %}
+
 {% block content %}
-    {{
-        sectionHero(
-            accent = 'cyan',
-            titleText = content.title,
-            image = heroImage
-        )
-    }}
+    {% set pageAccent = 'cyan' %}
+    {{ sectionHero(
+        titleText = title,
+        image = heroImage,
+        accent = pageAccent
+    ) }}
 
     <main role="main" class="nudge-up">
-        <section class="content-box inner--wide-only accent--cyan a--border-top">
-            <div class=" s-prose s-prose--long">
-                {{ content.introduction | safe }}
-            </div>
-        </section>
 
-        {% if content.segments.length > 0 %}
-            <div class="inner">
-                {% for s in content.segments %}
-                    {% set themes = cycler('blue', 'pink-dark', 'orange', 'green', 'turquoise', 'pink', 'cyan') %}
-                    {{ segment(
-                        title = s.title,
-                        text = s.content,
-                        color = themes.next(),
-                        imagePath = s.photo,
-                        imageIsAbsolute = true
-                    ) }}
-                {% endfor %}
-            </div>
+        {% if content.relatedContent %}
+            <section class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
+                <div class="page-section__content accent--{{ pageAccent }} a--border-top">
+                    <article class="content-box s-prose s-prose--long">
+                        {{ content.introduction | safe }}
+                    </article>
+                </div>
+                <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
+                    <aside class="content-box s-prose s-prose--links">
+                        {{ content.relatedContent | safe }}
+                    </aside>
+                </div>
+            </section>
+        {% else %}
+            <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
+                <div class=" s-prose s-prose--long">
+                    {{ content.introduction | safe }}
+                </div>
+            </section>
         {% endif %}
 
         {% if content.outro %}
-            <section class="content-box inner--wide-only accent--blue a--border-top">
+            <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class=" s-prose s-prose--long">
                     {{ content.outro | safe }}
                 </div>

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -21,19 +21,19 @@
         {% if content.relatedContent %}
             <section class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class="page-section__content accent--{{ pageAccent }} a--border-top">
-                    <article class="content-box s-prose s-prose--long">
+                    <article class="content-box s-prose s-prose--legacy js-annotate-links">
                         {{ content.introduction | safe }}
                     </article>
                 </div>
                 <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
-                    <aside class="content-box s-prose s-prose--links">
+                    <aside class="content-box s-prose js-annotate-links">
                         {{ content.relatedContent | safe }}
                     </aside>
                 </div>
             </section>
         {% else %}
             <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
-                <div class=" s-prose s-prose--long">
+                <div class="s-prose s-prose--legacy js-annotate-links">
                     {{ content.introduction | safe }}
                 </div>
             </section>
@@ -41,7 +41,7 @@
 
         {% if content.outro %}
             <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
-                <div class=" s-prose s-prose--long">
+                <div class="s-prose s-prose--legacy">
                     {{ content.outro | safe }}
                 </div>
             </section>


### PR DESCRIPTION
Reworks information page template to support secondary content and hero images, so be used for BBO.

Adds extra logic to show icons for downloads and external links within content areas. I've opted to do this in JavaScript as an enhancement rather than CSS as it gives more flexibility and room to unit test the logic.

![localhost_3000_funding_programmes_building-better-opportunities_guide-to-delivering-european-funding 1](https://user-images.githubusercontent.com/123386/35673400-629ca6d0-0739-11e8-82a2-785cc7ee28b6.png)
