### PR TITLE
Add a basic sitemap

### DIFF
--- a/controllers/route-helpers.js
+++ b/controllers/route-helpers.js
@@ -1,0 +1,85 @@
+const { compact, compose, concat, filter, flatMap, getOr, map, pick, sortBy, uniqBy } = require('lodash/fp');
+const contentApi = require('../services/content-api');
+const routes = require('./routes');
+
+const sortedUniqByPath = compose(sortBy('path'), uniqBy('path'));
+const isLive = route => route.live === true;
+
+/**
+ * Build a flat list of all canonical routes
+ * Combines application routes and routes defined by the CMS
+ */
+function getCanonicalRoutes({ includeDraft = false } = {}) {
+    const routerCanonicalUrls = flatMap(section => {
+        const withoutWildcards = filter(_ => _.path.indexOf('*') === -1);
+        const mapSummary = map((page, key) => {
+            return {
+                title: key,
+                path: section.path + page.path,
+                live: page.live
+            };
+        });
+
+        return compose(mapSummary, withoutWildcards)(section.pages);
+    })(routes.sections);
+
+    return contentApi.getRoutes().then(cmsCanonicalUrls => {
+        const combined = concat(routerCanonicalUrls, cmsCanonicalUrls);
+        const filtered = includeDraft === true ? combined : combined.filter(isLive);
+        const sorted = sortedUniqByPath(filtered);
+        return sorted;
+    });
+}
+
+function getPageRedirects(sections) {
+    const flatMapAliases = sectionPath => {
+        return flatMap(page => {
+            const getAliases = getOr([], 'aliases');
+            return getAliases(page).map(urlPath => {
+                return {
+                    path: urlPath,
+                    destination: sectionPath + page.path,
+                    live: true
+                };
+            });
+        });
+    };
+
+    const flatMapSections = flatMap(section => {
+        return flatMapAliases(section.path)(section.pages);
+    });
+
+    return compact(flatMapSections(sections));
+}
+
+function getCustomRedirects(redirectsList) {
+    const pickProps = pick(['path', 'destination', 'live']);
+    const customRedirects = redirectsList.map(pickProps);
+    return compact(customRedirects);
+}
+
+/**
+ * Build a flat list of all all canonical redirects
+ * Concatenate all legacy redirects + any page aliases
+ */
+function getCombinedRedirects({ includeDraft = false }) {
+    const pageRedirects = getPageRedirects(routes.sections);
+    const customRedirects = getCustomRedirects(routes.legacyRedirects);
+
+    const combined = concat(customRedirects, pageRedirects);
+    const filtered = includeDraft === true ? combined : combined.filter(isLive);
+    const sorted = sortedUniqByPath(filtered);
+
+    return Promise.resolve(sorted);
+}
+
+function getVanityRedirects() {
+    const sorted = sortedUniqByPath(routes.vanityRedirects);
+    return Promise.resolve(sorted);
+}
+
+module.exports = {
+    getCanonicalRoutes,
+    getCombinedRedirects,
+    getVanityRedirects
+};

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -13,6 +13,7 @@ const router = express.Router();
 
 const routerSetup = require('../setup');
 const routeCommon = require('../common');
+const { getCanonicalRoutes } = require('../route-helpers');
 const surveyService = require('../../services/surveys');
 const contentApi = require('../../services/content-api');
 
