### PR TITLE
Add new tab styles

### DIFF
--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -72,7 +72,7 @@ $palette: (
     'pale-green': #f5fafb,
     'pale-grey': #f5f6fa,
     'pale-pink': #feebf3,
-    'border-tint': rgba(202, 202, 202, 0.5)
+    'border': rgba(202, 202, 202, 0.5)
 );
 
 // which of the above colours should have accents generated?

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -71,7 +71,8 @@ $palette: (
     'pale': #fdfefe,
     'pale-green': #f5fafb,
     'pale-grey': #f5f6fa,
-    'pale-pink': #feebf3
+    'pale-pink': #feebf3,
+    'border-tint': rgba(202, 202, 202, 0.5)
 );
 
 // which of the above colours should have accents generated?

--- a/assets/sass/components/tabs.scss
+++ b/assets/sass/components/tabs.scss
@@ -141,3 +141,45 @@
         }
     }
 }
+
+/* =========================================================================
+   Programme Tabs
+   ========================================================================= */
+/* @TODO: Refactor tab styles */
+
+.tabs--programme .tabs__tabset {
+    background-color: palette('pale-grey');
+    border: solid palette('border-tint');
+    border-width: 0 1px 1px;
+    display: flex;
+
+    li {
+        @include poppins();
+        font-size: 16px;
+        margin: 0;
+        display: inline-block;
+        border-left: 1px solid palette('border-tint');
+        flex: 1;
+
+        &:first-child {
+            border-left: 0;
+        }
+    }
+
+    .tab {
+        color: palette('blue-text');
+        display: block;
+        font-weight: bold;
+        padding: 12px ($spacingUnit * 1.5) 14px;
+        text-decoration: none;
+        border-top: 4px solid transparent;
+        white-space: nowrap;
+        text-align: center;
+    }
+    .tab.tab--active {
+        border-width: 4px 0 0;
+        border-top-color: palette('pink');
+        background-color: white;
+        color: palette('pink');
+    }
+}

--- a/assets/sass/components/tabs.scss
+++ b/assets/sass/components/tabs.scss
@@ -2,39 +2,57 @@
    Tabs
    ========================================================================= */
 
