### PR TITLE
Reinstate static header

### DIFF
--- a/assets/sass/scaffolding/header.scss
+++ b/assets/sass/scaffolding/header.scss
@@ -113,16 +113,6 @@ $logoOffset: $navLinkPadding - 5px;
     }
 }
 
-html:not(.contrast--high) .global-header {
-    color: white;
-    position: absolute;
-    z-index: 1;
-
-    @media print {
-        position: static;
-    }
-}
-
 /* =========================================================================
    Global Navigation
    ========================================================================= */
@@ -201,7 +191,21 @@ html:not(.contrast--high) .global-header {
     }
 }
 
-html:not(.contrast--high) .global-nav {
+/* =========================================================================
+   Global Header / Navigation - Overlaid header
+   ========================================================================= */
+
+html:not(.contrast--high) body:not(.has-static-header) .global-header {
+    color: white;
+    position: absolute;
+    z-index: 1;
+
+    @media print {
+        position: static;
+    }
+}
+
+html:not(.contrast--high) body:not(.has-static-header) .global-nav {
     .global-nav__link a,
     .global-nav__lang a {
         @include on-interact {

--- a/views/pages/experimental/apply/form.njk
+++ b/views/pages/experimental/apply/form.njk
@@ -1,4 +1,6 @@
-{% extends "../../../layouts/main.njk" %}
+{% extends "layouts/main.njk" %}
+
+{% set bodyClass = 'has-static-header' %}
 
 {% macro errorList(errors, shouldBeLinked)  %}
     {% if errors | length > 0 %}

--- a/views/pages/experimental/apply/reaching-communities-startpage.njk
+++ b/views/pages/experimental/apply/reaching-communities-startpage.njk
@@ -1,6 +1,8 @@
 {% from "components/icons.njk" import iconArrowRight %}
 
-{% extends "../../../layouts/main.njk" %}
+{% extends "layouts/main.njk" %}
+
+{% set bodyClass = 'has-static-header' %}
 
 {% macro startButton(url, label = 'Start') %}
     <a class="btn btn--start" href="{{ url }}">

--- a/views/pages/experimental/apply/review.njk
+++ b/views/pages/experimental/apply/review.njk
@@ -1,4 +1,6 @@
-{% extends "../../../layouts/main.njk" %}
+{% extends "layouts/main.njk" %}
+
+{% set bodyClass = 'has-static-header' %}
 
 {% block content %}
     <div class="content-box inner inner--wide-only accent--pink a--border-top">

--- a/views/pages/experimental/apply/success.njk
+++ b/views/pages/experimental/apply/success.njk
@@ -1,5 +1,7 @@
 {% extends "layouts/main.njk" %}
 
+{% set bodyClass = 'has-static-header' %}
+
 {% block content %}
     <div class="content-box inner inner--wide-only accent--pink a--border-top">
         <div class="u-constrained-content s-prose spaced">


### PR DESCRIPTION
Even though all hero images have been updated to the new header, we still use a static header on one page:

<img width="1205" alt="screen shot 2018-03-12 at 10 03 34" src="https://user-images.githubusercontent.com/123386/37277819-c44717ae-25dd-11e8-8789-b67431143d0d.png">

<img width="1082" alt="screen shot 2018-03-12 at 10 10 52" src="https://user-images.githubusercontent.com/123386/37277818-c42e9f3a-25dd-11e8-9d36-197fd5345b96.png">