### PR TITLE
Layout and heading level cleanup

### DIFF
--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -35,10 +35,6 @@ $spacingUnit: 20px;
 // Common border width used for theme accents
 $accentBorderWidth: 4px;
 
-// used for sitewide text boxes
-// (and also referenced in bordered grid)
-$contentBoxHorizontalPadding: 20px;
-
 /* =========================================================================
    Global Variables: Font Stacks
    ========================================================================= */

--- a/assets/sass/components/data.scss
+++ b/assets/sass/components/data.scss
@@ -271,7 +271,12 @@
     }
 
     .map-info__stat {
-        margin-bottom: 0;
+        margin-bottom: $spacingUnit / 2;
+    }
+
+    .map-info__stat-data,
+    .map-info__stat-caption {
+        display: block;
     }
 }
 

--- a/assets/sass/components/navigation.scss
+++ b/assets/sass/components/navigation.scss
@@ -100,8 +100,10 @@
     }
 }
 .quicklinks--sticky {
-    position: sticky;
-    top: 0;
+    @media only screen and (min-height: 38em) {
+        position: sticky;
+        top: 0;
+    }
 
     @include mq('medium', 'max') {
         display: none;

--- a/assets/sass/components/segment.scss
+++ b/assets/sass/components/segment.scss
@@ -44,17 +44,12 @@
 
     .segment__aside {
         flex-grow: 1;
-        padding: 17px 20px 40px 20px;
-
-        @include mq('tablet', 'max') {
-            margin-top: 0;
-        }
+        padding: $spacingUnit;
+        margin-top: 0;
 
         @include mq('tablet') {
             @include bordered();
             background-color: palette('pale');
-            padding: 40px 20px;
-            margin-top: 0;
         }
     }
 }

--- a/assets/sass/globals/base.scss
+++ b/assets/sass/globals/base.scss
@@ -57,9 +57,7 @@ p {
 
 ol,
 ul,
-li,
-.unstyled,
-.unstyled li {
+li {
     list-style-type: none;
 }
 

--- a/assets/sass/scaffolding/content.scss
+++ b/assets/sass/scaffolding/content.scss
@@ -53,22 +53,11 @@
 .content-box {
     @include bordered();
     background-color: palette('pale');
-    padding: 20px $contentBoxHorizontalPadding 40px $contentBoxHorizontalPadding;
+    padding: $spacingUnit;;
     margin-bottom: $spacingUnit;
 
     &.content-box--flush {
         margin-bottom: 0;
-    }
-
-    &.content-box--flush-narrow-only {
-        @include mq('tablet', 'max') {
-            margin-bottom: 0;
-        }
-    }
-
-    // @TODO: Make this the default
-    &.content-box--even-inset {
-        padding: $spacingUnit;
     }
 
     &.content-box--borderless {

--- a/assets/sass/scaffolding/grid.scss
+++ b/assets/sass/scaffolding/grid.scss
@@ -137,7 +137,7 @@ $paddedGridGutterLarge: 30px;
                             // the border should be 15px outside
                             .content-box & {
                                 &:after {
-                                    left: -#{ $contentBoxHorizontalPadding + 15px};
+                                    left: -#{ $spacingUnit + 15px};
                                 }
                             }
                         }

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -125,16 +125,26 @@
     }
 
     h3 {
-        margin: 1em 0 0.4em;
+        margin: 0 0 0.4em;
         font-size: 21px;
     }
 
     h4 {
-        margin: 1em 0 0.4em;
+        margin: 0 0 0.4em;
         font-size: 20px;
     }
 
-    ol, ul {
+    p + h3,
+    ol + h3,
+    ul + h3,
+    p + h4,
+    ol + h4,
+    ul + h4 {
+        margin-top: 1em;
+    }
+
+    ol,
+    ul {
         margin-bottom: 1em;
 
         li {
@@ -162,7 +172,6 @@
         table-layout: fixed;
         margin: 0 0 1em;
         padding: 0;
-
 
         tr {
             background-color: palette('pale-grey');
@@ -220,7 +229,6 @@
         }
     }
 
-
     .video-container {
         margin: 0 -10px 1em;
 
@@ -268,5 +276,4 @@
         padding: 10px;
         border-radius: 2px;
     }
-
 }

--- a/assets/sass/utilities/utilities-text.scss
+++ b/assets/sass/utilities/utilities-text.scss
@@ -2,10 +2,11 @@
    Utilities: Text
    ========================================================================= */
 
+.unstyled,
+.unstyled li,
 .u-list-unstyled,
 .u-list-unstyled li {
     list-style-type: none !important;
-    margin-left: 0 !important;
 }
 
 .u-align-center {

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -59,7 +59,7 @@
             {% if linkUrl %}</a>{% endif %}
         </div>
         <div class="photo-card__body">
-            <h4 class="photo-card__header t5">{{ title }}</h4>
+            <h3 class="photo-card__header t5">{{ title }}</h3>
             {% if grantAmount %}
                 <p class="photo-card__subheader t7">
                     Grant: {{ grantAmount }}

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -45,12 +45,12 @@
 
 {% macro nestedMenu(navigationModel, currentUrl) %}
     <nav class="nested-menu">
-        <h4 class="nested-menu__section">
+        <h2 class="nested-menu__section t4">
             <a class="nested-menu__section-link"
                 href="{{ navigationModel.section.link }}">
                 {{ navigationModel.section.label }}
             </a>
-        </h4>
+        </h2>
         <ul class="nested-menu__children">
             {% for child in navigationModel.children %}
                 <li class="nested-menu__item">

--- a/views/components/segment.njk
+++ b/views/components/segment.njk
@@ -1,12 +1,12 @@
 {% import "./headers.njk" as headers %}
 
 {% macro segment(title, text, color, imagePath, id, imageIsAbsolute = false) %}
-    <div class="segment accent--{{ color }} a--border-top">
+    <div class="segment accent--{{ color }} a--border-top accent-content--{{ color }}">
         {% if imagePath %}
             <div class="grid__item__inner segment__media">
                 <img src="{% if imageIsAbsolute %}{{ imagePath }}{% else %}{{ imagePath | getImagePath }}{% endif %}" alt="" />
                 {{ headers.overlayText(
-                    tag = 'h4',
+                    tag = 'h2',
                     text = title,
                     additionalClasses = 'segment__title grid__item__title grid__item__title--top',
                     id = id

--- a/views/layouts/profiles.njk
+++ b/views/layouts/profiles.njk
@@ -22,7 +22,7 @@
             <div class="page-section__content accent--{{ pageAccent }} a--border-top">
                 {% for profile in profiles %}
                     <section id="profile-{{ profile.title | slugify }}"
-                        class="content-box content-box--even-inset{% if loop.index > 1 %} accent--{{ pageAccent }} a--border-top{% endif %}">
+                        class="content-box {% if loop.index > 1 %} accent--{{ pageAccent }} a--border-top{% endif %}">
                         {{ profileSummary(profile) }}
                     </section>
                 {% endfor %}
@@ -30,7 +30,7 @@
                 {% block extraPrimaryContent %}{% endblock %}
             </div>
             <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
-                <aside class="content-box content-box--even-inset">
+                <aside class="content-box">
                     {{ nestedMenu(navigation, getCurrentUrl(request)) }}
                 </aside>
 

--- a/views/pages/about/senior-management-team.njk
+++ b/views/pages/about/senior-management-team.njk
@@ -3,8 +3,7 @@
 {% extends "layouts/profiles.njk" %}
 
 {% block extraPrimaryContent %}
-    <section class="content-box content-box--even-inset
-        accent--{{ pageAccent }} a--border-top">
+    <section class="content-box accent--{{ pageAccent }} a--border-top">
         <h3 class="t1 accent--{{ pageAccent }} a--text">{{ copy.expenses.title }}</h3>
         {{ linksList(copy.expenses.documents, isDocumentsList = true) }}
     </section>

--- a/views/pages/funding/over10k.njk
+++ b/views/pages/funding/over10k.njk
@@ -19,12 +19,14 @@
         )
     }}
 
-    <article role="main" class="nudge-up">
+    <main role="main" class="nudge-up">
         <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
-            <p>{{ copy.intro }}</p>
-            <h3 class="t1">{{ copy.callToAction }}</h3>
+            <div class="s-prose s-prose--long">
+                <p>{{ copy.intro }}</p>
+                <h2>{{ copy.callToAction }}</h2>
+            </div>
 
-            <ul class="unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
+            <ul class="u-list-unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
                <li class="grid__item">
                    <a href="{{ buildUrl('funding/programmes?min=10000&location=england') }}"
                       class="btn accent--{{ pageAccent }} a--btn btn--block btn--small"
@@ -67,8 +69,5 @@
                 <a href="{{ buildUrl('funding/search-past-grants') }}" class="btn btn--outline accent--turquoise btn--a btn--block btn--small">{{ copy.browseAll }}</a>
             </div>
         </div>
-
-    </article>
-
-
+    </main>
 {% endblock %}

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -21,7 +21,7 @@
     ) }}
 
     <main role="main" class="nudge-up">
-        <section class="content-box content-box--tinted content-box--even-inset
+        <section class="content-box content-box--tinted
             inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="s-prose u-constrained-content-wide">
                 {% if entry.intro %}

--- a/views/pages/funding/programmes.njk
+++ b/views/pages/funding/programmes.njk
@@ -9,14 +9,16 @@
 {% set socialImage = heroImage %}
 
 {% block content %}
+    {% set pageAccent = 'pink' %}
     <main role="main">
         {{ hero(
             titleText = title,
             image = heroImage,
-            accent = 'green'
+            accent = pageAccent
         ) }}
 
-        <section class="inner--wide-only content-box content-box--even-inset accent--green a--border-top nudge-up">
+        <section class="content-box inner--wide-only
+            accent--{{ pageAccent }} a--border-top nudge-up">
             {{ selectionTrail(
                 trail = activeBreadcrumbs,
                 itemCount = programmes.length
@@ -26,7 +28,7 @@
 
             {% if programmes | length > 0 %}
                 {{ programmeList(
-                    accent = 'pink',
+                    accent = pageAccent,
                     labels = copy.details,
                     programmes = programmes
                 ) }}

--- a/views/pages/funding/under10k.njk
+++ b/views/pages/funding/under10k.njk
@@ -20,18 +20,18 @@
     }}
 
     <main class="nudge-up">
-        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long">
             <p>{{ copy.intro }}</p>
 
-            <ul class="list-bullets">
+            <ul>
                 {% for item in copy.ideas %}
                     <li>{{ item }}</li>
                 {% endfor %}
             </ul>
 
-            <h3 class="accent--{{ pageAccent }} t1 t--underline">{{ copy.callToAction }}</h3>
+            <h2>{{ copy.callToAction }}</h2>
 
-            <ul class="unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
+            <ul class="u-list-unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
                <li class="grid__item">
                    <a href="{{ buildUrl('funding/programmes/national-lottery-awards-for-all-england') }}"
                       class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">

--- a/views/pages/listings/informationPage.njk
+++ b/views/pages/listings/informationPage.njk
@@ -57,7 +57,7 @@
                 </div>
             </section>
         {% else %}
-            <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">
+            <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class="s-prose s-prose--long accent-content--{{ pageAccent }} u-constrained-content-wide js-annotate-links">
                     {{ primaryContent() }}
                 </div>
@@ -88,7 +88,7 @@
         {{ caseStudyCollection(content.caseStudies, accent = pageAccent) }}
 
         {% if content.outro %}
-            <section class="content-box content-box--even-inset inner--wide-only accent--{{ pageAccent }} a--border-top">
+            <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <div class="s-prose s-prose--long accent-content--{{ pageAccent }}">
                     {{ content.outro | safe }}
                 </div>

--- a/views/pages/toplevel/benefits.njk
+++ b/views/pages/toplevel/benefits.njk
@@ -8,28 +8,32 @@
 {% set socialImage = heroImage %}
 
 {% block content %}
+    {% set pageAccent = 'blue' %}
     {{
         hero(
             titleText = title,
             image = heroImage,
-            accent = 'blue'
+            accent = pageAccent
         )
     }}
 
     <main class="nudge-up">
-        <div class="inner--wide-only accent--blue a--border-top content-box s-prose">
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="u-align-center">
                 <a class="btn accent--pink a--btn central-gap spaced--l" href="{{ buildUrl('toplevel', 'jobs') }}">{{ copy['call-to-action'] }}</a>
             </div>
 
-            {% for benefit in copy.benefits %}
-                <h3 class="t2">{{ benefit.title }}</h3>
-                {{ benefit.text | safe }}
-            {% endfor %}
+            <div class="s-prose s-prose--long accent-content--{{ pageAccent }}">
+                {% for benefit in copy.benefits %}
+                    <h2>{{ benefit.title }}</h2>
+                    {{ benefit.text | safe }}
+                {% endfor %}
+            </div>
         </div>
 
         <div class="inner spaced">
-            <img src="{{ 'jobs/equality-sponsors.png' | getImagePath }}" alt="The logos of Positive About Disabled People, Stonewall, Investors In People, Business Disability Forum and Living Wage Employer" />
+            <img src="{{ 'jobs/equality-sponsors.png' | getImagePath }}"
+                alt="The logos of Positive About Disabled People, Stonewall, Investors In People, Business Disability Forum and Living Wage Employer" />
         </div>
     </main>
 {% endblock %}

--- a/views/pages/toplevel/contact.njk
+++ b/views/pages/toplevel/contact.njk
@@ -9,23 +9,17 @@
 {% set socialImage = heroImage %}
 
 {% block content %}
-
     {% set pageAccent = 'turquoise' %}
+    {{ hero(
+        titleText = title,
+        image = heroImage,
+        accent = pageAccent
+    ) }}
 
-    {{
-        hero(
-            titleText = title,
-            image = heroImage,
-            accent = pageAccent
-        )
-    }}
-
-    <article role="main" class="nudge-up">
-
+    <main role="main" class="nudge-up">
         <div class="inner--wide-only s-prose s-prose--long">
-
             {% set applicationQuery %}
-                <h3 class="t2">{{ copy.offices.england }}</h3>
+                <h3>{{ copy.offices.england }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '0345 4 10 20 30' | makePhoneLink | safe }}<br />
                     <strong class="u-tone-foreground-highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0345 4 10 20 30 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -33,7 +27,7 @@
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.address }}</strong>: 1 Plough Place, {{ copy.offices.london }}, EC4A 1DE
                 </p>
 
