### PR TITLE
Add board page, share template for profiles

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -775,8 +775,7 @@ about:
       linkText: "Darganfod ein fframwaith strategol: Galluogi Pobl i Arwain"
       linkHref: "/welsh/about/strategic-framework"
       imageCaption: Dawn Austwick, Prif Weithredwr
-  seniorManagement:
-    title: Uwch dîm rheoli
+  ourPeople:
     navigation:
       section:
         label: Ein pobl
@@ -796,9 +795,11 @@ about:
         link: /welsh/about-big/our-people/wales-committee-members
       - label: Pwyllgor Ariannu’r Deyrnas Unedig’
         link: /welsh/about-big/our-people/uk-funding-committee
-    expenses:
-      title: Senior Management Team expenses
-      documents:
+    seniorManagement:
+      title: Uwch dîm rheoli
+      expenses:
+        title: Senior Management Team expenses
+        documents:
         - label: Year ending 31 March 2015
           url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_14_15.xlsx
         - label: Year ending 31 March 2014
@@ -812,6 +813,8 @@ about:
           url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_10_11.xls
         - label: Year ending 31 March 2010
           url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_09_10.xls
+    board:
+      title: Our Board
   foi:
     title: Rhyddid Gwybodaeth
     sections:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1101,15 +1101,14 @@ about:
       linkText: "Discover our strategic framework: People in the Lead"
       linkHref: "/about/strategic-framework"
       imageCaption: Dawn Austwick, CEO
-  seniorManagement:
-    title: Senior Management Team
+  ourPeople:
     navigation:
       section:
         label: Our People
         link: /about-big/our-people
       children:
       - label: Board
-        link: /about-big/our-people/board
+        link: /about/our-people/board
       - label: Senior management team
         link: /about/our-people/senior-management-team
       - label: England committee members
@@ -1122,22 +1121,26 @@ about:
         link: /about-big/our-people/wales-committee-members
       - label: UK funding committee
         link: /about-big/our-people/uk-funding-committee
-    expenses:
-      title: Senior Management Team expenses
-      documents:
-        - label: Year ending 31 March 2015
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_14_15.xlsx
-        - label: Year ending 31 March 2014
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_13_14.xlsx
-        - label: Year ending 31 March 2013
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_12-13.xls
-        - label: Year ending 31 March 2012
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_11_12.xls
-        - label: Year ending 31 March 2011
-          caption: Amended on 11/12/13 to correct accounting error
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_10_11.xls
-        - label: Year ending 31 March 2010
-          url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_09_10.xls
+    seniorManagement:
+      title: Senior Management Team
+      expenses:
+        title: Senior Management Team expenses
+        documents:
+          - label: Year ending 31 March 2015
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_14_15.xlsx
+          - label: Year ending 31 March 2014
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_13_14.xlsx
+          - label: Year ending 31 March 2013
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_12-13.xls
+          - label: Year ending 31 March 2012
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_11_12.xls
+          - label: Year ending 31 March 2011
+            caption: Amended on 11/12/13 to correct accounting error
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_10_11.xls
+          - label: Year ending 31 March 2010
+            url: https://www.biglotteryfund.org.uk/-/media/Files/Corporate%20documents/SMT%20expenses/smt_expenses_09_10.xls
+    board:
+      title: Our Board
   foi:
     title: Freedom of Information
     sections:

