### PR TITLE
Section outline improvements

### DIFF
--- a/assets/sass/components/news.scss
+++ b/assets/sass/components/news.scss
@@ -9,14 +9,19 @@
 
 .latest-news {
     position: relative;
+    padding: $spacingUnit / 2;
+
+    @include mq('medium') {
+        padding: $spacingUnit;
+    }
 }
 .latest-news__footer {
     margin-bottom: $spacingUnit;
 
     @include mq('medium') {
         position: absolute;
-        top: 0;
-        right: 0;
+        top: $spacingUnit;
+        right: $spacingUnit;
         margin: 0;
     }
 }

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -4,7 +4,7 @@ const ab = require('express-ab');
 const config = require('config');
 const moment = require('moment');
 const Raven = require('raven');
-const { assign, find, findIndex, get, last, uniq } = require('lodash');
+const { assign, find, findIndex, get, last, map, uniq } = require('lodash');
 
 const cached = require('../../middleware/cached');
 const { splitPercentages } = require('../../modules/ab');
@@ -128,6 +128,8 @@ function initProgrammesList(router, options) {
                         });
                     }
                 }
+
+                templateData.activeBreadcrumbsSummary = map(templateData.activeBreadcrumbs, 'label').join(', ');
 
                 res.render(options.template, templateData);
             })

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -1,7 +1,7 @@
 {% import "components/headers.njk" as headers %}
 
 {% macro hero(titleText, image, accent = 'blue') %}
-    <div class="hero">
+    <section class="hero">
         <div class="hero__image">
             <picture>
                 <source srcset="{{ image.large }}" media="(min-width: 980px)">
@@ -26,11 +26,11 @@
                 </span>
             {% endif %}
         </div>
-    </div>
+    </section>
 {% endmacro %}
 
 {% macro superHero(title, content, imageDefault, imageCandidates) %}
-    <div class="super-hero js-random-hero" data-image-candidates='{{ imageCandidates | dump | safe }}'>
+    <section class="super-hero js-random-hero" data-image-candidates='{{ imageCandidates | dump | safe }}'>
         <div class="super-hero__image js-random-hero__image">
             <picture>
                 <source srcset="{{ imageDefault.large }}" media="(min-width: 980px)">
@@ -53,7 +53,7 @@
                 </div>
             {% endif %}
         </div>
-    </div>
+    </section>
 {% endmacro %}
 
 

--- a/views/components/news.njk
+++ b/views/components/news.njk
@@ -1,10 +1,10 @@
 {% macro articleTeaser(article) %}
     <article class="article-teaser">
-        <h4 class="article-teaser__title t2">
+        <h3 class="article-teaser__title t2">
             <a class="u-link-minimal" href="{{ article.link }}">
                 {{ article.title }}
             </a>
-        </h4>
+        </h3>
         <p class="article-teaser__summary">
             {{ article.summary }}
             <a href="{{ article.link }}" class="accent--pink a--text u-weight-heavy">
@@ -12,30 +12,4 @@
             </a>
         </p>
     </article>
