### PR TITLE
Remove a/b test for AFA England and Wales

### DIFF
--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -254,12 +254,7 @@ function initProgrammeDetailAwardsForAll(router, options) {
 function init({ router, routeConfig }) {
     initProgrammesList(router, routeConfig.programmes);
     if (config.get('abTests.enabled')) {
-        let routesToTest = [
-            routeConfig.programmeDetailAfaEngland,
-            routeConfig.programmeDetailAfaScotland,
-            routeConfig.programmeDetailAfaWales
-        ];
-        routesToTest.forEach(route => {
+        [routeConfig.programmeDetailAfaScotland].forEach(route => {
             initProgrammeDetailAwardsForAll(router, route);
         });
     }

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -184,20 +184,10 @@ sections.funding.addRoutes({
     programmeDetail: dynamicRoute({
         path: '/programmes/*'
     }),
-    programmeDetailAfaEngland: dynamicRoute({
-        path: '/programmes/national-lottery-awards-for-all-england',
-        applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=en',
-        experimentId: 'O9FsbkKfSeOammAP0JrEyA'
-    }),
     programmeDetailAfaScotland: dynamicRoute({
         path: '/programmes/national-lottery-awards-for-all-scotland',
         applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=sc',
         experimentId: 'EcAwbF34R5mbCaWW-y_rFQ'
-    }),
-    programmeDetailAfaWales: dynamicRoute({
-        path: '/programmes/national-lottery-awards-for-all-wales',
-        applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=wales',
-        experimentId: 'Ko6MLYegQfaRO1rVU1UB3w'
     }),
     buildingBetterOpportunities: cmsRoute({
         path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',


### PR DESCRIPTION
Remove a/b test for AFA England and Wales. Takes them to 100%. Waiting on confirmation from Scotland so not completely removing the test code yet.