### PR TITLE
Redirect regional URLs

### DIFF
--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -23,10 +23,6 @@ const legacyRedirects = [
     aliasFor('/funding', '/funding/funding-guidance/applying-for-funding'),
     aliasFor('/funding/programmes', '/Home/Funding/Funding*Finder'),
     aliasFor('/funding/programmes?location=scotland', '/funding/scotland-portfolio'),
-    aliasFor(
-        '/funding/programmes/national-lottery-awards-for-all-england',
-        '/england/global-content/programmes/england/awards-for-all-england'
-    ),
 
     // Migrated Programme Pages [LIVE]
     programmeRedirect('england/awards-for-all-england', 'national-lottery-awards-for-all-england'),
@@ -65,10 +61,6 @@ const vanityRedirects = sections => {
         vanity('/prog_a4a_eng', '/funding/programmes/national-lottery-awards-for-all-england'),
         vanity('/englandwebinars', '/funding/programmes/national-lottery-awards-for-all-england'),
         vanity('/awardsforallscotland', '/funding/programmes/national-lottery-awards-for-all-scotland'),
-        vanity(
-            '/england/global-content/programmes/scotland/awards-for-all-scotland',
-            '/funding/programmes/national-lottery-awards-for-all-scotland'
-        ),
         vanity('/prog_a4a_ni', '/funding/programmes/awards-for-all-northern-ireland'),
         vanity('/a4awales', '/funding/programmes/national-lottery-awards-for-all-wales'),
         vanity('/prog_a4a_wales', '/funding/programmes/national-lottery-awards-for-all-wales'),
@@ -83,10 +75,6 @@ const vanityRedirects = sections => {
         vanity('/esf', '/funding/programmes/building-better-opportunities'),
         vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
         vanity(
-            '/wales/global-content/programmes/scotland/awards-for-all-scotland',
-            '/funding/programmes/national-lottery-awards-for-all-scotland'
-        ),
-        vanity(
             '/guidancetrackingprogress',
             '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress'
         ),
@@ -97,7 +85,6 @@ const vanityRedirects = sections => {
         vanity('/news-and-events/contact-press-team', `/contact#${anchors.contactPress}`),
         vanity('/welsh/news-and-events/contact-press-team', `/welsh/contact#${anchors.contactPress}`),
         vanity('/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
-        vanity('/england/about-big/customer-service/making-a-complaint', `/contact#${anchors.contactComplaints}`),
         vanity('/welsh/about-big/customer-service/making-a-complaint', `/welsh/contact#${anchors.contactComplaints}`),
         vanity('/about-big/customer-service/fraud', `/contact#${anchors.contactFraud}`),
         vanity('/welsh/about-big/customer-service/fraud', `/welsh/contact#${anchors.contactFraud}`),

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -50,14 +50,7 @@ sections.toplevel.addRoutes({
         path: '/contact',
         template: 'pages/toplevel/contact',
         lang: 'toplevel.contact',
-        aliases: [
-            '/about-big/contact-us',
-            '/help-and-support',
-            '/england/about-big/contact-us',
-            '/wales/about-big/contact-us',
-            '/scotland/about-big/contact-us',
-            '/northernireland/about-big/contact-us'
-        ]
+        aliases: ['/about-big/contact-us', '/help-and-support']
     }),
     data: dynamicRoute({
         path: '/data',
@@ -68,15 +61,7 @@ sections.toplevel.addRoutes({
         path: '/jobs',
         template: 'pages/toplevel/jobs',
         lang: 'toplevel.jobs',
-        aliases: [
-            '/about-big/jobs',
-            '/about-big/jobs/how-to-apply',
-            '/about-big/jobs/current-vacancies',
-            '/scotland/about-big/jobs/current-vacancies',
-            '/wales/about-big/jobs/current-vacancies',
-            '/england/about-big/jobs/current-vacancies',
-            '/northernireland/about-big/jobs/current-vacancies'
-        ]
+        aliases: ['/about-big/jobs', '/about-big/jobs/how-to-apply', '/about-big/jobs/current-vacancies']
     }),
     benefits: staticRoute({
         path: '/jobs/benefits',

--- a/integration-tests/test-suites/core.test.js
+++ b/integration-tests/test-suites/core.test.js
@@ -23,6 +23,11 @@ describe('Core sections and features', () => {
 
     after(() => helper.after(server));
 
+    let agent;
+    beforeEach(() => {
+        agent = chai.request.agent(server);
+    });
+
     it('should contain meta title', () => {
         return chai
             .request(server)
@@ -160,5 +165,35 @@ describe('Core sections and features', () => {
                 expect(res).to.have.status(302);
                 expect(res).to.redirectTo('https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk+something');
             });
+    });
+
+    it('should redirect regional urls', () => {
+        return Promise.all([
+            helper.redirectRequest({
+                agent: agent,
+                originalPath: '/england/about-big/publications/corporate-documents',
+                redirectedPath: '/about-big/publications/corporate-documents'
+            }),
+            helper.redirectRequest({
+                agent: agent,
+                originalPath: '/scotland/about-big/publications/corporate-documents',
+                redirectedPath: '/about-big/publications/corporate-documents'
+            }),
+            helper.redirectRequest({
+                agent: agent,
+                originalPath: '/wales/about-big/publications/corporate-documents',
+                redirectedPath: '/about-big/publications/corporate-documents'
+            }),
+            helper.redirectRequest({
+                agent: agent,
+                originalPath: '/northernireland/about-big/publications/corporate-documents',
+                redirectedPath: '/about-big/publications/corporate-documents'
+            })
+        ]).then(results => {
+            results.forEach(result => {
+                expect(result.res.status).to.equal(301);
+                expect(result.res).to.redirectTo(result.redirectedPath);
+            });
+        });
     });
 });

--- a/integration-tests/test-suites/server.test.js
+++ b/integration-tests/test-suites/server.test.js
@@ -10,7 +10,6 @@ const { vanityRedirects } = require('../../controllers/routes');
 
 describe('Basic server tests', () => {
     let server;
-
     before(done => {
         helper.before(serverInstance => {
             server = serverInstance;
@@ -19,6 +18,11 @@ describe('Basic server tests', () => {
     });
 
     after(() => helper.after(server));
+
+    let agent;
+    beforeEach(() => {
+        agent = chai.request.agent(server);
+    });
 
     it('should respond to /', () => {
         return chai
@@ -30,27 +34,14 @@ describe('Basic server tests', () => {
     });
 
     it('should redirect trailing slashes', () => {
-        function redirectRequest({ originalPath, redirectedPath }) {
-            return chai
-                .request(server)
-                .get(originalPath)
-                .redirects(0)
-                .catch(err => err.response)
-                .then(res => {
-                    return {
-                        res,
-                        originalPath,
-                        redirectedPath
-                    };
-                });
-        }
-
         return Promise.all([
-            redirectRequest({
+            helper.redirectRequest({
+                agent: agent,
                 originalPath: '/funding/',
                 redirectedPath: '/funding'
             }),
-            redirectRequest({
+            helper.redirectRequest({
+                agent: agent,
                 originalPath: '/funding/programmes/?location=wales',
                 redirectedPath: '/funding/programmes?location=wales'
             })

--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,5 +1,6 @@
 'use strict';
 const slashes = require('connect-slashes');
+const { isRegionalUrl, stripRegion } = require('../modules/urls');
 
 function redirectNonWww(req, res, next) {
     const host = req.headers.host;
@@ -14,8 +15,17 @@ function redirectNonWww(req, res, next) {
 
 const removeTrailingSlashes = slashes(false);
 
+function redirectRegion(req, res, next) {
+    if (isRegionalUrl(req.originalUrl)) {
+        res.redirect(301, stripRegion(req.originalUrl));
+    } else {
+        next();
+    }
+}
+
 module.exports = {
-    all: [redirectNonWww, removeTrailingSlashes],
+    all: [redirectNonWww, removeTrailingSlashes, redirectRegion],
     redirectNonWww,
-    removeTrailingSlashes
+    removeTrailingSlashes,
+    redirectRegion
 };

--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -93,13 +93,11 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
 };
 
 const proxyPassthrough = (req, res, next) => {
-    console.log('attempting to proxy ' + req.originalUrl);
     return proxyLegacyPage({
         req,
         res,
         followRedirect: false
-    }).catch(function(e) {
-        console.log('err ', e);
+    }).catch(function() {
         next();
     });
 };

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -52,6 +52,24 @@ function cymreigio(urlPath) {
     return [urlPath, makeWelsh(urlPath)];
 }
 
+const REGEX_IS_REGIONAL = /^\/(england|scotland|wales|northernireland)\//i;
+
+/**
+ * isRegionalUrl
+ * Does the url path start with scotland, england, wales or nothernireland
+ */
+function isRegionalUrl(urlPath) {
+    return REGEX_IS_REGIONAL.test(urlPath);
+}
+
+/**
+ * stripRegion
+ * Strip scotland, england, wales, or nothernireland from the urlPath
+ */
+function stripRegion(urlPath) {
+    return urlPath.replace(REGEX_IS_REGIONAL, '/');
+}
+
 function getBaseUrl(req) {
     const headerProtocol = req.get('X-Forwarded-Proto');
     const protocol = headerProtocol ? headerProtocol : req.protocol;
@@ -111,6 +129,8 @@ module.exports = {
     removeWelsh,
     localify,
     cymreigio,
+    isRegionalUrl,
+    stripRegion,
     getBaseUrl,
     getFullUrl,
     hasTrailingSlash,

--- a/modules/urls.test.js
+++ b/modules/urls.test.js
@@ -3,7 +3,17 @@
 const chai = require('chai');
 const expect = chai.expect;
 
-const { getBaseUrl, isWelsh, localify, hasTrailingSlash, stripTrailingSlashes, normaliseQuery } = require('./urls');
+const {
+    getBaseUrl,
+    hasTrailingSlash,
+    isRegionalUrl,
+    isWelsh,
+    localify,
+    normaliseQuery,
+    stripRegion,
+    stripTrailingSlashes
+} = require('./urls');
+
 const httpMocks = require('node-mocks-http');
 
 describe('URL Helpers', () => {
@@ -123,6 +133,27 @@ describe('URL Helpers', () => {
                 org: 'Voluntary or community organisation',
                 sc: '1'
             });
+        });
+    });
+
+    describe('#isRegionalUrl', () => {
+        it('should determine if a url is a regional variant', () => {
+            expect(isRegionalUrl('/about-big/some/url')).to.be.false;
+            expect(isRegionalUrl('/about-big/some/scotland/url')).to.be.false;
+            expect(isRegionalUrl('/england/about-big/some/url')).to.be.true;
+            expect(isRegionalUrl('/scotland/about-big/some/url')).to.be.true;
+            expect(isRegionalUrl('/wales/about-big/some/url')).to.be.true;
+            expect(isRegionalUrl('/northernIreland/about-big/some/url')).to.be.true;
+        });
+    });
+
+    describe('#stripRegion', () => {
+        it('should strip regional component from the start of a url path', () => {
+            expect(stripRegion('/some/url')).to.equal('/some/url');
+            expect(stripRegion('/england/some/url')).to.equal('/some/url');
+            expect(stripRegion('/scotland/some/url')).to.equal('/some/url');
+            expect(stripRegion('/wales/some/url')).to.equal('/some/url');
+            expect(stripRegion('/northernIreland/some/url')).to.equal('/some/url');
         });
     });
 });


### PR DESCRIPTION
Adds a new redirect middleware which is responsible for redirecting region specific URLs so that for example `/{england,scotland,wales/northernireland}/about-big/publications/corporate-documents` all redirect to `/about-big/publications/corporate-documents`