### PR TITLE
Update canonical urls for under/over 10k pages

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -3595,6 +3595,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/over10k",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": true
         },
         "MaxTTL": 31536000,
@@ -3835,6 +3894,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/funding/scotland-portfolio",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -10238,6 +10356,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/over10k",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": true
         },
         "MaxTTL": 31536000,
@@ -10478,6 +10655,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/scotland-portfolio",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -12306,65 +12542,6 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/welsh/over10k",
-        "SmoothStreaming": false,
-        "DefaultTTL": 86400,
-        "AllowedMethods": {
-            "Items": [
-                "HEAD",
-                "GET"
-            ],
-            "CachedMethods": {
-                "Items": [
-                    "HEAD",
-                    "GET"
-                ],
-                "Quantity": 2
-            },
-            "Quantity": 2
-        },
-        "MinTTL": 0,
-        "Compress": false
-    },
-    {
-        "TrustedSigners": {
-            "Enabled": false,
-            "Items": [],
-            "Quantity": 0
-        },
-        "LambdaFunctionAssociations": {
-            "Items": [],
-            "Quantity": 0
-        },
-        "TargetOriginId": "ELB_LIVE",
-        "ViewerProtocolPolicy": "redirect-to-https",
-        "ForwardedValues": {
-            "Headers": {
-                "Items": [
-                    "Accept",
-                    "Host"
-                ],
-                "Quantity": 2
-            },
-            "Cookies": {
-                "Forward": "whitelist",
-                "WhitelistedNames": {
-                    "Items": [
-                        "contrastMode",
-                        "blf-alpha-session",
-                        "_csrf",
-                        "blf-ab-afa-v2"
-                    ],
-                    "Quantity": 4
-                }
-            },
-            "QueryStringCacheKeys": {
-                "Items": [],
-                "Quantity": 0
-            },
-            "QueryString": false
-        },
-        "MaxTTL": 31536000,
         "PathPattern": "/welsh/publicity",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -12661,65 +12838,6 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/uk-wide",
-        "SmoothStreaming": false,
-        "DefaultTTL": 86400,
-        "AllowedMethods": {
-            "Items": [
-                "HEAD",
-                "GET"
-            ],
-            "CachedMethods": {
-                "Items": [
-                    "HEAD",
-                    "GET"
-                ],
-                "Quantity": 2
-            },
-            "Quantity": 2
-        },
-        "MinTTL": 0,
-        "Compress": false
-    },
-    {
-        "TrustedSigners": {
-            "Enabled": false,
-            "Items": [],
-            "Quantity": 0
-        },
-        "LambdaFunctionAssociations": {
-            "Items": [],
-            "Quantity": 0
-        },
-        "TargetOriginId": "ELB_LIVE",
-        "ViewerProtocolPolicy": "redirect-to-https",
-        "ForwardedValues": {
-            "Headers": {
-                "Items": [
-                    "Accept",
-                    "Host"
-                ],
-                "Quantity": 2
-            },
-            "Cookies": {
-                "Forward": "whitelist",
-                "WhitelistedNames": {
-                    "Items": [
-                        "contrastMode",
-                        "blf-alpha-session",
-                        "_csrf",
-                        "blf-ab-afa-v2"
-                    ],
-                    "Quantity": 4
-                }
-            },
-            "QueryStringCacheKeys": {
-                "Items": [],
-                "Quantity": 0
-            },
-            "QueryString": false
-        },
-        "MaxTTL": 31536000,
-        "PathPattern": "/welsh/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -3595,6 +3595,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/over10k",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": true
         },
         "MaxTTL": 31536000,
@@ -3835,6 +3894,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/funding/scotland-portfolio",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/funding/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -10238,6 +10356,65 @@
                 "Items": [],
                 "Quantity": 0
             },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/over10k",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
             "QueryString": true
         },
         "MaxTTL": 31536000,
