### PR TITLE
Programme tweaks

### DIFF
--- a/controllers/funding/funding.js
+++ b/controllers/funding/funding.js
@@ -25,9 +25,9 @@ function init({ router, routeConfig }) {
                  */
                 const findBySlug = slug => find(programmes, p => p.urlPath === `funding/programmes/${slug}`);
                 const latestProgrammes = [
-                    findBySlug('helping-working-families'),
-                    findBySlug('empowering-young-people'),
-                    findBySlug('national-lottery-awards-for-all-england')
+                    findBySlug('reaching-communities-england'),
+                    findBySlug('national-lottery-awards-for-all-england'),
+                    findBySlug('empowering-young-people')
                 ];
 
                 renderLandingPage(latestProgrammes);

--- a/views/components/tabs.njk
+++ b/views/components/tabs.njk
@@ -21,7 +21,7 @@
     <section id="{{ paneId }}" class="tab__pane{% if accordion %} tab__pane--accordion{% endif %}{% if setActive %} pane--active{% endif %}">
         {% if accordion and title %}
             <header class="tab__pane-header">
-                {{ tab(title, paneId, tabSetId = tabSetId, setActive = setActive, id = tabId) }}
+                {{ tab(title, paneId, tabSetId = tabSetId, setActive = setActive, id = "accordion-" + tabId) }}
                 <span class="tab__arrow">{{ iconArrowDown() }}</span>
             </header>
         {% endif %}


### PR DESCRIPTION
Fixes a couple of things failing the accessibility checks.

- There are duplicate IDs between the accordion headings and the tabs which cause the a11y tests to fail. In the meantime, until we revisit these, I've added  a prefix to the accordion headings to remove duplication
- Updates the funding landing page as HWF has expired which breaks the test (pushed the expiry date back a couple of days for now), now the new RC pages are live we can show this in place of HWF.