--- a/controllers/about/boardRoute.js
+++ b/controllers/about/boardRoute.js
@@ -9,13 +9,13 @@ function init({ router, routeConfig }) {
         contentApi
             .getProfiles({
                 locale: locale,
-                section: 'seniorManagementTeam'
+                section: 'boardMembers'
             })
             .then(profiles => {
                 if (profiles.length > 0) {
                     res.render(routeConfig.template, {
-                        title: copy.seniorManagement.title,
-                        copy: copy.seniorManagement,
+                        title: copy.board.title,
+                        copy: copy.board,
                         navigation: copy.navigation,
                         profiles: profiles
                     });

--- a/controllers/about/index.js
+++ b/controllers/about/index.js
@@ -5,6 +5,7 @@ const routerSetup = require('../setup');
 const routeCommon = require('../common');
 const ebulletinRoute = require('./ebulletin');
 const seniorManagementRoute = require('./seniorManagement');
+const boardRoute = require('./boardRoute');
 const { shouldServe } = require('../../modules/pageLogic');
 
 const router = express.Router();
@@ -26,6 +27,13 @@ module.exports = (pages, sectionPath, sectionId) => {
         seniorManagementRoute.init({
             router: router,
             routeConfig: pages.seniorManagement
+        });
+    }
+
+    if (shouldServe(pages.board)) {
+        boardRoute.init({
+            router: router,
+            routeConfig: pages.board
         });
     }
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -280,7 +280,12 @@ sections.about.addRoutes({
         path: '/our-people/senior-management-team',
         sMaxAge: '30m',
         template: 'pages/about/senior-management-team',
-        lang: 'about.seniorManagement',
+        live: false
+    }),
+    board: dynamicRoute({
+        path: '/our-people/board',
+        sMaxAge: '30m',
+        template: 'pages/about/board',
         live: false
     }),
     freedomOfInformation: staticRoute({

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -64,3 +64,24 @@
         </ul>
     </nav>
 {% endmacro %}
+
+{% macro quickLinks(links, isSticky = false) %}
+    <nav class="quicklinks quicklinks--sticky">
+        <ul class="quicklinks__list">
+            {% for link in links %}
+            <li class="quicklinks__item">
+                <a class="quicklinks__link" href="{{ link.href }}">
+                    <span class="quicklinks__link-label">
+                        {{ link.label }}
+                    </span>
+                    {% if link.caption %}
+                        <span class="quicklinks__link-caption">
+                            {{ link.caption }}
+                        </span>
+                    {% endif %}
+                </a>
+            </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endmacro %}

--- a/views/layouts/profiles.njk
+++ b/views/layouts/profiles.njk
@@ -1,0 +1,51 @@
+{% from "components/hero.njk" import sectionHero %}
+{% from "components/nav.njk" import nestedMenu, quickLinks %}
+{% from "components/profiles.njk" import profileSummary %}
+
+{% extends "layouts/main.njk" %}
+
+{% block title %}{{ title }} | {% endblock %}
+
+{% set pageAccent = 'pink' %}
+{% set bodyClass = "has-full-bleed-header" %}
+{% set heroImage = heroImages.rathlinIslandDevelopment %}
+{% set socialImage = heroImage %}
+
+{% block content %}
+    {{ sectionHero(
+        titleText = title,
+        image = heroImage,
+        accent = pageAccent
+    ) }}
+
+    <main class="nudge-up">
+        <div class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
+            <div class="page-section__content accent--{{ pageAccent }} a--border-top">
+                {% for profile in profiles %}
+                    <section id="profile-{{ profile.title | slugify }}"
+                        class="content-box content-box--even-inset{% if loop.index > 1 %} accent--{{ pageAccent }} a--border-top{% endif %}">
+                        {{ profileSummary(profile) }}
+                    </section>
+                {% endfor %}
+
+                {% block extraPrimaryContent %}{% endblock %}
+            </div>
+            <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
+                <aside class="content-box content-box--even-inset">
+                    {{ nestedMenu(navigation, getCurrentUrl(request)) }}
+                </aside>
+
+                {% set quickLinksList = [] %}
+                {% for profile in profiles %}
+                    {% set quickLink = {
+                        href: '#profile-' + profile.title | slugify,
+                        label: profile.title,
+                        caption: profile.role
+                    } %}
+                    {% set quickLinksList = (quickLinksList.push(quickLink), quickLinksList) %}
+                {% endfor %}
+                {{ quickLinks(quickLinksList, isSticky = true) }}
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/views/pages/about/board.njk
+++ b/views/pages/about/board.njk
@@ -1,0 +1,5 @@
+{% extends "layouts/profiles.njk" %}
+
+{% block extraPrimaryContent %}
+    {# TBD #}
+{% endblock %}

--- a/views/pages/about/senior-management-team.njk
+++ b/views/pages/about/senior-management-team.njk
@@ -1,62 +1,11 @@
-{% from "components/hero.njk" import sectionHero %}
-{% from "components/nav.njk" import nestedMenu %}
 {% from "components/lists.njk" import linksList %}
-{% from "components/profiles.njk" import profileSummary %}
 
-{% extends "layouts/main.njk" %}
+{% extends "layouts/profiles.njk" %}
 
-{% block title %}{{ title }} | {% endblock %}
-
-{% set pageAccent = 'pink' %}
-{% set bodyClass = "has-full-bleed-header" %}
-{% set heroImage = heroImages.rathlinIslandDevelopment %}
-{% set socialImage = heroImage %}
-
-{% block content %}
-    {{ sectionHero(
-        titleText = title,
-        image = heroImage,
-        accent = pageAccent
-    ) }}
-
-    <main class="nudge-up">
-        <div class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
-            <div class="page-section__content accent--{{ pageAccent }} a--border-top">
-                {% for profile in profiles %}
-                    <section id="profile-{{ profile.title | slugify }}"
-                        class="content-box content-box--even-inset{% if loop.index > 1 %} accent--{{ pageAccent }} a--border-top{% endif %}">
-                        {{ profileSummary(profile) }}
-                    </section>
-                {% endfor %}
-
-                <section class="content-box content-box--even-inset
-                    accent--{{ pageAccent }} a--border-top">
-                    <h3 class="t1 accent--{{ pageAccent }} a--text">{{ copy.expenses.title }}</h3>
-                    {{ linksList(copy.expenses.documents, isDocumentsList = true) }}
-                </section>
-            </div>
-            <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
-                <aside class="content-box content-box--even-inset">
-                    {{ nestedMenu(copy.navigation, getCurrentUrl(request)) }}
-                </aside>
-
-                <nav class="quicklinks quicklinks--sticky">
-                    <ul class="quicklinks__list">
-                        {% for profile in profiles %}
-                        <li class="quicklinks__item">
-                            <a class="quicklinks__link" href="#profile-{{ profile.title | slugify }}">
-                                <span class="quicklinks__link-label">
-                                    {{ profile.title }}
-                                </span>
-                                <span class="quicklinks__link-caption">
-                                    {{ profile.role }}
-                                </span>
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </nav>
-            </div>
-        </div>
-    </main>
+{% block extraPrimaryContent %}
+    <section class="content-box content-box--even-inset
+        accent--{{ pageAccent }} a--border-top">
+        <h3 class="t1 accent--{{ pageAccent }} a--text">{{ copy.expenses.title }}</h3>
+        {{ linksList(copy.expenses.documents, isDocumentsList = true) }}
+    </section>
 {% endblock %}


### PR DESCRIPTION
Adds an initial version of the board page. Updates the templates to allow sharing between this and the SMT page.

![board](https://user-images.githubusercontent.com/123386/36897517-c646e394-1e0e-11e8-9de2-88506ccc230e.gif)
