### PR TITLE
Add the "AWSELB" cookie

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -49,9 +49,10 @@
             "contrastMode",
             "blf-alpha-session",
             "_csrf",
-            "blf-ab-afa-v2"
+            "blf-ab-afa-v2",
+            "AWSELB"
           ],
-          "Quantity": 4
+          "Quantity": 5
         }
       }
     },
@@ -114,9 +115,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -285,9 +287,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -457,9 +460,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -523,9 +527,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -852,9 +857,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -915,9 +921,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -983,9 +990,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1047,9 +1055,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1113,9 +1122,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1172,9 +1182,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -49,9 +49,10 @@
             "contrastMode",
             "blf-alpha-session",
             "_csrf",
-            "blf-ab-afa-v2"
+            "blf-ab-afa-v2",
+            "AWSELB"
           ],
-          "Quantity": 4
+          "Quantity": 5
         }
       }
     },
@@ -114,9 +115,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -285,9 +287,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -457,9 +460,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -523,9 +527,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -852,9 +857,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -915,9 +921,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -983,9 +990,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1047,9 +1055,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1113,9 +1122,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },
@@ -1172,9 +1182,10 @@
                 "contrastMode",
                 "blf-alpha-session",
                 "_csrf",
-                "blf-ab-afa-v2"
+                "blf-ab-afa-v2",
+                "AWSELB"
               ],
-              "Quantity": 4
+              "Quantity": 5
             }
           }
         },

--- a/config/default.json
+++ b/config/default.json
@@ -20,7 +20,8 @@
         "contrast": "contrastMode",
         "session": "blf-alpha-session",
         "csrf": "_csrf",
-        "abTestAwardsForAll": "blf-ab-afa-v2"
+        "abTestAwardsForAll": "blf-ab-afa-v2",
+        "elasticLoadBalancer": "AWSELB"
     },
     "anchors": {
         "contactPress": "press",


### PR DESCRIPTION
We set session stickiness for the load balancer so a repeat visitor gets the same instance (for 5 minutes), but there were two issues:

1. We only set this for the HTTP listener (now rectified so the HTTPS one gets it too)
2. We drop the cookie at Cloudfront so nobody ever got this set

This PR adds back that cookie which might help the (admittedly rare) edge case where someone visits the site during a deploy and gets broken CSS/JS (eg. because the load balancer routes their assets request to the new instance with different hashes).