### PR TITLE
Update nudge up to work in IE

### DIFF
--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -39,21 +39,17 @@ $nudgeAmount: 25px;
     text-align: center;
 }
 
-@mixin nudged-up {
-    margin-top: -$nudgeAmount;
-    position: relative;
-    z-index: 10;
-}
-
 @mixin nudged-down {
     position: absolute;
     bottom: $nudgeAmount + 30px;
 }
 
 .nudge-up {
-    margin-top: 0;
     @include mq('tablet') {
-        @include nudged-up();
+        top: -$nudgeAmount;
+        margin-bottom: -$nudgeAmount;
+        position: relative;
+        z-index: 10;
     }
 }
 


### PR DESCRIPTION
Spotted whilst fixing https://github.com/biglotteryfund/blf-alpha/pull/626.

Updates the `nudge-up` to "stretch" the page using `top` and a negative `margin-bottom` instead of `margin-top`. Works in IE.