### PR TITLE
Route cleanup

### DIFF
--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -373,7 +373,6 @@ const programmeRedirects = [
     programmeMigration('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland', true),
     programmeMigration('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity', true),
     programmeMigration('scotland/grants-for-improving-lives', 'grants-for-improving-lives', true),
-    programmeMigration('england/building-better-opportunities', 'building-better-opportunities', true),
     programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants', true),
     programmeMigration('wales/people-and-places-large-grants', 'people-and-places-large-grants', true),
     programmeMigration('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio', true),
@@ -381,6 +380,7 @@ const programmeRedirects = [
     programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders', true),
     programmeMigration('northern-ireland/people-and-communities', 'people-and-communities', true),
     programmeMigration('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales', true),
+    programmeMigration('england/building-better-opportunities', 'building-better-opportunities', true),
     // Draft
     programmeMigration('england/parks-for-people', 'parks-for-people', false),
     programmeMigration('scotland/community-assets', 'community-assets', false),
@@ -395,181 +395,59 @@ const programmeRedirects = [
  *
  * Set up some vanity URL redirects that can't be defined in the aliases on the routes above
  */
-const vanityDestinations = {
-    publicity: routes.sections.funding.path + routes.sections.funding.pages.manageFunding.path,
-    contact: routes.sections.toplevel.path + routes.sections.toplevel.pages.contact.path
-};
+function vanity(urlPath, destination, isLive = false) {
+    return {
+        path: urlPath,
+        destination: destination,
+        isPostable: false,
+        allowQueryStrings: false,
+        live: isLive
+    };
+}
+
 const vanityRedirects = [
-    {
-        name: 'Funding Finder Alias',
-        path: '/Home/Funding/Funding*Finder',
-        destination: '/funding/programmes',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Funding Finder Alias (Welsh)',
-        path: '/welsh/Home/Funding/Funding*Finder',
-        destination: '/welsh/funding/programmes',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Awards For All England',
-        paths: ['/prog_a4a_eng', '/a4aengland'],
-        destination: '/funding/programmes/national-lottery-awards-for-all-england',
-        live: true
-    },
-    {
-        name: 'Awards For All Scotland',
-        path: '/awardsforallscotland',
-        destination: '/funding/programmes/national-lottery-awards-for-all-scotland',
-        live: true
-    },
-    {
-        name: 'Awards For All Northern Ireland',
-        path: '/prog_a4a_ni',
-        destination: '/funding/programmes/awards-for-all-northern-ireland',
-        live: true
-    },
-    {
-        name: 'Awards For All Wales',
-        paths: ['/prog_a4a_wales', '/a4awales'],
-        destination: '/funding/programmes/national-lottery-awards-for-all-wales',
-        live: true
-    },
-    {
-        name: 'Reaching Communities England',
-        path: '/prog_reaching_communities',
-        destination: '/funding/programmes/reaching-communities-england',
-        live: true
-    },
-    {
-        name: 'Helping Working Families',
-        path: '/helpingworkingfamilies',
-        destination: '/helping-working-families',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Helping Working Families (Welsh)',
-        path: '/helputeuluoeddgweithio',
-        destination: '/welsh/helping-working-families',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Grants for improving lives',
-        path: '/improvinglives',
-        destination: '/funding/programmes/grants-for-improving-lives',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Grants for community-led activity',
-        path: '/communityled',
-        destination: '/funding/programmes/grants-for-community-led-activity',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Building Better Opportunities',
-        path: '/esf',
-        destination: '/funding/programmes/building-better-opportunities',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Coastal Communities Fund',
-        path: '/ccf',
-        destination: '/funding/programmes/coastal-communities-fund',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'People and Communities',
-        path: '/peopleandcommunities',
-        destination: '/funding/programmes/people-and-communities',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        name: 'Guidance on tracking progress',
-        path: '/guidancetrackingprogress',
-        destination:
-            'funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress',
-        aliasOnly: true,
-        live: true
-    },
-    {
-        // this has to be here and not as an alias
-        // otherwise it won't be recognised as a welsh URL
-        name: 'Publicity (Welsh)',
-        path: '/cyhoeddusrwydd',
-        destination: '/welsh' + vanityDestinations.publicity,
-        aliasOnly: true,
-        live: true
-    },
-    {
-        // this stays here (and not as an alias) as express doesn't care about URL case
-        // and this link is the same (besides case) as an existing alias
-        // (annoyingly, the Title Case version of this link persists on the web... for now.)
-        name: 'Logo page',
-        path: '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
-        destination: routes.sections.funding.path + routes.sections.funding.pages.logos.path,
-        aliasOnly: true,
-        live: true
-    },
-    // the following aliases use custom destinations (eg. with URL anchors)
+    vanity('/Home/Funding/Funding*Finder', '/funding/programmes', true),
+    vanity('/welsh/Home/Funding/Funding*Finder', '/funding/programmes', true),
+    vanity('/funding/scotland-portfolio', '/funding/programmes?location=scotland', true),
+    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england', true),
+    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england', true),
+    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland', true),
+    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland', true),
+    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales', true),
+    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales', true),
+    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england', true),
+    vanity('/helpingworkingfamilies', '/helping-working-families', true),
+    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families', true),
+    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives', true),
+    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity', true),
+    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities', true),
+    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding', true),
+    vanity('/ccf', '/funding/programmes/coastal-communities-fund', true),
+    vanity('/esf', '/funding/programmes/building-better-opportunities', true),
+    vanity(
+        '/guidancetrackingprogress',
+        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress',
+        true
+    ),
+
+    // This stays here (and not as an alias) as express doesn't care about URL case
+    // and this link is the same (besides case) as an existing alias
+    // (annoyingly, the Title Case version of this link persists on the web... for now.)
+    vanity(
+        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
+        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
+        true
+    ),
+
+    // The following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
-    {
-        name: 'Contact press team',
-        path: '/news-and-events/contact-press-team',
-        destination: vanityDestinations.contact + '#' + anchors.contactPress,
-        live: true
-    },
-    {
-        name: 'Contact press team (Welsh)',
-        path: '/welsh/news-and-events/contact-press-team',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactPress,
-        live: true
-    },
-    {
-        name: 'Complaint page',
-        path: '/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
-        live: true
-    },
-    {
-        name: 'Complaint page (England)',
-        path: '/england/about-big/customer-service/making-a-complaint',
-        destination: vanityDestinations.contact + '#' + anchors.contactComplaints,
-        live: true
-    },
-    {
-        name: 'Complaint page (Welsh)',
-        path: '/welsh/about-big/customer-service/making-a-complaint',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactComplaints,
-        live: true
-    },
-    {
-        name: 'Fraud page',
-        path: '/about-big/customer-service/fraud',
-        destination: vanityDestinations.contact + '#' + anchors.contactFraud,
-        live: true
-    },
-    {
-        name: 'Fraud page (Welsh)',
-        path: '/welsh/about-big/customer-service/fraud',
-        destination: '/welsh' + vanityDestinations.contact + '#' + anchors.contactFraud,
-        live: true
-    },
-    {
-        name: 'Scotland Portfoilo',
-        path: '/funding/scotland-portfolio',
-        destination: '/funding/programmes?location=scotland',
-        live: true
-    }
+    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`, true),
+    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactComplaints}`, true),
+    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactPress}`, true),
+    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`, true),
+    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`, true),
+    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`, true),
+    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`, true)
 ];
 
 /**

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -40,7 +40,6 @@ const routes = {
                     path: '/',
                     template: 'pages/toplevel/home',
                     lang: 'toplevel.home',
-                    code: 0,
                     static: false,
                     live: true,
                     isPostable: true,
@@ -58,7 +57,6 @@ const routes = {
                     path: '/contact',
                     template: 'pages/toplevel/contact',
                     lang: 'toplevel.contact',
-                    code: 4,
                     static: true,
                     live: true,
                     aliases: [
@@ -83,7 +81,6 @@ const routes = {
                     path: '/jobs',
                     template: 'pages/toplevel/jobs',
                     lang: 'toplevel.jobs',
-                    code: 7,
                     static: true,
                     live: true,
                     aliases: [
@@ -106,7 +103,6 @@ const routes = {
                     path: '/under10k',
                     template: 'pages/toplevel/under10k',
                     lang: 'toplevel.under10k',
-                    code: 29,
                     static: true,
                     live: true,
                     aliases: [
@@ -122,7 +118,6 @@ const routes = {
                     path: '/over10k',
                     template: 'pages/toplevel/over10k',
                     lang: 'toplevel.over10k',
-                    code: 30,
                     static: true,
                     live: true
                 },
@@ -131,7 +126,6 @@ const routes = {
                     path: '/empowering-young-people',
                     template: 'pages/toplevel/eyp',
                     lang: 'toplevel.eyp',
-                    code: 0,
                     static: true,
                     live: true,
                     aliases: [
@@ -175,7 +169,6 @@ const routes = {
                     path: '/funding-guidance/managing-your-funding',
                     template: 'pages/funding/guidance/managing-your-funding',
                     lang: 'funding.guidance.managing-your-funding',
-                    code: 2,
                     static: true,
                     live: true,
                     aliases: [
@@ -189,7 +182,6 @@ const routes = {
                     path: '/funding-guidance/managing-your-funding/ordering-free-materials',
                     template: 'pages/funding/guidance/order-free-materials',
                     lang: 'funding.guidance.order-free-materials',
-                    code: 3,
                     live: true,
                     isPostable: true,
                     isWildcard: true,
@@ -207,7 +199,6 @@ const routes = {
                     path: '/funding-guidance/managing-your-funding/social-media',
                     template: 'pages/funding/guidance/help-with-publicity',
                     lang: 'funding.guidance.help-with-publicity',
-                    code: 12,
                     static: true,
                     live: true
                 },
@@ -216,7 +207,6 @@ const routes = {
                     path: '/funding-guidance/managing-your-funding/press',
                     template: 'pages/funding/guidance/getting-press-coverage',
                     lang: 'funding.guidance.getting-press-coverage',
-                    code: 18,
                     static: true,
                     live: true
                 },
@@ -225,7 +215,6 @@ const routes = {
                     path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
                     template: 'pages/funding/guidance/logos',
                     lang: 'funding.guidance.logos',
-                    code: 1,
                     static: true,
                     live: true,
                     aliases: [
@@ -310,7 +299,6 @@ const routes = {
                     path: '/',
                     template: 'pages/toplevel/about',
                     lang: 'toplevel.about',
-                    code: 0,
                     static: true,
                     live: false,
                     aliases: [
@@ -322,7 +310,6 @@ const routes = {
                     path: '/customer-service/freedom-of-information',
                     template: 'pages/about/freedom-of-information',
                     lang: 'about.foi',
-                    code: 85,
                     static: true,
                     live: true,
                     aliases: [
@@ -335,7 +322,6 @@ const routes = {
                     path: '/customer-service/data-protection',
                     template: 'pages/about/data-protection',
                     lang: 'about.dataProtection',
-                    code: 84,
                     static: true,
                     live: true,
                     aliases: [

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -34,8 +34,7 @@ router.get('/status/pages', (req, res) => {
     const totals = {
         canonical: [],
         aliases: [],
-        vanityRedirects: routes.vanityRedirects.filter(r => r.aliasOnly).map(r => r.path),
-        redirectedPages: routes.vanityRedirects.filter(r => !r.aliasOnly).map(r => r.path)
+        vanityRedirects: routes.vanityRedirects.map(r => r.path)
     };
 
     for (let s in routes.sections) {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -183,17 +183,12 @@ function generateUrlList(routes) {
         urlList.newSite.push(makeUrlObject(pageObject, makeWelsh(pageObject.path)));
     });
 
-    // add vanity redirects too
+    /**
+     * Vanity redirects
+     */
     routes.vanityRedirects.filter(isLive).forEach(redirect => {
-        if (redirect.paths) {
-            redirect.paths.forEach(path => {
-                let page = { path: path };
-                urlList.newSite.push(makeUrlObject(page));
-            });
-        } else {
-            let page = { path: redirect.path };
-            urlList.newSite.push(makeUrlObject(page));
-        }
+        const pageObject = { path: redirect.path };
+        urlList.newSite.push(makeUrlObject(pageObject));
     });
 
     // Legacy proxied routes

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -152,10 +152,6 @@ describe('Cloudfront Helpers', () => {
                 {
                     path: '/test',
                     live: true
-                },
-                {
-                    paths: ['/supports', '/multiple', '/redirects'],
-                    live: true
                 }
             ],
             otherUrls: [
@@ -173,7 +169,7 @@ describe('Cloudfront Helpers', () => {
 
         it('should filter out non-live routes', done => {
             let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.length).to.equal(11);
+            expect(urlList.newSite.length).to.equal(8);
             done();
         });
 

--- a/server.js
+++ b/server.js
@@ -124,19 +124,10 @@ routes.programmeRedirects.forEach(route => {
  * Vanity URL Redirects
  */
 routes.vanityRedirects.forEach(route => {
-    if (route.paths) {
-        route.paths.forEach(routePath => {
-            serveRedirect({
-                sourcePath: routePath,
-                destinationPath: route.destination
-            });
-        });
-    } else {
-        serveRedirect({
-            sourcePath: route.path,
-            destinationPath: route.destination
-        });
-    }
+    serveRedirect({
+        sourcePath: route.path,
+        destinationPath: route.destination
+    });
 });
 
 // redirect all bad link aliases to their canonical equivalents

--- a/views/pages/tools/pagelist.njk
+++ b/views/pages/tools/pagelist.njk
@@ -22,6 +22,10 @@
                 margin: 20px auto;
             }
 
+            ul li p {
+                margin: 0;
+            }
+
             h2 {
                 border-bottom: 1px solid #999999;
                 padding-bottom: 10px;
@@ -33,11 +37,6 @@
                 font-size: 75%;
                 font-weight: normal;
                 color: #666666;
-            }
-
-            article {
-                margin-left: 40px;
-                margin-bottom: 40px;
             }
 
             .status:after {
@@ -63,11 +62,14 @@
         <main>
 
             <h2>Totals</h2>
+            {% set totalCanonical =  totals.canonical.length * 2 %}
+            {% set totalAliases = totals.aliases.length * 2  %}
+            {% set totalVanity = totals.vanityRedirects.length  %}
             <ul>
-                <li><strong>Live canonical pages</strong>: {{ totals.canonical.length * 2 }} (English and Welsh versions)</li>
-                <li><strong>Live alias URLs</strong>: {{ totals.aliases.length * 2 + totals.redirectedPages.length }} (links that now point to the above pages)</li>
-                <li><strong>Live vanity redirects</strong>: {{ totals.vanityRedirects.length }} (links that redirect to pages)</li>
-                <li><strong>GRAND TOTAL</strong>: {{ totals.canonical.length * 2 + totals.aliases.length * 2 + totals.redirectedPages.length }} (Canonical + Aliases)</li>
+                <li><strong>Live canonical pages</strong>: {{ totalCanonical }} (English and Welsh versions)</li>
+                <li><strong>Live alias URLs</strong>: {{ totalAliases }} (links that now point to the above pages)</li>
+                <li><strong>Live vanity redirects</strong>: {{ totalVanity }} (links that redirect to pages)</li>
+                <li><strong>GRAND TOTAL</strong>: {{ totalCanonical + totalAliases + totalVanity }} (Canonical + Aliases + Vanity URLs)</li>
             </ul>
 
             <button id="js-open-links">Open all canonical English pages in tabs?</button>
@@ -75,7 +77,7 @@
             {% for sectionName, section in routes %}
                 <h2>Section: {{ section.name }}</h2>
                 {% for pageName, page in section.pages %}
-                    <h3>{% if page.code %}Page #{{ page.code }} &ndash; {% endif %}{{ page.name }} <span class="status {% if page.live %}status--live{% else %}status--draft{% endif %}"></span></h3>
+                    <h3>{{ page.name }} <span class="status {% if page.live %}status--live{% else %}status--draft{% endif %}"></span></h3>
                     <article>
                         <h4>Canonical URL <span>(eg. the definitive version of this page)</span></h4>
                         {% set link = buildUrl(sectionName, pageName) %}
@@ -100,16 +102,9 @@
             <h2>Vanity URLs</h2>
             {% for r in vanityRedirects %}
                 <article>
-                    <h3>{{ r.name }}</h3>
                     <ul>
-                        {% if r.paths %}
-                            {% for path in r.paths %}
-                                <li><h4>URL: <a href="{{ path }}">{{ path }}</a> <span>eg. https://www.biglotteryfund.org.uk{{ path }}</span></h4></li>
-                            {% endfor %}
-                        {% else %}
-                            <li><h4>URL: <a href="{{ r.path }}">{{ r.path }}</a> <span>eg. https://www.biglotteryfund.org.uk{{ r.path }}</span></h4></li>
-                        {% endif %}
-                        <li><p><strong>Destination: </strong> <a href="{{ r.destination }}">{{ r.destination }}</a></p></li>
+                        <li><p><strong>Source:</strong> <a href="{{ r.path }}">{{ r.path }}</a></p></li>
+                        <li><p><strong>Destination:</strong> <a href="{{ r.destination }}">{{ r.destination }}</a></p></li>
                     </ul>
                 </article>
             {% endfor %}


### PR DESCRIPTION
This PR goes some way to simplifying how vanity redirects are handled. Main changes are:

- Write a helper function to cover common config for vanity redirects
- Remove distinction of `aliasOnly` for vanity redirects. We were definitely using it inconsistently.
- Remove ability to have an array of paths as well as a single path, favour an additional vanity config instead
- Remove "codes" from routes, not sure they have much meaning to us anymore.

I'm sure there's more we could do to keep the routes manageable, but hopefully a start.

Tests should pass, and cloudfront routes haven't changed so fairly happy I've not removed any routes by mistake.

If it weren't for a couple of really long URLs these would all now be one-liners…