### PR TITLE
Refactor footer links and adds corporate documents

### DIFF
--- a/assets/sass/scaffolding/footer.scss
+++ b/assets/sass/scaffolding/footer.scss
@@ -28,6 +28,27 @@
         padding: 60px 0;
     }
 }
-.footer__header {
-    margin-bottom: $spacingUnit;
+
+.footer-links {
+    @include mq('small') {
+        columns: 2;
+    }
+
+    li {
+        margin: 0;
+        padding: 0;
+        border-bottom: 1px solid lighten(palette('charcoal'), 10%);
+
+        @include mq('medium') {
+            border-bottom: none;
+            margin-bottom: $spacingUnit / 1.5;
+        }
+    }
+
+    a {
+        @include mq('medium', 'max') {
+            padding: $spacingUnit ($spacingUnit / 2);
+            display: block;
+        }
+    }
 }

--- a/assets/sass/scaffolding/lists.scss
+++ b/assets/sass/scaffolding/lists.scss
@@ -2,20 +2,6 @@
    Lists (Common List Objects)
    ========================================================================= */
 
-.list-spaced {
-    li {
-        padding: 25px 30px;
-        border-bottom: 1px solid lighten(palette('charcoal'), 10%);
-        margin-bottom: 0;
-
-        @include mq('tablet') {
-            margin-bottom: $spacingUnit / 1.5;
-            padding: 0;
-            border-bottom: none;
-        }
-    }
-}
-
 .list-bullets {
     margin-bottom: 20px;
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -20,15 +20,27 @@ global:
     email: ymholiadau.cymru@cronfaloterifawr.org.uk
   footerLinks:
     title: Dolenni gwib
-    foi: Rhyddid Gwybodaeth
-    privacy-policy: Polisi Preifatrwydd
-    terms: Telerau
-    cookies: Cwcis
-    jobs: Swyddi
-    contact: Cyswllt
-    site-map: Map o'r wefan
-    accessibility: Hygyrchedd
-    tenderOpportunities: Cyfleoedd tendro
+    links:
+    - label: Rhyddid Gwybodaeth
+      href: "/welsh/about/customer-service/freedom-of-information"
+    - label: Cyfleoedd tendro
+      href: "/welsh/about-big/tender-opportunities"
+    - label: Dogfennau corfforaethol
+      href: "/welsh/about-big/publications/corporate-documents"
+    - label: Polisi Preifatrwydd
+      href: "/welsh/about-big/customer-service/privacy-policy"
+    - label: Telerau
+      href: "/welsh/about-big/customer-service/terms-of-use"
+    - label: Cyswllt
+      href: "/welsh/contact"
+    - label: Swyddi
+      href: "/welsh/jobs"
+    - label: Cwcis
+      href: "/welsh/about-big/customer-service/cookies"
+    - label: Map o'r wefan
+      href: "/welsh/sitemap"
+    - label: Hygyrchedd
+      href: "/welsh/about-big/our-approach/accessibility"
     grantFootnote: Dyfarnwyd y grant a ddangosir o fewn y 12 mis diwethaf
   accessibility:
     skipToContent: Ewch i'r cynnwys

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,15 +20,27 @@ global:
     email: general.enquiries@biglotteryfund.org.uk
   footerLinks:
     title: Quick links
-    foi: Freedom of Information
-    privacy-policy: Privacy Policy
-    terms: Terms
-    cookies: Cookies
-    jobs: Jobs
-    contact: Contact
-    site-map: Site map
-    accessibility: Accessibility
-    tenderOpportunities: Tender opportunities
+    links:
+    - label: Freedom of Information
+      href: "/about/customer-service/freedom-of-information"
+    - label: Tender opportunities
+      href: "/about-big/tender-opportunities"
+    - label: Corporate documents
+      href: "/about-big/publications/corporate-documents"
+    - label: Privacy Policy
+      href: "/about-big/customer-service/privacy-policy"
+    - label: Terms
+      href: "/about-big/customer-service/terms-of-use"
+    - label: Contact
+      href: "/contact"
+    - label: Jobs
+      href: "/jobs"
+    - label: Cookies
+      href: "/about-big/customer-service/cookies"
+    - label: Site map
+      href: "/sitemap"
+    - label: Accessibility
+      href: "/about-big/our-approach/accessibility"
     grantFootnote: The grant amount shown was awarded within the last 12 months
   accessibility:
     skipToContent: Skip to content

--- a/views/includes/footer.njk
+++ b/views/includes/footer.njk
@@ -2,30 +2,18 @@
     <div class="footer__inner inner">
         <ul class="grid grid--top grid--wide-only">
             <li class="grid__item u-desktop-only">
-                <ul class="list-spaced">
-                    <li><strong>{{ __("global.brand.title") | safe }}</strong></li>
-                    <li><address>1 Plough Place, {{ __("global.contact.city") | safe }} EC4A 1DE</address></li>
-                    <li><a href="mailto:{{ __("global.contact.email") | safe }}">{{ __("global.contact.email") | safe }}</a></li>
-                    <li>{{ __("global.contact.phone") | safe }}</li>
-                </ul>
+                <h5 class="t6 u-uppercase">{{ __("global.brand.title") | safe }}</h5>
+                <p><address>1 Plough Place, {{ __("global.contact.city") | safe }} EC4A 1DE</address></p>
+                <p><a href="mailto:{{ __("global.contact.email") | safe }}">{{ __("global.contact.email") | safe }}</a></p>
+                <p>{{ __("global.contact.phone") | safe }}</p>
             </li>
             <li class="grid__item">
-                <h4 class="footer__header t6 u-desktop-only u-uppercase">{{ __("global.footerLinks.title") | safe }}</h4>
-                <div class="grid grid--wide-only grid--top list-spaced">
-                    <ul class="grid__item">
-                        <li><a href="{{ buildUrl('about/customer-service/freedom-of-information') }}">{{ __("global.footerLinks.foi") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('about-big/customer-service/privacy-policy') }}">{{ __("global.footerLinks.privacy-policy") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('about-big/customer-service/terms-of-use') }}">{{ __("global.footerLinks.terms") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('about-big/customer-service/cookies') }}">{{ __("global.footerLinks.cookies") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('about-big/tender-opportunities') }}">{{ __("global.footerLinks.tenderOpportunities") | safe }}</a></li>
-                    </ul>
-                    <ul class="grid__item">
-                        <li><a href="{{ buildUrl('jobs') }}">{{ __("global.footerLinks.jobs") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('contact') }}">{{ __("global.footerLinks.contact") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('sitemap') }}">{{ __("global.footerLinks.site-map") | safe }}</a></li>
-                        <li><a href="{{ buildUrl('about-big/our-approach/accessibility') }}">{{ __("global.footerLinks.accessibility") | safe }}</a></li>
-                    </ul>
-                </div>
+                <h5 class="t6 u-uppercase u-desktop-only">{{ __("global.footerLinks.title") | safe }}</h5>
+                <ul class="footer-links">
+                    {% for link in __("global.footerLinks.links") %}
+                        <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+                    {% endfor %}
+                </ul>
             </li>
         </ul>
         {% if globalFootnote %}


### PR DESCRIPTION
Adds corporate documents to the footer and uses it as an opportunity to refactor a little.

- Moves link urls, not just labels, into YML 
- `list-spaced` was being used on the address for side-effects rather than it's intended styles so I've made that regular paragraph text and renamed `list-spaced` to specifically be `footer-links`
- Improves the touch area for links on small screens (add padding to links instead of list items)

<img width="1069" alt="screen shot 2018-03-09 at 11 16 40" src="https://user-images.githubusercontent.com/123386/37205107-630b2a42-238b-11e8-8644-456d32430db8.png">
