### PR TITLE
Inject hero images

### DIFF
--- a/controllers/common.js
+++ b/controllers/common.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const Raven = require('raven');
 const { forEach, isEmpty } = require('lodash');
-const { get, getOr } = require('lodash/fp');
+const { getOr } = require('lodash/fp');
 
 const { renderNotFoundWithError } = require('./http-errors');
 const { sMaxAge } = require('../middleware/cached');
+const injectHeroImage = require('../middleware/inject-hero');
 const { shouldServe } = require('../modules/pageLogic');
-const { defaultHeroImage, withFallbackImage } = require('../modules/images');
+const { withFallbackImage } = require('../modules/images');
 const { isWelsh, stripTrailingSlashes } = require('../modules/urls');
 const { serveRedirects } = require('../modules/redirects');
 const contentApi = require('../services/content-api');
@@ -26,30 +26,6 @@ function setupRedirects(sectionPath, page) {
         redirects: redirects,
         makeBilingual: true
     });
-}
-
-function injectHeroImage(page) {
-    const heroSlug = get('heroSlug')(page);
-    return function(req, res, next) {
-        if (heroSlug) {
-            contentApi
-                .getHeroImage({
-                    locale: req.i18n.getLocale(),
-                    slug: heroSlug
-                })
-                .then(heroImage => {
-                    res.locals.heroImage = heroImage;
-                    next();
-                })
-                .catch(err => {
-                    Raven.captureException(err);
-                    res.locals.heroImage = defaultHeroImage;
-                    next();
-                });
-        } else {
-            next();
-        }
-    };
 }
 
 function handleCmsPage(sectionId) {

--- a/controllers/funding/funding.js
+++ b/controllers/funding/funding.js
@@ -1,9 +1,10 @@
 const { find } = require('lodash');
 const { sMaxAge } = require('../../middleware/cached');
+const injectHeroImage = require('../../middleware/inject-hero');
 const contentApi = require('../../services/content-api');
 
 function init({ router, routeConfig }) {
-    router.get(routeConfig.path, sMaxAge(routeConfig.sMaxAge), (req, res) => {
+    router.get(routeConfig.path, sMaxAge(routeConfig.sMaxAge), injectHeroImage(routeConfig), (req, res) => {
         function renderLandingPage(programmes) {
             const lang = req.i18n.__(routeConfig.lang);
             res.render(routeConfig.template, {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -242,6 +242,7 @@ sections.about.addRoutes({
         sMaxAge: '30m',
         template: 'pages/toplevel/about',
         lang: 'about.landing',
+        heroSlug: 'mental-health-foundation',
         aliases: [
             '/about-big',
             '/england/about-big',

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -121,7 +121,8 @@ sections.funding.addRoutes({
         sMaxAge: '30m',
         template: 'pages/toplevel/funding',
         lang: 'toplevel.funding',
-        aliases: ['/home/funding']
+        aliases: ['/home/funding'],
+        heroSlug: 'active-plus-communities'
     }),
     under10k: dynamicRoute({
         path: '/under10k',
@@ -229,7 +230,8 @@ sections.research.addRoutes({
         path: '/',
         sMaxAge: '30m',
         template: 'pages/toplevel/research',
-        lang: 'toplevel.research'
+        lang: 'toplevel.research',
+        heroSlug: 'grassroots-project'
     })
 });
 

--- a/middleware/inject-hero.js
+++ b/middleware/inject-hero.js
@@ -1,0 +1,29 @@
+const Raven = require('raven');
+const { get } = require('lodash/fp');
+const contentApi = require('../services/content-api');
+const { defaultHeroImage } = require('../modules/images');
+
+module.exports = function injectHeroImage(page) {
+    const heroSlug = get('heroSlug')(page);
+    return function(req, res, next) {
+        if (heroSlug) {
+            contentApi
+                .getHeroImage({
+                    locale: req.i18n.getLocale(),
+                    slug: heroSlug
+                })
+                .then(heroImage => {
+                    res.locals.heroImage = heroImage;
+                    next();
+                })
+                .catch(err => {
+                    Raven.captureException(err);
+                    res.locals.heroImage = defaultHeroImage;
+                    next();
+                });
+        } else {
+            res.locals.heroImage = defaultHeroImage;
+            next();
+        }
+    };
+};

--- a/modules/images.js
+++ b/modules/images.js
@@ -155,14 +155,13 @@ const heroImages = {
     })
 };
 
-/**
- * Allow for pages without heroes
- * @TODO: Define better default hero image.
- */
-const withFallbackImage = heroImage => heroImage || heroImages.streetDreams;
+const defaultHeroImage = heroImages.streetDreams;
+
+const withFallbackImage = heroImage => heroImage || defaultHeroImage;
 
 module.exports = {
+    heroImages,
+    defaultHeroImage,
     createHeroImage,
-    heroImages: heroImages,
     withFallbackImage
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -19891,6 +19891,416 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sqlite3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
+      "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.9.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.5"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+          "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.6",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
     "sqlstring": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.0.tgz",

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -102,6 +102,10 @@ function filterBySlugs(list, slugs) {
  * API Methods
  ***********************************************/
 
+function getHeroImage({ locale, slug }) {
+    return fetch(`/v1/${locale}/hero-image/${slug}`).then(response => response.data.attributes);
+}
+
 function getHomepage({ locale }) {
     return fetch(`/v1/${locale}/homepage`).then(response => response.data.attributes);
 }
@@ -182,6 +186,7 @@ module.exports = {
     getCmsPath,
     mergeWelshBy,
     // API methods
+    getHeroImage,
     getHomepage,
     getPromotedNews,
     getFundingProgrammes,

--- a/views/pages/toplevel/about.njk
+++ b/views/pages/toplevel/about.njk
@@ -5,7 +5,6 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
-{% set heroImage = heroImages.mentalHealthFoundation %}
 {% set socialImage = heroImage %}
 
 {% block content %}

--- a/views/pages/toplevel/funding.njk
+++ b/views/pages/toplevel/funding.njk
@@ -6,7 +6,6 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
-{% set heroImage = heroImages.activePlus %}
 {% set socialImage = heroImage %}
 
 {% block content %}

--- a/views/pages/toplevel/research.njk
+++ b/views/pages/toplevel/research.njk
@@ -5,7 +5,6 @@
 
 {% block title %}{{ title }} | {% endblock %}
 
-{% set heroImage = heroImages.grassroots %}
 {% set socialImage = heroImage %}
 
 {% block content %}


### PR DESCRIPTION
Add api method and middleware to allow hero images to be injected from the CMS. Allows hero images to be stored in a single place in the CMS and means hero images are consistently optimised through Imgix. Updates `/funding`, `/research` and `/about` to use images from the CMS.