### PR TITLE
Make tab styles consistent

### DIFF
--- a/assets/sass/components/tabs.scss
+++ b/assets/sass/components/tabs.scss
@@ -32,8 +32,8 @@
         text-align: center;
     }
 
-    &:last-child .tab {
-        border-right-width: 1px;
+    &:first-child .tab {
+        border-left: none;
     }
 
     .tab.tab--active {
@@ -41,14 +41,6 @@
         border-bottom-color: transparent;
         background-color: white;
         color: palette('pink');
-    }
-
-    &:first-child .tab.tab--active {
-        border-left-color: transparent;
-    }
-
-    &:last-child .tab.tab--active {
-        border-right-color: transparent;
     }
 }
 

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -21,8 +21,8 @@
     ) }}
 
     <main role="main" class="nudge-up">
-        <section class="content-box content-box--flush
-            inner--wide-only accent--{{ pageAccent }} a--border-top u-no-bottom-border">
+        <section class="content-box content-box--tinted content-box--even-inset
+            inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="s-prose u-constrained-content-wide">
                 {% if entry.intro %}
                     {{ entry.intro | safe }}

--- a/views/pages/toplevel/region.njk
+++ b/views/pages/toplevel/region.njk
@@ -67,14 +67,14 @@
 
     <main class="nudge-up">
         <section class="content-box content-box--tinted content-box--even-inset
-            inner--wide-only accent--{{ pageAccent }} a--border-top u-no-bottom-border">
+            inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="s-prose u-constrained-content-wide">
                 <p>{{ copy.introduction }}</p>
             </div>
         </section>
 
         {% macro tabContent(content, pageAccent) %}
-            <div class="content-box u-no-top-border">
+            <div class="content-box content-box--frameless">
                 {{ content | safe }}
             </div>
         {% endmacro %}


### PR DESCRIPTION
This change was originally to fix a border bug on region landing pages spotted by @mattandrews during our a11y review. However on discussing with @ChloeAlper we decided to use it as an opportunity to make the tabs styles consistent between region pages (e.g. https://www.biglotteryfund.org.uk/wales) and funding programmes (https://www.biglotteryfund.org.uk/funding/programmes/national-lottery-awards-for-all-england)

Chloe's rationale is to consistently use the pink-tint for intro content, allow space between intro and tabs, and to remove bounding boxes from content areas within tabs to make tabs scan consistently in all contexts. Tabs themselves are still up for grabs, but for now consistency FTW.

<img width="1005" alt="screen shot 2018-04-09 at 15 02 53" src="https://user-images.githubusercontent.com/123386/38502509-81878d96-3c07-11e8-96a1-8f6cc77132d0.png">
<img width="1015" alt="screen shot 2018-04-09 at 15 02 57" src="https://user-images.githubusercontent.com/123386/38502510-81a10f50-3c07-11e8-9730-c3fd42f00914.png">

Before:

<img width="1017" alt="screen shot 2018-04-09 at 15 05 12" src="https://user-images.githubusercontent.com/123386/38502511-81bad2d2-3c07-11e8-8006-88ec98f12bf4.png">
<img width="1065" alt="screen shot 2018-04-09 at 15 09 30" src="https://user-images.githubusercontent.com/123386/38502716-06ef72be-3c08-11e8-9786-65b44cba5883.png">