-// the tabs themselves (eq. square, blocky elements)
-.tabs__tabset {
-    background-color: #ffffff;
+/* =========================================================================
+   Tabs: Tabsets
+   ========================================================================= */
+// The tabs themselves (eq. square, blocky elements)
 
-    li {
-        font-family: 'Poppins', arial, sans-serif;
+.tabset {
+    background-color: palette('pale-grey');
+    border: solid palette('border');
+    border-width: 0 1px 1px;
+    display: flex;
+
+    li.tabset__item {
+        @include poppins();
         font-size: 16px;
         margin: 0;
         display: inline-block;
-    }
+        border-left: 1px solid palette('border');
+        flex: 1;
 
-    a {
-        color: #000000;
-        display: block;
-        padding: $spacingUnit / 2 $spacingUnit;
-        text-decoration: none;
-    }
-
-    .tab {
-        &.tab--active {
-            font-weight: 600;
-            border-bottom: 4px solid palette('pink');
-            color: palette('pink');
-            a {
-                color: palette('pink');
-            }
+        &:first-child {
+            border-left: 0;
         }
     }
 
+    .tab {
+        color: palette('blue-text');
+        display: block;
+        font-weight: bold;
+        padding: 12px ($spacingUnit * 1.5) 14px;
+        text-decoration: none;
+        border-top: 4px solid transparent;
+        white-space: nowrap;
+        text-align: center;
+    }
+
+    .tab.tab--active {
+        border-width: 4px 0 0;
+        border-top-color: palette('pink');
+        background-color: white;
+        color: palette('pink');
+    }
+}
+
+/**
+ * Tabset display states
+ */
+.tabset {
     // hide main tabset for non-JS users
     // (they get the accordion)
     .no-js & {
-        display: none;
+        display: none !important;
     }
 
     // also hide tabset on mobile
@@ -44,13 +62,45 @@
 
     // hide tabsets on print
     @media print {
-        display: none;
+        display: none !important;
     }
 }
 
+/* =========================================================================
+   Tab Panes
+   ========================================================================= */
+// The tab content areas
+
+.js-on .tab__pane {
+    .tab__pane-content {
+        display: none;
+    }
+
+    &.pane--active {
+        > .tab__pane-content {
+            display: block;
+        }
+    }
+
+    @media print {
+        .tab__pane-content {
+            display: block !important;
+        }
+    }
+}
+
+/**
+ * Accordion behaviour for small screens
+ */
 .tab__pane--accordion {
+    @include mq('tablet') {
+        .tab__pane-header {
+            display: none;
+        }
+    }
+
     // accordion headers (also shown for non-JS users)
-    header {
+    .tab__pane-header {
         a {
             color: #ffffff;
             background-color: palette('blue');
@@ -77,109 +127,39 @@
             }
         }
     }
+}
+.js-on .tab__pane--accordion {
+    .tab__pane-header {
+        position: relative;
 
-    .js-on & {
-        header {
-            position: relative;
+        .tab__arrow {
+            pointer-events: none;
+            width: 45px;
+            height: 100%;
+            position: absolute;
+            top: 0;
+            right: $spacingUnit;
 
-            .tab__arrow {
-                pointer-events: none;
-                width: 45px;
+            @include mq(tablet) {
+                right: $spacingUnit * 2;
+            }
+
+            svg {
                 height: 100%;
-                position: absolute;
-                top: 0;
-                right: $spacingUnit;
-
-                @include mq(tablet) {
-                    right: $spacingUnit * 2;
-                }
-
-                svg {
-                    height: 100%;
-                    width: 100%;
-                }
-            }
-        }
-
-        &.pane--active {
-            > header {
-                a {
-                    background-color: #9e9e9e;
-                }
-                .tab__arrow {
-                    transform: rotate(180deg);
-                    //transition: transform 0.5s ease-in-out;
-                }
-            }
-        }
-    }
-}
-
-// the tab panes (eg. the content boxes displayed when tabs are clicked)
-.tab__pane {
-    .js-on & {
-        @include mq('tablet') {
-            header {
-                display: none;
-            }
-        }
-
-        article {
-            display: none;
-        }
-
-        &.pane--active {
-            > article {
-                display: block;
+                width: 100%;
             }
         }
     }
 
-    @media print {
-        article {
-            display: block !important;
+    &.pane--active {
+        > .tab__pane--accordion {
+            a {
+                background-color: #9e9e9e;
+            }
+            .tab__arrow {
+                transform: rotate(180deg);
+                //transition: transform 0.5s ease-in-out;
+            }
         }
-    }
-}
-
-/* =========================================================================
-   Programme Tabs
-   ========================================================================= */
-/* @TODO: Refactor tab styles */
-
-.tabs--programme .tabs__tabset {
-    background-color: palette('pale-grey');
-    border: solid palette('border-tint');
-    border-width: 0 1px 1px;
-    display: flex;
-
-    li {
-        @include poppins();
-        font-size: 16px;
-        margin: 0;
-        display: inline-block;
-        border-left: 1px solid palette('border-tint');
-        flex: 1;
-
-        &:first-child {
-            border-left: 0;
-        }
-    }
-
-    .tab {
-        color: palette('blue-text');
-        display: block;
-        font-weight: bold;
-        padding: 12px ($spacingUnit * 1.5) 14px;
-        text-decoration: none;
-        border-top: 4px solid transparent;
-        white-space: nowrap;
-        text-align: center;
-    }
-    .tab.tab--active {
-        border-width: 4px 0 0;
-        border-top-color: palette('pink');
-        background-color: white;
-        color: palette('pink');
     }
 }

--- a/assets/sass/components/tabs.scss
+++ b/assets/sass/components/tabs.scss
@@ -9,9 +9,9 @@
 
 .tabset {
     background-color: palette('pale-grey');
-    border: solid palette('border');
-    border-width: 0 1px 1px;
+    border-right: 1px solid palette('border');
     display: flex;
+    flex-wrap: wrap;
 
     li.tabset__item {
         @include poppins();
@@ -19,11 +19,8 @@
         margin: 0;
         display: inline-block;
         border-left: 1px solid palette('border');
+        border-width: 0 1px;
         flex: 1;
-
-        &:first-child {
-            border-left: 0;
-        }
     }
 
     .tab {
@@ -33,12 +30,12 @@
         padding: 12px ($spacingUnit * 1.5) 14px;
         text-decoration: none;
         border-top: 4px solid transparent;
+        border-bottom: 1px solid palette('border');
         white-space: nowrap;
         text-align: center;
     }
 
     .tab.tab--active {
-        border-width: 4px 0 0;
         border-top-color: palette('pink');
         background-color: white;
         color: palette('pink');

--- a/assets/sass/components/tabs.scss
+++ b/assets/sass/components/tabs.scss
@@ -20,7 +20,7 @@
         display: inline-block;
         border-left: 1px solid palette('border');
         border-width: 0 1px;
-        flex: 1;
+        flex: 1 1 auto;
     }
 
     .tab {
@@ -37,6 +37,7 @@
 
     .tab.tab--active {
         border-top-color: palette('pink');
+        border-bottom-color: transparent;
         background-color: white;
         color: palette('pink');
     }

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -109,5 +109,5 @@ $nudgeAmount: 25px;
 }
 
 .bordered {
-    @include bordered();
+    border: 1px solid palette('border');
 }

--- a/assets/sass/utilities/utilities-display.scss
+++ b/assets/sass/utilities/utilities-display.scss
@@ -3,6 +3,9 @@
    ========================================================================== */
 /* Low level utility classes and display helpers */
 
+.u-bordered {
+    border: 1px solid palette('border');
+}
 .u-no-top-border {
     border-top: none !important;
 }

--- a/assets/sass/utilities/utilities-display.scss
+++ b/assets/sass/utilities/utilities-display.scss
@@ -3,6 +3,13 @@
    ========================================================================== */
 /* Low level utility classes and display helpers */
 
+.u-no-top-border {
+    border-top: none !important;
+}
+.u-no-bottom-border {
+    border-bottom: none !important;
+}
+
 @include mq('desktop', 'max') {
     .u-wide-only {
         display: none !important;

--- a/views/components/tabs.njk
+++ b/views/components/tabs.njk
@@ -8,21 +8,23 @@
 {% endmacro %}
 
 {% macro tabSet(tabSetId, paneSetId, tabs, tabSetClasses, tabClasses, trackClicksAsPageviews) %}
-    <ul class="js-tabset tabs__tabset{% if tabSetClasses %} {{ tabSetClasses }}{% endif %}"
+    <ul class="js-tabset tabset{% if tabSetClasses %} {{ tabSetClasses }}{% endif %}"
         data-paneset="{{ paneSetId }}"{% if not trackClicksAsPageviews %} data-do-not-track-pageviews="true"{% endif %}
         id="js-tabs-{{ tabSetId }}">
         {% for t in tabs %}
-            <li{% if tabClasses %} class="{{ tabClasses }}"{% endif %}>{{ t }}</li>
+            <li class="tabset__item{% if tabClasses %} {{ tabClasses }}{% endif %}">{{ t }}</li>
         {% endfor %}
     </ul>
 {% endmacro %}
 
 {% macro pane(paneId, title, content, accordion = false, setActive = false, tabSetId = false, tabId = false) %}
     <section id="{{ paneId }}" class="tab__pane{% if accordion %} tab__pane--accordion{% endif %}{% if setActive %} pane--active{% endif %}">
-        <header class="tab__pane-header">
-            {{ tab(title, paneId, tabSetId = tabSetId, setActive = setActive, id = tabId) }}
-            <span class="tab__arrow">{{ iconArrowDown() }}</span>
-        </header>
+        {% if accordion and title %}
+            <header class="tab__pane-header">
+                {{ tab(title, paneId, tabSetId = tabSetId, setActive = setActive, id = tabId) }}
+                <span class="tab__arrow">{{ iconArrowDown() }}</span>
+            </header>
+        {% endif %}
         <article class="tab__pane-content">{{ content | safe }}</article>
     </section>
 {% endmacro %}

--- a/views/pages/funding/guidance/logos.njk
+++ b/views/pages/funding/guidance/logos.njk
@@ -102,7 +102,7 @@
 {% endmacro %}
 
 {% set logosMonolingual %}
-    <div class="bordered padded">
+    <div class="u-bordered u-no-top-border padded">
         <ul class="unstyled grid grid--wide-only grid--equal grid--2-up grid--padded">
             <li class="grid__item">
                 <div class="grid__item__inner accent--turquoise bordered padded">
@@ -129,35 +129,36 @@
 {% endset %}
 
 {% set infoMonolingual %}
-    <div class="bordered padded">
+    <div class="u-bordered u-no-top-border padded">
         {{ howToUseLogo | safe }}
     </div>
 {% endset %}
 
 {# england, scotland and NI #}
 {% set contentMonolingual %}
-    <div class="bordered padded">
-        {{ tabs.tabs(
-            id = 'logo-monolingual',
-            content = [
-                {
-                    title: copy.logoDownloads.monolingual,
-                    content: logosMonolingual,
-                    active: true
-                },
-                {
-                    title: copy.howToUseLogo.title,
-                    content: infoMonolingual
-                }
-            ],
-            trackClicksAsPageviews = false
-        )}}
-    </div>
+    {{ tabs.tabs(
+        id = 'logo-monolingual',
+        content = [
+            {
+                title: copy.logoDownloads.monolingual,
+                content: logosMonolingual,
+                active: true
+            },
+            {
+                title: copy.howToUseLogo.title,
+                content: infoMonolingual
+            }
+        ],
+        trackClicksAsPageviews = false
+    )}}
 {% endset %}
+
+
+{# Wales #}
 
 {% set logosBilingual %}
     {# logo pane #}
-    <div class="bordered padded">
+    <div class="u-bordered u-no-top-border padded">
         <ul class="unstyled grid grid--wide-only grid--equal grid--2-up grid--padded">
             <li class="grid__item">
                 <div class="grid__item__inner accent--turquoise bordered padded">
@@ -185,30 +186,27 @@
 
 {% set infoBilingual %}
     {# how to #}
-    <div class="bordered padded">
+    <div class="u-bordered u-no-top-border padded">
         {{ howToUseLogo | safe }}
     </div>
 {% endset %}
 
-{# wales #}
 {% set contentBilingual %}
-    <div class="bordered padded">
-        {{ tabs.tabs(
-            id = 'logo-bilingual',
-            content = [
-                {
-                    title: copy.logoDownloads.bilingual,
-                    content: logosBilingual,
-                    active: true
-                },
-                {
-                    title: copy.howToUseLogo.title,
-                    content: infoBilingual
-                }
-            ],
-            trackClicksAsPageviews = false
-        )}}
-    </div>
+    {{ tabs.tabs(
+        id = 'logo-bilingual',
+        content = [
+            {
+                title: copy.logoDownloads.bilingual,
+                content: logosBilingual,
+                active: true
+            },
+            {
+                title: copy.howToUseLogo.title,
+                content: infoBilingual
+            }
+        ],
+        trackClicksAsPageviews = false
+    )}}
 {% endset %}
 
 {% block content %}
@@ -227,26 +225,34 @@
             <p>{{ copy.body | safe }}</p>
             <p><strong>{{ copy.locationPrompt }}</strong></p>
 
-            {{ tabs.tabs(
-                id = 'region',
-                content = [
-                    {
-                        title: copy.locations.monolingual,
-                        content: contentMonolingual
-                    },
-                    {
-                        title: copy.locations.bilingual,
-                        content: contentBilingual
-                    }
-                ],
-                classes = {
-                    tabSet: 'unstyled grid grid--padded grid--equal grid--2-up grid--wide-only',
-                    tabItem: 'grid__item',
-                    tabs: 'btn btn--block btn--small accent--blue a--btn'
-                },
-                accordion = true,
-                trackClicksAsPageviews = false
-            )}}
+            <div class="js-tabset" data-paneset="paneset-regions">
+                <ul class="unstyled grid grid--padded grid--equal grid--2-up grid--wide-only">
+                    <li class="grid__item">
+                        <a href="#region1" class="btn btn--block btn--small accent--blue a--btn js-tab">
+                            {{ copy.locations.monolingual }}
+                        </a>
+                    </li>
+                    <li class="grid__item">
+                        <a href="#region2" class="btn btn--block btn--small accent--blue a--btn js-tab">
+                            {{ copy.locations.bilingual }}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="js-paneset" id="paneset-regions">
+                {{ tabs.pane(
+                    paneId = 'region1',
+                    content = contentMonolingual,
+                    accordion = false
+                ) }}
+
+                {{ tabs.pane(
+                    paneId = 'region2',
+                    content = contentBilingual,
+                    accordion = false
+                ) }}
+            </div>
         </div>
 
     </article>

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -44,7 +44,7 @@
         {% endmacro %}
 
         {% set tabItems = [] %}
-        {% for section in entry.contentSections %}
+        {% for section in entry.contentSections -%}
             {% set newTab = {
                 "id": "section-" + loop.index,
                 "title": section.title,
@@ -52,19 +52,16 @@
                 "active": loop.index === 1
             } %}
             {% set tabItems = (tabItems.push(newTab), tabItems) %}
-        {% endfor %}
+        {%- endfor %}
 
         <div class="inner--wide-only">
             {% if entry.contentSections.length > 1 %}
-                <div class="tabs--programme">
-                    {# @TODO this introduces lots of blank lines in source #}
-                    {{
-                        tabs(
-                            id = entry.title | slugify,
-                            content = tabItems
-                        )
-                    }}
-                </div>
+                {{
+                    tabs(
+                        id = entry.title | slugify,
+                        content = tabItems
+                    )
+                }}
             {% else %}
                 {% set section = entry.contentSections[0] %}
                 <div class="content-box content-box--borderless">

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -23,8 +23,8 @@
 
     <main role="main">
         {% if entry.intro or entry.summary %}
-            <section class="nudge-up content-box content-box--tinted content-box--flush-narrow-only
-                inner--wide-only accent--pink a--border-top ">
+            <section class="nudge-up content-box content-box--flush
+                inner--wide-only accent--{{ pageAccent }} a--border-top u-no-bottom-border">
                 <div class="s-prose u-constrained-content-wide">
                     {{ entry.intro | safe }}
                     {{ programmeStats(
@@ -36,7 +36,7 @@
         {% endif %}
 
         {% macro tabContent(content, pageAccent) %}
-            <div class="content-box content-box--borderless">
+            <div class="content-box content-box--frameless">
                 <div class="s-prose s-prose--long u-constrained-content-wide accent-content--{{ pageAccent }} js-content">
                     {{ content | safe }}
                 </div>
@@ -56,13 +56,15 @@
 
         <div class="inner--wide-only">
             {% if entry.contentSections.length > 1 %}
-                {# @TODO this introduces lots of blank lines in source #}
-                {{
-                    tabs(
-                        id = entry.title | slugify,
-                        content = tabItems
-                    )
-                }}
+                <div class="tabs--programme">
+                    {# @TODO this introduces lots of blank lines in source #}
+                    {{
+                        tabs(
+                            id = entry.title | slugify,
+                            content = tabItems
+                        )
+                    }}
+                </div>
             {% else %}
                 {% set section = entry.contentSections[0] %}
                 <div class="content-box content-box--borderless">

--- a/views/pages/toplevel/eyp.njk
+++ b/views/pages/toplevel/eyp.njk
@@ -153,7 +153,7 @@
 {% endset %}
 
 {% set applyForFunding %}
-    <div class="content-box content-box--borderless">
+    <div class="content-box content-box--frameless">
         <div class="s-prose s-prose--long u-constrained-content-wide">
         <p><strong>Before you apply, you'll need to:</strong></p>
 
@@ -189,7 +189,7 @@
     {{ hero.header('eyp', heroContent, 'pink', "L'Arche Belfast, Grant: £573,164") }}
 
     <article role="main" class="nudge-up">
-        <div class="content-box content-box--tinted inner--wide-only accent--pink a--border-top">
+        <div class="content-box content-box--flush inner--wide-only accent--pink a--border-top u-no-bottom-border">
             <div class="s-prose s-prose--long u-constrained-content-wide">
                 <p>Empowering Young People is a grants programme designed to support projects in Northern Ireland that give young people aged 8 to 25 the ability to overcome the challenges they face.</p>
 
@@ -198,7 +198,7 @@
             </div>
         </div>
 
-        <div class="inner--wide-only spaced">
+        <div class="inner--wide-only spaced tabs--programme">
             {{
                 tabs(
                     id = 'eyp',

--- a/views/pages/toplevel/eyp.njk
+++ b/views/pages/toplevel/eyp.njk
@@ -198,7 +198,7 @@
             </div>
         </div>
 
-        <div class="inner--wide-only spaced tabs--programme">
+        <div class="inner--wide-only spaced">
             {{
                 tabs(
                     id = 'eyp',

--- a/views/pages/toplevel/working-families.njk
+++ b/views/pages/toplevel/working-families.njk
@@ -61,7 +61,7 @@
             </div>
         {% endmacro %}
 
-        <div class="inner--wide-only tabs--programme">
+        <div class="inner--wide-only">
             {{
                 tabs(
                     id = 'working-families',

--- a/views/pages/toplevel/working-families.njk
+++ b/views/pages/toplevel/working-families.njk
@@ -25,8 +25,8 @@
     }}
 
     <main role="main" class="nudge-up">
-        <section class="content-box content-box--tinted content-box--flush-narrow-only
-            inner--wide-only accent--pink a--border-top ">
+        <section class="content-box content-box--flush
+            inner--wide-only accent--pink a--border-top u-no-bottom-border">
             <div class="s-prose u-constrained-content-wide">
                 {{ copy.intro | safe }}
                 {{ copy.grantSummary | safe }}
@@ -34,7 +34,7 @@
         </section>
 
         {% macro tabContent(sections) %}
-            <div class="content-box content-box--borderless">
+            <div class="content-box content-box--frameless">
                 <div class="s-prose s-prose--long u-constrained-content-wide">
                 {% for section in sections %}
                     {% if section.title %}
@@ -61,7 +61,7 @@
             </div>
         {% endmacro %}
 
-        <div class="inner--wide-only">
+        <div class="inner--wide-only tabs--programme">
             {{
                 tabs(
                     id = 'working-families',


### PR DESCRIPTION
Add new tab styles. ~Scoped to programme pages for now as I was struggling to follow the tab logic used on other pages (e.g. logos); at least on a Friday afternoon. So limiting the scope for now.~ **Edit:** Updated logos page to avoid collision with default tab styles, tab styles now updated site-wide.

<img width="1028" alt="screen shot 2018-02-02 at 16 38 26" src="https://user-images.githubusercontent.com/123386/35744243-c88aac7c-0837-11e8-840f-3d5f10e6c6fa.png">

<img width="994" alt="screen shot 2018-02-05 at 10 42 49" src="https://user-images.githubusercontent.com/123386/35800710-a9b8feee-0a61-11e8-9f06-c9b9b4e1bb81.png">
