### PR TITLE
Use rich-text version of description

### DIFF
--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -52,7 +52,7 @@
         <div class="programme-card__body">
             {% if programme.description %}
                 <div class="programme-card__description">
-                    <p>{{ programme.description }}</p>
+                    {{ programme.description | safe }}
                 </div>
             {% endif %}
             <div class="programme-card__details">


### PR DESCRIPTION
We currently have two "intro/description" fields for programme pages. This PR updates the templates to allow us to use the rich text version of the field.