### PR TITLE
Update text/design for Reaching Communities emails

### DIFF
--- a/assets/sass/emails.scss
+++ b/assets/sass/emails.scss
@@ -53,3 +53,24 @@ blockquote {
         width: 150px;
     }
 }
+
+.data__step {
+    border-bottom: 1px solid palette('pink');
+    padding-bottom: 3px;
+    font-weight: bold;
+}
+
+.data__label {
+    font-weight: bold;
+}
+
+small {
+    display: block;
+    font-size: 11px;
+    color: #666666;
+    margin-bottom: 10px;
+}
+
+.space-above {
+    margin-top: 50px;
+}

--- a/models/index.js
+++ b/models/index.js
@@ -14,6 +14,12 @@ if (DB_HOST) {
         host: DB_HOST,
         logging: false,
         dialect: 'mysql',
+        define: {
+            charset: 'utf8mb4',
+            dialectOptions: {
+                collate: 'utf8mb4_general_ci'
+            }
+        },
         // http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-security
         operatorsAliases: false,
         pool: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,7 +586,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -4056,7 +4056,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -4253,7 +4253,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "diff-match-patch": {
@@ -4415,7 +4415,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -4567,7 +4567,7 @@
     "email-validator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
-      "integrity": "sha1-sH8757rB3AmbxD519q45n1UtWoA="
+      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -6992,7 +6992,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -7017,7 +7017,7 @@
     "graphlib": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -7034,7 +7034,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "gulp": {
@@ -11879,7 +11879,7 @@
     "nock": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha1-Fjla9MRbD9hNGkqWaBVOFvpmJNs=",
+      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -12737,7 +12737,7 @@
     "nyc": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha1-E/335+8i0CfGHRdHWPaXimj09eU=",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -17509,7 +17509,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
       }
@@ -17903,7 +17903,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -19489,7 +19489,7 @@
     "snyk-go-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz",
-      "integrity": "sha1-v0YmVsqt4GA5cLaOdW9LOJw66qo=",
+      "integrity": "sha512-uuPXt/NDROmG/pnQveOdur/ToG3h4W64F8r+3L7ZCMPikkRkieoCMGpfMYhEgG+oMlO1bzAsf+YGvMfY0o96Kg==",
       "requires": {
         "graphlib": "2.1.5",
         "toml": "2.3.3"
@@ -19498,7 +19498,7 @@
     "snyk-gradle-plugin": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
-      "integrity": "sha1-71rqXRMpBcvwMVxy2dlrJKpKdd0=",
+      "integrity": "sha512-FucMRR+Rc6LBaSIYxiBl+jvb7R00SgA0QfMT+RGxLIZlDk1lagvA/jIkv+mRadwHVSV/ShIFSZLmS7agfPclVg==",
       "requires": {
         "clone-deep": "0.3.0"
       }
@@ -19530,12 +19530,12 @@
     "snyk-mvn-plugin": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz",
-      "integrity": "sha1-FcExMaNo3eSHdj3pNVetX7lXL/4="
+      "integrity": "sha512-CkOAkOYVpEXm/c0peKNpEhbSIqb6SxNM28L5Rt5XZOkZ00Ud3uhz26+AicZVgvhe3in8A2CzOIAPyMUL2ueW4A=="
     },
     "snyk-nuget-plugin": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
-      "integrity": "sha1-vNxQPq/p8+60Akt1be1NDDsmXRI=",
+      "integrity": "sha512-F38Amr8AxbalFfUmjLM+57P2Gq2vUh9dWsP7oE2DPXO/f7tW00jwyWhJ5D39Zx+elBoXDxWYvAp14IJnxV18Ag==",
       "requires": {
         "debug": "3.1.0",
         "es6-promise": "4.2.4",
@@ -19546,7 +19546,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           },
@@ -19561,14 +19561,14 @@
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk="
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
         }
       }
     },
     "snyk-php-plugin": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