-                <h3 class="t2">{{ copy.offices.ni }}</h3>
+                <h3>{{ copy.offices.ni }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '028 9055 1455' | makePhoneLink | safe }}<br />
                     <strong class="u-tone-foreground-highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 028 9055 1431 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -42,7 +36,7 @@
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.address }}</strong>: 1 Cromac Quay, Belfast, BT7 2JD
                 </p>
 
-                <h3 class="t2">{{ copy.offices.scotland }}</h3>
+                <h3>{{ copy.offices.scotland }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '0300 123 7110' | makePhoneLink | safe }}<br />
                     <strong class="u-tone-foreground-highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 0300 123 7110 ({{ copy['hearing-speech-impairment']}})<br />
@@ -52,7 +46,7 @@
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.address }}</strong>: Pacific House, 70 Wellington Street, Glasgow, G2 6UA
                 </p>
 
-                <h3 class="t2">{{ copy.offices.wales }}</h3>
+                <h3>{{ copy.offices.wales }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '0300 123 0735' | makePhoneLink | safe }}<br />
                     <strong class="u-tone-foreground-highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0300 123 0735 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -61,7 +55,7 @@
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.address }}</strong>: {{ copy.wales.address2 }}<br />
                 </p>
 
-                <h3 class="t2">{{ copy.ukPortfolio.title }}</h3>
+                <h3>{{ copy.ukPortfolio.title }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '0345 4 10 20 30' | makePhoneLink | safe }}<br />
                     <strong class="u-tone-foreground-highlight">{{ copy.methods['text-relay'] }}</strong>: 18001 {{ copy.plus }} 0300 123 4567 ({{ copy['hearing-speech-impairment'] }})<br />
