### PR TITLE
Dynamic case studies

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -841,27 +841,6 @@ funding:
       o wybodaeth am ein grantiau Deyrnas Unedig gyfan</a>. Rydym yn gwneud grantiau
       <a href="/welsh/over10k">dros £10,000</a> ar gyfer prosiectau tymor hirach hefyd. '
     projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
-    projects:
-    - name: Papyrus
-      amount: ''
-      link: ''
-      image: under10k/hbf.jpg
-      description: 'Yn atal hunanladdiad pobl ifainc ar draws y Deyrnas Unedig, mae
-        Papyrus yn cynnig cymorth, cyngor a chefnogaeth i bobl ifainc sydd â meddyliau
-        hunanddinistriol, eu cyfeillion a''u teuluoedd. '
-    - name: Ragroof Players
-      amount: ''
-      link: ''
-      image: under10k/ragroof.jpg
-      description: Mae'r Ragroof Players yn creu sioeau theatr, prosiectau perfformiad,
-        dawnsiau te a digwyddiadau wedi eu teilwra sy'n dathlu dawns gymdeithasol
-        a theatr boblogaidd.
-    - name: Cyngor Ffoaduriaid Cymru
-      amount: ''
-      link: ''
-      image: under10k/wrc.jpg
-      description: Mae Cyngor Ffoaduriaid Cymru'n cefnogi'r rhai sy'n ffoi rhag erledigaeth,
-        gwrthdaro a gormes.
     browseFundedProjects: Pori'r holl brosiectau a ariannwyd
   over10k:
     title: Darganfod ein rhaglenni grant am symiau dros £10,000
@@ -878,26 +857,6 @@ funding:
       northernIreland: Gogledd Iwerddon
       ukWide: Bydd fy mhrosiect yn helpu pobl ar draws y Deyrnas Unedig
     projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
-    projects:
-    - name: Croxteth Gems
-      amount: ''
-      link: ''
-      image: over10k/croxteth.jpg
-      description: 'Fel grŵp wrth wraidd ei gymuned, mae Cymdeithas Gymunedol Croxteth
-        Gems wedi cefnogi pobl ifainc a theuluoedd ers bron 50 mlynedd. '
-    - name: Dads in Mind
-      amount: ''
-      link: ''
-      image: over10k/dads.jpg
-      description: 'Mae Dads in Mind yn cefnogi tadau sy''n profi problemau iechyd
-        meddwl gysylltiedig yn uniongyrchol â beichiogrwydd a bod yn dad ac yn cynnig
-        cefnogaeth i''r rhai y mae eu partneriaid wedi''u heffeithio hefyd. '
-    - name: Cruse Bereavement Care
-      amount: ''
-      link: ''
-      image: over10k/cruse.jpg
-      description: 'Mae Gofal mewn Galar Cruse yn cynnig cefnogaeth, cyngor a gwybodaeth
-        i blant, pobl ifainc ac oedolion pan fydd rhywun yn marw. '
     browseAll: Pori'r holl brosiectau a ariannwyd
   guidance:
     order-free-materials:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -636,87 +636,6 @@ toplevel:
       text: "<p>Rydym yn gweithio i sefydlu diwylliant o hyfforddiant yn y Gronfa
         Loteri Fawr trwy weithdai, cyngor a chanllawiau, sesiynau 1:1 a'n rhwydwaith
         hyfforddiant ein hunain.</p>"
