### PR TITLE
Search tracking update

### DIFF
--- a/controllers/toplevel/legacyPages.js
+++ b/controllers/toplevel/legacyPages.js
@@ -1,29 +1,9 @@
 const queryString = require('query-string');
-const { includes, reduce, toString } = require('lodash');
+const { toString } = require('lodash');
 
 const { legacyProxiedRoutes } = require('../routes');
-const { localify } = require('../../modules/urls');
+const { localify, normaliseQuery } = require('../../modules/urls');
 const { proxyLegacyPage, postToLegacyForm } = require('../../modules/legacy');
-
-/**
- * Normalize query
- * Old format URLs often get passed through as: ?area=Scotland&amp;amount=10001 - 50000
- * urlencoded &amp; needs to be normalised when fetching individual query param
- */
-function normaliseQuery(originalQuery) {
-    function reducer(newQuery, value, key) {
-        const prefix = 'amp;';
-        if (includes(key, prefix)) {
-            newQuery[key.replace(prefix, '')] = value;
-        } else {
-            newQuery[key] = value;
-        }
-
-        return newQuery;
-    }
-
-    return reduce(originalQuery, reducer, {});
-}
 
 function reformatQueryString({ originalAreaQuery, originalAmountQuery }) {
     originalAreaQuery = toString(originalAreaQuery).toLowerCase();

--- a/controllers/toplevel/legacyPages.js
+++ b/controllers/toplevel/legacyPages.js
@@ -71,6 +71,5 @@ function init({ router }) {
 
 module.exports = {
     init,
-    normaliseQuery,
     reformatQueryString
 };

--- a/controllers/toplevel/legacyPages.test.js
+++ b/controllers/toplevel/legacyPages.test.js
@@ -2,27 +2,9 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { normaliseQuery, reformatQueryString } = require('./legacyPages');
+const { reformatQueryString } = require('./legacyPages');
 
 describe('Legacy pages', () => {
-    describe('#normaliseQuery', () => {
-        it('should normalise &amp; encoding in query strings', () => {
-            expect(
-                normaliseQuery({
-                    area: 'England',
-                    'amp;amount': '10001 - 50000',
-                    'amp;org': 'Voluntary or community organisation',
-                    'amp;sc': '1'
-                })
-            ).to.eql({
-                area: 'England',
-                amount: '10001 - 50000',
-                org: 'Voluntary or community organisation',
-                sc: '1'
-            });
-        });
-    });
-
     describe('#reformatQueryString', () => {
         it('should return an empty string if no valid query is passed', () => {
             [null, undefined, ''].forEach(falseyValue => {

--- a/controllers/toplevel/search.js
+++ b/controllers/toplevel/search.js
@@ -1,12 +1,15 @@
 const querystring = require('querystring');
 const { noCache } = require('../../middleware/cached');
-const { trackPageview } = require('../../modules/analytics');
+const { customEvent } = require('../../modules/analytics');
+const { normaliseQuery } = require('../../modules/urls');
 
 function init({ router, routeConfig }) {
     const queryBase = 'https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk';
     router.get(routeConfig.path, noCache, (req, res) => {
+        req.query = normaliseQuery(req.query);
+
         if (req.query.q) {
-            trackPageview(req);
+            customEvent('Search', 'Term', req.q);
             res.redirect(`${queryBase}+${querystring.escape(req.query.q)}`);
         } else {
             res.redirect('/');

--- a/controllers/toplevel/search.js
+++ b/controllers/toplevel/search.js
@@ -9,7 +9,7 @@ function init({ router, routeConfig }) {
         req.query = normaliseQuery(req.query);
 
         if (req.query.q) {
-            customEvent('Search', 'Term', req.q);
+            customEvent('Search', 'Term', req.query.q);
             res.redirect(`${queryBase}+${querystring.escape(req.query.q)}`);
         } else {
             res.redirect('/');

--- a/integration-tests/test-suites/core.test.js
+++ b/integration-tests/test-suites/core.test.js
@@ -149,4 +149,16 @@ describe('Core sections and features', () => {
                 );
             });
     });
+
+    it('should redirect legacy site search queries to google site search', () => {
+        return chai
+            .request(server)
+            .get('/search?lang=en-GB&amp;q=something&amp;type=All&amp;order=r')
+            .redirects(0)
+            .catch(err => err.response)
+            .then(res => {
+                expect(res).to.have.status(302);
+                expect(res).to.redirectTo('https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk+something');
+            });
+    });
 });

--- a/integration-tests/test-suites/legacy.test.js
+++ b/integration-tests/test-suites/legacy.test.js
@@ -99,33 +99,31 @@ describe('Legacy pages', () => {
         });
     });
 
-    describe('Legacy ~/link.aspx URLs', () => {
-        it('Should redirect top-level ~/link.aspx urls', () => {
-            return chai
-                .request(server)
-                .get('/~/link.aspx?_id=50fab7d4b5a248f8a8c8f5d4d33f9e0f&_z=z')
-                .redirects(0)
-                .catch(err => err.response)
-                .then(res => {
-                    expect(res.status).to.equal(301);
-                    expect(res).to.redirectTo(
-                        '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
-                    );
-                });
-        });
+    it('Should redirect top-level ~/link.aspx urls', () => {
+        return chai
+            .request(server)
+            .get('/~/link.aspx?_id=50fab7d4b5a248f8a8c8f5d4d33f9e0f&_z=z')
+            .redirects(0)
+            .catch(err => err.response)
+            .then(res => {
+                expect(res.status).to.equal(301);
+                expect(res).to.redirectTo(
+                    '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
+                );
+            });
+    });
 
-        it('Should redirect wildcard ~/link.aspx urls', () => {
-            return chai
-                .request(server)
-                .get('/global-content/programmes/england/~/link.aspx?_id=50FAB7D4B5A248F8A8C8F5D4D33F9E0F&_z=z')
-                .redirects(0)
-                .catch(err => err.response)
-                .then(res => {
-                    expect(res.status).to.equal(301);
-                    expect(res).to.redirectTo(
-                        '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
-                    );
-                });
-        });
+    it('Should redirect wildcard ~/link.aspx urls', () => {
+        return chai
+            .request(server)
+            .get('/global-content/programmes/england/~/link.aspx?_id=50FAB7D4B5A248F8A8C8F5D4D33F9E0F&_z=z')
+            .redirects(0)
+            .catch(err => err.response)
+            .then(res => {
+                expect(res.status).to.equal(301);
+                expect(res).to.redirectTo(
+                    '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'
+                );
+            });
     });
 });

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const { includes, reduce } = require('lodash');
 
 const WELSH_REGEX = /^\/welsh(\/|$)/;
 
@@ -83,6 +84,26 @@ function stripTrailingSlashes(urlPath) {
     return urlPath;
 }
 
+/**
+ * Normalize query
+ * Old format URLs often get passed through as: ?area=Scotland&amp;amount=10001 - 50000
+ * urlencoded &amp; needs to be normalised when fetching individual query param
+ */
+function normaliseQuery(originalQuery) {
+    function reducer(newQuery, value, key) {
+        const prefix = 'amp;';
+        if (includes(key, prefix)) {
+            newQuery[key.replace(prefix, '')] = value;
+        } else {
+            newQuery[key] = value;
+        }
+
+        return newQuery;
+    }
+
+    return reduce(originalQuery, reducer, {});
+}
+
 module.exports = {
     WELSH_REGEX,
     isWelsh,
@@ -93,5 +114,6 @@ module.exports = {
     getBaseUrl,
     getFullUrl,
     hasTrailingSlash,
-    stripTrailingSlashes
+    stripTrailingSlashes,
+    normaliseQuery
 };

--- a/modules/urls.test.js
+++ b/modules/urls.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { getBaseUrl, isWelsh, localify, hasTrailingSlash, stripTrailingSlashes } = require('./urls');
+const { getBaseUrl, isWelsh, localify, hasTrailingSlash, stripTrailingSlashes, normaliseQuery } = require('./urls');
 const httpMocks = require('node-mocks-http');
 
 describe('URL Helpers', () => {
@@ -105,6 +105,24 @@ describe('URL Helpers', () => {
             expect(stripTrailingSlashes(pathWithSlash)).to.equal('/foo');
             expect(stripTrailingSlashes(pathWithoutSlash)).to.equal('/bar');
             expect(stripTrailingSlashes(pathToHomepage)).to.equal('/');
+        });
+    });
+
+    describe('#normaliseQuery', () => {
+        it('should normalise &amp; encoding in query strings', () => {
+            expect(
+                normaliseQuery({
+                    area: 'England',
+                    'amp;amount': '10001 - 50000',
+                    'amp;org': 'Voluntary or community organisation',
+                    'amp;sc': '1'
+                })
+            ).to.eql({
+                area: 'England',
+                amount: '10001 - 50000',
+                org: 'Voluntary or community organisation',
+                sc: '1'
+            });
         });
     });
 });


### PR DESCRIPTION
- Switch tracking to event tracking rather than pageviews
- Normalise query string to account for legacy site url encoding
- Add integration test for legacy search queries