@@ -79,7 +73,7 @@
             {% endset %}
 
             {% set other %}
-                <h3 class="t2">{{ copy.offices.corporate }}</h3>
+                <h3>{{ copy.offices.corporate }}</h3>
 
                 <p>
                     1 Plough Place<br />
@@ -95,26 +89,26 @@
             {% endset %}
 
             {% set pressQuery %}
-                <h3 class="t2">{{ copy.offices.england }}/{{ copy.offices.uk }}</h3>
+                <h3>{{ copy.offices.england }}/{{ copy.offices.uk }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '020 7211 1888' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: 07867 500572)<br />
                     <strong class="u-tone-foreground-highlight">Email:</strong> <a href="mailto:pressoffice@biglotteryfund.org.uk">pressoffice@biglotteryfund.org.uk</a>
                 </p>
 
-                <h3 class="t2">{{ copy.offices.ni }}</h3>
+                <h3>{{ copy.offices.ni }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '02890 551 432' | makePhoneLink | safe }} {{ __('global.misc.or') }} {{ '02890 551 450' | makePhoneLink | safe }} <br />
                     ({{ copy['out-of-hours'] }}: {{ '07580 811 135' | makePhoneLink | safe }})
                 </p>
 
-                <h3 class="t2">{{ copy.offices.scotland }}</h3>
+                <h3>{{ copy.offices.scotland }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '0141 242 1458' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: {{ '07880 737 157' | makePhoneLink | safe }})
                 </p>
 
