### PR TITLE
Improve how isBilingual is defined

### DIFF
--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -10,8 +10,7 @@
 {% endmacro %}
 
 {% macro navLangLink() %}
-    {% set showLangLink = isBilingual | default(true) %}
-    {% if showLangLink %}
+    {% if isBilingual %}
         {% if locale == 'en' %}
             <a class="qa-lang-switcher" href="{{ getCurrentUrl(request, 'cy') }}">Cymraeg</a>
         {% else %}

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -49,4 +49,10 @@
 <link rel="icon" type="image/png" sizes="16x16" href="{{ 'favicon/favicon-16x16.png' | getImagePath }}">
 <meta name="msapplication-TileImage" content="{{ 'favicon/ms-icon-144x144.png' | getImagePath }}">
 
-{# todo: <link rel="alternate" hreflang="cy" href="#" /> #}
+{% if isBilingual %}
+    {% if locale == 'en' %}
+        <link rel="alternate" hreflang="cy" href="{{ getCurrentUrl(request, 'cy') }}" />
+    {% else %}
+        <link rel="alternate" hreflang="en" href="{{ getCurrentUrl(request, 'en') }}" />
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
Improve how `isBilingual` is defined so that we define an initial `app.locals` value of `true` and then override it as needed on a per route basis. As a result allows us to do fix this TODO: `todo: <link rel="alternate" hreflang="cy" href="#" />`