### PR TITLE
Order stat fixes

### DIFF
--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -117,7 +117,8 @@ const sendResetEmail = (req, res) => {
                     let sendEmail = mail.send({
                         subject: 'Reset the password for your Big Lottery Fund website account',
                         text: `Please click the following link to reset your password: ${resetUrl}`,
-                        sendTo: email
+                        sendTo: email,
+                        sendFrom: 'Big Lottery Fund <noreply@blf.digital>'
                     });
 
                     sendEmail.catch(() => {

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -34,6 +34,7 @@ const sendActivationEmail = (user, req, isBrandNewUser) => {
         let emailData = {
             subject: 'Activate your Big Lottery Fund website account',
             text: `Please click the following link to activate your account: ${activateUrl}`,
+            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             sendTo: email
         };
 

--- a/services/orders.js
+++ b/services/orders.js
@@ -61,11 +61,16 @@ function getAllOrders() {
             acc[normalisedDate] = acc[normalisedDate] + 1;
             return acc;
         }, {});
-        
-        ordersByDay = sortBy(map(ordersByDay, (order, date) => ({
-            x: date,
-            y: order
-        })), 'x');
+
+        ordersByDay = sortBy(
+            map(ordersByDay, (order, date) => ({
+                x: date,
+                y: order
+            })),
+            'x'
+        );
+
+        const averageOrdersPerDay = Math.round(meanBy(ordersByDay, 'y'));
 
         return {
             orders,
@@ -77,7 +82,8 @@ function getAllOrders() {
             orderReasons,
             grantAmounts,
             ordersByPostcodes,
-            ordersByDay
+            ordersByDay,
+            averageOrdersPerDay
         };
     });
 }

--- a/services/orders.js
+++ b/services/orders.js
@@ -42,7 +42,7 @@ function getAllOrders() {
 
         // @TODO this can be removed after July 1st when all order records will have the correct options
         const filterIsRecentOrder = filter(_ => moment(_.createdAt).isAfter(LAUNCH_DATE));
-        const filterHasCode = filter(_ => _.code !== '');
+        const filterHasCode = filter(_ => _.code !== '' && _.code !== 'null');
 
         // order items by total ordered
         let mostPopularItemsByQuantity = orderByCount(itemsByQuantity);

--- a/views/pages/tools/orders.njk
+++ b/views/pages/tools/orders.njk
@@ -9,7 +9,7 @@
 {% macro statBlock(number, caption) %}
     <div class="col-sm text-center">
         <h5 class="display-2">{{ number }}</h5>
-        <h6>{{ caption }}</h6>
+        <h6>{{ caption | safe }}</h6>
     </div>
 {% endmacro %}
 
@@ -21,9 +21,10 @@
 
     <div class="container mb-4">
         <div class="row">
-            {{ statBlock(data.averageProductsPerOrder, 'average products per order') }}
-            {{ statBlock(data.orders.length, 'total orders') }}
-            {{ statBlock(data.averageItemQuantityPerOrder, 'average quantity per order') }}
+            {{ statBlock(data.averageProductsPerOrder, 'average products <br />per order') }}
+            {{ statBlock(data.orders.length, 'total orders<br />from website') }}
+            {{ statBlock(data.averageItemQuantityPerOrder, 'average quantity of <br />items per order') }}
+            {{ statBlock(data.averageOrdersPerDay, 'average orders <br />per day') }}
         </div>
     </div>
 


### PR DESCRIPTION
Few minor things:

- Removes this cheeky option:
![image](https://user-images.githubusercontent.com/394376/36851665-ab367180-1d61-11e8-8d9c-c6cfd99df7df.png)

- Sends registration/password emails from internal domain (so staff can sign up!)

- Adds an "average orders per day" headline stat (so we can judge when a day's performance is above-average)