@@ -211,10 +212,10 @@ module.exports = (pages, sectionPath, sectionId) => {
     });
 
     router.get('/sitemap.xml', sMaxAge('30m'), (req, res) => {
-        contentApi.getCanonicalUrls().then(canonicalUrls => {
+        getCanonicalRoutes().then(canonicalRoutes => {
             const sitemapInstance = sitemap.createSitemap({
                 hostname: getBaseUrl(req),
-                urls: canonicalUrls.map(route => ({
+                urls: canonicalRoutes.map(route => ({
                     url: route.path
                 }))
             });

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -6,6 +6,7 @@ const { sortBy } = require('lodash');
 const { body, validationResult } = require('express-validator/check');
 const xss = require('xss');
 const moment = require('moment');
+const sitemap = require('sitemap');
 const Raven = require('raven');
 
 const router = express.Router();
@@ -15,9 +16,10 @@ const routeCommon = require('../common');
 const surveyService = require('../../services/surveys');
 const contentApi = require('../../services/content-api');
 
+const { getBaseUrl } = require('../../modules/urls');
 const { homepageHero } = require('../../modules/images');
 const regions = require('../../config/content/regions.json');
-const { noCache } = require('../../middleware/cached');
+const { noCache, sMaxAge } = require('../../middleware/cached');
 
 const homepageRoute = require('./homepage');
 const searchRoute = require('./search');
@@ -206,6 +208,25 @@ module.exports = (pages, sectionPath, sectionId) => {
 
         let text = pathsToBlock.reduce((acc, path) => acc + buildBlocklist(path), 'User-agent: *\n');
         res.send(text);
+    });
+
+    router.get('/sitemap.xml', sMaxAge('30m'), (req, res) => {
+        contentApi.getCanonicalUrls().then(canonicalUrls => {
+            const sitemapInstance = sitemap.createSitemap({
+                hostname: getBaseUrl(req),
+                urls: canonicalUrls.map(route => ({
+                    url: route.path
+                }))
+            });
+
+            sitemapInstance.toXML(function(err, xml) {
+                if (err) {
+                    return res.status(500).end();
+                }
+                res.header('Content-Type', 'application/xml');
+                res.send(xml);
+            });
+        });
     });
 
     routeCommon.init({

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -70,14 +70,11 @@ router.get('/status/pages', toolsSecurityHeaders(), (req, res) => {
 
     const redirectRoutes = sortedUniqBy(concat(customRedirects, pageRedirects), 'destination');
 
-    contentApi.getRoutes().then(cmsCanonicalUrls => {
-        const allCanonicalRoutes = sortedUniqBy(concat(routerCanonicalUrls, cmsCanonicalUrls), 'path');
-
+    contentApi.getCanonicalUrls().then(allCanonicalRoutes => {
         const vanityRoutes = routes.vanityRedirects;
 
         const totals = {
-            canonicalApp: routerCanonicalUrls.map(_ => _.live).length,
-            canonicalCms: cmsCanonicalUrls.map(_ => _.live).length,
+            canonical: allCanonicalRoutes.map(_ => _.live).length,
             vanity: vanityRoutes.map(_ => _.live).length,
             redirects: redirectRoutes.map(_ => _.live).length
         };

--- a/controllers/toplevel/tools.js
+++ b/controllers/toplevel/tools.js
@@ -75,7 +75,7 @@ router.route('/tools/survey-results').get(cached.noCache, requiredAuthed, toolsS
             });
         })
         .catch(err => {
-            renderError(err);
+            res.send(err);
         });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19033,6 +19033,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "dev": true,
+      "requires": {
+        "underscore": "1.8.3",
+        "url-join": "1.1.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -22156,6 +22166,12 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+      "dev": true
     },
     "url-parse-lax": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "pretty": "^2.0.0",
     "prompt": "^1.0.0",
     "run-sequence": "^2.2.0",
+    "sitemap": "^1.13.0",
     "webpack": "^4.0.1",
     "webpack-cli": "^2.0.9"
   },

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -1,6 +1,5 @@
-const { compose, concat, find, filter, flatMap, get, getOr, map, sortedUniqBy, take } = require('lodash/fp');
+const { find, get, getOr, map, take } = require('lodash/fp');
 const request = require('request-promise-native');
-const routes = require('../controllers/routes');
 
 const mapAttrs = response => map('attributes')(response.data);
 
@@ -136,30 +135,6 @@ function getRoutes() {
     return fetch('/v1/list-routes').then(mapAttrs);
 }
 
-function getCanonicalUrls() {
-    /**
-     * Build a flat list of all canonical application routes
-     */
-    const routerCanonicalUrls = flatMap(section => {
-        const withoutWildcards = filter(_ => _.path.indexOf('*') === -1);
-        const mapSummary = map((page, key) => {
-            return {
-                title: key,
-                path: section.path + page.path,
-                live: page.live
-            };
-        });
-
-        return compose(mapSummary, withoutWildcards)(section.pages);
-    })(routes.sections);
-
-    return getRoutes().then(cmsCanonicalUrls => {
-        const sortedUniqByPath = sortedUniqBy('path');
-        const combined = concat(routerCanonicalUrls, cmsCanonicalUrls);
-        return sortedUniqByPath(combined);
-    });
-}
-
 module.exports = {
     setApiUrl,
     getApiUrl,
@@ -170,6 +145,5 @@ module.exports = {
     getListingPage,
     getProfiles,
     getSurveys,
-    getRoutes,
-    getCanonicalUrls
+    getRoutes
 };

--- a/services/surveys.js
+++ b/services/surveys.js
@@ -24,7 +24,6 @@ function findAll() {
         let mergedSurveys = surveys.map(survey => {
             // append responses to the relevant choice
             survey.choices = survey.choices.map(choice => {
-
                 let surveyVotes = votes.filter(v => v.survey_id === survey.id);
 
                 // retrieve the votes for this survey's choices

--- a/views/pages/tools/pagelist.njk
+++ b/views/pages/tools/pagelist.njk
@@ -10,10 +10,7 @@
     <section class="mb-4">
         <h2 class="mb-4">Totals</h2>
         <ul class="list-unstyled">
-            <li><strong>{{ totals.canonicalApp }}</strong> live canonical application URLs</li>
-            <li><strong>{{ totals.canonicalCms }}</strong> live canonical pages served from the CMS</li>
-            <li><strong>{{ totals.canonicalApp + totals.canonicalCms }}</strong> total canonical URLs</li>
-            <li>-</li>
+            <li><strong>{{ totals.canonical }}</strong> live canonical URLs</li>
             <li><strong>{{ totals.vanity }}</strong> live vanity URLs</li>
             <li><strong>{{ totals.redirects }}</strong> live redirect URLs</li>
         </ul>

--- a/views/pages/tools/pagelist.njk
+++ b/views/pages/tools/pagelist.njk
@@ -25,7 +25,7 @@
 
         <p><button class="btn btn-primary" id="js-open-links">Open all English canonical pages?</button></p>
         <ul class="list-unstyled">
-            {% for route in allCanonicalRoutes %}
+            {% for route in canonicalRoutes %}
                 <li>
                     <article class="border-top py-2">
                         <h3 class="h6">


### PR DESCRIPTION
This might be a little pre-emptive but this PR reuses the code from `/status/pages` to build a basic `sitemap.xml` file. This can only cover application and CMS pages, not legacy pages so it's not complete. But as there isn't a `/sitemap.xml` on the legacy site and https://www.biglotteryfund.org.uk/sitemap is patchy it might still be worth adding this in as is.