### PR TITLE
Fix an issue where oldest/newest survey votes were counted by choice,…

### DIFF
--- a/services/surveys.js
+++ b/services/surveys.js
@@ -24,14 +24,15 @@ function findAll() {
         let mergedSurveys = surveys.map(survey => {
             // append responses to the relevant choice
             survey.choices = survey.choices.map(choice => {
+
+                let surveyVotes = votes.filter(v => v.survey_id === survey.id);
+
                 // retrieve the votes for this survey's choices
-                choice.responses = votes.filter(v => {
-                    return v.survey_id === survey.id && v.choice_id === choice.id;
-                });
+                choice.responses = surveyVotes.filter(v => v.choice_id === choice.id);
 
                 // fill in gaps for days without votes
-                let oldestVote = minBy(choice.responses, 'createdAt');
-                let newestVote = maxBy(choice.responses, 'createdAt');
+                let oldestVote = minBy(surveyVotes, 'createdAt');
+                let newestVote = maxBy(surveyVotes, 'createdAt');
 
                 // calculate votes per day (or substitute with zeroes)
                 if (newestVote && oldestVote) {


### PR DESCRIPTION
Noticed this quirk earlier:

![image](https://user-images.githubusercontent.com/394376/36785533-10049fde-1c7b-11e8-88db-749690c9e14d.png)

This is because when we "fill in the blanks" on the graph, we take the oldest/newest votes from the votes for _that choice_ (eg. the oldest "yes" and the newest "yes"), which means that if nobody's voted "yes" for a while, the graph has a missing final point.

This change uses the entire voting range to calculate oldest/newest, resulting in this graph:

![image](https://user-images.githubusercontent.com/394376/36785523-02a8c3d8-1c7b-11e8-975b-655018925848.png)

Much better, eh?