### PR TITLE
Remove falsey values from cloudfront routes

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -558,10 +558,9 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
-              "version",
-              false
+              "version"
             ],
-            "Quantity": 3
+            "Quantity": 2
           },
           "QueryString": true,
           "Cookies": {
@@ -1194,10 +1193,9 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
-              "version",
-              false
+              "version"
             ],
-            "Quantity": 3
+            "Quantity": 2
           },
           "QueryString": true,
           "Cookies": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -558,10 +558,9 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
-              "version",
-              false
+              "version"
             ],
-            "Quantity": 3
+            "Quantity": 2
           },
           "QueryString": true,
           "Cookies": {
@@ -1194,10 +1193,9 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
-              "version",
-              false
+              "version"
             ],
-            "Quantity": 3
+            "Quantity": 2
           },
           "QueryString": true,
           "Cookies": {

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -47,12 +47,11 @@ function createSection({ path, controllerPath, langTitlePath }) {
 
 /**
  * Default parameters for cloudfront routes
- * Restrictive by default, GET-only, no-query-strings
+ * Restrictive by default
  */
 const defaults = {
     isPostable: false,
-    live: false,
-    queryStrings: false
+    live: false
 };
 
 /**

--- a/controllers/route-types.test.js
+++ b/controllers/route-types.test.js
@@ -38,8 +38,7 @@ describe('Route types', () => {
         ).to.eql({
             path: '/some/url',
             isPostable: false,
-            live: true,
-            queryStrings: false
+            live: true
         });
 
         expect(
@@ -50,8 +49,7 @@ describe('Route types', () => {
         ).to.eql({
             path: '/some/url',
             isPostable: false,
-            live: false,
-            queryStrings: false
+            live: false
         });
     });
 
@@ -64,8 +62,7 @@ describe('Route types', () => {
             path: '/some/url',
             isPostable: false,
             static: true,
-            live: true,
-            queryStrings: false
+            live: true
         });
     });
 
@@ -93,8 +90,7 @@ describe('Route types', () => {
             path: '/some/url',
             isPostable: false,
             useCmsContent: true,
-            live: true,
-            queryStrings: false
+            live: true
         });
     });
 
@@ -116,8 +112,7 @@ describe('Route types', () => {
             path: '/from/url',
             destination: '/to/url',
             isPostable: false,
-            live: true,
-            queryStrings: false
+            live: true
         });
     });
 });


### PR DESCRIPTION
https://github.com/biglotteryfund/blf-alpha/pull/826 exposed a bug with the route types. `queryStrings` should be an array or undefined. There was some old defaults code hanging around which set certain values to `false`. This PR fixes that.