### PR TITLE
DRY-up redirects code

### DIFF
--- a/modules/redirects.js
+++ b/modules/redirects.js
@@ -1,7 +1,23 @@
 'use strict';
 const config = require('config');
+const app = require('../server');
 const { customEvent } = require('../modules/analytics');
-const { isWelsh, removeWelsh } = require('../modules/urls');
+const { shouldServe } = require('../modules/pageLogic');
+const { isWelsh, makeWelsh, removeWelsh } = require('../modules/urls');
+
+function serveRedirects({ redirects, makeBilingual = false }) {
+    redirects.filter(shouldServe).forEach(redirect => {
+        app.get(redirect.path, (req, res) => {
+            res.redirect(301, redirect.destination);
+        });
+
+        if (makeBilingual) {
+            app.get(makeWelsh(redirect.path), (req, res) => {
+                res.redirect(301, makeWelsh(redirect.destination));
+            });
+        }
+    });
+}
 
 /**
  * Redirect archived links to the national archives
@@ -21,6 +37,7 @@ function redirectNoWelsh(req, res, next) {
 }
 
 module.exports = {
+    serveRedirects,
     redirectArchived,
     redirectNoWelsh
 };

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const viewGlobalsService = require('./modules/viewGlobals');
 const { shouldServe } = require('./modules/pageLogic');
 const { proxyPassthrough, postToLegacyForm, redirectUglyLink } = require('./modules/legacy');
 const { renderError, renderNotFound, renderUnauthorised } = require('./controllers/http-errors');
-const { redirectArchived, redirectNoWelsh } = require('./modules/redirects');
+const { serveRedirects, redirectArchived, redirectNoWelsh } = require('./modules/redirects');
 const routes = require('./controllers/routes');
 
 const favicon = require('serve-favicon');
@@ -99,37 +99,22 @@ for (let sectionId in routes.sections) {
     }
 }
 
-function serveRedirect({ sourcePath, destinationPath }) {
-    app.get(sourcePath, (req, res) => {
-        res.redirect(301, destinationPath);
-    });
-}
-
 /**
  * Legacy Redirects
  * Redirecy legacy URLs to new locations
  * For these URLs handle both english and welsh variants
  */
-routes.legacyRedirects.filter(shouldServe).forEach(route => {
-    serveRedirect({
-        sourcePath: route.path,
-        destinationPath: route.destination
-    });
-    serveRedirect({
-        sourcePath: makeWelsh(route.path),
-        destinationPath: makeWelsh(route.destination)
-    });
+serveRedirects({
+    redirects: routes.legacyRedirects,
+    makeBilingual: true
 });
 
 /**
  * Vanity URLs
  * Sharable short-urls redirected to canonical URLs.
  */
-routes.vanityRedirects.filter(shouldServe).forEach(route => {
-    serveRedirect({
-        sourcePath: route.path,
-        destinationPath: route.destination
-    });
+serveRedirects({
+    redirects: routes.vanityRedirects
 });
 
 /**

--- a/services/content-api.test.js
+++ b/services/content-api.test.js
@@ -79,7 +79,7 @@ describe('Content API', () => {
             });
     });
 
-    it.only('should fetch merged welsh funding programmes', () => {
+    it('should fetch merged welsh funding programmes', () => {
         return contentApi
             .getFundingProgrammes({
                 locale: 'cy'


### PR DESCRIPTION
We have three types of redirects: routes-level aliases, standalone aliases, and vanity redirects. This PR reworks the code around those to handle them all in the same way.