### PR TITLE
Update materials

### DIFF
--- a/config/content/materials.json
+++ b/config/content/materials.json
@@ -29,7 +29,6 @@
             },
             "description": "310mm x 260mm",
             "image": "plaque-perspex.jpg",
-            "outOfStock": false,
             "maximum": 1,
             "notAllowedWithItem": 3,
             "products": [

--- a/config/content/materials.json
+++ b/config/content/materials.json
@@ -174,6 +174,7 @@
         },
         {
             "id": 11,
+            "disabled": true,
             "name": {
                 "en": "Medium sticker",
                 "cy": "Sticer canolig"

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -13,6 +13,7 @@ const { errorTranslator } = require('../../modules/validators');
 const ordersService = require('../../services/orders');
 
 const materials = require('../../config/content/materials.json');
+let availableItems = materials.items.filter(i => !i.disabled);
 
 const materialsOrderKey = 'orderedMaterials';
 const translateError = errorTranslator('global.forms');
@@ -196,7 +197,7 @@ function modifyItems(req, orderKey, code) {
     const id = parseInt(req.params.id);
     const action = req.body.action;
 
-    const itemToBeAdded = materials.items.find(i => i.id === id);
+    const itemToBeAdded = availableItems.find(i => i.id === id);
     const isValidAction = itemToBeAdded && validActions.indexOf(action) !== -1;
 
     if (isValidAction) {
@@ -346,7 +347,7 @@ function init({ router, routeConfig }) {
                 title: lang.title,
                 copy: lang,
                 description: 'Order items free of charge to acknowledge your grant',
-                materials: materials.items,
+                materials: availableItems,
                 formFields: materialFields,
                 orders: orders,
                 numOrders: numOrders,


### PR DESCRIPTION
Removes the medium sticker from the order form as we're discontinuing it.

This is a bit of a quirk: I've added a new `disabled` flag so we can continue to show past orders for this item in the stats page, otherwise there's just a blank space where its name appears in the list. This might be a reason to eventually move these items to the CMS, but it works for now.