### PR TITLE
Information page updates

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -151,9 +151,10 @@
 }
 
 @mixin downloadIcon() {
-    padding-left: 24px;
     background-repeat: no-repeat;
     background-position: left 6px;
+    padding-left: 20px;
+    margin-left: 2px;
     background-size: 14px;
     background-image: svg-url(
         '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><path d="M27.414 19.414l-10 10a2 2 0 0 1-2.828 0l-10-10a2 2 0 1 1 2.828-2.828L14 23.172V4a2 2 0 1 1 4 0v19.172l6.586-6.586c.39-.39.902-.586 1.414-.586s1.024.195 1.414.586a2 2 0 0 1 0 2.828z" fill="#1a44a1"/></svg>'
@@ -161,9 +162,10 @@
 }
 
 @mixin linkIcon() {
-    padding-right: 24px;
     background-repeat: no-repeat;
-    background-position: center right;
+    background-position: right 6px;
+    padding-right: 20px;
+    margin-right: 2px;
     background-size: 12px;
     background-image: svg-url(
         '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="32"><path d="M20 24H4V8.06L8 8V4H0v24h24V18h-4v6zM12 4l4 4-6 6 4 4 6-6 4 4V4H12z" fill="#1a44a1"/></svg>'

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -98,11 +98,8 @@
 
 /**
  * Common styles for longer blocks of text
- * `long` is used for new content, e.g., programme pages
- * `legacy` is use for legacy migrated content pages
  */
-.s-prose--long,
-.s-prose--legacy {
+.s-prose--long {
     h1,
     h2,
     h3,
@@ -110,6 +107,31 @@
     h5,
     h6 {
         font-weight: 600;
+        line-height: 1.2;
+    }
+
+    h2 {
+        font-size: 21px;
+
+        &::after {
+            @include underlined();
+        }
+    }
+
+    p + h2,
+    ol + h2,
+    ul + h2 {
+        margin-top: 1.5em;
+    }
+
+    h3 {
+        margin: 1em 0 0.4em;
+        font-size: 21px;
+    }
+
+    h4 {
+        margin: 1em 0 0.4em;
+        font-size: 20px;
     }
 
     ol, ul {
@@ -129,55 +151,75 @@
     }
 
     table {
+        $table-spacing: 4px;
+
         font-size: 90%;
         box-sizing: border-box;
         width: 100%;
-        padding: 0;
-        border-collapse: collapse;
+        max-width: 40em;
+        border-collapse: separate;
+        border-spacing: 0;
         table-layout: fixed;
         margin: 0 0 1em;
+        padding: 0;
+
+
+        tr {
+            background-color: palette('pale-grey');
+
+            &:nth-child(even) {
+                background-color: darken(palette('pale-grey'), 3%);
+            }
+
+            td {
+                border: solid white;
+                border-width: $table-spacing 0 0 $table-spacing;
+
+                &:first-of-type {
+                    border-left: 0;
+                }
+            }
+        }
 
         thead,
         th {
-            font-weight: bold;
+            font-weight: normal;
             vertical-align: middle;
+            font-family: font-stack('display');
         }
+
         thead {
-            border-bottom: 3px solid palette('off-white');
-        }
-        tr {
-            border-bottom: 1px solid palette('off-white');
-        }
-        tr:last-of-type {
-            border-bottom: none;
+            color: white;
+            background-color: palette('pink');
+
+            tr {
+                background-color: transparent;
+            }
+
+            tr th {
+                border-left: $table-spacing solid lighten(palette('pink'), 5%);
+
+                &:first-of-type {
+                    border-left: 0;
+                }
+            }
         }
 
         th,
         td {
-            padding: 10px 8px;
+            padding: 1em;
             text-align: left;
+
+            > p {
+                margin: 0;
+            }
         }
+
         td {
             vertical-align: top;
         }
     }
 
-    code,
-    pre {
-        overflow-x: auto;
-        white-space: pre-wrap;
-        font-family: Hack, Consolas, monospace;
-        font-size: 14px;
-        padding: 10px;
-        border-radius: 2px;
-        color: palette('pale');
-        background-color: palette('charcoal');
-    }
-
-    pre {
-        padding: 10px;
-        border-radius: 2px;
-    }
 
     .video-container {
         margin: 0 -10px 1em;
@@ -185,15 +227,6 @@
         @include mq('medium') {
             margin: 0 1.5em 1.5em;
         }
-    }
-}
-
-/**
- * Expanded prose styles for long blocks of text
- */
-.s-prose--long {
-    h2::after {
-        @include underlined();
     }
 
     figure,
@@ -218,44 +251,22 @@
             margin-right: $spacingUnit * 3;
         }
     }
-}
 
-/**
- * Expanded prose styles for legacy pages
- */
-.s-prose--legacy {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        font-weight: 600;
-        line-height: 1.2;
+    code,
+    pre {
+        overflow-x: auto;
+        white-space: pre-wrap;
+        font-family: Hack, Consolas, monospace;
+        font-size: 14px;
+        padding: 10px;
+        border-radius: 2px;
+        color: palette('pale');
+        background-color: palette('charcoal');
     }
 
-    h2 {
-        color: palette('pink');
-        margin: 1.5em 0 0.5em;
-        font-size: 24px;
-
-        @include mq('medium') {
-            font-size: 30px;
-            max-width: 22em;
-        }
-
-        &:first-of-type {
-            margin-top: 0;
-        }
+    pre {
+        padding: 10px;
+        border-radius: 2px;
     }
 
-    h3 {
-        margin: 1em 0 0.4em;
-        font-size: 22px;
-    }
-
-    h4 {
-        margin: 1em 0 0.4em;
-        font-size: 20px;
-    }
 }

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -16,7 +16,6 @@
 // Global, element-level styles
 
 @import 'globals/base';
-@import 'globals/accents';
 @import 'globals/layout';
 @import 'globals/typography';
 @import 'globals/forms';
@@ -69,6 +68,7 @@
 // ========================================================================= //
 // Single use clases, prefixed with u-
 
+@import 'utilities/utilities-accents';
 @import 'utilities/utilities-theme';
 @import 'utilities/utilities-display';
 @import 'utilities/utilities-text';

--- a/assets/sass/utilities/utilities-accents.scss
+++ b/assets/sass/utilities/utilities-accents.scss
@@ -145,8 +145,10 @@
     }
 
     .accent-content--#{$name} {
-        h2 {
-            color: $colour;
+        h1, h2, h3, h4, h5, h6 {
+            &::after {
+                border-color: $colour;
+            }
         }
     }
 }

--- a/controllers/common.js
+++ b/controllers/common.js
@@ -38,7 +38,7 @@ function handleCmsPage(sectionId) {
             })
             .then(content => {
                 const title = content.title;
-                const heroImage = withFallbackImage(content.hero);
+                const heroImage = content.hero;
 
                 if (content.children) {
                     res.render('pages/listings/listingPage', {

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -45,7 +45,7 @@
         {% if content.relatedContent %}
             <section class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class="page-section__content accent--{{ pageAccent }} a--border-top">
-                    <article class="content-box s-prose s-prose--legacy u-constrained-content-wide js-annotate-links">
+                    <article class="content-box s-prose s-prose--long accent-content--{{ pageAccent }} u-constrained-content-wide js-annotate-links">
                         {{ primaryContent() }}
                     </article>
                 </div>

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -3,7 +3,11 @@
 
 {% extends "layouts/main.njk" %}
 
-{% set socialImage = heroImage %}
+{% if heroImage %}
+    {% set socialImage = heroImage %}
+{% else %}
+    {% set bodyClass = 'has-static-header' %}
+{% endif %}
 
 {% block title %}{{ title }} | {% endblock %}
 
@@ -19,20 +23,30 @@
 
 {% block content %}
     {% set pageAccent = content.themeColour | default('pink') %}
-    {{ hero(
-        titleText = title,
-        image = heroImage,
-        accent = pageAccent
-    ) }}
 
-    <main role="main" class="nudge-up">
+    {% if heroImage %}
+        {{ hero(
+            titleText = title,
+            image = heroImage,
+            accent = pageAccent
+        ) }}
+    {% endif %}
+
+    {% macro primaryContent() %}
+        {% if not heroImage %}
+           <h1>{{ content.title }}</h1>
+        {% endif %}
+        {{ content.introduction | safe }}
+        {{ segmentLinks(content.segments) }}
+    {% endmacro %}
+
+    <main{% if heroImage %} class="nudge-up"{% endif %}>
 
         {% if content.relatedContent %}
             <section class="page-section inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class="page-section__content accent--{{ pageAccent }} a--border-top">
                     <article class="content-box s-prose s-prose--legacy u-constrained-content-wide js-annotate-links">
-                        {{ content.introduction | safe }}
-                        {{ segmentLinks(content.segments) }}
+                        {{ primaryContent() }}
                     </article>
                 </div>
                 <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
@@ -43,9 +57,8 @@
             </section>
         {% else %}
             <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">
-                <div class="s-prose s-prose--legacy u-constrained-content-wide js-annotate-links">
-                    {{ content.introduction | safe }}
-                    {{ segmentLinks(content.segments) }}
+                <div class="s-prose s-prose--long accent-content--{{ pageAccent }} u-constrained-content-wide js-annotate-links">
+                    {{ primaryContent() }}
                 </div>
             </section>
         {% endif %}
@@ -53,7 +66,7 @@
         {% if content.segments.length > 0 %}
             {% for segment in content.segments %}
                 <section id="segment-{{ loop.index }}" class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">
-                    <div class="s-prose s-prose--legacy u-constrained-content-wide">
+                    <div class="s-prose s-prose--long accent-content--{{ pageAccent }} u-constrained-content-wide">
                         <h2 class="t1">{{ segment.title }}</h2>
                         {{ segment.content | safe }}
                     </div>
@@ -66,7 +79,7 @@
 
         {% if content.outro %}
             <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">
-                <div class="s-prose s-prose--legacy">
+                <div class="s-prose s-prose--long accent-content--{{ pageAccent }}">
                     {{ content.outro | safe }}
                 </div>
             </section>


### PR DESCRIPTION
Updates to information pages:

- Support information pages without hero images
- Add new table styles
- Remove the concept of "legacy" prose styles and standardise on one style for long running blocks of text.
- Load accents styles to utilities and load later to make sure they take precedence over other styles
