### PR TITLE
Streamline cookie whitelist

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -46,12 +46,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "contrastMode",
-            "blf-alpha-session",
-            "_csrf",
-            "blf-ab-afa-v2"
+            "contrastMode"
           ],
-          "Quantity": 4
+          "Quantity": 1
         }
       }
     },
@@ -111,12 +108,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -282,12 +276,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -454,12 +445,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -520,12 +508,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -539,6 +524,67 @@
           "Quantity": 0
         },
         "PathPattern": "/funding/programmes"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              false
+            ],
+            "Quantity": 3
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/national-lottery-awards-for-all-scotland"
       },
       {
         "TargetOriginId": "LEGACY",
@@ -849,12 +895,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -912,12 +955,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -980,12 +1020,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1044,12 +1081,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1110,12 +1144,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1161,6 +1192,67 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              false
+            ],
+            "Quantity": 3
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [],
             "Quantity": 0
           },
@@ -1169,12 +1261,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1190,6 +1279,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 19
+    "Quantity": 21
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -46,12 +46,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "contrastMode",
-            "blf-alpha-session",
-            "_csrf",
-            "blf-ab-afa-v2"
+            "contrastMode"
           ],
-          "Quantity": 4
+          "Quantity": 1
         }
       }
     },
@@ -111,12 +108,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -282,12 +276,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -454,12 +445,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -520,12 +508,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -539,6 +524,67 @@
           "Quantity": 0
         },
         "PathPattern": "/funding/programmes"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              false
+            ],
+            "Quantity": 3
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/national-lottery-awards-for-all-scotland"
       },
       {
         "TargetOriginId": "LEGACY",
@@ -849,12 +895,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -912,12 +955,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -980,12 +1020,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1044,12 +1081,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1110,12 +1144,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1161,6 +1192,67 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              false
+            ],
+            "Quantity": 3
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [],
             "Quantity": 0
           },
@@ -1169,12 +1261,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session",
-                "_csrf",
-                "blf-ab-afa-v2"
+                "contrastMode"
               ],
-              "Quantity": 4
+              "Quantity": 1
             }
           }
         },
@@ -1190,6 +1279,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 19
+    "Quantity": 21
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -19,7 +19,6 @@
     "cookies": {
         "contrast": "contrastMode",
         "session": "blf-alpha-session",
-        "csrf": "_csrf",
         "abTestAwardsForAll": "blf-ab-afa-v2"
     },
     "anchors": {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const config = require('config');
 const { archivedRoutes, legacyRedirects, vanityRedirects } = require('./aliases');
 const {
     createSection,
@@ -187,7 +188,8 @@ sections.funding.addRoutes({
     programmeDetailAfaScotland: dynamicRoute({
         path: '/programmes/national-lottery-awards-for-all-scotland',
         applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=sc',
-        experimentId: 'EcAwbF34R5mbCaWW-y_rFQ'
+        experimentId: 'EcAwbF34R5mbCaWW-y_rFQ',
+        cookies: [config.get('cookies.abTestAwardsForAll')]
     }),
     buildingBetterOpportunities: cmsRoute({
         path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,17 +1,6 @@
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
 // https://on.cypress.io/plugins-guide
-// ***********************************************************
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-module.exports = (on, config) => {
+module.exports = () => {
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
 };


### PR DESCRIPTION
This PR separate cookie config from the global whitelist. Allowing only cookies to be whitelisted in different contexts.

- Sets global whitelist to only contrast cookie
- Whitelist AFA A/B cookie only on AFA pages

This PR removes CSRF and session cookies from the whitelist, under the guise that any page that requires these two will be uncached requests so not subject to the cache whitelist. The main benefit is that we can avoid session cookies from sharding the cache, hopefully brining the cache hit ratio up.

Thoughts very welcome.