### PR TITLE
Tighten up spacing in lists in prose copy

### DIFF
--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -112,9 +112,20 @@
         font-weight: 600;
     }
 
-    ol li,
-    ul li {
-        margin-left: $spacingUnit * 3;
+    ol, ul {
+        margin-bottom: 1em;
+
+        li {
+            margin-left: 1.5em;
+
+            @include mq('medium') {
+                margin-left: 2.5em;
+            }
+
+            > p {
+                margin-bottom: 0;
+            }
+        }
     }
 
     table {


### PR DESCRIPTION
Craft/Redactor seems to add `<p>`s into list items, pending seeing if we can remove these at the source I've tightened up the spacing on list items with paragraphs in them.

**Before**

<img width="929" alt="screen shot 2018-03-22 at 10 30 25" src="https://user-images.githubusercontent.com/123386/37765456-0dabdd36-2dbc-11e8-8e3d-8a5ba9e895c6.png">

**After**

![image](https://user-images.githubusercontent.com/123386/37765481-20d3e4ee-2dbc-11e8-8793-f2de10c788d7.png)
