### PR TITLE
Fix Welsh legacy pages

### DIFF
--- a/integration-tests/test-suites/legacy.test.js
+++ b/integration-tests/test-suites/legacy.test.js
@@ -140,4 +140,15 @@ describe('Legacy pages', () => {
                 );
             });
     });
+
+    it('should serve welsh versions of legacy pages', () => {
+        return chai
+            .request(server)
+            .get('/welsh/research/communities-and-places')
+            .redirects(0)
+            .catch(err => err.response)
+            .then(res => {
+                expect(res.status).to.equal(200);
+            });
+    });
 });

--- a/server.js
+++ b/server.js
@@ -156,7 +156,7 @@ app.get('/error-unauthorised', (req, res) => {
 app
     .route('*')
     .all(stripCSPHeader)
-    .get(redirectNoWelsh, proxyPassthrough)
+    .get(proxyPassthrough, redirectNoWelsh)
     .post(postToLegacyForm);
 
 /**


### PR DESCRIPTION
Had our middlewares mixed up. This checks for a Welsh version before resorting to English.