### PR TITLE
Follow redirects in proxied pages

### DIFF
--- a/integration-tests/test-suites/legacy.test.js
+++ b/integration-tests/test-suites/legacy.test.js
@@ -126,4 +126,18 @@ describe('Legacy pages', () => {
                 );
             });
     });
+
+    it('should follow redirects on the legacy site', () => {
+        return chai
+            .request(server)
+            .get('/welshlanguage')
+            .redirects(0)
+            .catch(err => err.response)
+            .then(res => {
+                expect(res.status).to.equal(301);
+                expect(res).to.redirectTo(
+                    '/about-big/customer-service/welsh-language-scheme'
+                );
+            });
+    });
 });

--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -21,6 +21,7 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
         strictSSL: false,
         jar: true,
         followRedirect: followRedirect,
+        maxRedirects: 1,
         resolveWithFullResponse: true
     }).then(response => {
         let body = response.body;
@@ -93,14 +94,28 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
 };
 
 const proxyPassthrough = (req, res, next) => {
-    console.log('attempting to proxy ' + req.originalUrl);
     return proxyLegacyPage({
         req,
         res,
         followRedirect: false
-    }).catch(function(e) {
-        console.log('err ', e);
-        next();
+    }).catch(function(err) {
+        // some URLs are redirects, so let's see if this was one
+        if (err.statusCode === 301 || err.statusCode === 302) {
+
+            // was it a valid redirect or Sitecore's broken 404 page?
+            const brokenSitecorePath = '/sitecore/service/notfound.aspx';
+            let redirectDestination = get(err, 'response.headers.location', false);
+
+            if (redirectDestination.indexOf(brokenSitecorePath) === -1) {
+                // Make the redirect relative to the current environment
+                // (they seem to come back from Sitecore with an absolute path)
+                let liveUrl = `https://${config.get('siteDomain')}`;
+                redirectDestination = redirectDestination.replace(liveUrl, '');
+                return res.redirect(301, redirectDestination);
+            }
+        }
+        // either it wasn't a redirect, or Sitecore said no
+        return next();
     });
 };
 

--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -101,7 +101,6 @@ const proxyPassthrough = (req, res, next) => {
     }).catch(function(err) {
         // some URLs are redirects, so let's see if this was one
         if (err.statusCode === 301 || err.statusCode === 302) {
-
             // was it a valid redirect or Sitecore's broken 404 page?
             const brokenSitecorePath = '/sitecore/service/notfound.aspx';
             let redirectDestination = get(err, 'response.headers.location', false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12231,7 +12231,7 @@
     },
     "passport": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/passport/-/passport-0.3.2.tgz",
       "integrity": "sha1-ndAJ+RXo/glbASSgG4+C2gdRAQI=",
       "requires": {
         "passport-strategy": "1.0.0",


### PR DESCRIPTION
Some URLs (eg. `/welshlanguage`) return redirects from Sitecore. This PR adds support for following these (assuming they're not the broken 404 page redirect loop).