-  under10k:
-    title: Arian i Bawb y Loteri Genedlaethol - Sut i gael grant o hyd at £10,000
-    intro: 'Gall grant gan y Loteri Genedlaethol helpu gwneud gwahaniaeth yn eich
-      cymuned. Mae Arian i Bawb y Loteri Genedlaethol yn cynnig grantiau rhwng £300
-      a £10,000 i gefnogi''r hyn sy''n bwysig i bobl a chymunedau. Byddwn yn ariannu
-      mudiadau gyda syniadau gwych am brosiect a fydd yn:'
-    ideas:
-    - Siapio'r lleoedd a lleoliadau sy'n bwysig i gymunedau
-    - Dod â mwy o bobl ynghyd ac adeiladu cysylltiadau cryf o fewn ac ar draws cymunedau
-    - Galluogi mwy o bobl i gyflawni eu potensial trwy weithio i ddelio â phroblemau
-      yn y cam cynharaf posib.
-    callToAction: Eisiau gwybod mwy? Dechreuwch drwy ddweud wrthym ble fydd eich prosiect
-      wedi'i leoli
-    locations:
-      england: Lloegr
-      scotland: Yr Alban
-      wales: Cymru
-      northernIreland: Gogledd Iwerddon
-    ukWideInfo: 'O bryd i''w gilydd mae''r Gronfa''n gwneud grantiau o dan £10,000
-      i brosiectau sydd o fudd i bobl ym mhob cwr o''r Deyrnas Unedig. <a href="https://www.biglotteryfund.org.uk/global-content/programmes/uk-wide/uk-portfolio">Mwy
-      o wybodaeth am ein grantiau Deyrnas Unedig gyfan</a>. Rydym yn gwneud grantiau
-      <a href="/welsh/over10k">dros £10,000</a> ar gyfer prosiectau tymor hirach hefyd. '
-    projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
-    projects:
-    - name: Papyrus
-      amount: ''
-      link: ''
-      image: under10k/hbf.jpg
-      description: 'Yn atal hunanladdiad pobl ifainc ar draws y Deyrnas Unedig, mae
-        Papyrus yn cynnig cymorth, cyngor a chefnogaeth i bobl ifainc sydd â meddyliau
-        hunanddinistriol, eu cyfeillion a''u teuluoedd. '
-    - name: Ragroof Players
-      amount: ''
-      link: ''
-      image: under10k/ragroof.jpg
-      description: Mae'r Ragroof Players yn creu sioeau theatr, prosiectau perfformiad,
-        dawnsiau te a digwyddiadau wedi eu teilwra sy'n dathlu dawns gymdeithasol
-        a theatr boblogaidd.
-    - name: Cyngor Ffoaduriaid Cymru
-      amount: ''
-      link: ''
-      image: under10k/wrc.jpg
-      description: Mae Cyngor Ffoaduriaid Cymru'n cefnogi'r rhai sy'n ffoi rhag erledigaeth,
-        gwrthdaro a gormes.
-    browseFundedProjects: Pori'r holl brosiectau a ariannwyd
-  over10k:
-    title: Darganfod ein rhaglenni grant am symiau dros £10,000
-    intro: 'Mae grantiau mawr yn cael eu gwneud trwy amrywiaeth o raglenni sy''n cynnwys
-      pob cenedl yn y Deyrnas Unedig. Mae''r math hwn o grant hyblyg a thymor hirach
-      wedi''i anelu at fudiadau y mae eu huchelgeisiau''n cael eu siapio gan y bobl
-      y maent yn eu gwasanaethu. '
-    callToAction: Eisiau gwybod mwy? Dechreuwch drwy ddweud wrthym ble fydd eich prosiect
-      wedi'i leoli
-    locations:
-      england: Lloegr
-      scotland: Yr Alban
-      wales: Cymru
-      northernIreland: Gogledd Iwerddon
-      ukWide: Bydd fy mhrosiect yn helpu pobl ar draws y Deyrnas Unedig
-    projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
-    projects:
-    - name: Croxteth Gems
-      amount: ''
-      link: ''
-      image: over10k/croxteth.jpg
-      description: 'Fel grŵp wrth wraidd ei gymuned, mae Cymdeithas Gymunedol Croxteth
-        Gems wedi cefnogi pobl ifainc a theuluoedd ers bron 50 mlynedd. '
-    - name: Dads in Mind
-      amount: ''
-      link: ''
-      image: over10k/dads.jpg
-      description: 'Mae Dads in Mind yn cefnogi tadau sy''n profi problemau iechyd
-        meddwl gysylltiedig yn uniongyrchol â beichiogrwydd a bod yn dad ac yn cynnig
-        cefnogaeth i''r rhai y mae eu partneriaid wedi''u heffeithio hefyd. '
-    - name: Cruse Bereavement Care
-      amount: ''
-      link: ''
-      image: over10k/cruse.jpg
-      description: 'Mae Gofal mewn Galar Cruse yn cynnig cefnogaeth, cyngor a gwybodaeth
-        i blant, pobl ifainc ac oedolion pan fydd rhywun yn marw. '
-    browseAll: Pori'r holl brosiectau a ariannwyd
 about:
   landing:
     title: Gwaith y Gronfa Loteri Fawr