-{% endmacro %}
-
-{% macro latestNews(articles) %}
-    <div class="latest-news">
-        <div class="latest-news__header">
-            <h3 class="t1 t--underline a--text accent--blue">
-                <a class="u-link-minimal" href="{{ buildUrl("uk-wide/news-and-events") }}">
-                    {{ __('global.misc.latestNews') }}
-                </a>
-            </h3>
-        </div>
-        <div class="latest-news__content">
-            <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
-                {% for article in articles %}
-                    <li class="grid__item">
-                        {{ articleTeaser(article) }}
-                    </li>
-                {% endfor %}
-            </ul>
-        </div>
-        <div class="latest-news__footer">
-            <a class="latest-news__more" href="{{ buildUrl("uk-wide/news-and-events") }}">
-                {{ __('global.misc.viewAllNews') }}
-            </a>
-        </div>
-    </div>
 {% endmacro %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -63,16 +63,16 @@
 {% endmacro %}
 
 {% macro programmeList(programmes, accent, labels) %}
-    <div class="programmes-list">
+    <ol class="programmes-list">
         {% for programme in programmes %}
-            <div class="programmes-list__item">
+            <li class="programmes-list__item">
                 {{ programmeCard(
                     programme = programme.content,
                     accent = accent
                 ) }}
-            </div>
+            </li>
         {% endfor %}
-    </div>
+    </ol>
 {% endmacro %}
 
 {% macro selectionTrail(trail, itemCount) %}

--- a/views/includes/ebulletin.njk
+++ b/views/includes/ebulletin.njk
@@ -1,13 +1,13 @@
 {% from "components/forms.njk" import textInput, radios with context %}
 
 <form method="post" action="/about/ebulletin">
-    <h3 class="t1 t--underline accent--pink a--text">{{ __('toplevel.ebulletin.title') }}</h3>
+    <h2 class="t1 t--underline accent--pink a--text">{{ __('toplevel.ebulletin.title') }}</h2>
     {% if request.flash and request.flash('ebulletinStatus') %}
         {% if request.flash('ebulletinStatus') === 'success' %}
-            <h5 class="t5">{{ __('toplevel.ebulletin.responses.success.title') }}</h5>
+            <h3 class="t5">{{ __('toplevel.ebulletin.responses.success.title') }}</h3>
             <p>{{ __('toplevel.ebulletin.responses.success.body') | safe }}</p>
         {% else %}
-            <h5 class="t5">{{ __('toplevel.ebulletin.responses.error.title') }}</h5>
+            <h3 class="t5">{{ __('toplevel.ebulletin.responses.error.title') }}</h3>
             <p>{{ __('toplevel.ebulletin.responses.error.body') }}</p>
         {% endif %}
     {% else %}

--- a/views/includes/footer.njk
+++ b/views/includes/footer.njk
@@ -2,13 +2,13 @@
     <div class="footer__inner inner">
         <ul class="grid grid--top grid--wide-only">
             <li class="grid__item u-desktop-only">
-                <h5 class="t6 u-uppercase">{{ __("global.brand.title") | safe }}</h5>
+                <p class="t6 u-uppercase">{{ __("global.brand.title") | safe }}</p>
                 <p><address>1 Plough Place, {{ __("global.contact.city") | safe }} EC4A 1DE</address></p>
                 <p><a href="mailto:{{ __("global.contact.email") | safe }}">{{ __("global.contact.email") | safe }}</a></p>
                 <p>{{ __("global.contact.phone") | safe }}</p>
             </li>
             <li class="grid__item">
-                <h5 class="t6 u-uppercase u-desktop-only">{{ __("global.footerLinks.title") | safe }}</h5>
+                <h2 class="t6 u-uppercase u-desktop-only">{{ __("global.footerLinks.title") | safe }}</h2>
                 <ul class="footer-links">
                     {% for link in __("global.footerLinks.links") %}
                         <li><a href="{{ link.href }}">{{ link.label }}</a></li>

--- a/views/pages/funding/programmes.njk
+++ b/views/pages/funding/programmes.njk
@@ -22,6 +22,8 @@
                 itemCount = programmes.length
             ) }}
 
