### PR TITLE
Community assets redirects

### DIFF
--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -31,28 +31,26 @@ const legacyRedirects = [
 
     // Migrated Programme Pages [LIVE]
     programmeRedirect('england/awards-for-all-england', 'national-lottery-awards-for-all-england'),
+    programmeRedirect('england/building-better-opportunities', 'building-better-opportunities'),
+    programmeRedirect('england/place-based-social-action', 'place-based-social-action'),
     programmeRedirect('england/reaching-communities-england', 'reaching-communities-england'),
     programmeRedirect('northern-ireland/awards-for-all-northern-ireland', 'awards-for-all-northern-ireland'),
     programmeRedirect('northern-ireland/empowering-young-people', 'empowering-young-people'),
+    programmeRedirect('northern-ireland/people-and-communities', 'people-and-communities'),
     programmeRedirect('scotland/awards-for-all-scotland', 'national-lottery-awards-for-all-scotland'),
+    programmeRedirect('scotland/community-assets', 'community-assets'),
     programmeRedirect('scotland/grants-for-community-led-activity', 'grants-for-community-led-activity'),
     programmeRedirect('scotland/grants-for-improving-lives', 'grants-for-improving-lives'),
-    programmeRedirect('wales/people-and-places-medium-grants', 'people-and-places-medium-grants'),
-    programmeRedirect('wales/helping-working-families', 'helping-working-families'),
-    programmeRedirect('wales/people-and-places-large-grants', 'people-and-places-large-grants'),
-    programmeRedirect('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio'),
+    programmeRedirect('scotland/scottish-land-fund', 'scottish-land-fund'),
     programmeRedirect('uk-wide/coastal-communities', 'coastal-communities-fund'),
     programmeRedirect('uk-wide/lottery-funding', 'other-lottery-funders'),
-    programmeRedirect('northern-ireland/people-and-communities', 'people-and-communities'),
+    programmeRedirect('uk-wide/uk-portfolio', 'awards-from-the-uk-portfolio'),
     programmeRedirect('wales/awards-for-all-wales', 'national-lottery-awards-for-all-wales'),
-    programmeRedirect('england/building-better-opportunities', 'building-better-opportunities'),
-    programmeRedirect('scotland/scottish-land-fund', 'scottish-land-fund'),
-    programmeRedirect('england/place-based-social-action', 'place-based-social-action'),
+    programmeRedirect('wales/helping-working-families', 'helping-working-families'),
+    programmeRedirect('wales/people-and-places-large-grants', 'people-and-places-large-grants'),
+    programmeRedirect('wales/people-and-places-medium-grants', 'people-and-places-medium-grants'),
 
     // Migrated Programme Pages [DRAFT]
-    programmeRedirect('england/parks-for-people', 'parks-for-people', false),
-    programmeRedirect('scotland/community-assets', 'community-assets', false),
-    programmeRedirect('uk-wide/east-africa-disability-fund', 'east-africa-disability-fund', false),
     programmeRedirect('scotland/our-place', 'our-place', false),
     programmeRedirect('uk-wide/forces-in-mind', 'forces-in-mind', false)
 ];

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -91,6 +91,8 @@ const vanityRedirects = sections => {
         vanity('/esf', '/funding/programmes/building-better-opportunities'),
         vanity('/scottishlandfund', 'funding/programmes/scottish-land-fund'),
         vanity('/slf', 'funding/programmes/scottish-land-fund'),
+        vanity('/communityassets', 'funding/programmes/community-assets'),
+        vanity('/prog_growing_community_assets', 'funding/programmes/community-assets'),
         vanity(
             '/wales/global-content/programmes/scotland/awards-for-all-scotland',
             '/funding/programmes/national-lottery-awards-for-all-scotland'


### PR DESCRIPTION
Adds redirects for Community Assets:

- /global-content/programmes/scotland/community-assets
- /prog_growing_community_assets
- /communityassets

(Also sorted the list of programme migration redirects so apologies for the diff noise)