-                <h3 class="t2">{{ copy.offices.wales }}</h3>
+                <h3>{{ copy.offices.wales }}</h3>
                 <p>
                     <strong class="u-tone-foreground-highlight">{{ copy.methods.phone }}</strong>: {{ '029 2067 8236' | makePhoneLink | safe }}<br />
                     ({{ copy['out-of-hours'] }}: {{ '07870 566 867' | makePhoneLink | safe }})
@@ -129,7 +123,5 @@
             {{ segment.segment(copy.topics.fraud.title, copy.topics.fraud.body, 'brown', 'contact/7.jpg', id = anchors.contactFraud) }}
             {{ segment.segment(copy.topics.other.title, other, 'turquoise', 'contact/5.jpg') }}
         </div>
-
-    </article>
-
+    </main>
 {% endblock %}

--- a/views/pages/toplevel/data.njk
+++ b/views/pages/toplevel/data.njk
@@ -22,7 +22,7 @@
 
     <article role="main" class="nudge-up">
         <div class="inner accent--pink a--border-top stats-holder content-box content-box--borderless">
-            <h3 class="t2 t--underline accent--pink">{{ copy.keyStats }}</h3>
+            <h2 class="t2 t--underline accent--pink">{{ copy.keyStats }}</h2>
             {{ statsGrid(copy.data) }}
         </div>
     </article>
