### PR TITLE
Remove jar flag, cookies not needed

### DIFF
--- a/services/content-api.js
+++ b/services/content-api.js
@@ -84,8 +84,7 @@ function getListingPage({ locale, path, previewMode }) {
         qs: addPreviewParams(previewMode, {
             path: path
         }),
-        json: true,
-        jar: !!previewMode // send client cookies in preview mode to allow Craft auth
+        json: true
     }).then(response => {
         const attributes = response.data.map(item => item.attributes);
         const match = attributes.find(_ => _.path === path);


### PR DESCRIPTION
I think I'm right that we no longer need this as we took a different approach for handling preview? @mattandrews 