### PR TITLE
Content tweaks

### DIFF
--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -6,6 +6,37 @@
     https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/
     http://css-tricks.com/opt-in-typography/
 */
+.u-constrained-content {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    ul,
+    ol {
+        max-width: 35em;
+    }
+}
+
+.u-constrained-content-wide {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        max-width: 30em;
+    }
+
+    p,
+    ul,
+    ol {
+        max-width: 42em;
+    }
+}
+
 .s-prose {
     ul,
     ol {
@@ -150,7 +181,11 @@
     }
 
     .video-container {
-        margin-bottom: 1em;
+        margin: 0 -10px 1em;
+
+        @include mq('medium') {
+            margin: 0 1.5em 1.5em;
+        }
     }
 }
 

--- a/assets/sass/utilities/utilities-text.scss
+++ b/assets/sass/utilities/utilities-text.scss
@@ -74,11 +74,3 @@
     background-color: rgba(0, 0, 0, 0.4);
     padding: 4px 6px;
 }
-
-.u-constrained-content {
-    max-width: 35em;
-}
-
-.u-constrained-content-wide {
-    max-width: 42em;
-}

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -1,7 +1,7 @@
 'use strict';
 const express = require('express');
 const moment = require('moment');
-const { concat, compact, filter, flatMap, map, pick, sortBy } = require('lodash');
+const { concat, compact, filter, flatMap, map, pick, sortedUniqBy } = require('lodash');
 
 const routes = require('../routes');
 const appData = require('../../modules/appData');
@@ -66,10 +66,10 @@ router.get('/status/pages', toolsSecurityHeaders(), (req, res) => {
         })
     );
 
-    const redirectRoutes = sortBy(concat(customRedirects, pageRedirects), 'destination');
+    const redirectRoutes = sortedUniqBy(concat(customRedirects, pageRedirects), 'destination');
 
     contentApi.getRoutes().then(cmsCanonicalUrls => {
-        const allCanonicalRoutes = sortBy(concat(routerCanonicalUrls, cmsCanonicalUrls), 'path');
+        const allCanonicalRoutes = sortedUniqBy(concat(routerCanonicalUrls, cmsCanonicalUrls), 'path');
 
         const vanityRoutes = routes.vanityRedirects;
 


### PR DESCRIPTION
Make an adjustment to how constrained content is defined. Constrain text-level elements rather than the whole container. Allows non-text content to be aligned centrally.

(Also sneakily fixes a duplication issue with the page-list urls)