@@ -30,7 +30,7 @@
 
     <aside class="accent--{{ pageAccent }} a--border-top map-holder">
         <div class="inner--wide-only expanded map-holder__inner content-box content-box--frameless no-space">
-            <h3 class="t2 t--underline accent--{{ pageAccent }}">{{ copy.map.title }}</h3>
+            <h2 class="t2 t--underline accent--{{ pageAccent }}">{{ copy.map.title }}</h2>
 
             <div class="map-wrapper">
                 {% include "../../includes/uk-svg.njk" %}
@@ -40,16 +40,22 @@
                 {% for region in grants %}
                     <section id="region-{{ region.id }}" class="tab__pane{% if loop.first %} pane--active{% endif %}">
                         <article class="map-info accent--{{ pageAccent }} a--border-top padded region--{{ region.id }}--b-t">
-                            <h4 class="t2 t--underline region--{{ region.id }}--b-b">{{ copy.regions[region.id] }}</h4>
+                            <h3 class="t2 t--underline region--{{ region.id }}--b-b">{{ copy.regions[region.id] }}</h3>
 
-                            <h5 class="map-info__stat t2 accent--{{ pageAccent }} a--text">{{ region.population | numberWithCommas }}</h5>
-                            <h6 class="t8"><strong>{{ copy.map.population }}</strong></h6>
+                            <p class="map-info__stat">
+                                <span class="map-info__stat-data t2 accent--{{ pageAccent }} a--text">{{ region.population | numberWithCommas }}</span>
+                                <span class="map-info__stat-caption t8"><strong>{{ copy.map.population }}</strong></span>
+                            </p>
 
