### PR TITLE
Spacing tweak for funding programmes

### DIFF
--- a/assets/sass/components/programmes.scss
+++ b/assets/sass/components/programmes.scss
@@ -76,7 +76,10 @@
 
     .programme-card__title,
     .programme-card__body {
-        @include font-and-leading(18px, 27px);
+        font-size: 18px;
+    }
+    .programme-card__title {
+        line-height: 1.25;
     }
 }
 


### PR DESCRIPTION
Tiniest of tweaks to improve the spacing and alignment on `/funding`

<img width="1010" alt="screen shot 2018-03-02 at 12 01 49" src="https://user-images.githubusercontent.com/123386/36898241-e6ed7560-1e11-11e8-926c-2ae063dcbddb.png">

<img width="1003" alt="screen shot 2018-03-02 at 12 03 29" src="https://user-images.githubusercontent.com/123386/36898240-e6d1b79e-1e11-11e8-8327-bdb89c181e45.png">