### PR TITLE
Improve form submission handling

### DIFF
--- a/assets/sass/globals/forms.scss
+++ b/assets/sass/globals/forms.scss
@@ -205,12 +205,12 @@ $errorColor: #b00;
     }
 }
 
-.form-success-message {
+.form-message {
     background-color: palette('pale-pink');
     margin-bottom: $spacingUnit;
     padding: $spacingUnit / 2;
 }
-.form-success-message__title {
+.form-message__title {
     margin-bottom: 3px;
 }
 

--- a/controllers/apply/forms/create-form-model.js
+++ b/controllers/apply/forms/create-form-model.js
@@ -79,6 +79,8 @@ function createFormModel({ id, title, shortCode }) {
     let steps = [];
     let reviewStep;
     let successStep;
+    let errorStep;
+
     return {
         id: id,
         title: title,
@@ -133,6 +135,16 @@ function createFormModel({ id, title, shortCode }) {
             }
 
             return successStep;
+        },
+        registerErrorStep: function(stepConfig) {
+            errorStep = stepConfig;
+        },
+        getErrorStep: function() {
+            if (!errorStep) {
+                throw new Error('Must register error step');
+            }
+
+            return errorStep;
         }
     };
 }

--- a/controllers/apply/forms/create-form-router.js
+++ b/controllers/apply/forms/create-form-router.js
@@ -1,4 +1,4 @@
-const { get, isEmpty, set } = require('lodash');
+const { get, isEmpty, set, unset } = require('lodash');
 const { validationResult } = require('express-validator/check');
 const { matchedData } = require('express-validator/filter');
 const cached = require('../../../middleware/cached');
@@ -96,9 +96,13 @@ module.exports = function(router, formModel) {
             let processSuccess = successStep.processor(formData);
             processSuccess
                 .then(() => {
-                    res.render('pages/apply/success', {
-                        form: formModel,
-                        success: successStep
+                    // Clear the submission from the session on successfull
+                    unset(req.session, formModel.getSessionProp());
+                    req.session.save(() => {
+                        res.render('pages/apply/success', {
+                            form: formModel,
+                            success: successStep
+                        });
                     });
                 })
                 .catch(err => {

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -127,7 +127,7 @@ formModel.registerStep({
                     type: 'text',
                     name: 'project-location',
                     label: "In your own words, describe the location(s) that you'll be running your project(s) in",
-                    placeholder: 'eg. "Newtown community centre" or "Alfreton, Derby and Ripley"',
+                    placeholder: 'eg. "Newcastle community centre" or "Alfreton, Derby and Ripley"',
                     isRequired: true,
                     size: 60,
                     validator: function(field) {

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -237,6 +237,10 @@ formModel.registerReviewStep({
 
 formModel.registerSuccessStep({
     title: 'We have received your idea',
+    message: `
+<h2 class="t2 t--underline accent--pink">What happens next?</h2>
+<p>Thank you for submitting your idea. A local funding officer will contact you within fifteen days.</p>
+`,
     processor: function(formData) {
         const flatData = formModel.getStepValuesFlattened(formData);
 
@@ -301,6 +305,14 @@ formModel.registerSuccessStep({
             );
         });
     }
+});
+
+formModel.registerErrorStep({
+    title: 'There was an problem submitting your idea',
+    message: `
+<p>There was a problem submitting your idea, we have been notified of the problem.</p>
+<p>Please return to the review step and try again. If you still see an error please call <a href="tel:03454102030">0345 4 10 20 30</a> (Monday–Friday 9am–5pm).</p>
+`
 });
 
 module.exports = formModel;

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -1,6 +1,5 @@
-const { check } = require('express-validator/check');
 const { castArray, get, isArray } = require('lodash');
-const Raven = require('raven');
+const { check } = require('express-validator/check');
 
 const app = require('../../../server');
 const mail = require('../../../modules/mail');
@@ -296,12 +295,6 @@ formModel.registerSuccessStep({
                                 .then(() => resolve(formData));
                         })
                         .catch(err => {
-                            Raven.captureMessage('Error converting template to inline CSS', {
-                                extra: err,
-                                tags: {
-                                    feature: 'reaching-communities'
-                                }
-                            });
                             return reject(err);
                         });
                 }

--- a/cypress/integration/3_apply_spec.js
+++ b/cypress/integration/3_apply_spec.js
@@ -31,6 +31,6 @@ describe('Application tests', function() {
 
         // Success
         cy.url().should('include', '/apply/your-idea/success');
-        cy.get('.form-success-message').should('contain', 'We have received your idea');
+        cy.get('.form-message').should('contain', 'We have received your idea');
     });
 });

--- a/cypress/integration/3_apply_spec.js
+++ b/cypress/integration/3_apply_spec.js
@@ -27,6 +27,10 @@ describe('Application tests', function() {
         cy.get(submitSelector).click();
 
         // Review
-        cy.url().should('include', '/apply/your-idea/review');
+        cy.get('.content-box .btn').click();
+
+        // Success
+        cy.url().should('include', '/apply/your-idea/success');
+        cy.get('.form-success-message').should('contain', 'We have received your idea');
     });
 });

--- a/views/pages/apply/error.njk
+++ b/views/pages/apply/error.njk
@@ -1,5 +1,5 @@
 {% extends "layouts/main.njk" %}
-{% block title %}Success | {{ form.title }} | {% endblock %}
+{% block title %}Error | {{ form.title }} | {% endblock %}
 {% set bodyClass = 'has-static-header' %}
 
 {% block content %}
@@ -10,6 +10,8 @@
             </div>
 
             {{ stepConfig.message | safe }}
+
+            <p><a class="btn" href="{{returnUrl}}">Back</a></p>
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
When `process.env.DONT_SEND_EMAIL` is set we were returning an object where we normally return a promise. This was breaking the confirmation screen of the reaching communities form when under tests. To fix this, we now always return a promise allowing any dependent steps to happen even if we are skipping sending the actual email.

Edit: Updated the router further to serve a real error screen if there is a problem processing submissions.

<img width="1036" alt="screen shot 2018-04-06 at 09 20 58" src="https://user-images.githubusercontent.com/123386/38410358-3f6eb3f4-397c-11e8-8dc6-70a8808a45ad.png">
