### PR TITLE
Move build prep to after_success to avoid duplicate runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ script:
 - npm run lint
 - npm run build-production
 - npm test
-before_deploy:
+after_success:
 - npm prune --production > /dev/null 2>&1
 - sh deploy/store_deploy_info.sh
 - zip -qr latest * -x .\* -x "README.md" -x assets/\* -x "gulpfile.js"


### PR DESCRIPTION
Noticed that builds on `master` were 3+ minutes longer than PR builds. I think the culprit is the `before_deploy` step, due to this line in the docs: "Note that before_deploy and after_deploy are run before and after every deploy provider, so will run multiple times if there are multiple providers."

See https://docs.travis-ci.com/user/customizing-the-build/#Deploying-your-Code

~We only need this to happen once, so testing moving this to the `after_success` block, which counterintuitively sounds like it should run _before_ deployment.~

Edit: Spotted the build lifecycle https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle. `after_success` is the right place for this.