### PR TITLE
Allow environment secrets to override global values

### DIFF
--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const assert = require('assert');
 const AWS = require('aws-sdk');
-const { chunk, flatten } = require('lodash');
+const { chunk, flatten, partition, unionBy } = require('lodash');
 
 AWS.config.update({ region: 'eu-west-1' });
 
@@ -47,6 +47,12 @@ function getParametersInChunks(parameterNames) {
     });
 }
 
+function normaliseParameterName(parameter) {
+    parameter.OriginalName = parameter.Name;
+    parameter.Name = parameter.Name.replace(/\/Web\/(Global|Test|Prod)\//, '');
+    return parameter;
+}
+
 function getParametersForEnvironment(environment) {
     return new Promise((resolve, reject) => {
         const describeParametersOpts = {
@@ -74,16 +80,19 @@ function getParametersForEnvironment(environment) {
                         throw new Error("Number of results doesn't match the amount requested");
                     }
 
-                    /**
-                     * Normalise parameter names
-                     * i.e. remove /Web/Global, /Web/Prod namespace.
-                     */
-                    const normalisedParameters = allParameters.map(parameter => {
-                        parameter.Name = parameter.Name.replace(/\/Web\/(Global|Test|Prod)\//, '');
-                        return parameter;
+                    const [rawGlobalParameters, rawEnvironmentParameters] = partition(allParameters, parameter => {
+                        return /^\/Web\/Global/.test(parameter.Name);
                     });
 
-                    resolve(normalisedParameters);
+                    const globalParameters = rawGlobalParameters.map(normaliseParameterName);
+                    const environmentParameters = rawEnvironmentParameters.map(normaliseParameterName);
+
+                    /**
+                     * Take union of /Web/Global and /Web/$Environment parameters
+                     * Favour environment specific parameters over global ones
+                     */
+                    const combinedParameters = unionBy(environmentParameters, globalParameters, 'Name');
+                    resolve(combinedParameters);
                 });
         });
     });


### PR DESCRIPTION
Allow environment secrets to override global values. Take a union of the global and environment values  to allow environment specific secrets to take precedence over existing global secrets.