### PR TITLE
Streamline routes

### DIFF
--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -1,0 +1,100 @@
+'use strict';
+
+function createSection({ path, controllerPath, langTitlePath }) {
+    return {
+        path,
+        controller: function(pages, sectionPath, sectionId) {
+            return require(controllerPath)(pages, sectionPath, sectionId);
+        },
+        langTitlePath,
+        pages: null
+    };
+}
+
+const defaults = {
+    isPostable: false,
+    allowQueryStrings: false,
+    live: false
+};
+
+function withDefaults(props) {
+    return Object.assign({}, defaults, props);
+}
+
+function basicRoute(props) {
+    return Object.assign(
+        {},
+        defaults,
+        {
+            live: true
+        },
+        props
+    );
+}
+
+function staticRoute(props) {
+    const staticDefaults = {
+        static: true,
+        live: true
+    };
+    return Object.assign({}, defaults, staticDefaults, props);
+}
+
+function dynamicRoute(props) {
+    const dynamicDefaults = {
+        static: false,
+        live: true
+    };
+    return Object.assign({}, defaults, dynamicDefaults, props);
+}
+
+function cmsRoute(props) {
+    const cmsDefaults = {
+        useCmsContent: true,
+        live: true
+    };
+    return Object.assign({}, defaults, cmsDefaults, props);
+}
+
+function legacyRoute(props) {
+    const legacyDefaults = {
+        isPostable: true,
+        allowQueryStrings: true,
+        live: true
+    };
+    return Object.assign({}, legacyDefaults, props);
+}
+
+function vanity(urlPath, destination, isLive = false) {
+    return withDefaults({
+        path: urlPath,
+        destination: destination,
+        live: isLive
+    });
+}
+
+/**
+ * Programme Migration
+ * Handle redirects from /global-content/programmes to /funding/programmes
+ */
+function programmeMigration(from, to, isLive) {
+    return {
+        path: `/global-content/programmes/${from}`,
+        destination: `/funding/programmes/${to}`,
+        isPostable: false,
+        allowQueryStrings: false,
+        live: !isLive ? false : true
+    };
+}
+
+module.exports = {
+    createSection,
+    withDefaults,
+    basicRoute,
+    staticRoute,
+    dynamicRoute,
+    cmsRoute,
+    legacyRoute,
+    vanity,
+    programmeMigration
+};

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -1,5 +1,12 @@
 'use strict';
 
