### PR TITLE
Remove sentry logging of search queries

### DIFF
--- a/controllers/toplevel/search.js
+++ b/controllers/toplevel/search.js
@@ -1,30 +1,25 @@
 const querystring = require('querystring');
-const Raven = require('raven');
 const { noCache } = require('../../middleware/cached');
 const { customEvent } = require('../../modules/analytics');
 const { normaliseQuery } = require('../../modules/urls');
-const { SENTRY_DSN } = require('../../modules/secrets');
 
 function init({ router, routeConfig }) {
     const queryBase = 'https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk';
     router.get(routeConfig.path, noCache, (req, res) => {
         req.query = normaliseQuery(req.query);
 
-        if (req.query.q) {
-            customEvent('Search', 'Term', req.query.q);
-            // debug: send search logs to Sentry to work out where extra searches come from
-            if (SENTRY_DSN) {
-                Raven.captureMessage('Search term', {
-                    level: 'info',
-                    extra: {
-                        query: req.query.q
-                    },
-                    tags: {
-                        feature: 'search'
-                    }
-                });
-            }
+        const redirectToSiteSearch = () => {
             res.redirect(`${queryBase}+${querystring.escape(req.query.q)}`);
+        };
+
+        if (req.query.q) {
+            customEvent('Search', 'Term', req.query.q)
+                .then(() => {
+                    redirectToSiteSearch();
+                })
+                .catch(() => {
+                    redirectToSiteSearch();
+                });
         } else {
             res.redirect('/');
         }

--- a/modules/analytics.js
+++ b/modules/analytics.js
@@ -28,23 +28,21 @@ function sendPayload(data) {
 }
 
 function customEvent(category, action, label) {
-    if (category && action) {
-        const payload = {
-            t: 'event',
-            ec: category,
-            ea: action
-        };
+    const payload = {
+        t: 'event',
+        ec: category,
+        ea: action
+    };
 
-        if (label) {
-            payload.el = label;
-        }
-
-        sendPayload(payload);
+    if (label) {
+        payload.el = label;
     }
+
+    return sendPayload(payload);
 }
 
 function trackPageview(req) {
-    sendPayload({
+    return sendPayload({
         t: 'pageview',
         dl: getFullUrl(req)
     });


### PR DESCRIPTION
This PR does two things:

1. Removes Sentry logging from search queries as it was chewing up our quota
2. Wait for the call to analytics to resolve before redirecting (redirecting anyway if the promise fails)

Will be interesting if this second point changes the tracking results. Wondering if the fact that the request to analytics was left unresolved could've been causing some of the multiplying of results.