### PR TITLE
Clearer separation between redirects and routes

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -8520,6 +8520,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/welsh/england/global-content/programmes/england/awards-for-all-england",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/welsh/empowering-young-people",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -9888,6 +9947,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/press",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/scotland-portfolio",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -8520,6 +8520,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/welsh/england/global-content/programmes/england/awards-for-all-england",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/welsh/empowering-young-people",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -9888,6 +9947,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/press",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/scotland-portfolio",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const config = require('config');
+const { aliasFor, vanity, programmeRedirect } = require('./route-types');
+
+const anchors = config.get('anchors');
+
+/**
+ * Legacy Redirects
+ */
+const legacyRedirects = [
+    aliasFor('/funding/programmes', '/Home/Funding/Funding*Finder'),
+    aliasFor('/funding/programmes?location=scotland', '/funding/scotland-portfolio'),
+    aliasFor(
+        '/funding/programmes/national-lottery-awards-for-all-england',
+        '/england/global-content/programmes/england/awards-for-all-england'
+    ),
+
+    // Migrated Programme Pages [LIVE]
+    programmeRedirect('england/awards-for-all-england', 'national-lottery-awards-for-all-england'),
+    programmeRedirect('england/reaching-communities-england', 'reaching-communities-england'),
+    programmeRedirect('northern-ireland/awards-for-all-northern-ireland', 'awards-for-all-northern-ireland'),
+    programmeRedirect('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland'),
+    programmeRedirect('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity'),
+    programmeRedirect('scotland/grants-for-improving-lives', 'grants-for-improving-lives'),
+    programmeRedirect('wales/people-and-places-medium-grants', 'people-and-places-medium-grants'),
+    programmeRedirect('wales/people-and-places-large-grants', 'people-and-places-large-grants'),
+    programmeRedirect('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio'),
+    programmeRedirect('uk-wide/coastal-communities', 'coastal-communities-fund'),
+    programmeRedirect('uk-wide/lottery-funding', 'other-lottery-funders'),
+    programmeRedirect('northern-ireland/people-and-communities', 'people-and-communities'),
+    programmeRedirect('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales'),
+    programmeRedirect('england/building-better-opportunities', 'building-better-opportunities'),
+
+    // Migrated Programme Pages [DRAFT]
+    programmeRedirect('england/parks-for-people', 'parks-for-people', false),
+    programmeRedirect('scotland/community-assets', 'community-assets', false),
+    programmeRedirect('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
+    programmeRedirect('scotland/our-place', 'our-place', false),
+    programmeRedirect('scotland/scottish-land-fund', 'scottish-land-fund', false),
+    programmeRedirect('uk-wide/forces-in-mind', 'forces-in-mind', false)
+];
+
+/**
+ * Vanity URLs
+ */
+const vanityRedirects = [
+    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
+    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
+    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
+    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
+    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england'),
+    vanity('/helpingworkingfamilies', '/helping-working-families'),
+    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families'),
+    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives'),
+    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity'),
+    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities'),
+    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
+    vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
+    vanity('/esf', '/funding/programmes/building-better-opportunities'),
+    vanity(
+        '/guidancetrackingprogress',
+        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
+    ),
+    vanity(
+        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
+        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos'
+    ),
+    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
+    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
+    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
+    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
+    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`),
+    vanity('/prog_people_places', '/funding/programmes?min=10000&location=wales'),
+    vanity('/global-content/programmes/wales/people-and-places', '/funding/programmes?min=10000&location=wales')
+];
+
+module.exports = {
+    legacyRedirects,
+    vanityRedirects
+};

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -111,9 +111,23 @@ function legacyRoute(props) {
 }
 
 /**
- * Vanity redirect
- * Redirect help accepting `from` and `to` location.
- * Allows redirects to be defined using a concise syntax
+ * Alias for
+ * Redirect helper accepting `to` and `from`
+ * Allows aliases to be defined using a concise syntax
+ */
+function aliasFor(to, from, isLive = true) {
+    return Object.assign({}, defaults, {
+        path: from,
+        destination: to,
+        live: isLive
+    });
+}
+
+/**
+ * Vanity
+ * Syntax sugar. Provides the aame functionality as
+ * aliasFor() but with the `from` and `to` arguments swapped.
+ * Allows vanity URLs to be defined using a concise syntax
  */
 function vanity(from, to, isLive = true) {
     return Object.assign({}, defaults, {
@@ -128,7 +142,7 @@ function vanity(from, to, isLive = true) {
  * Handle redirects from /global-content/programmes to /funding/programmes
  * Same behaviour as vanity() but with prefilled url prefix.
  */
-function programmeMigration(from, to, isLive = true) {
+function programmeRedirect(from, to, isLive = true) {
     return Object.assign({}, defaults, {
         path: `/global-content/programmes/${from}`,
         destination: `/funding/programmes/${to}`,
@@ -144,6 +158,7 @@ module.exports = {
     wildcardRoute,
     cmsRoute,
     legacyRoute,
+    aliasFor,
     vanity,
-    programmeMigration
+    programmeRedirect
 };

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,6 +1,7 @@
 'use strict';
+
 const path = require('path');
-const config = require('config');
+const { legacyRedirects, vanityRedirects } = require('./aliases');
 const {
     createSection,
     basicRoute,
@@ -8,12 +9,8 @@ const {
     dynamicRoute,
     wildcardRoute,
     cmsRoute,
-    legacyRoute,
-    vanity,
-    programmeMigration
+    legacyRoute
 } = require('./route-types');
-
-const anchors = config.get('anchors');
 
 const sections = {
     toplevel: createSection({
@@ -267,85 +264,6 @@ const legacyProxiedRoutes = {
         path: '/welsh/funding/funding-finder'
     })
 };
-
-/**
- * Legacy Redirects
- */
-const legacyRedirects = [
-    // Migrated Programme Pages [LIVE]
-    programmeMigration('england/awards-for-all-england', 'national-lottery-awards-for-all-england'),
-    programmeMigration('england/reaching-communities-england', 'reaching-communities-england'),
-    programmeMigration('northern-ireland/awards-for-all-northern-ireland', 'awards-for-all-northern-ireland'),
-    programmeMigration('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland'),
-    programmeMigration('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity'),
-    programmeMigration('scotland/grants-for-improving-lives', 'grants-for-improving-lives'),
-    programmeMigration('wales/people-and-places-medium-grants', 'people-and-places-medium-grants'),
-    programmeMigration('wales/people-and-places-large-grants', 'people-and-places-large-grants'),
-    programmeMigration('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio'),
-    programmeMigration('uk-wide/coastal-communities', 'coastal-communities-fund'),
-    programmeMigration('uk-wide/lottery-funding', 'other-lottery-funders'),
-    programmeMigration('northern-ireland/people-and-communities', 'people-and-communities'),
-    programmeMigration('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales'),
-    programmeMigration('england/building-better-opportunities', 'building-better-opportunities'),
-
-    // Migrated Programme Pages [DRAFT]
-    programmeMigration('england/parks-for-people', 'parks-for-people', false),
-    programmeMigration('scotland/community-assets', 'community-assets', false),
-    programmeMigration('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
-    programmeMigration('scotland/our-place', 'our-place', false),
-    programmeMigration('scotland/scottish-land-fund', 'scottish-land-fund', false),
-    programmeMigration('uk-wide/forces-in-mind', 'forces-in-mind', false)
-];
-
-/**
- * Vanity URLs
- */
-const vanityRedirects = [
-    vanity('/Home/Funding/Funding*Finder', '/funding/programmes'),
-    vanity('/welsh/Home/Funding/Funding*Finder', '/funding/programmes'),
-    vanity('/funding/scotland-portfolio', '/funding/programmes?location=scotland'),
-    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
-    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
-    vanity(
-        '/england/global-content/programmes/england/awards-for-all-england',
-        '/funding/programmes/national-lottery-awards-for-all-england'
-    ),
-    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
-    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
-    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
-    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
-    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england'),
-    vanity('/helpingworkingfamilies', '/helping-working-families'),
-    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families'),
-    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives'),
-    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity'),
-    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities'),
-    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
-    vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
-    vanity('/esf', '/funding/programmes/building-better-opportunities'),
-    vanity(
-        '/guidancetrackingprogress',
-        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
-    ),
-    // This stays here (and not as an alias) as express doesn't care about URL case
-    // and this link is the same (besides case) as an existing alias
-    // (annoyingly, the Title Case version of this link persists on the web... for now.)
-    vanity(
-        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
-        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos'
-    ),
-    // The following aliases use custom destinations (eg. with URL anchors)
-    // so can't live in the regular aliases section (as they all have the same destination)
-    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
-    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
-    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
-    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
-    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
-    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
-    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`),
-    vanity('/prog_people_places', '/funding/programmes?min=10000&location=wales'),
-    vanity('/global-content/programmes/wales/people-and-places', '/funding/programmes?min=10000&location=wales')
-];
 
 /**
  * Other Routes


### PR DESCRIPTION
- Moves aliases and vanity redirects into a separate file
- Works towards a clearer separation between general aliases (redirecting old sections) and vanity URLs (publicity use, top-level url paths).