### PR TITLE
Fix Welsh links on legacy pages

### DIFF
--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -40,19 +40,14 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
             dom.window.document.title = '[PROXIED] ' + titleText;
         }
 
+        const regionNav = dom.window.document.getElementById('regionNav');
         const pageIsWelsh = isWelsh(req.path);
-        const hasWelshLink = dom.window.document.querySelectorAll('[hreflang="cy"]').length > 0;
-        const hasEnglishLink = dom.window.document.querySelectorAll('[hreflang="en"]').length > 0;
+        const hasWelshLink = regionNav.querySelectorAll('[hreflang="cy"]').length > 0;
+        const hasEnglishLink = regionNav.querySelectorAll('[hreflang="en"]').length > 0;
 
-        const appendLanguageLink = localeToAppend => {
-            let linkPath, linkText;
-            if (localeToAppend === 'cy') {
-                linkPath = makeWelsh(req.path);
-                linkText = 'Cymraeg';
-            } else {
-                linkPath = removeWelsh(req.path);
-                linkText = 'English';
-            }
+        const appendLanguageLink = (localeToAppend, nav) => {
+            const linkPath = localeToAppend === 'cy' ? makeWelsh(req.path) : removeWelsh(req.path);
+            const linkText = localeToAppend === 'cy' ? 'Cymraeg' : 'English';
             const listItem = dom.window.document.createElement('li');
             listItem.setAttribute('id', 'ctl12_langLi');
             listItem.setAttribute('class', 'last');
@@ -64,15 +59,15 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
                    data-blf-alpha="true">
                    ${linkText}
                </a>`;
-            dom.window.document.getElementById('regionNav').appendChild(listItem);
+            nav.appendChild(listItem);
         };
 
         // some pages aren't welsh but *do* have the link
         // other pages aren't welsh but don't (due to cookies etc)
         if (!pageIsWelsh && !hasWelshLink) {
-            appendLanguageLink('cy');
+            appendLanguageLink('cy', regionNav);
         } else if (pageIsWelsh && !hasEnglishLink) {
-            appendLanguageLink('en');
+            appendLanguageLink('en', regionNav);
         }
 
         // rewrite main ASP.net form to point to this page


### PR DESCRIPTION
Due to quirks of Sitecore, proxying and cookies, links on legacy pages between English/Welsh are sporadic in appearance. This code tweaks our proxying technique to append these links if found.

Some pages already have Welsh/English links and don't need them to be appended, eg:

- **Press release**: [English](https://www.biglotteryfund.org.uk/global-content/press-releases/wales/060318_wal_a4aw_release_march18) vs [Welsh](https://www.biglotteryfund.org.uk/welsh/global-content/press-releases/wales/060318_wal_a4aw_release_march18)
(eg. this content when proxied already has the links)

... but some content is available in Welsh but has no discernible link to switch language:

- **Research: Open Data**: [English](https://www.biglotteryfund.org.uk/research/open-data) vs [Welsh](https://www.biglotteryfund.org.uk/welsh/research/open-data)
(eg. this content when proxied does not have the links)

This PR checks to see whether the page is missing its opposite language link, and if so, adds it.