### PR TITLE
Remove useRemoteImages flags

### DIFF
--- a/modules/assets.js
+++ b/modules/assets.js
@@ -20,7 +20,11 @@ function getCachebustedPath(urlPath, skipVirtualDir) {
 }
 
 function getImagePath(urlPath) {
-    return '/' + [assetVirtualDir, 'images', urlPath].join('/');
+    if (/^http(s?):\/\//.test(urlPath)) {
+        return urlPath;
+    } else {
+        return '/' + [assetVirtualDir, 'images', urlPath].join('/');
+    }
 }
 
 module.exports = {

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -45,15 +45,11 @@
     trailText,
     trailTextMore,
     imageUrl,
-    useRemoteImages,
     accent
 ) %}
     <div class="photo-card {% if accent %}accent--{{ accent }} a--border-top{% endif %}">
         <div class="photo-card__media">
             {% set imageUrlToUse = imageUrl | getImagePath %}
-            {% if useRemoteImages %}
-                {% set imageUrlToUse = imageUrl %}
-            {% endif %}
             {% if linkUrl %}<a href="{{ linkUrl }}">{% endif %}
                 <img
                     class="photo-card__image"
@@ -103,7 +99,6 @@
                             trailText = caseStudy.trailText,
                             trailTextMore = caseStudy.trailTextMore,
                             imageUrl = caseStudy.thumbnailUrl,
-                            useRemoteImages = true,
                             accent = accent
                         )
                     }}

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -90,14 +90,10 @@
 {% endmacro %}
 
 
-{% macro miniatureHero(titleText, imagePath, imagePathMobile = false, imageCaption = false, linkUrl = false, accent, useRemoteImages = false) %}
-    {% if not useRemoteImages %}
-        {% set imagePath = imagePath | getImagePath %}
-        {% if imagePathMobile %}
-            {% set imagePathMobile = imagePathMobile | getImagePath %}
-        {% else %}
-            {% set imagePathMobile = imagePath %}
-        {% endif %}
+{% macro miniatureHero(titleText, imagePath, imagePathMobile = false, imageCaption = false, linkUrl = false, accent) %}
+    {% set imagePath = imagePath | getImagePath %}
+    {% if not imagePathMobile %}
+        {% set imagePathMobile = imagePath %}
     {% endif %}
     <div class="miniature-hero accent--{{ accent }} a--border-top--large">
         <div class="miniature-hero__inner">


### PR DESCRIPTION
Remove useRemoteImages flags in favour of checking for the type of link in the `getImagePath` method. Saves needing to thread boolean flags around templates.