@@ -899,6 +818,87 @@ about:
       i wneud hynny o dan <a href=\"http://www.legislation.gov.uk/ukpga/1998/29/contents\">Ddeddf
       Diogelu Data 1998</a>.</p>"
 funding:
+  under10k:
+    title: Arian i Bawb y Loteri Genedlaethol - Sut i gael grant o hyd at £10,000
+    intro: 'Gall grant gan y Loteri Genedlaethol helpu gwneud gwahaniaeth yn eich
+      cymuned. Mae Arian i Bawb y Loteri Genedlaethol yn cynnig grantiau rhwng £300
+      a £10,000 i gefnogi''r hyn sy''n bwysig i bobl a chymunedau. Byddwn yn ariannu
+      mudiadau gyda syniadau gwych am brosiect a fydd yn:'
+    ideas:
+    - Siapio'r lleoedd a lleoliadau sy'n bwysig i gymunedau
+    - Dod â mwy o bobl ynghyd ac adeiladu cysylltiadau cryf o fewn ac ar draws cymunedau
+    - Galluogi mwy o bobl i gyflawni eu potensial trwy weithio i ddelio â phroblemau
+      yn y cam cynharaf posib.
+    callToAction: Eisiau gwybod mwy? Dechreuwch drwy ddweud wrthym ble fydd eich prosiect
+      wedi'i leoli
+    locations:
+      england: Lloegr
+      scotland: Yr Alban
+      wales: Cymru
+      northernIreland: Gogledd Iwerddon
+    ukWideInfo: 'O bryd i''w gilydd mae''r Gronfa''n gwneud grantiau o dan £10,000
+      i brosiectau sydd o fudd i bobl ym mhob cwr o''r Deyrnas Unedig. <a href="https://www.biglotteryfund.org.uk/global-content/programmes/uk-wide/uk-portfolio">Mwy
+      o wybodaeth am ein grantiau Deyrnas Unedig gyfan</a>. Rydym yn gwneud grantiau
+      <a href="/welsh/over10k">dros £10,000</a> ar gyfer prosiectau tymor hirach hefyd. '
+    projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
+    projects:
+    - name: Papyrus
+      amount: ''
+      link: ''
+      image: under10k/hbf.jpg
+      description: 'Yn atal hunanladdiad pobl ifainc ar draws y Deyrnas Unedig, mae
+        Papyrus yn cynnig cymorth, cyngor a chefnogaeth i bobl ifainc sydd â meddyliau
+        hunanddinistriol, eu cyfeillion a''u teuluoedd. '
+    - name: Ragroof Players
+      amount: ''
+      link: ''
+      image: under10k/ragroof.jpg
+      description: Mae'r Ragroof Players yn creu sioeau theatr, prosiectau perfformiad,
+        dawnsiau te a digwyddiadau wedi eu teilwra sy'n dathlu dawns gymdeithasol
+        a theatr boblogaidd.
+    - name: Cyngor Ffoaduriaid Cymru
+      amount: ''
+      link: ''
+      image: under10k/wrc.jpg
+      description: Mae Cyngor Ffoaduriaid Cymru'n cefnogi'r rhai sy'n ffoi rhag erledigaeth,
+        gwrthdaro a gormes.
+    browseFundedProjects: Pori'r holl brosiectau a ariannwyd
+  over10k:
+    title: Darganfod ein rhaglenni grant am symiau dros £10,000
+    intro: 'Mae grantiau mawr yn cael eu gwneud trwy amrywiaeth o raglenni sy''n cynnwys
+      pob cenedl yn y Deyrnas Unedig. Mae''r math hwn o grant hyblyg a thymor hirach
+      wedi''i anelu at fudiadau y mae eu huchelgeisiau''n cael eu siapio gan y bobl
+      y maent yn eu gwasanaethu. '
+    callToAction: Eisiau gwybod mwy? Dechreuwch drwy ddweud wrthym ble fydd eich prosiect
+      wedi'i leoli
+    locations:
+      england: Lloegr
+      scotland: Yr Alban
+      wales: Cymru
+      northernIreland: Gogledd Iwerddon
+      ukWide: Bydd fy mhrosiect yn helpu pobl ar draws y Deyrnas Unedig
+    projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
+    projects:
+    - name: Croxteth Gems
+      amount: ''
+      link: ''
+      image: over10k/croxteth.jpg
+      description: 'Fel grŵp wrth wraidd ei gymuned, mae Cymdeithas Gymunedol Croxteth
+        Gems wedi cefnogi pobl ifainc a theuluoedd ers bron 50 mlynedd. '
+    - name: Dads in Mind
+      amount: ''
+      link: ''
+      image: over10k/dads.jpg
+      description: 'Mae Dads in Mind yn cefnogi tadau sy''n profi problemau iechyd
+        meddwl gysylltiedig yn uniongyrchol â beichiogrwydd a bod yn dad ac yn cynnig
+        cefnogaeth i''r rhai y mae eu partneriaid wedi''u heffeithio hefyd. '
+    - name: Cruse Bereavement Care
+      amount: ''
+      link: ''
+      image: over10k/cruse.jpg
+      description: 'Mae Gofal mewn Galar Cruse yn cynnig cefnogaeth, cyngor a gwybodaeth
+        i blant, pobl ifainc ac oedolion pan fydd rhywun yn marw. '
+    browseAll: Pori'r holl brosiectau a ariannwyd
   guidance:
     order-free-materials:
       title: Sut i gael deunyddiau â'n brand arnynt am ddim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -905,25 +905,6 @@ funding:
       out more about our UK-wide funding</a>. We also make grants of <a href="/over10k">more
       than £10,000</a> for longer term projects.
     projectExamples: Examples of projects that have been funded