-      "integrity": "sha1-UcGRcd7gzTUVinqoNf4CqX3ISrg=",
+      "integrity": "sha512-EVN5ilP2PJ5EEBWUvSjzI1kHTRyJxqCQXm5Bb2Kkl4z1cNCFO9ScxjwUDO7cJmQCDQUhHGflDd611ToWmlEYnQ==",
       "requires": {
         "debug": "3.1.0"
       },
@@ -19576,7 +19576,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           },
@@ -19625,7 +19625,7 @@
     "snyk-python-plugin": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
-      "integrity": "sha1-zjHwtofyPRJ/evORgOopAbKJH+w="
+      "integrity": "sha512-YHDi+tEffbqOVp66sFxEYLSIcHcr/ORkxnqulyM7m1jOqzdgb8Rq/460DyGhm09wMEEdvvgt6v+Ld+QGM8GzYw=="
     },
     "snyk-resolve": {
       "version": "1.0.0",
@@ -19700,7 +19700,7 @@
     "snyk-sbt-plugin": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
-      "integrity": "sha1-VhV4bxmCXuZKy1CxoEGEO0qcTg8=",
+      "integrity": "sha512-R8L2+wzB7Zc8BZPmszAoQDjtl9tjLjE6Pf3Mu6tjv22+2rbyADlyfHg7FR+vmQXVFtOuJa43p1orXoaZGatE0g==",
       "requires": {
         "debug": "2.6.9"
       },
@@ -21267,7 +21267,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
     "toposort-class": {
       "version": "1.0.1",
@@ -21408,7 +21408,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {
@@ -23732,7 +23732,7 @@
     "yargs": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
+      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "requires": {
         "cliui": "4.0.0",
         "decamelize": "1.2.0",
@@ -23756,7 +23756,7 @@
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -23788,7 +23788,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -586,7 +586,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assign-symbols": {
@@ -4056,7 +4056,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -4253,7 +4253,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
     },
     "diff-match-patch": {
@@ -4415,7 +4415,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -4567,7 +4567,7 @@
     "email-validator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
-      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
+      "integrity": "sha1-sH8757rB3AmbxD519q45n1UtWoA="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -6992,7 +6992,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -7017,7 +7017,7 @@
     "graphlib": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -7034,7 +7034,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "gulp": {
@@ -11879,7 +11879,7 @@
     "nock": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
+      "integrity": "sha1-Fjla9MRbD9hNGkqWaBVOFvpmJNs=",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -12737,7 +12737,7 @@
     "nyc": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+      "integrity": "sha1-E/335+8i0CfGHRdHWPaXimj09eU=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -17509,7 +17509,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "2.0.6"
       }
@@ -17903,7 +17903,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -19489,7 +19489,7 @@
     "snyk-go-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz",
-      "integrity": "sha512-uuPXt/NDROmG/pnQveOdur/ToG3h4W64F8r+3L7ZCMPikkRkieoCMGpfMYhEgG+oMlO1bzAsf+YGvMfY0o96Kg==",
+      "integrity": "sha1-v0YmVsqt4GA5cLaOdW9LOJw66qo=",
       "requires": {
         "graphlib": "2.1.5",
         "toml": "2.3.3"
@@ -19498,7 +19498,7 @@
     "snyk-gradle-plugin": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
-      "integrity": "sha512-FucMRR+Rc6LBaSIYxiBl+jvb7R00SgA0QfMT+RGxLIZlDk1lagvA/jIkv+mRadwHVSV/ShIFSZLmS7agfPclVg==",
+      "integrity": "sha1-71rqXRMpBcvwMVxy2dlrJKpKdd0=",
       "requires": {
         "clone-deep": "0.3.0"
       }
@@ -19530,12 +19530,12 @@
     "snyk-mvn-plugin": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz",
-      "integrity": "sha512-CkOAkOYVpEXm/c0peKNpEhbSIqb6SxNM28L5Rt5XZOkZ00Ud3uhz26+AicZVgvhe3in8A2CzOIAPyMUL2ueW4A=="
+      "integrity": "sha1-FcExMaNo3eSHdj3pNVetX7lXL/4="
     },
     "snyk-nuget-plugin": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
-      "integrity": "sha512-F38Amr8AxbalFfUmjLM+57P2Gq2vUh9dWsP7oE2DPXO/f7tW00jwyWhJ5D39Zx+elBoXDxWYvAp14IJnxV18Ag==",
+      "integrity": "sha1-vNxQPq/p8+60Akt1be1NDDsmXRI=",
       "requires": {
         "debug": "3.1.0",
         "es6-promise": "4.2.4",
@@ -19546,7 +19546,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           },
@@ -19561,14 +19561,14 @@
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk="
         }
       }
     },
     "snyk-php-plugin": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
-      "integrity": "sha512-EVN5ilP2PJ5EEBWUvSjzI1kHTRyJxqCQXm5Bb2Kkl4z1cNCFO9ScxjwUDO7cJmQCDQUhHGflDd611ToWmlEYnQ==",
+      "integrity": "sha1-UcGRcd7gzTUVinqoNf4CqX3ISrg=",
       "requires": {
         "debug": "3.1.0"
       },
@@ -19576,7 +19576,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           },
@@ -19625,7 +19625,7 @@
     "snyk-python-plugin": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