-                            <h5 class="map-info__stat t2 accent--{{ pageAccent }} a--text">{{ region.totalAwarded }}</h5>
-                            <h6 class="t8"><strong>{{ copy.map.totalAwarded }}</strong></h6>
+                            <p class="map-info__stat">
+                                <span class="map-info__stat-data t2 accent--{{ pageAccent }} a--text">{{ region.totalAwarded }}</span>
+                                <span class="map-info__stat-caption t8"><strong>{{ copy.map.totalAwarded }}</strong></span>
+                            </p>
 
-                            <h5 class="map-info__stat t2 accent--{{ pageAccent }} a--text">{{ region.beneficiaries | numberWithCommas }}</h5>
-                            <h6 class="t8"><strong>{{ copy.map.totalBeneficiaries }}</strong></h6>
+                            <p class="map-info__stat">
+                                <span class="map-info__stat-data t2 accent--{{ pageAccent }} a--text">{{ region.beneficiaries | numberWithCommas }}</span>
+                                <span class="map-info__stat-caption t8"><strong>{{ copy.map.totalBeneficiaries }}</strong></span>
+                            </p>
                         </article>
                     </section>
                 {% endfor %}

--- a/views/pages/toplevel/funding.njk
+++ b/views/pages/toplevel/funding.njk
@@ -20,14 +20,12 @@
     }}
 
     <main class="nudge-up">
-        <section class="content-box content-box--even-inset
-            inner--wide-only accent--{{ pageAccent }} a--border-top">
+        <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
             {{ sectionLinks(copy.sectionLinks) }}
         </section>
 
         {% if latestProgrammes.length > 0 %}
-            <section class="content-box content-box--even-inset
-                inner--wide-only accent--{{ pageAccent }} a--border-top">
+            <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <h2 class="t1">{{ copy.latestProgrammes }}</h2>
 
                 <ul class="grid grid--3-up grid--padded--large grid--equal grid--wide-only">

--- a/views/pages/toplevel/jobs.njk
+++ b/views/pages/toplevel/jobs.njk
@@ -9,67 +9,65 @@
 {% set socialImage = heroImage %}
 
 {% block content %}
+    {% set pageAccent = 'blue' %}
     {{
         hero(
-            accent = 'blue',
             titleText = title,
-            image = heroImage
+            image = heroImage,
+            accent = pageAccent
         )
     }}
 
-    <article role="main" class="nudge-up">
-
-        <div class="inner--wide-only accent--blue a--border-top content-box">
-
+    <main role="main" class="nudge-up">
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long">
             <div class="u-align-center">
-                <a class="btn accent--pink a--btn central-gap spaced--l" href="https://atsv7.wcn.co.uk/search_engine/jobs.cgi?owner=5031783&ownertype=fair&submitSearchForm=1&submitSearchForm=Search&vac_xtra5031783.30_5031783=&posting_code=53">{{ copy['call-to-action'] }}</a>
+                <a class="btn accent--{{ pageAccent }} a--btn central-gap spaced--l" href="https://atsv7.wcn.co.uk/search_engine/jobs.cgi?owner=5031783&ownertype=fair&submitSearchForm=1&submitSearchForm=Search&vac_xtra5031783.30_5031783=&posting_code=53">{{ copy['call-to-action'] }}</a>
             </div>
 
-            <h3 class="t2">{{ copy.sections.whyWork.title }}</h3>
+            <h2>{{ copy.sections.whyWork.title }}</h2>
             {{ copy.sections.whyWork.body | safe }}
-
         </div>
 
-        <div class="inner--wide-only accent--green a--border-top content-box">
-            <h3 class="t2">{{ copy.sections.benefits.title }}</h3>
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long">
+            <h2>{{ copy.sections.benefits.title }}</h2>
             {{ copy.sections.benefits.body | safe }}
             <ul class="list-bullets u-tone-foreground-highlight">
                 {% for benefit in copy.sections.benefits.list %}
                     <li><strong>{{ benefit }}</strong></li>
                 {% endfor %}
             </ul>