+            <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
+
             {% if programmes | length > 0 %}
                 {{ programmeList(
                     accent = 'pink',

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -2,7 +2,7 @@
 {% from "components/caseStudies.njk" import caseStudyFeature %}
 {% from "components/forms.njk" import textInput, radios with context %}
 {% from "components/hero.njk" import homepageSuperHero %}
-{% from "components/news.njk" import latestNews with context %}
+{% from "components/news.njk" import articleTeaser with context %}
 {% from "components/social.njk" import socialLinks %}
 
 {% extends "layouts/main.njk" %}
@@ -14,16 +14,16 @@
 {% block content %}
     {% set pageAccent = "blue" %}
 
-    {{
-        homepageSuperHero(
-            copy = copy.hero,
-            imageDefault = heroImage.default,
-            imageCandidates = heroImage.candidates
-        )
-    }}
+    <main role="main">
+        {{
+            homepageSuperHero(
+                copy = copy.hero,
+                imageDefault = heroImage.default,
+                imageCandidates = heroImage.candidates
+            )
+        }}
 
-    <article role="main">
-        <div class="inner">
+        <section class="inner">
             {# case studies #}
             <div class="carousel js-carousel
                 swiper-container
@@ -59,31 +59,48 @@
                         </li>
                     {% endfor %}
                 </ul>
-
             </div>
 
-            {# funding finder #}
             <div class="central-gap">
                 <a href="{{ buildUrl('funding/search-past-grants') }}"
-                   class="btn btn--block accent--{{ pageAccent }} a--btn spaced">{{ copy.browseFundedProjects }}</a>
+                    class="btn btn--block accent--{{ pageAccent }} a--btn spaced">
+                    {{ copy.browseFundedProjects }}
+                </a>
             </div>
+        </section>
 
-            {# News Posts #}
-            {% if news.length %}
-                <section class="accent--{{ pageAccent }} a--border-top">
-                    <div class="padded padded--wide-only">
-                        {{ latestNews(news) }}
-                    </div>
-                </section>
-            {% endif %}
+        {# Latest News #}
+        {% if news.length %}
+        <section class="latest-news accent--{{ pageAccent }} a--border-top inner">
+            <header class="latest-news__header">
+                <h2 class="t1 t--underline a--text accent--blue">
+                    <a class="u-link-minimal" href="{{ buildUrl("uk-wide/news-and-events") }}">
+                        {{ __('global.misc.latestNews') }}
+                    </a>
+                </h2>
+            </header>
+            <div class="latest-news__content">
+                <ul class="unstyled grid grid--3-up grid--padded--large grid--equal grid--wide-only">
+                    {% for article in news %}
+                        <li class="grid__item">
+                            {{ articleTeaser(article) }}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <footer class="latest-news__footer">
+                <a class="latest-news__more" href="{{ buildUrl("uk-wide/news-and-events") }}">
+                    {{ __('global.misc.viewAllNews') }}
+                </a>
+            </footer>
+        </section>
+        {% endif %}
 
-        </div>
-
-        <div class="inner--wide-only spaced">
-            {# tweets #}
-            {% set twitterAccount = appData.config.get('social.twitterAccounts.' + locale)  %}
+        <section class="inner--wide-only spaced">
             <ul class="unstyled grid grid--wide-only grid--equal">
                 <li class="grid__item grid__item--large accent--{{ pageAccent }} a--border-top padded">
+                    {# Twitter Feed #}
+                    {% set twitterAccount = appData.config.get('social.twitterAccounts.' + locale)  %}
                     <a class="twitter-timeline" data-dnt="true" data-chrome="noheader" data-tweet-limit="3"
                         href="https://twitter.com/{{ twitterAccount }}?ref_src=twsrc%5Etfw"
                     >
@@ -92,6 +109,7 @@
                     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
                 </li>
                 <li class="grid__item accent--pink a--border-top">
+                    {# Ebulletin #}
                     <div class="form-ebulletin padded spaced">
                         {% include "includes/ebulletin.njk" %}
                     </div>
@@ -99,8 +117,6 @@
                     {{ socialLinks(copy.social) }}
                 </li>
             </ul>
-
-        </div>
-    </article>
-
+        </section>
+    </main>
 {% endblock %}


### PR DESCRIPTION
WIP changes to pages to improve section outlining

## Homepage

Before:

![image](https://user-images.githubusercontent.com/123386/38495972-95c0bc24-3bf3-11e8-8d0d-59c3c7e63b72.png)

After: 

<img width="1364" alt="screen shot 2018-04-09 at 12 28 17" src="https://user-images.githubusercontent.com/123386/38495974-986f2e38-3bf3-11e8-8d9c-c119ed84a56a.png">

## Programmes List

Adds a summary version of the breadcrumbs as a h2. Makes the list of programmes…y'know…a list.

Before:

![image](https://user-images.githubusercontent.com/123386/38496005-c49088fe-3bf3-11e8-96c8-9adf42db8a1f.png)

After:

![image](https://user-images.githubusercontent.com/123386/38496014-cf40d1dc-3bf3-11e8-9baa-0ab209a5b41c.png)