-    projects:
-    - name: Papyrus
-      amount: ''
-      link: '/funding/big-stories/papyrus'
-      image: under10k/hbf.jpg
-      description: Preventing youth suicide across the UK, Papyrus offer help, advice
-        and support to young people with suicidal thoughts and their friends and family.
-    - name: Ragroof Players
-      amount: ''
-      link: '/funding/big-stories/ragroof-players'
-      image: under10k/ragroof.jpg
-      description: The Ragroof Players create theatre shows, performance projects,
-        tea dances, and bespoke events that celebrate social dance and popular theatre.
-    - name: Welsh Refugee Council
-      amount: ''
-      link: '/funding/big-stories/welsh-refugee-council'
-      image: under10k/wrc.jpg
-      description: The Welsh Refugee Council supports those fleeing persecution, conflict
-        and oppression.
     browseFundedProjects: Browse all funded projects
   over10k:
     title: Discover our funding programmes for amounts above £10,000
@@ -939,26 +920,6 @@ funding:
       northernIreland: Northern Ireland
       ukWide: My project will help people right across the UK
     projectExamples: Examples of projects that have been funded
-    projects:
-    - name: Croxteth Gems
-      amount: ''
-      link: '/funding/big-stories/croxteth-gems'
-      image: over10k/croxteth.jpg
-      description: A group at the very heart of its community, Croxteth Gems Community
-        Association has been supporting young people and families for almost 50 years.
-    - name: Dads in Mind
-      amount: ''
-      link: '/funding/big-stories/dads-in-mind'
-      image: over10k/dads.jpg
-      description: Dads in Mind supports dads directly experiencing mental health
-        issues related to pregnancy and parenthood and also offers support to those
-        whose partners are affected.
-    - name: Cruse Bereavement Care
-      amount: ''
-      link: '/funding/big-stories/cruse-bereavement-care'
-      image: over10k/cruse.jpg
-      description: Cruse Bereavement Care offer support, advice and information to
-        children, young people and adults when someone dies.
     browseAll: Browse all funded projects
   guidance:
     order-free-materials:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -704,84 +704,6 @@ toplevel:
       text: "<p>We are working to establish a coaching culture at the Big Lottery
         Fund through workshops, advice and guides, 1:1 sessions and our own coaching
         network.</p>"