+/**
+ * Create a top-level section
+ *
+ * path - top-level URL path, e.g. /funding
+ * controllerPath - path to controller file
+ * langTitlePath - locale property for translated page title
+ */
 function createSection({ path, controllerPath, langTitlePath }) {
     return {
         path,
@@ -11,16 +18,20 @@ function createSection({ path, controllerPath, langTitlePath }) {
     };
 }
 
+/**
+ * Default parameters for cloudfront routes
+ * Restrictive by default, GET-only, no-query-strings
+ */
 const defaults = {
     isPostable: false,
     allowQueryStrings: false,
     live: false
 };
 
-function withDefaults(props) {
-    return Object.assign({}, defaults, props);
-}
-
+/**
+ * Basic route, typically used for custom routes
+ * Restrictive by default, GET-only, no-query-strings
+ */
 function basicRoute(props) {
     return Object.assign(
         {},
@@ -32,6 +43,11 @@ function basicRoute(props) {
     );
 }
 
+/**
+ * Static route
+ * Triggers 'routeStatic' behaviour, doesn't need
+ * a custom route handler, only a template path.
+ */
 function staticRoute(props) {
     const staticDefaults = {
         static: true,
@@ -40,6 +56,10 @@ function staticRoute(props) {
     return Object.assign({}, defaults, staticDefaults, props);
 }
 
+/**
+ * Dynamic route
+ * Common route type with a dynamic route handler
+ */
 function dynamicRoute(props) {
     const dynamicDefaults = {
         static: false,
@@ -48,6 +68,26 @@ function dynamicRoute(props) {
     return Object.assign({}, defaults, dynamicDefaults, props);
 }
 
+/**
+ * Wildcard route
+ * Extends from dynamic route, used when we require wildcard parameters
+ * e.g. /some/route/:dynamicId
+ * Used on the Free Materials form
+ */
+function wildcardRoute(props) {
+    const wildcardDefaults = {
+        static: false,
+        live: true,
+        isWildcard: true
+    };
+    return Object.assign({}, defaults, wildcardDefaults, props);
+}
+
+/**
+ * CMS route
+ * Triggers 'routeStatic' behaviour, and fetches content dynamically from CMS
+ * e.g. Programme detail pages
+ */
 function cmsRoute(props) {
     const cmsDefaults = {
         useCmsContent: true,
@@ -56,6 +96,11 @@ function cmsRoute(props) {
     return Object.assign({}, defaults, cmsDefaults, props);
 }
 
+/**
+ * Legacy route
+ * Permissive defaults, POST and query-strings allowed
+ * Used on proxied legacy pages, e.g. funding finder
+ */
 function legacyRoute(props) {
     const legacyDefaults = {
         isPostable: true,
@@ -65,10 +110,15 @@ function legacyRoute(props) {
     return Object.assign({}, legacyDefaults, props);
 }
 
-function vanity(urlPath, destination, isLive = false) {
-    return withDefaults({
-        path: urlPath,
-        destination: destination,
+/**
+ * Vanity redirect
+ * Redirect help accepting `from` and `to` location.
+ * Allows redirects to be defined using a concise syntax
+ */
+function vanity(from, to, isLive = true) {
+    return Object.assign({}, defaults, {
+        path: from,
+        destination: to,
         live: isLive
     });
 }
@@ -76,23 +126,22 @@ function vanity(urlPath, destination, isLive = false) {
 /**
  * Programme Migration
  * Handle redirects from /global-content/programmes to /funding/programmes
+ * Same behaviour as vanity() but with prefilled url prefix.
  */
-function programmeMigration(from, to, isLive) {
-    return {
+function programmeMigration(from, to, isLive = true) {
+    return Object.assign({}, defaults, {
         path: `/global-content/programmes/${from}`,
         destination: `/funding/programmes/${to}`,
-        isPostable: false,
-        allowQueryStrings: false,
-        live: !isLive ? false : true
-    };
+        live: isLive
+    });
 }
 
 module.exports = {
     createSection,
-    withDefaults,
     basicRoute,
     staticRoute,
     dynamicRoute,
+    wildcardRoute,
     cmsRoute,
     legacyRoute,
     vanity,

--- a/controllers/route-types.test.js
+++ b/controllers/route-types.test.js
@@ -1,0 +1,87 @@
+/* eslint-env mocha */
+const chai = require('chai');
+const expect = chai.expect;
+
+const { basicRoute, staticRoute, dynamicRoute, cmsRoute, legacyRoute } = require('./route-types');
+
+describe('Route types', () => {
+    it('should define a basic route', () => {
+        expect(
+            basicRoute({
+                path: '/some/url'
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: false,
+            allowQueryStrings: false,
+            live: true
+        });
+
+        expect(
+            basicRoute({
+                path: '/some/url',
+                live: false
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: false,
+            allowQueryStrings: false,
+            live: false
+        });
+    });
+
+    it('should define a static route', () => {
+        expect(
+            staticRoute({
+                path: '/some/url'
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: false,
+            allowQueryStrings: false,
+            static: true,
+            live: true
+        });
+    });
+
+    it('should define a dynamic route', () => {
+        expect(
+            dynamicRoute({
+                path: '/some/url'
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: false,
+            allowQueryStrings: false,
+            static: false,
+            live: true
+        });
+    });
+
+    it('should define a cmsRoute route', () => {
+        expect(
+            cmsRoute({
+                path: '/some/url'
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: false,
+            allowQueryStrings: false,
+            useCmsContent: true,
+            live: true
+        });
+    });
+
+    it('should define a legacy route', () => {
+        expect(
+            legacyRoute({
+                path: '/some/url'
+            })
+        ).to.eql({
+            path: '/some/url',
+            isPostable: true,
+            allowQueryStrings: true,
+            live: true
+        });
+    });
+});

--- a/controllers/route-types.test.js
+++ b/controllers/route-types.test.js
@@ -2,10 +2,10 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { basicRoute, staticRoute, dynamicRoute, cmsRoute, legacyRoute } = require('./route-types');
+const { basicRoute, staticRoute, dynamicRoute, cmsRoute, legacyRoute, vanity } = require('./route-types');
 
 describe('Route types', () => {
-    it('should define a basic route', () => {
+    it('should define a basic route schema', () => {
         expect(
             basicRoute({
                 path: '/some/url'
@@ -30,7 +30,7 @@ describe('Route types', () => {
         });
     });
 
-    it('should define a static route', () => {
+    it('should define a static route schema', () => {
         expect(
             staticRoute({
                 path: '/some/url'
@@ -44,7 +44,7 @@ describe('Route types', () => {
         });
     });
 
-    it('should define a dynamic route', () => {
+    it('should define a dynamic route schema', () => {
         expect(
             dynamicRoute({
                 path: '/some/url'
@@ -58,7 +58,7 @@ describe('Route types', () => {
         });
     });
 
-    it('should define a cmsRoute route', () => {
+    it('should define a cmsRoute schema', () => {
         expect(
             cmsRoute({
                 path: '/some/url'
@@ -72,7 +72,7 @@ describe('Route types', () => {
         });
     });
 
-    it('should define a legacy route', () => {
+    it('should define a legacy schema', () => {
         expect(
             legacyRoute({
                 path: '/some/url'
@@ -81,6 +81,16 @@ describe('Route types', () => {
             path: '/some/url',
             isPostable: true,
             allowQueryStrings: true,
+            live: true
+        });
+    });
+
+    it('should define a vanity redirect schema', () => {
+        expect(vanity('/from/url', '/to/url')).to.eql({
+            path: '/from/url',
+            destination: '/to/url',
+            isPostable: false,
+            allowQueryStrings: false,
             live: true
         });
     });

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,358 +1,244 @@
 'use strict';
+const path = require('path');
 const config = require('config');
+const {
+    createSection,
+    basicRoute,
+    staticRoute,
+    dynamicRoute,
+    cmsRoute,
+    legacyRoute,
+    vanity,
+    programmeMigration
+} = require('./route-types');
+
 const anchors = config.get('anchors');
 
-// pass some parameters onto each controller
-// so we can take route config and init all at once
-const loadController = path => {
-    return (pages, sectionPath, sectionId) => require(path)(pages, sectionPath, sectionId);
-};
-
-// define top-level controllers for the site
-const controllers = {
-    toplevel: loadController('./toplevel'),
-    funding: loadController('./funding'),
-    research: loadController('./research'),
-    about: loadController('./about')
-};
-
-// configure base paths for site sections
-const sectionPaths = {
-    toplevel: '',
-    funding: '/funding',
-    research: '/research',
-    about: '/about-big', // @TODO rename on launch
-    aboutLegacy: '/about-big' // used on the old site
-};
-
-// these top-level sections appear in the main site nav
-// (in the order presented here)
-const routes = {
-    sections: {
-        toplevel: {
-            name: 'Top-level pages',
-            langTitlePath: 'global.nav.home',
-            path: sectionPaths.toplevel,
-            controller: controllers.toplevel,
-            pages: {
-                home: {
-                    name: 'Home',
-                    path: '/',
-                    template: 'pages/toplevel/home',
-                    lang: 'toplevel.home',
-                    static: false,
-                    live: true,
-                    isPostable: true,
-                    aliases: [
-                        '/home',
-                        '/index.html',
-                        '/en-gb',
-                        '/england',
-                        '/uk-wide',
-                        '/funding/funding-guidance/applying-for-funding'
-                    ]
-                },
-                contact: {
-                    name: 'Contact',
-                    path: '/contact',
-                    template: 'pages/toplevel/contact',
-                    lang: 'toplevel.contact',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.toplevel + '/about-big/contact-us',
-                        sectionPaths.toplevel + '/help-and-support',
-                        sectionPaths.toplevel + '/england/about-big/contact-us',
-                        sectionPaths.toplevel + '/wales/about-big/contact-us',
-                        sectionPaths.toplevel + '/scotland/about-big/contact-us',
-                        sectionPaths.toplevel + '/northernireland/about-big/contact-us'
-                    ]
-                },
-                data: {
-                    name: 'Data',
-                    path: '/data',
-                    template: 'pages/toplevel/data',
-                    lang: 'toplevel.data',
-                    static: false,
-                    live: true
-                },
-                jobs: {
-                    name: 'Jobs',
-                    path: '/jobs',
-                    template: 'pages/toplevel/jobs',
-                    lang: 'toplevel.jobs',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.toplevel + '/about-big/jobs',
-                        sectionPaths.toplevel + '/about-big/jobs/how-to-apply',
-                        sectionPaths.toplevel + '/about-big/jobs/current-vacancies'
-                    ]
-                },
-                benefits: {
-                    name: 'Benefits',
-                    path: '/jobs/benefits',
-                    template: 'pages/toplevel/benefits',
-                    lang: 'toplevel.benefits',
-                    static: true,
-                    live: true,
-                    aliases: [sectionPaths.toplevel + '/about-big/jobs/benefits']
-                },
-                under10k: {
-                    name: 'Under 10k',
-                    path: '/under10k',
-                    template: 'pages/toplevel/under10k',
-                    lang: 'toplevel.under10k',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.funding + '/Awards-For-All',
-                        sectionPaths.funding + '/awards-for-all',
-                        sectionPaths.toplevel + '/awardsforall',
-                        sectionPaths.toplevel + '/a4a',
-                        sectionPaths.toplevel + '/A4A'
-                    ]
-                },
-                over10k: {
-                    name: 'Over 10k',
-                    path: '/over10k',
-                    template: 'pages/toplevel/over10k',
-                    lang: 'toplevel.over10k',
-                    static: true,
-                    live: true
-                },
-                eyp: {
-                    name: 'Empowering Young People',
-                    path: '/empowering-young-people',
-                    template: 'pages/toplevel/eyp',
-                    lang: 'toplevel.eyp',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.toplevel + '/global-content/programmes/northern-ireland/empowering-young-people'
-                    ]
-                },
-                helpingWorkingFamilies: {
-                    name: 'Helping Working Families',
-                    path: '/helping-working-families',
-                    template: 'pages/toplevel/working-families',
-                    lang: 'toplevel.helpingWorkingFamilies',
-                    static: true,
-                    live: true,
-                    aliases: [`${sectionPaths.toplevel}/global-content/programmes/wales/helping-working-families`]
-                }
-            }
-        },
-        funding: {
-            name: 'Funding',
-            langTitlePath: 'global.nav.funding',
-            path: sectionPaths.funding,
-            controller: controllers.funding,
-            pages: {
-                root: {
-                    name: 'Funding',
-                    path: '/',
-                    template: 'pages/toplevel/funding',
-                    lang: 'toplevel.funding',
-                    static: false,
-                    live: true,
-                    aliases: ['/home/funding']
-                },
-                applyingForFunding: {
-                    name: 'Applying for funding',
-                    path: '/funding-guidance/applying-for-funding/*',
-                    static: false,
-                    live: true
-                },
-                manageFunding: {
-                    name: 'Managing your funding',
-                    path: '/funding-guidance/managing-your-funding',
-                    template: 'pages/funding/guidance/managing-your-funding',
-                    lang: 'funding.guidance.managing-your-funding',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.funding + '/funding-guidance/managing-your-funding/help-with-publicity',
-                        '/welcome',
-                        '/publicity'
-                    ]
-                },
-                freeMaterials: {
-                    name: 'Ordering free materials',
-                    path: '/funding-guidance/managing-your-funding/ordering-free-materials',
-                    template: 'pages/funding/guidance/order-free-materials',
-                    lang: 'funding.guidance.order-free-materials',
-                    live: true,
-                    isPostable: true,
-                    isWildcard: true,
-                    aliases: [
-                        sectionPaths.funding +
-                            '/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
-                        '/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials',
-                        '/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials',
-                        '/england/funding/funding-guidance/managing-your-funding/ordering-free-materials',
-                        '/northernireland/funding/funding-guidance/managing-your-funding/ordering-free-materials'
-                    ]
-                },
-                helpWithPublicity: {
-                    name: 'Help with publicity',
-                    path: '/funding-guidance/managing-your-funding/social-media',
-                    template: 'pages/funding/guidance/help-with-publicity',
-                    lang: 'funding.guidance.help-with-publicity',
-                    static: true,
-                    live: true
-                },
-                pressCoverage: {
-                    name: 'Getting press coverage',
-                    path: '/funding-guidance/managing-your-funding/press',
-                    template: 'pages/funding/guidance/getting-press-coverage',
-                    lang: 'funding.guidance.getting-press-coverage',
-                    static: true,
-                    live: true
-                },
-                logos: {
-                    name: 'Logos',
-                    path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
-                    template: 'pages/funding/guidance/logos',
-                    lang: 'funding.guidance.logos',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        sectionPaths.funding +
-                            '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
-                        sectionPaths.funding + '/funding-guidance/managing-your-funding/logodownloads'
-                    ]
-                },
-                programmes: {
-                    name: 'Funding programmes',
-                    path: '/programmes',
-                    template: 'pages/funding/programmes',
-                    lang: 'funding.programmes',
-                    allowQueryStrings: true,
-                    static: false,
-                    live: true
-                },
-                programmeDetail: {
-                    name: 'Funding programme details',
-                    path: '/programmes/*',
-                    static: false,
-                    live: true
-                },
-                programmeDetailAfaEngland: {
-                    name: 'Awards For All England',
-                    path: '/programmes/national-lottery-awards-for-all-england',
-                    static: false,
-                    live: true
-                },
-                buildingBetterOpportunites: {
-                    name: 'Building Better Opportunites',
-                    path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',
-                    useCmsContent: true,
-                    live: true,
-                    aliases: [
-                        '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
-                    ]
-                },
-                informationChecks: {
-                    name: 'Information checks',
-                    path: '/funding-guidance/information-checks',
-                    useCmsContent: true,
-                    live: true,
-                    aliases: [
-                        '/informationchecks',
-                        '/funding/funding-guidance/applying-for-funding/information-checks'
-                    ]
-                },
-                electronicForms: {
-                    name: 'Help with PDFs',
-                    path: '/funding-guidance/help-using-our-application-forms',
-                    useCmsContent: true,
-                    live: true,
-                    aliases: [
-                        '/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms'
-                    ]
-                }
-            }
-        },
-        research: {
-            name: 'Research',
-            langTitlePath: 'global.nav.research',
-            path: sectionPaths.research,
-            controller: controllers.research,
-            pages: {
-                root: {
-                    name: 'Research',
-                    path: '/',
-                    template: 'pages/toplevel/research',
-                    lang: 'toplevel.research',
-                    static: true,
-                    live: false
-                }
-            }
-        },
-        // @TODO rename this to 'about' when ready to launch /about
-        'about-big': {
-            name: 'About',
-            langTitlePath: 'global.nav.about',
-            path: sectionPaths.about,
-            controller: controllers.about,
-            pages: {
-                root: {
-                    name: 'About',
-                    path: '/',
-                    template: 'pages/toplevel/about',
-                    lang: 'toplevel.about',
-                    static: true,
-                    live: false,
-                    aliases: [
-                        // sectionPaths.aboutLegacy
-                    ]
-                },
-                freedomOfInformation: {
-                    name: 'Freedom of Information',
-                    path: '/customer-service/freedom-of-information',
-                    template: 'pages/about/freedom-of-information',
-                    lang: 'about.foi',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        // sectionPaths.aboutLegacy + "/customer-service/freedom-of-information",
-                        '/freedom-of-information'
-                    ]
-                },
-                dataProtection: {
-                    name: 'Data Protection',
-                    path: '/customer-service/data-protection',
-                    template: 'pages/about/data-protection',
-                    lang: 'about.dataProtection',
-                    static: true,
-                    live: true,
-                    aliases: [
-                        // sectionPaths.aboutLegacy + "/customer-service/data-protection",
-                        '/data-protection'
-                    ]
-                }
-            }
-        }
-    }
+const sections = {
+    toplevel: createSection({
+        path: '',
+        langTitlePath: 'global.nav.home',
+        controllerPath: path.resolve(__dirname, './toplevel')
+    }),
+    funding: createSection({
+        path: '/funding',
+        langTitlePath: 'global.nav.funding',
+        controllerPath: path.resolve(__dirname, './funding')
+    }),
+    research: createSection({
+        path: '/research',
+        langTitlePath: 'global.nav.research',
+        controllerPath: path.resolve(__dirname, './research')
+    }),
+    'about-big': createSection({
+        path: '/about-big', // @TODO: Rename launching about page
+        langTitlePath: 'global.nav.about',
+        controllerPath: path.resolve(__dirname, './about')
+    })
 };
 
 /**
- * Programme Migration
- *
- * Handle redirects from /global-content/programmes to /funding/programmes
- * @TODO: Consider merging into a global-content/programmes/* handler
- *        once we decide to migrate all programme pages.
+ * Top-level Routes
  */
-function programmeMigration(from, to, isLive) {
-    return {
-        path: `/global-content/programmes/${from}`,
-        destination: `/funding/programmes/${to}`,
-        isPostable: false,
-        allowQueryStrings: false,
-        live: !isLive ? false : true
-    };
-}
+sections.toplevel.pages = {
+    home: dynamicRoute({
+        path: '/',
+        template: 'pages/toplevel/home',
+        lang: 'toplevel.home',
+        isPostable: true,
+        aliases: [
+            '/home',
+            '/index.html',
+            '/en-gb',
+            '/england',
+            '/uk-wide',
+            '/funding/funding-guidance/applying-for-funding'
+        ]
+    }),
+    contact: staticRoute({
+        path: '/contact',
+        template: 'pages/toplevel/contact',
+        lang: 'toplevel.contact',
+        aliases: [
+            '/about-big/contact-us',
+            '/help-and-support',
+            '/england/about-big/contact-us',
+            '/wales/about-big/contact-us',
+            '/scotland/about-big/contact-us',
+            '/northernireland/about-big/contact-us'
+        ]
+    }),
+    data: dynamicRoute({
+        path: '/data',
+        template: 'pages/toplevel/data',
+        lang: 'toplevel.data'
+    }),
+    jobs: staticRoute({
+        path: '/jobs',
+        template: 'pages/toplevel/jobs',
+        lang: 'toplevel.jobs',
+        aliases: ['/about-big/jobs', '/about-big/jobs/how-to-apply', '/about-big/jobs/current-vacancies']
+    }),
+    benefits: staticRoute({
+        path: '/jobs/benefits',
+        template: 'pages/toplevel/benefits',
+        lang: 'toplevel.benefits',
+        aliases: ['/about-big/jobs/benefits']
+    }),
+    under10k: staticRoute({
+        path: '/under10k',
+        template: 'pages/toplevel/under10k',
+        lang: 'toplevel.under10k',
+        aliases: ['/funding/Awards-For-All', '/funding/awards-for-all', '/awardsforall', '/a4a', '/A4A']
+    }),
+    over10k: staticRoute({
+        path: '/over10k',
+        template: 'pages/toplevel/over10k',
+        lang: 'toplevel.over10k'
+    }),
+    eyp: staticRoute({
+        path: '/empowering-young-people',
+        template: 'pages/toplevel/eyp',
+        lang: 'toplevel.eyp',
+        aliases: ['/global-content/programmes/northern-ireland/empowering-young-people']
+    }),
+    helpingWorkingFamilies: staticRoute({
+        path: '/helping-working-families',
+        template: 'pages/toplevel/working-families',
+        lang: 'toplevel.helpingWorkingFamilies',
+        aliases: ['/global-content/programmes/wales/helping-working-families']
+    })
+};
+
+/**
+ * Funding Routes
+ */
+sections.funding.pages = {
+    root: dynamicRoute({
+        path: '/',
+        template: 'pages/toplevel/funding',
+        lang: 'toplevel.funding',
+        aliases: ['/home/funding']
+    }),
+    applyingForFunding: staticRoute({
+        path: '/funding-guidance/applying-for-funding/*'
+    }),
+    manageFunding: staticRoute({
+        path: '/funding-guidance/managing-your-funding',
+        template: 'pages/funding/guidance/managing-your-funding',
+        lang: 'funding.guidance.managing-your-funding',
+        aliases: ['/funding/funding-guidance/managing-your-funding/help-with-publicity', '/welcome', '/publicity']
+    }),
+
+    // @TODO: This is the only route that uses isWildcard??
+    freeMaterials: {
+        path: '/funding-guidance/managing-your-funding/ordering-free-materials',
+        template: 'pages/funding/guidance/order-free-materials',
+        lang: 'funding.guidance.order-free-materials',
+        live: true,
+        isPostable: true,
+        isWildcard: true,
+        aliases: [
+            '/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
+            '/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials',
+            '/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials',
+            '/england/funding/funding-guidance/managing-your-funding/ordering-free-materials',
+            '/northernireland/funding/funding-guidance/managing-your-funding/ordering-free-materials'
+        ]
+    },
+    helpWithPublicity: staticRoute({
+        path: '/funding-guidance/managing-your-funding/social-media',
+        template: 'pages/funding/guidance/help-with-publicity',
+        lang: 'funding.guidance.help-with-publicity'
+    }),
+    pressCoverage: staticRoute({
+        path: '/funding-guidance/managing-your-funding/press',
+        template: 'pages/funding/guidance/getting-press-coverage',
+        lang: 'funding.guidance.getting-press-coverage',
+        static: true,
+        live: true
+    }),
+    logos: staticRoute({
+        path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
+        template: 'pages/funding/guidance/logos',
+        lang: 'funding.guidance.logos',
+        aliases: [
+            '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
+            '/funding/funding-guidance/managing-your-funding/logodownloads'
+        ]
+    }),
+    programmes: dynamicRoute({
+        path: '/programmes',
+        template: 'pages/funding/programmes',
+        lang: 'funding.programmes',
+        allowQueryStrings: true
+    }),
+    programmeDetail: dynamicRoute({
+        path: '/programmes/*'
+    }),
+    programmeDetailAfaEngland: dynamicRoute({
+        path: '/programmes/national-lottery-awards-for-all-england'
+    }),
+    buildingBetterOpportunites: cmsRoute({
+        path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',
+        aliases: [
+            '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
+        ]
+    }),
+    informationChecks: cmsRoute({
+        path: '/funding-guidance/information-checks',
+        aliases: ['/informationchecks', '/funding/funding-guidance/applying-for-funding/information-checks']
+    }),
+    electronicForms: cmsRoute({
+        path: '/funding-guidance/help-using-our-application-forms',
+        aliases: ['/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms']
+    })
+};
+
+/**
+ * Research Routes
+ */
+sections.research.pages = {
+    root: staticRoute({
+        path: '/',
+        template: 'pages/toplevel/research',
+        lang: 'toplevel.research',
+        live: false
+    })
+};
+
+/**
+ * About Routes
+ */
+sections['about-big'].pages = {
+    root: staticRoute({
+        path: '/',
+        template: 'pages/toplevel/about',
+        lang: 'toplevel.about',
+        live: false,
+        aliases: [
+            // 'about-big'
+        ]
+    }),
+    freedomOfInformation: staticRoute({
+        path: '/customer-service/freedom-of-information',
+        template: 'pages/about/freedom-of-information',
+        lang: 'about.foi',
+        aliases: [
+            // '/about-big/customer-service/freedom-of-information',
+            '/freedom-of-information'
+        ]
+    }),
+    dataProtection: staticRoute({
+        path: '/customer-service/data-protection',
+        template: 'pages/about/data-protection',
+        lang: 'about.dataProtection',
+        aliases: [
+            // '/about-big/customer-service/data-protection,
+            '/data-protection'
+        ]
+    })
+};
 
 const programmeRedirects = [
     // Live
@@ -380,20 +266,22 @@ const programmeRedirects = [
 ];
 
 /**
- * Vanity URLs
- *
- * Set up some vanity URL redirects that can't be defined in the aliases on the routes above
+ * Legacy proxied routes
+ * The following URLs are legacy pages that are being proxied to make small amends to them.
+ * They have not yet been redesigned or replaced so aren't ready to go into the main routes.
  */
-function vanity(urlPath, destination, isLive = false) {
-    return {
-        path: urlPath,
-        destination: destination,
-        isPostable: false,
-        allowQueryStrings: false,
-        live: isLive
-    };
-}
+const legacyProxiedRoutes = {
+    fundingFinder: legacyRoute({
+        path: '/funding/funding-finder'
+    }),
+    fundingFinderWelsh: legacyRoute({
+        path: '/welsh/funding/funding-finder'
+    })
+};
 
+/**
+ * Vanity URLs
+ */
 const vanityRedirects = [
     vanity('/Home/Funding/Funding*Finder', '/funding/programmes', true),
     vanity('/welsh/Home/Funding/Funding*Finder', '/funding/programmes', true),
@@ -440,107 +328,61 @@ const vanityRedirects = [
 ];
 
 /**
- * Legacy proxied routes
- * The following URLs are legacy pages that are being proxied to make small amends to them.
- * They have not yet been redesigned or replaced so aren't ready to go into the main routes.
- */
-function withLegacyDefaults(props) {
-    const defaults = {
-        isPostable: true,
-        allowQueryStrings: true,
-        live: false
-    };
-    return Object.assign({}, defaults, props);
-}
-const legacyProxiedRoutes = {
-    fundingFinder: withLegacyDefaults({
-        path: '/funding/funding-finder',
-        live: true
-    }),
-    fundingFinderWelsh: withLegacyDefaults({
-        path: '/welsh/funding/funding-finder',
-        live: true
-    })
-};
-
-/**
  * Other Routes
  * These are other paths that should be routed to this app via Cloudfront
  * but aren't explicit page routes (eg. static files, custom pages etc)
  */
 const otherUrls = [
-    {
-        path: '/assets/*',
-        isPostable: false,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
-        path: '/contrast/*',
-        isPostable: false,
-        allowQueryStrings: true,
-        live: true
-    },
-    {
-        path: '/error',
-        isPostable: false,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
+    basicRoute({
+        path: '/robots.txt'
+    }),
+    basicRoute({
+        path: '/assets/*'
+    }),
+    basicRoute({
+        path: '/error'
+    }),
+    basicRoute({
+        path: '/styleguide'
+    }),
+    basicRoute({
         path: '/tools/*',
         isPostable: true,
-        allowQueryStrings: true,
-        live: true
-    },
-    {
-        path: '/styleguide',
-        isPostable: false,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
-        path: '/robots.txt',
-        isPostable: false,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
+        allowQueryStrings: true
+    }),
+    basicRoute({
+        path: '/contrast/*',
+        allowQueryStrings: true
+    }),
+    basicRoute({
         path: '/ebulletin',
-        isPostable: true,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
+        isPostable: true
+    }),
+    basicRoute({
         path: '/surveys',
-        isPostable: false,
         allowQueryStrings: true,
         live: true
-    },
-    {
+    }),
+    basicRoute({
         path: '/survey/*',
-        isPostable: true,
-        allowQueryStrings: false,
-        live: true
-    },
-    {
+        isPostable: true
+    }),
+    basicRoute({
         path: '/user/*',
         isPostable: true,
-        allowQueryStrings: true,
-        live: true
-    },
-    {
+        allowQueryStrings: true
+    }),
+    basicRoute({
         path: '*~/link.aspx',
-        isPostable: false,
         allowQueryStrings: true,
         live: true
-    }
+    })
 ];
 
 module.exports = {
-    sections: routes.sections,
-    programmeRedirects: programmeRedirects,
-    vanityRedirects: vanityRedirects,
-    legacyProxiedRoutes: legacyProxiedRoutes,
-    otherUrls: otherUrls
+    sections: sections,
+    programmeRedirects,
+    legacyProxiedRoutes,
+    vanityRedirects,
+    otherUrls
 };

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -6,6 +6,7 @@ const {
     basicRoute,
     staticRoute,
     dynamicRoute,
+    wildcardRoute,
     cmsRoute,
     legacyRoute,
     vanity,
@@ -129,15 +130,11 @@ sections.funding.pages = {
         lang: 'funding.guidance.managing-your-funding',
         aliases: ['/funding/funding-guidance/managing-your-funding/help-with-publicity', '/welcome', '/publicity']
     }),
-
-    // @TODO: This is the only route that uses isWildcard??
-    freeMaterials: {
+    freeMaterials: wildcardRoute({
         path: '/funding-guidance/managing-your-funding/ordering-free-materials',
         template: 'pages/funding/guidance/order-free-materials',
         lang: 'funding.guidance.order-free-materials',
-        live: true,
         isPostable: true,
-        isWildcard: true,
         aliases: [
             '/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales',
             '/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials',
@@ -145,7 +142,7 @@ sections.funding.pages = {
             '/england/funding/funding-guidance/managing-your-funding/ordering-free-materials',
             '/northernireland/funding/funding-guidance/managing-your-funding/ordering-free-materials'
         ]
-    },
+    }),
     helpWithPublicity: staticRoute({
         path: '/funding-guidance/managing-your-funding/social-media',
         template: 'pages/funding/guidance/help-with-publicity',
@@ -159,12 +156,12 @@ sections.funding.pages = {
         live: true
     }),
     logos: staticRoute({
-        path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads',
+        path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
         template: 'pages/funding/guidance/logos',
         lang: 'funding.guidance.logos',
         aliases: [
-            '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
-            '/funding/funding-guidance/managing-your-funding/logodownloads'
+            '/funding/funding-guidance/managing-your-funding/logodownloads',
+            '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads'
         ]
     }),
     programmes: dynamicRoute({
@@ -240,31 +237,6 @@ sections['about-big'].pages = {
     })
 };
 
-const programmeRedirects = [
-    // Live
-    programmeMigration('england/awards-for-all-england', 'national-lottery-awards-for-all-england', true),
-    programmeMigration('england/reaching-communities-england', 'reaching-communities-england', true),
-    programmeMigration('northern-ireland/awards-for-all-northern-ireland', 'awards-for-all-northern-ireland', true),
-    programmeMigration('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland', true),
-    programmeMigration('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity', true),
-    programmeMigration('scotland/grants-for-improving-lives', 'grants-for-improving-lives', true),
-    programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants', true),
-    programmeMigration('wales/people-and-places-large-grants', 'people-and-places-large-grants', true),
-    programmeMigration('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio', true),
-    programmeMigration('uk-wide/coastal-communities', 'coastal-communities-fund', true),
-    programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders', true),
-    programmeMigration('northern-ireland/people-and-communities', 'people-and-communities', true),
-    programmeMigration('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales', true),
-    programmeMigration('england/building-better-opportunities', 'building-better-opportunities', true),
-    // Draft
-    programmeMigration('england/parks-for-people', 'parks-for-people', false),
-    programmeMigration('scotland/community-assets', 'community-assets', false),
-    programmeMigration('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
-    programmeMigration('scotland/our-place', 'our-place', false),
-    programmeMigration('scotland/scottish-land-fund', 'scottish-land-fund', false),
-    programmeMigration('uk-wide/forces-in-mind', 'forces-in-mind', false)
-];
-
 /**
  * Legacy proxied routes
  * The following URLs are legacy pages that are being proxied to make small amends to them.
@@ -280,51 +252,76 @@ const legacyProxiedRoutes = {
 };
 
 /**
+ * Legacy Redirects
+ */
+const legacyRedirects = [
+    // Migrated Programme Pages [LIVE]
+    programmeMigration('england/awards-for-all-england', 'national-lottery-awards-for-all-england'),
+    programmeMigration('england/reaching-communities-england', 'reaching-communities-england'),
+    programmeMigration('northern-ireland/awards-for-all-northern-ireland', 'awards-for-all-northern-ireland'),
+    programmeMigration('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland'),
+    programmeMigration('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity'),
+    programmeMigration('scotland/grants-for-improving-lives', 'grants-for-improving-lives'),
+    programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants'),
+    programmeMigration('wales/people-and-places-large-grants', 'people-and-places-large-grants'),
+    programmeMigration('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio'),
+    programmeMigration('uk-wide/coastal-communities', 'coastal-communities-fund'),
+    programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders'),
+    programmeMigration('northern-ireland/people-and-communities', 'people-and-communities'),
+    programmeMigration('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales'),
+    programmeMigration('england/building-better-opportunities', 'building-better-opportunities'),
+
+    // Migrated Programme Pages [DRAFT]
+    programmeMigration('england/parks-for-people', 'parks-for-people', false),
+    programmeMigration('scotland/community-assets', 'community-assets', false),
+    programmeMigration('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
+    programmeMigration('scotland/our-place', 'our-place', false),
+    programmeMigration('scotland/scottish-land-fund', 'scottish-land-fund', false),
+    programmeMigration('uk-wide/forces-in-mind', 'forces-in-mind', false)
+];
+
+/**
  * Vanity URLs
  */
 const vanityRedirects = [
-    vanity('/Home/Funding/Funding*Finder', '/funding/programmes', true),
-    vanity('/welsh/Home/Funding/Funding*Finder', '/funding/programmes', true),
-    vanity('/funding/scotland-portfolio', '/funding/programmes?location=scotland', true),
-    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england', true),
-    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england', true),
-    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland', true),
-    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland', true),
-    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales', true),
-    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales', true),
-    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england', true),
-    vanity('/helpingworkingfamilies', '/helping-working-families', true),
-    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families', true),
-    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives', true),
-    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity', true),
-    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities', true),
-    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding', true),
-    vanity('/ccf', '/funding/programmes/coastal-communities-fund', true),
-    vanity('/esf', '/funding/programmes/building-better-opportunities', true),
+    vanity('/Home/Funding/Funding*Finder', '/funding/programmes'),
+    vanity('/welsh/Home/Funding/Funding*Finder', '/funding/programmes'),
+    vanity('/funding/scotland-portfolio', '/funding/programmes?location=scotland'),
+    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
+    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
+    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
+    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
+    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england'),
+    vanity('/helpingworkingfamilies', '/helping-working-families'),
+    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families'),
+    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives'),
+    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity'),
+    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities'),
+    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
+    vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
+    vanity('/esf', '/funding/programmes/building-better-opportunities'),
     vanity(
         '/guidancetrackingprogress',
-        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress',
-        true
+        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
     ),
-
     // This stays here (and not as an alias) as express doesn't care about URL case
     // and this link is the same (besides case) as an existing alias
     // (annoyingly, the Title Case version of this link persists on the web... for now.)
     vanity(
         '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
-        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
-        true
+        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos'
     ),
-
     // The following aliases use custom destinations (eg. with URL anchors)
     // so can't live in the regular aliases section (as they all have the same destination)
-    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`, true),
-    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactComplaints}`, true),
-    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactPress}`, true),
-    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`, true),
-    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`, true),
-    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`, true),
-    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`, true)
+    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
+    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
+    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
+    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
+    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`)
 ];
 
 /**
@@ -381,8 +378,8 @@ const otherUrls = [
 
 module.exports = {
     sections: sections,
-    programmeRedirects,
     legacyProxiedRoutes,
+    legacyRedirects,
     vanityRedirects,
     otherUrls
 };

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -175,29 +175,33 @@ function generateUrlList(routes) {
     }
 
     /**
-     * Programme migration routes
+     * Legacy proxied routes
      */
-    routes.programmeRedirects.filter(isLive).forEach(routeConfig => {
+    const liveLegacyRoutes = filter(routes.legacyProxiedRoutes, isLive);
+    forEach(liveLegacyRoutes, routeConfig => {
+        urlList.newSite.push(makeUrlObject(routeConfig));
+    });
+
+    /**
+     * Legacy Redirects
+     */
+    routes.legacyRedirects.filter(isLive).forEach(routeConfig => {
         const pageObject = { path: routeConfig.path };
         urlList.newSite.push(makeUrlObject(pageObject));
         urlList.newSite.push(makeUrlObject(pageObject, makeWelsh(pageObject.path)));
     });
 
     /**
-     * Vanity redirects
+     * Vanity URLs
      */
     routes.vanityRedirects.filter(isLive).forEach(redirect => {
         const pageObject = { path: redirect.path };
         urlList.newSite.push(makeUrlObject(pageObject));
     });
 
-    // Legacy proxied routes
-    const liveLegacyRoutes = filter(routes.legacyProxiedRoutes, isLive);
-    forEach(liveLegacyRoutes, routeConfig => {
-        urlList.newSite.push(makeUrlObject(routeConfig));
-    });
-
-    // Add the miscellaneous routes
+    /**
+     * Other Routes
+     */
     routes.otherUrls.filter(isLive).forEach(routeConfig => {
         urlList.newSite.push(makeUrlObject(routeConfig));
     });

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -139,7 +139,7 @@ describe('Cloudfront Helpers', () => {
                     }
                 }
             },
-            programmeRedirects: [
+            legacyRedirects: [
                 {
                     path: '/global-content/programmes/example',
                     destination: '/funding/programmes/example',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . bin/* --ignore-pattern public/",
     "test-deps": "snyk test",
     "test-unit-client": "mocha assets/**/*.test.js --bail --exit",
-    "test-unit-server": "mocha {controllers,middleware,modules}/**/*.test.js --bail --exit",
+    "test-unit-server": "mocha {controllers,middleware,modules}/{*,**/*}.test.js --bail --exit",
     "test-unit": "npm run test-unit-client && npm run test-unit-server",
     "test-integration": "mocha integration-tests/integration-tests.js --bail --exit --timeout 20s",
     "test": "npm run test-unit && npm run test-integration",

--- a/server.js
+++ b/server.js
@@ -107,9 +107,11 @@ function serveRedirect({ sourcePath, destinationPath }) {
 }
 
 /**
- * Programme Migration Redirects
+ * Legacy Redirects
+ * Redirecy legacy URLs to new locations
+ * For these URLs handle both english and welsh variants
  */
-routes.programmeRedirects.forEach(route => {
+routes.legacyRedirects.forEach(route => {
     serveRedirect({
         sourcePath: route.path,
         destinationPath: route.destination
@@ -121,7 +123,8 @@ routes.programmeRedirects.forEach(route => {
 });
 
 /**
- * Vanity URL Redirects
+ * Vanity URLs
+ * Sharable short-urls redirected to canonical URLs.
  */
 routes.vanityRedirects.forEach(route => {
     serveRedirect({
@@ -130,16 +133,24 @@ routes.vanityRedirects.forEach(route => {
     });
 });
 
-// redirect all bad link aliases to their canonical equivalents
-// (you're welcome, Sitecore)
+/**
+ * Sitecore links
+ * Redirect all bad link aliases to their canonical equivalents
+ */
 app.get('*~/link.aspx', redirectUglyLink);
 
-// alias for error pages for old site -> new
+/**
+ * Error route
+ * Alias for error pages for old site -> new
+ */
 app.get('/error', (req, res) => {
     renderNotFound(req, res);
 });
 
-// catch 404 and forward to error handler
+/**
+ * 404 Handler
+ * Catch 404s render not found page
+ */
 app.use((req, res) => {
     renderNotFound(req, res);
 });

--- a/views/pages/tools/pagelist.njk
+++ b/views/pages/tools/pagelist.njk
@@ -75,9 +75,12 @@
             <button id="js-open-links">Open all canonical English pages in tabs?</button>
 
             {% for sectionName, section in routes %}
-                <h2>Section: {{ section.name }}</h2>
+                <h2>Section: {{ sectionName }}</h2>
                 {% for pageName, page in section.pages %}
-                    <h3>{{ page.name }} <span class="status {% if page.live %}status--live{% else %}status--draft{% endif %}"></span></h3>
+                    <h3>
+                        {{ pageName }}
+                        <span class="status {% if page.live %}status--live{% else %}status--draft{% endif %}"></span>
+                    </h3>
                     <article>
                         <h4>Canonical URL <span>(eg. the definitive version of this page)</span></h4>
                         {% set link = buildUrl(sectionName, pageName) %}


### PR DESCRIPTION
This PR does some more work to streamline routes code. I'm approaching this with a few main goals:

- Routes file should be shorter (Met with 544 lines to 389)
- Reduce nesting in routes file to improve scanability
- Reduce duplication by defining common _shapes_ of routes
- Make route configs more testable

Does this make sense?

The specific changes are:

- Inline loadController code
- Extract route type helpers
- Reduce nesting of primary routes
- Cleanup main routes using route types
- Trim names, use object keys
- Add unit tests for route-types