-            <a href="{{ buildUrl('toplevel', 'benefits') }}" class="btn btn--small">{{ copy.sections.benefits.postscript }}</a>
+            <p>
+                <a class="btn btn--small accent--{{ pageAccent }} a--btn"
+                    href="{{ buildUrl('toplevel', 'benefits') }}">
+                    {{ copy.sections.benefits.postscript }}
+                </a>
+            </p>
         </div>
 
         {% if copy.sections.currentVacancies and copy.sections.currentVacancies.vacancies.length > 0 %}
             <div class="content-box content-box--borderless
-                inner--wide-only accent--blue a--border-top"
-                id="current-vacancies">
-
-                <h3 class="t1 t--underline accent--pink">
+                inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long" id="current-vacancies">
+                <h2 class="t1 t--underline accent--{{ pageAccent }}">
                     {{ copy.sections.currentVacancies.title }}
-                </h3>
-
+                </h2>
                 {{ linkGrid(copy.sections.currentVacancies.vacancies, 'blue') }}
             </div>
         {% endif %}
 
-        <div class="inner--wide-only accent--turquoise a--border-top content-box">
-            <h3 class="t2">{{ copy.sections.offices.title }}</h3>
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long">
+            <h2>{{ copy.sections.offices.title }}</h2>
             <div class="google-map">
                 <iframe src="https://www.google.com/maps/d/embed?mid=1ANUmJnn8RObMDFvo50elNW58F7A&hl=en" width="100%" height="480" frameborder="0"></iframe>
             </div>
         </div>
 
-        <div class="inner--wide-only accent--orange a--border-top content-box">
-            <h3 class="t2">{{ copy.sections.equalities.title }}</h3>
+        <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top s-prose s-prose--long">
+            <h2>{{ copy.sections.equalities.title }}</h2>
             {{ copy.sections.equalities.body | safe }}
         </div>
 
         <div class="inner spaced">
             <img src="{{ 'jobs/equality-sponsors.png' | getImagePath }}" alt="The logos of Positive About Disabled People, Stonewall, Investors In People, Business Disability Forum and Living Wage Employer" />
         </div>
-
-    </article>
-
+    </main>
 {% endblock %}

--- a/views/pages/toplevel/region.njk
+++ b/views/pages/toplevel/region.njk
@@ -66,7 +66,7 @@
     {% endset %}
 
     <main class="nudge-up">
-        <section class="content-box content-box--tinted content-box--even-inset
+        <section class="content-box content-box--tinted
             inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="s-prose u-constrained-content-wide">
                 <p>{{ copy.introduction }}</p>

--- a/views/pages/toplevel/research.njk
+++ b/views/pages/toplevel/research.njk
@@ -20,15 +20,13 @@
 
     <main class="nudge-up">
         {# Section Links #}
-        <section class="content-box content-box--even-inset
-            inner--wide-only accent--{{ pageAccent }} a--border-top">
+        <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
             <p>{{ copy.intro }}</p>
             {{ sectionLinks(copy.sectionLinks) }}
         </section>
 
         {# Downloads #}
-        <section class="content-box content-box--even-inset
-            inner--wide-only accent--{{ pageAccent }} a--border-top">
+        <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
             <div class="s-prose">
                 <h2 class="t1">{{ copy.downloads.title }}</h2>
                 <ul class="u-list-unstyled">


### PR DESCRIPTION
A few changes to fix up some layout and heading level issues.

- Removes the need for `content-box--even-inset`, we always add it so making those styles the default
- Fixes up some spacing issues with segments and prose styles within them
- Fixes document outline on contact page as a result

<img width="902" alt="screen shot 2018-04-10 at 09 42 50" src="https://user-images.githubusercontent.com/123386/38546264-17b4d3f4-3ca4-11e8-8f0a-e5049f5b7301.png">
<img width="1189" alt="screen shot 2018-04-10 at 09 42 40" src="https://user-images.githubusercontent.com/123386/38546265-17d0098a-3ca4-11e8-8786-09f5dc522be4.png">
<img width="1018" alt="screen shot 2018-04-10 at 09 42 12" src="https://user-images.githubusercontent.com/123386/38546268-1806a094-3ca4-11e8-94f4-6dfe53143578.png">
<img width="1029" alt="screen shot 2018-04-10 at 09 42 18" src="https://user-images.githubusercontent.com/123386/38546266-17eec118-3ca4-11e8-9033-fa816f588f53.png">


