### PR TITLE
Add AFA Scotland redirect

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -2231,6 +2231,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/england/global-content/programmes/scotland/awards-for-all-scotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/error",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -7389,6 +7389,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/wales/global-content/programmes/scotland/awards-for-all-scotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/welcome",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -2231,6 +2231,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/england/global-content/programmes/scotland/awards-for-all-scotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/error",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -7389,6 +7389,65 @@
             "QueryString": false
         },
         "MaxTTL": 31536000,
+        "PathPattern": "/wales/global-content/programmes/scotland/awards-for-all-scotland",
+        "SmoothStreaming": false,
+        "DefaultTTL": 86400,
+        "AllowedMethods": {
+            "Items": [
+                "HEAD",
+                "GET"
+            ],
+            "CachedMethods": {
+                "Items": [
+                    "HEAD",
+                    "GET"
+                ],
+                "Quantity": 2
+            },
+            "Quantity": 2
+        },
+        "MinTTL": 0,
+        "Compress": false
+    },
+    {
+        "TrustedSigners": {
+            "Enabled": false,
+            "Items": [],
+            "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+            "Items": [],
+            "Quantity": 0
+        },
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "ForwardedValues": {
+            "Headers": {
+                "Items": [
+                    "Accept",
+                    "Host"
+                ],
+                "Quantity": 2
+            },
+            "Cookies": {
+                "Forward": "whitelist",
+                "WhitelistedNames": {
+                    "Items": [
+                        "contrastMode",
+                        "blf-alpha-session",
+                        "_csrf",
+                        "blf-ab-afa-v2"
+                    ],
+                    "Quantity": 4
+                }
+            },
+            "QueryStringCacheKeys": {
+                "Items": [],
+                "Quantity": 0
+            },
+            "QueryString": false
+        },
+        "MaxTTL": 31536000,
         "PathPattern": "/welcome",
         "SmoothStreaming": false,
         "DefaultTTL": 86400,

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -70,7 +70,10 @@ const vanityRedirects = [
     vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
     vanity('/esf', '/funding/programmes/building-better-opportunities'),
     vanity('/scottishlandfund', '/funding/programmes/scottish-land-fund'),
-    vanity('/wales/global-content/programmes/scotland/awards-for-all-scotland', '/funding/programmes/scottish-land-fund'),
+    vanity(
+        '/wales/global-content/programmes/scotland/awards-for-all-scotland',
+        '/funding/programmes/scottish-land-fund'
+    ),
     vanity(
         '/guidancetrackingprogress',
         '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -69,7 +69,8 @@ const vanityRedirects = [
     vanity('/cyhoeddusrwydd', '/welsh/funding/funding-guidance/managing-your-funding'),
     vanity('/ccf', '/funding/programmes/coastal-communities-fund'),
     vanity('/esf', '/funding/programmes/building-better-opportunities'),
-    vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
+    vanity('/scottishlandfund', '/funding/programmes/scottish-land-fund'),
+    vanity('/wales/global-content/programmes/scotland/awards-for-all-scotland', '/funding/programmes/scottish-land-fund'),
     vanity(
         '/guidancetrackingprogress',
         '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -79,7 +79,7 @@ const vanityRedirects = sections => {
         vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
         vanity(
             '/wales/global-content/programmes/scotland/awards-for-all-scotland',
-            '/funding/programmes/scottish-land-fund'
+            '/funding/programmes/national-lottery-awards-for-all-scotland'
         ),
         vanity(
             '/guidancetrackingprogress',

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -60,6 +60,9 @@ const vanityRedirects = sections => {
         vanity('/a4aengland', '/funding/programmes/national-lottery-awards-for-all-england'),
         vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
         vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
+        vanity(
+            '/england/global-content/programmes/scotland/awards-for-all-scotland', '/funding/programmes/national-lottery-awards-for-all-scotland'
+        ),
         vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
         vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
         vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -61,7 +61,8 @@ const vanityRedirects = sections => {
         vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
         vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
         vanity(
-            '/england/global-content/programmes/scotland/awards-for-all-scotland', '/funding/programmes/national-lottery-awards-for-all-scotland'
+            '/england/global-content/programmes/scotland/awards-for-all-scotland',
+            '/funding/programmes/national-lottery-awards-for-all-scotland'
         ),
         vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
         vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "prettier --write",
       "eslint"
     ],
-    "controllers/routes.js": [
+    "{controllers/routes.js,controllers/aliases.js}": [
       "./bin/generate-cloudfront-config"
     ]
   },


### PR DESCRIPTION
Redirects https://www.biglotteryfund.org.uk/wales/global-content/programmes/scotland/awards-for-all-scotland to its rightful place.

Also adds the route aliases to the "linter" so changes there auto-regenerate the configs, too.