@@ -10478,6 +10655,65 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/funding/scotland-portfolio",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
+        "PathPattern": "/welsh/funding/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {
@@ -12306,65 +12542,6 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
-        "PathPattern": "/welsh/over10k",
-        "SmoothStreaming": false,
-        "DefaultTTL": 86400,
-        "AllowedMethods": {
-            "Items": [
-                "HEAD",
-                "GET"
-            ],
-            "CachedMethods": {
-                "Items": [
-                    "HEAD",
-                    "GET"
-                ],
-                "Quantity": 2
-            },
-            "Quantity": 2
-        },
-        "MinTTL": 0,
-        "Compress": false
-    },
-    {
-        "TrustedSigners": {
-            "Enabled": false,
-            "Items": [],
-            "Quantity": 0
-        },
-        "LambdaFunctionAssociations": {
-            "Items": [],
-            "Quantity": 0
-        },
-        "TargetOriginId": "ELB-TEST",
-        "ViewerProtocolPolicy": "redirect-to-https",
-        "ForwardedValues": {
-            "Headers": {
-                "Items": [
-                    "Accept",
-                    "Host"
-                ],
-                "Quantity": 2
-            },
-            "Cookies": {
-                "Forward": "whitelist",
-                "WhitelistedNames": {
-                    "Items": [
-                        "contrastMode",
-                        "blf-alpha-session",
-                        "_csrf",
-                        "blf-ab-afa-v2"
-                    ],
-                    "Quantity": 4
-                }
-            },
-            "QueryStringCacheKeys": {
-                "Items": [],
-                "Quantity": 0
-            },
-            "QueryString": false
-        },
-        "MaxTTL": 31536000,
         "PathPattern": "/welsh/publicity",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
@@ -12661,65 +12838,6 @@
         },
         "MaxTTL": 31536000,
         "PathPattern": "/welsh/uk-wide",
