### PR TITLE
Remove unwanted prose class

### DIFF
--- a/views/pages/toplevel/contact.njk
+++ b/views/pages/toplevel/contact.njk
@@ -17,7 +17,7 @@
     ) }}
 
     <main role="main" class="nudge-up">
-        <div class="inner--wide-only s-prose s-prose--long">
+        <div class="inner--wide-only">
             {% set applicationQuery %}
                 <h3>{{ copy.offices.england }}</h3>
                 <p>


### PR DESCRIPTION
Looks like my previous branch fixed the spacing on the contact page but not the line-height issue (good catch @mattandrews) on miniature heroes. This was down to an unwanted prose class wrapping the whole page. 