### PR TITLE
Add case studies to funding programme pages

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -45,6 +45,7 @@ global:
     otherEnterBelow: Arall (nodwch isod)
   misc:
     caseStudies: Astudiaethau achos
+    projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
     readMore: Darllen mwy
     or: neu
   programmes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ global:
     otherEnterBelow: Other (please enter below)
   misc:
     seeProgramme: See programme
+    projectExamples: Examples of projects that have been funded
     caseStudies: Case studies
     readMore: Read more
     or: or

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -81,3 +81,35 @@
         </div>
     </div>
 {% endmacro %}
+
+{% macro caseStudyCollection(caseStudies, customSectionTitle = false) %}
+    {% if caseStudies.length > 0 %}
+    <section id="case-studies" class="inner">
+        <h2 class="t1">
+            {%- if customSectionTitle -%}
+                {{ customSectionTitle }}
+            {%- else -%}
+                {{ __('global.misc.caseStudies') }}
+            {%- endif -%}
+        </h2>
+        <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
+            {%- for caseStudy in caseStudies -%}
+                <li class="grid__item">
+                    {{
+                        caseStudyCard(
+                            title = caseStudy.title,
+                            grantAmount = caseStudy.grantAmount,
+                            linkUrl = caseStudy.linkUrl,
+                            trailText = caseStudy.trailText,
+                            trailTextMore = caseStudy.trailTextMore,
+                            imageUrl = caseStudy.thumbnailUrl,
+                            useRemoteImages = true,
+                            accent = pageAccent
+                        )
+                    }}
+                </li>
+            {%- endfor -%}
+        </ul>
+    </section>
+    {% endif %}
+{% endmacro %}

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -1,14 +1,14 @@
-{% from "../../components/hero.njk" import sectionHero %}
-{% from "../../components/tabs.njk" import tabs %}
-{% from "../../components/programmes.njk" import programmeStats with context %}
+{% from "components/hero.njk" import sectionHero %}
+{% from "components/tabs.njk" import tabs %}
+{% from "components/programmes.njk" import programmeStats with context %}
+{% from "components/caseStudies.njk" import caseStudyCollection with context %}
 
-{% extends "../../layouts/main.njk" %}
+{% extends "layouts/main.njk" %}
+
 {% set bodyClass = "has-full-bleed-header" %}
-
 {% if entry.summary.area.value === 'wales' %}
     {% set bodyClass = bodyClass + " has-welsh-logo" %}
 {% endif %}
-
 {% set socialImage = heroImage %}
 
 {% block title %}{{ title }} | {% endblock %}
@@ -72,5 +72,11 @@
                 </div>
             {% endif %}
         </div>
+
+        {# Case Studies #}
+        {{ caseStudyCollection(
+            caseStudies = entry.caseStudies,
+            customSectionTitle = __('global.misc.projectExamples')
+        ) }}
     </main>
 {% endblock %}

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -1,5 +1,5 @@
 {% from "components/hero.njk" import sectionHero %}
-{% from "components/caseStudies.njk" import caseStudyCard with context %}
+{% from "components/caseStudies.njk" import caseStudyCollection with context %}
 
 {% extends "layouts/main.njk" %}
 
@@ -62,29 +62,8 @@
             {% endfor %}
         {% endif %}
 
-        {% if content.caseStudies.length > 0 %}
-            <section id="case-studies" class="inner">
-                <h2 class="t1">{{ __('global.misc.caseStudies') }}</h2>
-                <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
-                    {% for caseStudy in content.caseStudies %}
-                        <li class="grid__item">
-                            {{
-                                caseStudyCard(
-                                    title = caseStudy.title,
-                                    grantAmount = null,
-                                    linkUrl = caseStudy.linkUrl,
-                                    trailText = caseStudy.trailText,
-                                    trailTextMore = caseStudy.trailTextMore,
-                                    imageUrl = caseStudy.thumbnailUrl,
-                                    useRemoteImages = true,
-                                    accent = pageAccent
-                                )
-                            }}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </section>
-        {% endif %}
+        {# Case Studies #}
+        {{ caseStudyCollection(content.caseStudies) }}
 
         {% if content.outro %}
             <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">


### PR DESCRIPTION
Add case studies to funding programme pages. Already exists in the API but weren't being displayed on the page yet.