-        "SmoothStreaming": false,
-        "DefaultTTL": 86400,
-        "AllowedMethods": {
-            "Items": [
-                "HEAD",
-                "GET"
-            ],
-            "CachedMethods": {
-                "Items": [
-                    "HEAD",
-                    "GET"
-                ],
-                "Quantity": 2
-            },
-            "Quantity": 2
-        },
-        "MinTTL": 0,
-        "Compress": false
-    },
-    {
-        "TrustedSigners": {
-            "Enabled": false,
-            "Items": [],
-            "Quantity": 0
-        },
-        "LambdaFunctionAssociations": {
-            "Items": [],
-            "Quantity": 0
-        },
-        "TargetOriginId": "ELB-TEST",
-        "ViewerProtocolPolicy": "redirect-to-https",
-        "ForwardedValues": {
-            "Headers": {
-                "Items": [
-                    "Accept",
-                    "Host"
-                ],
-                "Quantity": 2
-            },
-            "Cookies": {
-                "Forward": "whitelist",
-                "WhitelistedNames": {
-                    "Items": [
-                        "contrastMode",
-                        "blf-alpha-session",
-                        "_csrf",
-                        "blf-ab-afa-v2"
-                    ],
-                    "Quantity": 4
-                }
-            },
-            "QueryStringCacheKeys": {
-                "Items": [],
-                "Quantity": 0
-            },
-            "QueryString": false
-        },
-        "MaxTTL": 31536000,
-        "PathPattern": "/welsh/under10k",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,
         "AllowedMethods": {

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -53,41 +53,45 @@ const legacyRedirects = [
 /**
  * Vanity URLs
  */
-const vanityRedirects = [
-    vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
-    vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
-    vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
-    vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
-    vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
-    vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
-    vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england'),
-    vanity('/helpingworkingfamilies', '/helping-working-families'),
-    vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families'),
-    vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives'),
-    vanity('/communityled', '/funding/programmes/grants-for-community-led-activity'),
-    vanity('/peopleandcommunities', '/funding/programmes/people-and-communities'),
-    vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
-    vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
-    vanity('/esf', '/funding/programmes/building-better-opportunities'),
-    vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
-    vanity(
-        '/guidancetrackingprogress',
-        '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
-    ),
-    vanity(
-        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
-        '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos'
-    ),
-    vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
-    vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
-    vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
-    vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
-    vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
-    vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
-    vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`),
-    vanity('/prog_people_places', '/funding/programmes?min=10000&location=wales'),
-    vanity('/global-content/programmes/wales/people-and-places', '/funding/programmes?min=10000&location=wales')
-];
+const vanityRedirects = sections => {
+    return [
+        vanity('/over10k', sections.funding.find('over10k')),
+        vanity('/under10k', sections.funding.find('under10k')),
+        vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
+        vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
+        vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
+        vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
+        vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+        vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
+        vanity('/prog_reaching_communities', '/funding/programmes/reaching-communities-england'),
+        vanity('/helpingworkingfamilies', '/helping-working-families'),
+        vanity('/helputeuluoeddgweithio', '/welsh/helping-working-families'),
+        vanity('/improvinglives', '/funding/programmes/grants-for-improving-lives'),
+        vanity('/communityled', '/funding/programmes/grants-for-community-led-activity'),
+        vanity('/peopleandcommunities', '/funding/programmes/people-and-communities'),
+        vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
+        vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
+        vanity('/esf', '/funding/programmes/building-better-opportunities'),
+        vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
+        vanity(
+            '/guidancetrackingprogress',
+            '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
+        ),
+        vanity(
+            '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads',
+            '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos'
+        ),
+        vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
+        vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
+        vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+        vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
+        vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
+        vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
+        vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`),
+        vanity('/prog_people_places', '/funding/programmes?min=10000&location=wales'),
+        vanity('/global-content/programmes/wales/people-and-places', '/funding/programmes?min=10000&location=wales')
+    ];
+};
 
 module.exports = {
     archivedRoutes,

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { get } = require('lodash');
+
 /**
  * Create a top-level section
  *
@@ -8,14 +10,39 @@
  * langTitlePath - locale property for translated page title
  */
 function createSection({ path, controllerPath, langTitlePath }) {
-    return {
-        path,
-        controller: function(pages, sectionPath, sectionId) {
-            return require(controllerPath)(pages, sectionPath, sectionId);
-        },
-        langTitlePath,
-        pages: null
+    const newSection = {
+        path: path,
+        pages: null,
+        langTitlePath: langTitlePath
     };
+
+    /**
+     * Controller loader function, allows us to auto-init routes
+     */
+    newSection.controller = function(pages, sectionPath, sectionId) {
+        return require(controllerPath)(pages, sectionPath, sectionId);
+    };
+
+    /**
+     * Setter for route pages
+     */
+    newSection.addRoutes = function(sectionRoutes) {
+        newSection.pages = sectionRoutes;
+    };
+
+    /**
+     * Find the cannonical path for a given page key
+     */
+    newSection.find = function(pageId) {
+        const pagePath = get(newSection.pages, `${pageId}.path`);
+        if (pagePath) {
+            return `${path}${pagePath}`;
+        } else {
+            throw new Error(`No route found for ${pageId}`);
+        }
+    };
+
+    return newSection;
 }
 
 /**

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -38,7 +38,7 @@ const sections = {
 /**
  * Top-level Routes
  */
-sections.toplevel.pages = {
+sections.toplevel.addRoutes({
     home: dynamicRoute({
         path: '/',
         template: 'pages/toplevel/home',
@@ -90,17 +90,6 @@ sections.toplevel.pages = {
         lang: 'toplevel.benefits',
         aliases: ['/about-big/jobs/benefits']
     }),
-    under10k: staticRoute({
-        path: '/under10k',
-        template: 'pages/toplevel/under10k',
-        lang: 'toplevel.under10k',
-        aliases: ['/funding/Awards-For-All', '/funding/awards-for-all', '/awardsforall', '/a4a', '/A4A']
-    }),
-    over10k: staticRoute({
-        path: '/over10k',
-        template: 'pages/toplevel/over10k',
-        lang: 'toplevel.over10k'
-    }),
     eyp: staticRoute({
         path: '/empowering-young-people',
         template: 'pages/toplevel/eyp',
@@ -113,17 +102,28 @@ sections.toplevel.pages = {
         lang: 'toplevel.helpingWorkingFamilies',
         aliases: ['/global-content/programmes/wales/helping-working-families']
     })
-};
+});
 
 /**
  * Funding Routes
  */
-sections.funding.pages = {
+sections.funding.addRoutes({
     root: dynamicRoute({
         path: '/',
         template: 'pages/toplevel/funding',
         lang: 'toplevel.funding',
         aliases: ['/home/funding']
+    }),
+    under10k: staticRoute({
+        path: '/under10k',
+        template: 'pages/toplevel/under10k',
+        lang: 'toplevel.under10k',
+        aliases: ['/funding/Awards-For-All', '/funding/awards-for-all', '/awardsforall', '/a4a', '/A4A']
+    }),
+    over10k: staticRoute({
+        path: '/over10k',
+        template: 'pages/toplevel/over10k',
+        lang: 'toplevel.over10k'
     }),
     manageFunding: staticRoute({
         path: '/funding-guidance/managing-your-funding',
@@ -191,23 +191,23 @@ sections.funding.pages = {
         path: '/funding-guidance/help-using-our-application-forms',
         aliases: ['/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms']
     })
-};
+});
 
 /**
  * Research Routes
  */
-sections.research.pages = {
+sections.research.addRoutes({
     root: staticRoute({
         path: '/',
         template: 'pages/toplevel/research',
         lang: 'toplevel.research'
     })
-};
+});
 
 /**
  * About Routes
  */
-sections['about-big'].pages = {
+sections['about-big'].addRoutes({
     root: staticRoute({
         path: '/',
         template: 'pages/toplevel/about',
@@ -241,7 +241,7 @@ sections['about-big'].pages = {
         isPostable: true,
         aliases: ['/about-big/ebulletin-subscription', '/ebulletin']
     })
-};
+});
 
 /**
  * Legacy proxied routes
@@ -307,9 +307,9 @@ const otherUrls = [
 
 module.exports = {
     sections: sections,
-    legacyProxiedRoutes,
-    archivedRoutes,
-    legacyRedirects,
-    vanityRedirects,
-    otherUrls
+    archivedRoutes: archivedRoutes,
+    legacyRedirects: legacyRedirects,
+    legacyProxiedRoutes: legacyProxiedRoutes,
+    vanityRedirects: vanityRedirects(sections),
+    otherUrls: otherUrls
 };

--- a/integration-tests/test-suites/core.test.js
+++ b/integration-tests/test-suites/core.test.js
@@ -84,24 +84,24 @@ describe('Core sections and features', () => {
     it('should include correct language switcher for en locale', () => {
         return chai
             .request(server)
-            .get('/over10k')
+            .get('/funding/over10k')
             .then(res => {
                 const { document } = new JSDOM(res.text).window;
                 const langSwitcherHref = document.querySelector('.qa-lang-switcher').href;
                 const urlPath = new URL(langSwitcherHref).pathname;
-                expect(urlPath).to.equal('/welsh/over10k');
+                expect(urlPath).to.equal('/welsh/funding/over10k');
             });
     });
 
     it('should include correct language switcher for cy locale', () => {
         return chai
             .request(server)
-            .get('/welsh/over10k')
+            .get('/welsh/funding/over10k')
             .then(res => {
                 const { document } = new JSDOM(res.text).window;
                 const langSwitcherHref = document.querySelector('.qa-lang-switcher').href;
                 const urlPath = new URL(langSwitcherHref).pathname;
-                expect(urlPath).to.equal('/over10k');
+                expect(urlPath).to.equal('/funding/over10k');
             });
     });
 


### PR DESCRIPTION
Update canonical urls for under/over 10k pages and reworks `createSection` to expose a little section finder method. Allows us to ask for canonical urls in aliases.