### PR TITLE
Move shouldServe up a level

### DIFF
--- a/modules/redirects.js
+++ b/modules/redirects.js
@@ -2,11 +2,10 @@
 const config = require('config');
 const app = require('../server');
 const { customEvent } = require('../modules/analytics');
-const { shouldServe } = require('../modules/pageLogic');
 const { isWelsh, makeWelsh, removeWelsh } = require('../modules/urls');
 
 function serveRedirects({ redirects, makeBilingual = false }) {
-    redirects.filter(shouldServe).forEach(redirect => {
+    redirects.forEach(redirect => {
         app.get(redirect.path, (req, res) => {
             res.redirect(301, redirect.destination);
         });

--- a/server.js
+++ b/server.js
@@ -105,7 +105,7 @@ for (let sectionId in routes.sections) {
  * For these URLs handle both english and welsh variants
  */
 serveRedirects({
-    redirects: routes.legacyRedirects,
+    redirects: routes.legacyRedirects.filter(shouldServe),
     makeBilingual: true
 });
 
@@ -114,7 +114,7 @@ serveRedirects({
  * Sharable short-urls redirected to canonical URLs.
  */
 serveRedirects({
-    redirects: routes.vanityRedirects
+    redirects: routes.vanityRedirects.filter(shouldServe)
 });
 
 /**


### PR DESCRIPTION
The location of `shouldServe` was causing route level redirects (e.g. `/about-big`) to fail on production as they don't have a `live` property so `shouldServe` would consider them "draft" pages. Moves this logic up a level to fix this bug.