### PR TITLE
Fix data map

### DIFF
--- a/assets/sass/components/data.scss
+++ b/assets/sass/components/data.scss
@@ -251,17 +251,13 @@
     }
 
     .js-on & {
+        display: none;
         @include mq('tablet') {
             width: 160px;
             position: absolute;
             z-index: 10;
             right: 0;
             top: 20px;
-            display: none;
-
-            &.pane--active {
-                display: block;
-            }
         }
 
         @include mq('desktop') {
@@ -277,6 +273,10 @@
     .map-info__stat {
         margin-bottom: 0;
     }
+}
+
+.js-on .pane--active .map-info {
+    display: block;
 }
 
 .map-holder__inner {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "express-ab": "^0.7.1",
     "express-cache-controller": "^1.0.1",
     "express-session": "^1.15.5",
-    "express-validator": "^4.2.1",
+    "express-validator": "^5.0.0",
     "fitvids": "^2.0.0",
     "hammerjs": "^2.0.8",
     "helmet": "^3.8.1",


### PR DESCRIPTION
I just noticed that the [data map](https://www.biglotteryfund.org.uk/data) was broken – this should restore it.