-  under10k:
-    title: National Lottery Awards for All - how to get a grant for up to £10,000
-    intro: 'National Lottery Funding can help you to make a difference in your community.
-      National Lottery Awards for All offers funding from £300 to £10,000 to support
-      what matters to people and communities. We will fund organisations with great
-      project ideas that:'
-    ideas:
-    - Shape the places and spaces that matter to communities
-    - Bring more people together and build strong relationships in and across communities
-    - Enable more people to fulfil their potential by working to address issues at
-      the earliest possible stage
-    callToAction: Want to know more? Start by telling us where your project is going
-      to be
-    locations:
-      england: England
-      scotland: Scotland
-      wales: Wales
-      northernIreland: Northern Ireland
-    ukWideInfo: Occasionally the Fund makes grants of under £10,000 to projects that
-      benefit people right across the UK. <a href="https://www.biglotteryfund.org.uk/global-content/programmes/uk-wide/uk-portfolio">Find
-      out more about our UK-wide funding</a>. We also make grants of <a href="/over10k">more
-      than £10,000</a> for longer term projects.
-    projectExamples: Examples of projects that have been funded
-    projects:
-    - name: Papyrus
-      amount: ''
-      link: '/funding/big-stories/papyrus'
-      image: under10k/hbf.jpg
-      description: Preventing youth suicide across the UK, Papyrus offer help, advice
-        and support to young people with suicidal thoughts and their friends and family.
-    - name: Ragroof Players
-      amount: ''
-      link: '/funding/big-stories/ragroof-players'
-      image: under10k/ragroof.jpg
-      description: The Ragroof Players create theatre shows, performance projects,
-        tea dances, and bespoke events that celebrate social dance and popular theatre.
-    - name: Welsh Refugee Council
-      amount: ''
-      link: '/funding/big-stories/welsh-refugee-council'
-      image: under10k/wrc.jpg
-      description: The Welsh Refugee Council supports those fleeing persecution, conflict
-        and oppression.
-    browseFundedProjects: Browse all funded projects
-  over10k:
-    title: Discover our funding programmes for amounts above £10,000
-    intro: Larger grants are made through a variety of programmes that cover every
-      nation within the United Kingdom. This kind of flexible, longer-term funding
-      is aimed at organisations whose ambitions are shaped by the people they serve.
-    callToAction: Want to know more? Start by telling us where your project is going
-      to be
-    locations:
-      england: England
-      scotland: Scotland
-      wales: Wales
-      northernIreland: Northern Ireland
-      ukWide: My project will help people right across the UK
-    projectExamples: Examples of projects that have been funded
-    projects:
-    - name: Croxteth Gems
-      amount: ''
-      link: '/funding/big-stories/croxteth-gems'
-      image: over10k/croxteth.jpg
-      description: A group at the very heart of its community, Croxteth Gems Community
-        Association has been supporting young people and families for almost 50 years.
-    - name: Dads in Mind
-      amount: ''
-      link: '/funding/big-stories/dads-in-mind'
-      image: over10k/dads.jpg
-      description: Dads in Mind supports dads directly experiencing mental health
-        issues related to pregnancy and parenthood and also offers support to those
-        whose partners are affected.
-    - name: Cruse Bereavement Care
-      amount: ''
-      link: '/funding/big-stories/cruse-bereavement-care'
-      image: over10k/cruse.jpg
-      description: Cruse Bereavement Care offer support, advice and information to
-        children, young people and adults when someone dies.
-    browseAll: Browse all funded projects
 about:
   landing:
     title: About the Big Lottery Fund
@@ -960,6 +882,84 @@ about:
       the <a href=\"http://www.legislation.gov.uk/ukpga/1998/29/contents\">Data Protection
       Act 1998</a>.</p>"
 funding:
+  under10k:
+    title: National Lottery Awards for All - how to get a grant for up to £10,000
+    intro: 'National Lottery Funding can help you to make a difference in your community.
+      National Lottery Awards for All offers funding from £300 to £10,000 to support
+      what matters to people and communities. We will fund organisations with great
+      project ideas that:'
+    ideas:
+    - Shape the places and spaces that matter to communities
+    - Bring more people together and build strong relationships in and across communities
+    - Enable more people to fulfil their potential by working to address issues at
+      the earliest possible stage
+    callToAction: Want to know more? Start by telling us where your project is going
+      to be
+    locations:
+      england: England
+      scotland: Scotland
+      wales: Wales
+      northernIreland: Northern Ireland
+    ukWideInfo: Occasionally the Fund makes grants of under £10,000 to projects that
+      benefit people right across the UK. <a href="https://www.biglotteryfund.org.uk/global-content/programmes/uk-wide/uk-portfolio">Find
+      out more about our UK-wide funding</a>. We also make grants of <a href="/over10k">more
+      than £10,000</a> for longer term projects.
+    projectExamples: Examples of projects that have been funded
+    projects:
+    - name: Papyrus
+      amount: ''
+      link: '/funding/big-stories/papyrus'
+      image: under10k/hbf.jpg
+      description: Preventing youth suicide across the UK, Papyrus offer help, advice
+        and support to young people with suicidal thoughts and their friends and family.
+    - name: Ragroof Players
+      amount: ''
+      link: '/funding/big-stories/ragroof-players'
+      image: under10k/ragroof.jpg
+      description: The Ragroof Players create theatre shows, performance projects,
+        tea dances, and bespoke events that celebrate social dance and popular theatre.
+    - name: Welsh Refugee Council
+      amount: ''
+      link: '/funding/big-stories/welsh-refugee-council'
+      image: under10k/wrc.jpg
+      description: The Welsh Refugee Council supports those fleeing persecution, conflict
+        and oppression.
+    browseFundedProjects: Browse all funded projects
+  over10k:
+    title: Discover our funding programmes for amounts above £10,000
+    intro: Larger grants are made through a variety of programmes that cover every
+      nation within the United Kingdom. This kind of flexible, longer-term funding
+      is aimed at organisations whose ambitions are shaped by the people they serve.
+    callToAction: Want to know more? Start by telling us where your project is going
+      to be
+    locations:
+      england: England
+      scotland: Scotland
+      wales: Wales
+      northernIreland: Northern Ireland
+      ukWide: My project will help people right across the UK
+    projectExamples: Examples of projects that have been funded
+    projects:
+    - name: Croxteth Gems
+      amount: ''
+      link: '/funding/big-stories/croxteth-gems'
+      image: over10k/croxteth.jpg
+      description: A group at the very heart of its community, Croxteth Gems Community
+        Association has been supporting young people and families for almost 50 years.
+    - name: Dads in Mind
+      amount: ''
+      link: '/funding/big-stories/dads-in-mind'
+      image: over10k/dads.jpg
+      description: Dads in Mind supports dads directly experiencing mental health
+        issues related to pregnancy and parenthood and also offers support to those
+        whose partners are affected.
+    - name: Cruse Bereavement Care
+      amount: ''
+      link: '/funding/big-stories/cruse-bereavement-care'
+      image: over10k/cruse.jpg
+      description: Cruse Bereavement Care offer support, advice and information to
+        children, young people and adults when someone dies.
+    browseAll: Browse all funded projects
   guidance:
     order-free-materials:
       title: How to get free branded materials

--- a/controllers/funding/10k.js
+++ b/controllers/funding/10k.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const contentApi = require('../../services/content-api');
+
+function init10k({ router, routeConfig, caseStudySlugs }) {
+    router.get(routeConfig.path, (req, res) => {
+        const lang = req.i18n.__(routeConfig.lang);
+        const currentLocale = req.i18n.getLocale();
+
+        const servePage = caseStudies => {
+            res.render(routeConfig.template, {
+                title: lang.title,
+                description: lang.description || false,
+                copy: lang,
+                caseStudies: caseStudies || []
+            });
+        };
+
+        contentApi
+            .getCaseStudies({
+                locale: currentLocale,
+                slugs: caseStudySlugs
+            })
+            .then(
+                caseStudies => {
+                    servePage(caseStudies);
+                },
+                function() {
+                    servePage();
+                }
+            );
+    });
+}
+
+function init({ router, under10kConfig, over10kConfig }) {
+    init10k({
+        router: router,
+        routeConfig: under10kConfig,
+        caseStudySlugs: ['papyrus', 'ragroof-players', 'welsh-refugee-council']
+    });
+
+    init10k({
+        router: router,
+        routeConfig: over10kConfig,
+        caseStudySlugs: ['croxteth-gems', 'dads-in-mind', 'cruse-bereavement-care']
+    });
+}
+
+module.exports = {
+    init
+};

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -4,9 +4,11 @@ const express = require('express');
 
 const routerSetup = require('../setup');
 const routeCommon = require('../common');
