### PR TITLE
Remove h1 from logo

### DIFF
--- a/views/includes/header.njk
+++ b/views/includes/header.njk
@@ -8,11 +8,9 @@
 <header class="global-header" role="banner">
     <div class="global-header__inner inner">
         <div class="global-header__content">
-            <a class="global-header__home-link"
+            <a class="global-header__logo"
                 href="{{ buildUrl('toplevel', '/') }}">
-                <h1 class="global-header__logo">
-                    <span class="u-visually-hidden">{{ __("global.brand.title") }}</span>
-                </h1>
+                <span class="u-visually-hidden">{{ __("global.brand.title") }}</span>
             </a>
             <nav class="global-header__hamburger u-mobile-only u-dont-print"
                 id="js-mobile-nav-toggle">


### PR DESCRIPTION
Removes the `<h1>` wrapping the page logo so as not to conflict with the primary title on the page. No reason for the logo to a be a h1 anyway as there's always a more appropriate primary heading.