### PR TITLE
Add news and events to CloudFront whitelist

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -703,6 +703,60 @@
         "PathPattern": "/js/*"
       },
       {
+        "TargetOriginId": "LEGACY",
+        "ViewerProtocolPolicy": "allow-all",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "*"
+            ],
+            "Quantity": 1
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "all"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/news-and-events"
+      },
+      {
         "TargetOriginId": "ELB_LIVE",
         "ViewerProtocolPolicy": "redirect-to-https",
         "MinTTL": 0,
@@ -1082,6 +1136,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 17
+    "Quantity": 18
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -703,6 +703,60 @@
         "PathPattern": "/js/*"
       },
       {
+        "TargetOriginId": "LEGACY",
+        "ViewerProtocolPolicy": "allow-all",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "*"
+            ],
+            "Quantity": 1
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "all"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/news-and-events"
+      },
+      {
         "TargetOriginId": "ELB-TEST",
         "ViewerProtocolPolicy": "redirect-to-https",
         "MinTTL": 0,
@@ -1082,6 +1136,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 17
+    "Quantity": 18
   }
 }

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -196,6 +196,7 @@ function generateBehaviours({ routesConfig, origins }) {
         '/css/*',
         '/images/*',
         '/default.css',
+        '/news-and-events',
         '/funding/search-past-grants',
         '/funding/search-past-grants/*'
     ].map(path =>


### PR DESCRIPTION
Add news and events to CloudFront whitelist, send directly to the legacy site. Should make the behaviour of the news list a little less weird.