+
 const landingPageRoute = require('./funding');
 const materialsRoute = require('./materials');
 const programmesRoute = require('./programmes');
+const tenKRoutes = require('./10k');
 
 const router = express.Router();
 
@@ -23,6 +25,15 @@ module.exports = (pages, sectionPath, sectionId) => {
     landingPageRoute.init({
         router: router,
         routeConfig: pages.root
+    });
+
+    /**
+     * 10k pages
+     */
+    tenKRoutes.init({
+        router: router,
+        under10kConfig: pages.under10k,
+        over10kConfig: pages.over10k
     });
 
     /**

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -124,16 +124,16 @@ sections.funding.addRoutes({
         lang: 'toplevel.funding',
         aliases: ['/home/funding']
     }),
-    under10k: staticRoute({
+    under10k: dynamicRoute({
         path: '/under10k',
-        template: 'pages/toplevel/under10k',
-        lang: 'toplevel.under10k',
+        template: 'pages/funding/under10k',
+        lang: 'funding.under10k',
         aliases: ['/funding/Awards-For-All', '/funding/awards-for-all', '/awardsforall', '/a4a', '/A4A']
     }),
-    over10k: staticRoute({
+    over10k: dynamicRoute({
         path: '/over10k',
-        template: 'pages/toplevel/over10k',
-        lang: 'toplevel.over10k'
+        template: 'pages/funding/over10k',
+        lang: 'funding.over10k'
     }),
     manageFunding: staticRoute({
         path: '/funding-guidance/managing-your-funding',

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -176,6 +176,8 @@ module.exports = {
     setApiUrl,
     getApiUrl,
     getCmsPath,
+    mergeWelshBy,
+    // API methods
     getPromotedNews,
     getFundingProgrammes,
     getFundingProgramme,

--- a/services/content-api.test.js
+++ b/services/content-api.test.js
@@ -35,6 +35,42 @@ describe('Content API', () => {
             .reply(200, JSON.stringify(fixtureListRoutes, null, 2));
     });
 
+    it('should merge welsh where available', () => {
+        const enResults = [
+            {
+                slug: 'one',
+                title: 'English'
+            },
+            {
+                slug: 'two',
+                title: 'English'
+            }
+        ];
+
+        const cyResults = [
+            {
+                slug: 'two',
+                title: 'Cymru'
+            }
+        ];
+
+        const cyExpected = [
+            {
+                slug: 'one',
+                title: 'English'
+            },
+            {
+                slug: 'two',
+                title: 'Cymru'
+            }
+        ];
+
+        const mergedEn = contentApi.mergeWelshBy('slug')('en', enResults, cyResults);
+        expect(mergedEn).to.deep.members(enResults);
+        const mergedCy = contentApi.mergeWelshBy('slug')('cy', enResults, cyResults);
+        expect(mergedCy).to.deep.have.members(cyExpected);
+    });
+
     it('should fetch promoted news', () => {
         return contentApi
             .getPromotedNews({

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -82,7 +82,7 @@
     </div>
 {% endmacro %}
 
-{% macro caseStudyCollection(caseStudies, customSectionTitle = false) %}
+{% macro caseStudyCollection(caseStudies, customSectionTitle = false, accent) %}
     {% if caseStudies.length > 0 %}
     <section id="case-studies" class="inner">
         <h2 class="t1">
@@ -104,7 +104,7 @@
                             trailTextMore = caseStudy.trailTextMore,
                             imageUrl = caseStudy.thumbnailUrl,
                             useRemoteImages = true,
-                            accent = pageAccent
+                            accent = accent
                         )
                     }}
                 </li>

--- a/views/pages/funding/over10k.njk
+++ b/views/pages/funding/over10k.njk
@@ -1,5 +1,5 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/caseStudies.njk" import caseStudyCard %}
+{% from "components/caseStudies.njk" import caseStudyCollection with context  %}
 
 {% extends "layouts/main.njk" %}
 
@@ -51,25 +51,14 @@
 
         </div>
 
-        <div class="inner">
-            <h3 class="t1">{{ copy.projectExamples }}</h3>
-            <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
-                {% for project in copy.projects %}
-                    <li class="grid__item">
-                        {{
-                            caseStudyCard(
-                                title = project.name,
-                                linkUrl = project.link,
-                                trailText = project.description,
-                                trailTextMore =  __('global.misc.readMore') + "…",
-                                imageUrl = project.image,
-                                accent = pageAccent
-                            )
-                        }}
-                    </li>
-                {% endfor %}
-            </ul>
+        {# Case Studies #}
+        {{ caseStudyCollection(
+            caseStudies = caseStudies,
+            customSectionTitle = copy.projectExamples,
+            accent = pageAccent
+        ) }}
 
+        <div class="inner">
             <div class="central-gap spaced">
                 <a href="{{ buildUrl('funding/search-past-grants') }}" class="btn btn--outline accent--turquoise btn--a btn--block btn--small">{{ copy.browseAll }}</a>
             </div>

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -75,7 +75,8 @@
         {# Case Studies #}
         {{ caseStudyCollection(
             caseStudies = entry.caseStudies,
-            customSectionTitle = __('global.misc.projectExamples')
+            customSectionTitle = __('global.misc.projectExamples'),
+            accent = pageAccent
         ) }}
     </main>
 {% endblock %}

--- a/views/pages/funding/under10k.njk
+++ b/views/pages/funding/under10k.njk
@@ -1,5 +1,5 @@
-{% from "components/caseStudies.njk" import caseStudyCard %}
 {% from "components/hero.njk" import hero %}
+{% from "components/caseStudies.njk" import caseStudyCollection with context  %}
 
 {% extends "layouts/main.njk" %}
 
@@ -19,7 +19,7 @@
         )
     }}
 
-    <article role="main" class="nudge-up">
+    <main class="nudge-up">
         <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
             <p>{{ copy.intro }}</p>
 
@@ -61,31 +61,17 @@
             <p>{{ copy.ukWideInfo | safe }}</p>
         </div>
 
-        <div class="inner">
-            <h3 class="t1">{{ copy.projectExamples }}</h3>
-            <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
-                {% for project in copy.projects %}
-                    <li class="grid__item">
-                        {{
-                            caseStudyCard(
-                                title = project.name,
-                                linkUrl = project.link,
-                                trailText = project.description,
-                                trailTextMore =  __('global.misc.readMore') + "…",
-                                imageUrl = project.image,
-                                accent = pageAccent
-                            )
-                        }}
-                    </li>
-                {% endfor %}
-            </ul>
+        {# Case Studies #}
+        {{ caseStudyCollection(
+            caseStudies = caseStudies,
+            customSectionTitle = copy.projectExamples,
+            accent = pageAccent
+        ) }}
 
+        <div class="inner">
             <div class="central-gap spaced">
                 <a href="{{ buildUrl('funding/search-past-grants') }}" class="btn btn--outline accent--{{ pageAccent }} btn--block btn--small">{{ copy.browseFundedProjects }}</a>
             </div>
         </div>
-
-    </article>
-
-
+    </main>
 {% endblock %}

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -62,7 +62,7 @@
         {% endif %}
 
         {# Case Studies #}
-        {{ caseStudyCollection(content.caseStudies) }}
+        {{ caseStudyCollection(content.caseStudies, accent = pageAccent) }}
 
         {% if content.outro %}
             <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">


### PR DESCRIPTION
This PR allows case studies to be fetched dynamically from the CMS. Using the 10k pages as the first use case.

- Adds `getCaseStudies` method, and cleans up language merging in `content-api`
- Moves 10k templates to funding section
- Updates 10k routes to by dynamic and fetch case studies from the CMS

<img width="1002" alt="screen shot 2018-03-09 at 12 28 39" src="https://user-images.githubusercontent.com/123386/37208678-2334f196-239a-11e8-9806-1139c1d74154.png">
