### PR TITLE
Update how cloudfront configs are generated

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ indent_style = space
 indent_size = 4
 max_line_length = 120
 
-[{*.yml,package.json}]
+[{*.yml,*.json}]
 indent_style = space
 indent_size = 2

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -57,7 +57,7 @@ forEach(cloudfrontDistributions, (distribution, distributionName) => {
     const behaviours = generateBehaviours(distribution);
 
     const confData = {
-        DefaultBehaviour: defaultBehaviour,
+        DefaultCacheBehavior: defaultBehaviour,
         CacheBehaviors: {
             Items: behaviours,
             Quantity: behaviours.length

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -1,77 +1,37 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
-const config = require('config');
-const { forEach, sortBy } = require('lodash');
+const util = require('util');
+const { forEach } = require('lodash');
 
-const { generateUrlList, makeBehaviourItem } = require('../modules/cloudfront');
 const routes = require('../controllers/routes');
 const cloudfrontDistributions = require('../config/app/distributions');
+const { generateBehaviours } = require('../modules/cloudfront');
 
-const cookies = config.get('cookies');
-const cookiesInUse = Object.keys(cookies).map(k => cookies[k]);
-
-/**
- * Generate Cloudfront behaviours
- * construct array of behaviours from a URL list
- */
-function generateBehaviours(origins) {
-    const urlsToSupport = generateUrlList(routes);
-
-    const customBehaviours = [
-        makeBehaviourItem({
-            originId: origins.legacy,
-            pathPattern: '/~/*',
-            isPostable: true,
-            allowAllQueryStrings: true,
-            allowAllCookies: true,
-            protocol: 'allow-all',
-            headersToKeep: ['*']
-        })
-    ];
-
-    const primaryBehaviours = urlsToSupport.map(url => {
-        return makeBehaviourItem({
-            originId: origins.newSite,
-            pathPattern: url.path,
-            isPostable: url.isPostable,
-            queryStringWhitelist: url.queryStrings,
-            cookiesInUse: cookiesInUse
-        });
-    });
-
-    return [].concat(customBehaviours).concat(sortBy(primaryBehaviours, 'PathPattern'));
-}
+const writeFile = util.promisify(fs.writeFile);
 
 /**
  * For each CloudFront distribution generate a config and store it
  */
 forEach(cloudfrontDistributions, (distribution, distributionName) => {
-    console.log(`Creating Cloudfront configuration for the "${distributionName}" distribution.`);
-
-    const defaultBehaviour = makeBehaviourItem({
-        originId: distribution.origins.newSite,
-        isPostable: true,
-        cookiesInUse: cookiesInUse
+    const behaviours = generateBehaviours({
+        routesConfig: routes,
+        origins: distribution.origins
     });
 
-    const behaviours = generateBehaviours(distribution.origins);
+    const distributionTag = `[${distributionName.toUpperCase()}]`;
+    const behaviourCount = behaviours.CacheBehaviors.Items.length;
 
-    const confData = {
-        DefaultCacheBehavior: defaultBehaviour,
-        CacheBehaviors: {
-            Items: behaviours,
-            Quantity: behaviours.length
-        }
-    };
+    const filePath = path.join(__dirname, `../config/cloudfront/${distributionName}.json`);
+    const relativeFilePath = path.relative(process.cwd(), filePath);
 
-    console.log(`Adding ${behaviours.length} URLs routing for "${distributionName}" distribution`);
-
-    try {
-        const confPath = path.join(__dirname, `../config/cloudfront/${distributionName}.json`);
-        fs.writeFileSync(confPath, JSON.stringify(confData, null, 4));
-        console.log(`An updated config for the "${distributionName}" distribution was saved in ${confPath}`);
-    } catch (err) {
-        return console.error('Error saving config', err);
-    }
+    writeFile(filePath, JSON.stringify(behaviours, null, 2), 'utf8')
+        .then(() => {
+            console.log(
+                `${distributionTag} Cloudfront configuration with ${behaviourCount} behaviours saved at ${relativeFilePath}.`
+            );
+        })
+        .catch(err => {
+            console.error('Error saving config', err);
+        });
 });

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -2,69 +2,75 @@
 const fs = require('fs');
 const path = require('path');
 const config = require('config');
-const { sortBy } = require('lodash');
+const { forEach, sortBy } = require('lodash');
 
 const { generateUrlList, makeBehaviourItem } = require('../modules/cloudfront');
 const routes = require('../controllers/routes');
-const CF_CONFIGS = require('../config/app/distributions');
-
-// make a list of every URL we need to serve
-// across all origins
-const urlsToSupport = generateUrlList(routes);
+const cloudfrontDistributions = require('../config/app/distributions');
 
 // lookup cookies from app config
 const cookies = config.get('cookies');
 const cookiesInUse = Object.keys(cookies).map(k => cookies[k]);
 
-// construct array of behaviours from a URL list
-// eg. route them to the relevant origins
-// based on the distribution (test/live)
-const generateBehaviours = (distribution, environment) => {
-    let behaviours = [];
-    for (let origin in urlsToSupport) {
-        let links = urlsToSupport[origin];
-        if (links.length > 0) {
-            console.log(
-                `Adding ${
-                    links.length
-                } URLs routing to "${origin}" to config for "${environment}" distribution`
-            );
-            // get name of origin server (for live/test)
-            let originServer = distribution.origins[origin];
-            links.forEach(url => {
-                behaviours.push(
-                    makeBehaviourItem({
-                        origin: origin,
-                        originServer: originServer,
-                        pathPattern: url.path,
-                        isPostable: url.isPostable,
-                        queryStringWhitelist: url.queryStrings,
-                        cookiesInUse: cookiesInUse
-                    })
-                );
-            });
-        }
-    }
+/**
+ * Generate Cloudfront behaviours
+ * construct array of behaviours from a URL list
+ */
+function generateBehaviours(distribution) {
+    const urlsToSupport = generateUrlList(routes);
 
-    // sort by path (to make diffing easier)
-    behaviours = sortBy(behaviours, 'PathPattern');
-    return behaviours;
-};
+    const customBehaviours = [
+        makeBehaviourItem({
+            origin: 'legacy',
+            originServer: distribution.origins.legacy,
+            pathPattern: '/~/*',
+            isPostable: true,
+            cookiesInUse: cookiesInUse
+        })
+    ];
+
+    const primaryBehaviours = urlsToSupport.map(url => {
+        return makeBehaviourItem({
+            origin: 'newSite',
+            originServer: distribution.origins.newSite,
+            pathPattern: url.path,
+            isPostable: url.isPostable,
+            queryStringWhitelist: url.queryStrings,
+            cookiesInUse: cookiesInUse
+        });
+    });
+
+    return [].concat(customBehaviours).concat(sortBy(primaryBehaviours, 'PathPattern'));
+}
 
 // for each cloudfront distribution, generate a config and store it
-for (let environment in CF_CONFIGS) {
-    console.log(
-        `Creating Cloudfront configuration for the "${environment}" distribution.`
-    );
-    const distribution = CF_CONFIGS[environment];
-    const behaviours = generateBehaviours(distribution, environment);
+forEach(cloudfrontDistributions, (distribution, distributionName) => {
+    console.log(`Creating Cloudfront configuration for the "${distributionName}" distribution.`);
+
+    const defaultBehaviour = makeBehaviourItem({
+        origin: 'newSite',
+        originServer: distribution.origins.newSite,
+        isPostable: true,
+        cookiesInUse: cookiesInUse
+    });
+
+    const behaviours = generateBehaviours(distribution);
+
+    const confData = {
+        DefaultBehaviour: defaultBehaviour,
+        CacheBehaviors: {
+            Items: behaviours,
+            Quantity: behaviours.length
+        }
+    };
+
+    console.log(`Adding ${behaviours.length} URLs routing for "${distributionName}" distribution`);
 
     try {
-        const confPath = path.join(__dirname, `../config/cloudfront/${environment}.json`);
-        const confData = JSON.stringify(behaviours, null, 4);
-        fs.writeFileSync(confPath, confData);
-        console.log(`An updated config for the "${environment}" distribution was saved in ${confPath}`);
+        const confPath = path.join(__dirname, `../config/cloudfront/${distributionName}.json`);
+        fs.writeFileSync(confPath, JSON.stringify(confData, null, 4));
+        console.log(`An updated config for the "${distributionName}" distribution was saved in ${confPath}`);
     } catch (err) {
         return console.error('Error saving config', err);
     }
-}
+});

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -8,7 +8,6 @@ const { generateUrlList, makeBehaviourItem } = require('../modules/cloudfront');
 const routes = require('../controllers/routes');
 const cloudfrontDistributions = require('../config/app/distributions');
 
-// lookup cookies from app config
 const cookies = config.get('cookies');
 const cookiesInUse = Object.keys(cookies).map(k => cookies[k]);
 
@@ -16,23 +15,24 @@ const cookiesInUse = Object.keys(cookies).map(k => cookies[k]);
  * Generate Cloudfront behaviours
  * construct array of behaviours from a URL list
  */
-function generateBehaviours(distribution) {
+function generateBehaviours(origins) {
     const urlsToSupport = generateUrlList(routes);
 
     const customBehaviours = [
         makeBehaviourItem({
-            origin: 'legacy',
-            originServer: distribution.origins.legacy,
+            originId: origins.legacy,
             pathPattern: '/~/*',
             isPostable: true,
-            cookiesInUse: cookiesInUse
+            allowAllQueryStrings: true,
+            allowAllCookies: true,
+            protocol: 'allow-all',
+            headersToKeep: ['*']
         })
     ];
 
     const primaryBehaviours = urlsToSupport.map(url => {
         return makeBehaviourItem({
-            origin: 'newSite',
-            originServer: distribution.origins.newSite,
+            originId: origins.newSite,
             pathPattern: url.path,
             isPostable: url.isPostable,
             queryStringWhitelist: url.queryStrings,
@@ -43,18 +43,19 @@ function generateBehaviours(distribution) {
     return [].concat(customBehaviours).concat(sortBy(primaryBehaviours, 'PathPattern'));
 }
 
-// for each cloudfront distribution, generate a config and store it
+/**
+ * For each CloudFront distribution generate a config and store it
+ */
 forEach(cloudfrontDistributions, (distribution, distributionName) => {
     console.log(`Creating Cloudfront configuration for the "${distributionName}" distribution.`);
 
     const defaultBehaviour = makeBehaviourItem({
-        origin: 'newSite',
-        originServer: distribution.origins.newSite,
+        originId: distribution.origins.newSite,
         isPostable: true,
         cookiesInUse: cookiesInUse
     });
 
-    const behaviours = generateBehaviours(distribution);
+    const behaviours = generateBehaviours(distribution.origins);
 
     const confData = {
         DefaultCacheBehavior: defaultBehaviour,

--- a/bin/update-cloudfront
+++ b/bin/update-cloudfront
@@ -122,7 +122,7 @@ function storeBackup(existingConfig) {
         const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
         const confPath = path.join(__dirname, `../config/cloudfront/backup/${timestamp}.json`);
         const backup = {
-            DefaultBehaviour: existingConfig.Distribution.DistributionConfig.DefaultBehaviour,
+            DefaultCacheBehavior: existingConfig.Distribution.DistributionConfig.DefaultCacheBehavior,
             CacheBehaviors: existingConfig.Distribution.DistributionConfig.CacheBehaviors
         };
         fs.writeFileSync(confPath, JSON.stringify(backup, null, 4));

--- a/bin/update-cloudfront
+++ b/bin/update-cloudfront
@@ -117,7 +117,34 @@ if (customConfig) {
         });
 }
 
-function beginUpdate(cacheBehaviors) {
+function storeBackup(existingConfig) {
+    try {
+        const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
+        const confPath = path.join(__dirname, `../config/cloudfront/backup/${timestamp}.json`);
+        const backup = {
+            DefaultBehaviour: existingConfig.Distribution.DistributionConfig.DefaultBehaviour,
+            CacheBehaviors: existingConfig.Distribution.DistributionConfig.CacheBehaviors
+        };
+        fs.writeFileSync(confPath, JSON.stringify(backup, null, 4));
+        console.log('A copy of the existing config was saved in ' + confPath);
+    } catch (err) {
+        return console.error('Error saving old config', err);
+    }
+}
+
+function listChanges(pathConfigs) {
+    let pathsByOrigin = groupBy(pathConfigs, 'origin');
+    let divider = '=================';
+    for (let origin in pathsByOrigin) {
+        console.log('\n', divider, origin, divider, '\n');
+        pathsByOrigin[origin].forEach(p => {
+            console.log(p.path);
+        });
+        console.log('\n');
+    }
+}
+
+function beginUpdate(savedConfig) {
     // create AWS SDK instance
     AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
     const cloudfront = new AWS.CloudFront();
@@ -135,26 +162,19 @@ function beginUpdate(cacheBehaviors) {
     // handle response from fetching config
     getDistributionConfig
         .then(existingConfig => {
-            // fetching the config worked
-
             // store the existing behaviour config locally, just in case...
-            try {
-                const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
-                const confPath = path.join(__dirname, `../config/cloudfront/backup/${timestamp}.json`);
-                let existingBehaviours = existingConfig.Distribution.DistributionConfig.CacheBehaviors.Items;
-                fs.writeFileSync(confPath, JSON.stringify(existingBehaviours, null, 4));
-                console.log('A copy of the existing config was saved in ' + confPath);
-            } catch (err) {
-                return console.error('Error saving old config', err);
-            }
+            storeBackup(existingConfig);
 
             // store etag for later update
             const etag = existingConfig.ETag;
 
             // clone the existing config and update the behaviours
-            let newConfigToWrite = cloneDeep(existingConfig);
-            newConfigToWrite.Distribution.DistributionConfig.CacheBehaviors.Items = cacheBehaviors;
-            newConfigToWrite.Distribution.DistributionConfig.CacheBehaviors.Quantity = cacheBehaviors.length;
+            const newConfigToWrite = cloneDeep(existingConfig);
+            newConfigToWrite.Distribution.DistributionConfig = Object.assign(
+                {},
+                newConfigToWrite.Distribution.DistributionConfig,
+                savedConfig
+            );
 
             // allow for diff/comparison before deploy
             const getUrls = item => {
@@ -172,19 +192,6 @@ function beginUpdate(cacheBehaviors) {
 
             const pathsAdded = filter(paths.after, obj => !find(paths.before, obj));
             const pathsRemoved = filter(paths.before, obj => !find(paths.after, obj));
-
-            const listChanges = paths => {
-                let pathsByOrigin = groupBy(paths, 'origin');
-                let divider = '=================';
-                for (let origin in pathsByOrigin) {
-                    console.log('\n', divider, origin, divider, '\n');
-                    pathsByOrigin[origin].forEach(p => {
-                        console.log(p.path);
-                    });
-                    console.log('\n');
-                }
-            };
-
             // warn users about changes
             console.log(
                 'There are currently ' +

--- a/config/app/distributions.js
+++ b/config/app/distributions.js
@@ -2,6 +2,7 @@ module.exports = {
     test: {
         distributionId: 'E3D5QJTWAG3GDP',
         origins: {
+            legacy: 'Custom-www.biglotteryfund.org.uk',
             newSite: 'ELB-TEST'
         }
     },

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -79,7 +79,6 @@ function generateUrlList(routes) {
     return urls;
 }
 
-
 const makeBehaviourItem = ({
     originId,
     pathPattern,
@@ -176,7 +175,7 @@ const makeBehaviourItem = ({
  * Generate Cloudfront behaviours
  * construct array of behaviours from a URL list
  */
-function generateBehaviours({routesConfig, origins}) {
+function generateBehaviours({ routesConfig, origins }) {
     const urlsToSupport = generateUrlList(routesConfig);
     const cookiesInUse = map(config.get('cookies'), (val, key) => key);
 
@@ -219,7 +218,6 @@ function generateBehaviours({routesConfig, origins}) {
         }
     };
 }
-
 
 module.exports = {
     generateUrlList,

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -91,7 +91,7 @@ const makeBehaviourItem = ({ origin, originServer, pathPattern, isPostable, quer
         // Strip trailing slashes
         // fixes /welsh => /welsh/ homepage confusion
         // but doesn't break root/homepage '/' path
-        behaviour.PathPattern = stripTrailingSlashes(pathPattern)
+        behaviour.PathPattern = stripTrailingSlashes(pathPattern);
     }
 
     const shouldAllowQueryStrings = isLegacy || queryStringWhitelist;

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -42,8 +42,7 @@ const makeBehaviourItem = ({ origin, originServer, pathPattern, isPostable, quer
     const cacheConfig = isLegacy ? BehaviourConfig['legacy'] : BehaviourConfig['newSite'];
 
     // Use all HTTP methods for legacy
-    const allowedHttpMethods =
-        isLegacy || isPostable ? BehaviourConfig.httpMethods.getAndPost : BehaviourConfig.httpMethods.getOnly;
+    const allowedHttpMethods = isPostable ? BehaviourConfig.httpMethods.getAndPost : BehaviourConfig.httpMethods.getOnly;
 
     // Allow any protocol for legacy, redirect to HTTPS for new
     const protocol = isLegacy ? BehaviourConfig.protocols.allowAll : BehaviourConfig.protocols.redirectToHttps;

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -7,7 +7,6 @@ const { defaultsDeep } = require('lodash');
 const { generateUrlList, makeBehaviourItem } = require('./cloudfront');
 
 describe('Cloudfront Helpers', () => {
-
     const testRoutes = {
         sections: {
             purple: {

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -2,11 +2,87 @@
 /* global describe, it */
 const chai = require('chai');
 const expect = chai.expect;
-const { defaultsDeep } = require('lodash');
 
+const { defaultsDeep } = require('lodash');
 const { generateUrlList, makeBehaviourItem } = require('./cloudfront');
 
 describe('Cloudfront Helpers', () => {
+
+    const testRoutes = {
+        sections: {
+            purple: {
+                path: '/purple',
+                pages: {
+                    monkey: {
+                        path: '/monkey/dishwasher',
+                        live: true,
+                        isWildcard: false,
+                        isPostable: true,
+                        aliases: ['/green/orangutan/fridge'],
+                        queryStrings: ['foo', 'bar']
+                    }
+                }
+            }
+        },
+        archivedRoutes: [
+            {
+                path: '/some/archived/path/*',
+                live: true
+            }
+        ],
+        otherUrls: [
+            {
+                path: '/unicorns',
+                isPostable: true,
+                live: true
+            },
+            {
+                path: '/draft',
+                live: false
+            }
+        ],
+        legacyRedirects: [
+            {
+                path: '/global-content/programmes/example',
+                destination: '/funding/programmes/example',
+                isPostable: false,
+                live: true
+            }
+        ],
+        vanityRedirects: [
+            {
+                path: '/test',
+                live: true
+            }
+        ]
+    };
+
+    describe('#generateUrlList', () => {
+        it('should filter out non-custom routes', done => {
+            const urls = generateUrlList(testRoutes);
+            expect(urls.length).to.equal(2);
+            done();
+        });
+
+        it('should generate the correct section/page path', done => {
+            const urls = generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).to.equal(1);
+            done();
+        });
+
+        it('should generate welsh versions of canonical routes', done => {
+            const urls = generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).to.equal(1);
+            done();
+        });
+
+        it('should store properties against routes', done => {
+            const urls = generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).to.equal(true);
+            done();
+        });
+    });
+
     describe('#makeBehaviourItem', () => {
         function withDefaults(behaviourConfig) {
             return defaultsDeep(behaviourConfig, {
@@ -108,81 +184,6 @@ describe('Cloudfront Helpers', () => {
                     }
                 })
             );
-        });
-    });
-
-    describe('#generateUrlList', () => {
-        const testRoutes = {
-            sections: {
-                purple: {
-                    path: '/purple',
-                    pages: {
-                        monkey: {
-                            path: '/monkey/dishwasher',
-                            live: true,
-                            isWildcard: false,
-                            isPostable: true,
-                            aliases: ['/green/orangutan/fridge'],
-                            queryStrings: ['foo', 'bar']
-                        }
-                    }
-                }
-            },
-            archivedRoutes: [
-                {
-                    path: '/some/archived/path/*',
-                    live: true
-                }
-            ],
-            otherUrls: [
-                {
-                    path: '/unicorns',
-                    isPostable: true,
-                    live: true
-                },
-                {
-                    path: '/draft',
-                    live: false
-                }
-            ],
-            legacyRedirects: [
-                {
-                    path: '/global-content/programmes/example',
-                    destination: '/funding/programmes/example',
-                    isPostable: false,
-                    live: true
-                }
-            ],
-            vanityRedirects: [
-                {
-                    path: '/test',
-                    live: true
-                }
-            ]
-        };
-
-        it('should filter out non-custom routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.length).to.equal(2);
-            done();
-        });
-
-        it('should generate the correct section/page path', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).to.equal(1);
-            done();
-        });
-
-        it('should generate welsh versions of canonical routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).to.equal(1);
-            done();
-        });
-
-        it('should store properties against routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).to.equal(true);
-            done();
         });
     });
 });

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -172,26 +172,26 @@ describe('Cloudfront Helpers', () => {
         };
 
         it('should filter out non-custom routes', done => {
-            let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.length).to.equal(2);
+            const urls = generateUrlList(testRoutes);
+            expect(urls.length).to.equal(2);
             done();
         });
 
         it('should generate the correct section/page path', done => {
-            let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.filter(r => r.path === '/purple/monkey/dishwasher').length).to.equal(1);
+            const urls =  generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).to.equal(1);
             done();
         });
 
         it('should generate welsh versions of canonical routes', done => {
-            let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).to.equal(1);
+            const urls = generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).to.equal(1);
             done();
         });
 
         it('should store properties against routes', done => {
-            let urlList = generateUrlList(testRoutes);
-            expect(urlList.newSite.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).to.equal(true);
+            const urls = generateUrlList(testRoutes);
+            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).to.equal(true);
             done();
         });
     });

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -178,7 +178,7 @@ describe('Cloudfront Helpers', () => {
         });
 
         it('should generate the correct section/page path', done => {
-            const urls =  generateUrlList(testRoutes);
+            const urls = generateUrlList(testRoutes);
             expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).to.equal(1);
             done();
         });


### PR DESCRIPTION
- Safe default config in addition to cache behaviours
- Simplify cloufront generation
- Add white-list route for assets
- Modify update-cloudfront to use new schema