-      "integrity": "sha512-YHDi+tEffbqOVp66sFxEYLSIcHcr/ORkxnqulyM7m1jOqzdgb8Rq/460DyGhm09wMEEdvvgt6v+Ld+QGM8GzYw=="
+      "integrity": "sha1-zjHwtofyPRJ/evORgOopAbKJH+w="
     },
     "snyk-resolve": {
       "version": "1.0.0",
@@ -19700,7 +19700,7 @@
     "snyk-sbt-plugin": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
-      "integrity": "sha512-R8L2+wzB7Zc8BZPmszAoQDjtl9tjLjE6Pf3Mu6tjv22+2rbyADlyfHg7FR+vmQXVFtOuJa43p1orXoaZGatE0g==",
+      "integrity": "sha1-VhV4bxmCXuZKy1CxoEGEO0qcTg8=",
       "requires": {
         "debug": "2.6.9"
       },
@@ -19890,6 +19890,416 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sqlite3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-4.0.0.tgz",
+      "integrity": "sha512-6OlcAQNGaRSBLK1CuaRbKwlMFBb9DEhzmZyQP+fltNRF6XcIMpVIfXCBEcXPe1d4v9LnhkQUYkknDbA5JReqJg==",
+      "requires": {
+        "nan": "2.9.2",
+        "node-pre-gyp": "0.9.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.5"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "bundled": true
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+          "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.19",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.9.0",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "rc": {
+          "version": "1.2.6",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.5",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "tar": {
+          "version": "4.4.0",
+          "bundled": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.1",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
     },
     "sqlstring": {
       "version": "2.3.0",
@@ -20857,7 +21267,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
     },
     "toposort-class": {
       "version": "1.0.1",
@@ -20998,7 +21408,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-is": {
@@ -23322,7 +23732,7 @@
     "yargs": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
       "requires": {
         "cliui": "4.0.0",
         "decamelize": "1.2.0",
@@ -23346,7 +23756,7 @@
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -23378,7 +23788,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",

--- a/views/emails/applicationSummary.njk
+++ b/views/emails/applicationSummary.njk
@@ -1,28 +1,45 @@
-<p>Dear {{ data['first-name'] }},</p>
-<p>Thank you for submitting your idea. A local funding officer will contact you within 28 days.</p>
-<p>Here's the data you submitted to us:</p>
+<!doctype html>
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="{{ 'stylesheets/emails.css' | getCachebustedPath(true) }}">
+        <link href="//fonts.googleapis.com/css?family=Poppins:300,500" rel="stylesheet">
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <div class="logo">
+            <img src="https://{{ appData.config.get('siteDomain') }}{{ 'logos/logo.png' | getImagePath }}" alt="Big Lottery Fund logo" />
+        </div>
 
-<pre>======</pre>
+        <p>Dear {{ data['first-name'] }},</p>
+        <p>Thank you for getting in touch with us.</p>
+        <p>You will see a copy of the information you submitted below. This will be forwarded to one of our funding officers who will get in touch within 7 days to let you know if we can help.</p>
+        <p>In the meantime, you can find out more about our funding and how we can support your community on our website: <a href="https://www.biglotteryfund.org.uk/england">www.biglotteryfund.org.uk/england</a></p>
+        <p>Thanks,</p>
+        <p><strong>The Big Lottery Fund</strong></p>
 
-{% for step in summary %}
-    <h2>{{ step.name }}</h2>
-    {% for fieldset in step.fieldsets %}
-        {% for field in fieldset.fields %}
-            {% if field.value %}
-                <h3>{{ field.label }}</h3>
-                {% if field.type === 'textarea' %}
-                    <p>{{ field.value | striptags(true) | escape | nl2br }}</p>
-                {% elseif field.type === 'checkbox' %}
-                    <p>{{ field.value | joinIfArray(', ') }}</p>
-                {% else %}
-                    <p>{{ field.value }}</p>
-                {% endif %}
-            {% endif %}
+        <h2 class="space-above">Your information</h2>
+        {% for step in summary %}
+            <h4 class="data__step">{{ step.name }}</h4>
+            {% for fieldset in step.fieldsets %}
+                {% for field in fieldset.fields %}
+                    {% if field.value %}
+                        <h5 class="data__label">{{ field.label }}</h5>
+                        {% if field.type === 'textarea' %}
+                            <p>{{ field.value | striptags(true) | escape | nl2br }}</p>
+                        {% elseif field.type === 'checkbox' %}
+                            <p>{{ field.value | joinIfArray(', ') }}</p>
+                        {% else %}
+                            <p>{{ field.value }}</p>
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
         {% endfor %}
-    {% endfor %}
-{% endfor %}
 
-<pre>======</pre>
+        <h5 class="space-above">Data protection</h5>
+        <small>The Big Lottery Fund is a public body with a duty to distribute National Lottery and other money in grants for good causes. We use the personal data you provide, such as contact details for individuals at your organisation, to help you apply for a grant and to assess your application.</small>
+        <small>We may share your personal data with organisations which help us with our grant making activities or others which have a legitimate interest in our work or have funded your grant. We will only share personal data which they need to carry out their work and subject to appropriate safety measures.</small>
+        <small>Our Data Protection and Privacy Notice gives more information about how we store and use personal data and the lawful basis for this. Please read the full Notice which is published on our website at www.biglotteryfund.org.uk/data-protection or contact us to request a hard copy. The Notice may be updated from time to time.</small>
 
-<p>Thanks,</p>
-<p><strong>The Big Lottery Fund</strong></p>
+    </body>
+</html>

--- a/views/emails/newMaterialOrder.njk
+++ b/views/emails/newMaterialOrder.njk
@@ -7,6 +7,7 @@
     <head>
         <link rel="stylesheet" type="text/css" href="{{ 'stylesheets/emails.css' | getCachebustedPath(true) }}">
         <link href="//fonts.googleapis.com/css?family=Poppins:300,500" rel="stylesheet">
+        <meta charset="UTF-8">
     </head>
     <body>
         <div class="logo">


### PR DESCRIPTION
This adds some formatting to the HTML emails and uses newly-supplied text.

One thing to note – I tested this with various encoding challenges (eg. words like `Dharmaśāstra`) and was seeing encoding errors when retrieving them from the session. I traced this to the database encoding itself and subsequently discovered that  `utf8mb4` [seems to be the correct MySQL encoding](https://mathiasbynens.be/notes/mysql-utf8mb4) to preserve these characters when storing. I've changed the `data` rows on the `sessions` table in each database environment to use this encoding, but it's worth remembering for any future data storage fields where we might be needing characters with accents etc. 