### PR TITLE
Fix tool caching

### DIFF
--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -92,7 +92,7 @@ router.get('/status/pages', toolsSecurityHeaders(), (req, res) => {
 });
 
 const requiredAuthed = auth.requireAuthedLevel(5);
-router.route('/tools/survey-results/').get(requiredAuthed, toolsSecurityHeaders(), cached.noCache, (req, res) => {
+router.route('/tools/survey-results/').get(cached.noCache, requiredAuthed, toolsSecurityHeaders(), (req, res) => {
     surveysService
         .findAll()
         .then(surveys => {

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -16,7 +16,7 @@ const router = express.Router();
 router.use(toolsSecurityHeaders());
 
 // serve a logged-in user's dashboard
-router.get(userEndpoints.dashboard, auth.requireAuthed, cached.noCache, dashboard.dashboard);
+router.get(userEndpoints.dashboard, cached.noCache, auth.requireAuthed, dashboard.dashboard);
 
 // register users
 router
@@ -41,7 +41,7 @@ router.get(userEndpoints.logout, cached.noCache, (req, res) => {
 });
 
 // activate an account
-router.get(userEndpoints.activate, auth.requireAuthed, cached.noCache, register.activateUser);
+router.get(userEndpoints.activate, cached.noCache, auth.requireAuthed, register.activateUser);
 
 // request a password reset email
 router


### PR DESCRIPTION
If you try to visit something restricted behind an auth check (eg. survey results), you'll be redirected to the login form. Once logging in, though, you'll be redirected back to the survey results, which has cached your unauthorised state, and sent back to the login form (which detects that you're logged in, so sends you to the dashboard).

This PR fixes things by setting the `Cache-Control` header earlier in the middleware chain (and fixing it in a few other places) so the HTTP redirect itself isn't cached.

eg:

```
curl -I $surveyResultUrl
HTTP/1.1 302 Moved Temporarily
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=300
Location: /user/login
```
