### PR TITLE
Remove precise-commits

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+public/
+views/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4256,12 +4256,6 @@
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
-    "diff-match-patch": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
-      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg=",
-      "dev": true
-    },
     "diffie-hellman": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
@@ -11544,12 +11538,6 @@
         "run-queue": "1.0.3"
       }
     },
-    "mri": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.0.tgz",
-      "integrity": "sha1-XAo/KcjM/7ux7JQdzsCdcfoy82o=",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -17364,50 +17352,6 @@
           "dev": true,
           "requires": {
             "has-flag": "1.0.0"
-          }
-        }
-      }
-    },
-    "precise-commits": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/precise-commits/-/precise-commits-1.0.2.tgz",
-      "integrity": "sha512-PYkoNTFXVvZRzJTDxdgzmPanhSNGj5Wtj2NgSo7IhwNXGcKktX+L4DJhyIrhFSLsWWAvd+cYyyU2eXlaX5QxzA==",
-      "dev": true,
-      "requires": {
-        "diff-match-patch": "1.0.0",
-        "execa": "0.9.0",
-        "find-up": "2.1.0",
-        "glob": "7.1.2",
-        "ignore": "3.3.7",
-        "mri": "1.1.0",
-        "ora": "1.4.0"
-      },
-      "dependencies": {
-        "cli-spinners": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
-          "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "ora": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
-          "integrity": "sha512-iMK1DOQxzzh2MBlVsU42G80mnrvUhqsMh74phHtDlrcTZPK0pH6o7l7DRshK+0YsxDyEuaOkziVdvM3T0QTzpw==",
-          "dev": true,
-          "requires": {
-            "chalk": "2.3.0",
-            "cli-cursor": "2.1.0",
-            "cli-spinners": "1.1.0",
-            "log-symbols": "2.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "startDev": "export DEBUG=blf-alpha:*; nodemon ./bin/www",
-    "lint": "eslint . bin/* --ignore-pattern public/ --ignore-pattern views/",
+    "lint": "eslint . bin/*",
     "test-deps": "snyk test",
     "test-client": "mocha assets/**/*.test.js --bail --exit",
     "test-server": "nyc --include={middleware,modules,services}/**/*.js --all mocha {controllers,middleware,modules,services}/{**/*,*}.test.js --bail --exit",
@@ -20,10 +20,14 @@
     "watch": "concurrently --kill-others 'webpack --mode=development --watch' 'gulp watch'",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",
-    "precommit": "precise-commits && lint-staged && npm run lint",
+    "precommit": "lint-staged",
     "prepush": "npm test"
   },
   "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "eslint"
+    ],
     "{controllers/routes.js,controllers/aliases.js,config/default.json}": [
       "./bin/generate-cloudfront-config"
     ]
@@ -152,7 +156,6 @@
     "nyc": "^11.4.1",
     "p-settle": "^2.0.0",
     "postcss-fout-with-a-class": "^1.1.0",
-    "precise-commits": "^1.0.2",
     "prettier": "^1.8.2",
     "pretty": "^2.0.0",
     "prompt": "^1.0.0",


### PR DESCRIPTION
Remove `precise-commits` because it's…too precise and does some exciting things. Reverting back to the previous `lint-staged` method.