### PR TITLE
Link text

### DIFF
--- a/assets/js/modules/carousel.split.js
+++ b/assets/js/modules/carousel.split.js
@@ -16,7 +16,6 @@ export const init = elems => {
             speed: 300,
             autoHeight: true,
             a11y: true,
-            loop: true,
             slidesPerView: 1
         });
 

--- a/assets/sass/components/news.scss
+++ b/assets/sass/components/news.scss
@@ -2,9 +2,19 @@
    News
    ========================================================================= */
 
-// .article-teaser {}
+.article-teaser {
+    margin: 0;
+}
+.article-teaser__title {
+    margin-bottom: $spacingUnit / 2;
+
+    @include mq('medium') {
+        margin-bottom: $spacingUnit;
+    }
+}
 .article-teaser__summary {
     font-size: 18px;
+    margin-bottom: 0;
 }
 
 .latest-news {

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -65,6 +65,7 @@ global:
     caseStudies: Astudiaethau achos
     projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
     readMore: Darllen mwy
+    readMoreAbout: Darllenwch fwy am
     or: neu
   programmes:
     programmeLabels:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ global:
     projectExamples: Examples of projects that have been funded
     caseStudies: Case studies
     readMore: Read more
+    readMoreAbout: "Read more about %s"
     or: or
   programmes:
     programmeLabels:

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -9,13 +9,11 @@
 ) %}
     <div class="case-study">
         <div class="case-study__image">
-            {% if link %}<a href="{{ buildUrl(link) }}">{% endif %}
-                <picture>
-                    <source srcset="{{ imageUrl | getImagePath }}" media="(min-width: 600px)">
-                    <source srcset="{{ imageSmallUrl | getImagePath }}">
-                    <img src="{{ imageSmallUrl | getImagePath }}" alt="{{ quoteName }} {{ projectName }}" />
-                </picture>
-            {% if link %}</a>{% endif %}
+            <picture>
+                <source srcset="{{ imageUrl | getImagePath }}" media="(min-width: 600px)">
+                <source srcset="{{ imageSmallUrl | getImagePath }}">
+                <img src="{{ imageSmallUrl | getImagePath }}" alt="{{ quoteName }} {{ projectName }}" />
+            </picture>
         </div>
         <div class="case-study__content">
                 <blockquote class="pullquote">
@@ -28,7 +26,8 @@
                             {% if quoteNameCaption %}
                                 <p class="t8 u-weight-normal">{{ quoteNameCaption }}</p>
                             {% endif %}
-                            {% if link %}<a href="{{ buildUrl(link) }}">{% endif %}
+                            {% if link %}<a href="{{ buildUrl(link) }}"
+                                aria-label="{{ __('global.misc.readMoreAbout', projectName) }}">{% endif %}
                                 <p class="t8 u-weight-normal">{{ projectName | safe }}</p>
                             {% if link %}</a>{% endif %}
                         </div>
@@ -69,7 +68,8 @@
                 {{ trailText }}
                 {% if linkUrl %}
                     <a href="{{ linkUrl }}"
-                        class="{% if accent %}accent--{{ accent }} a--text {% endif %}u-weight-heavy">
+                        class="{% if accent %}accent--{{ accent }} a--text {% endif %}u-weight-heavy"
+                        aria-label="{{ __('global.misc.readMoreAbout', title) }}">
                         {{ trailTextMore }}
                     </a>
                 {% endif %}

--- a/views/components/news.njk
+++ b/views/components/news.njk
@@ -7,9 +7,6 @@
         </h3>
         <p class="article-teaser__summary">
             {{ article.summary }}
-            <a href="{{ article.link }}" class="accent--pink a--text u-weight-heavy">
-                {{ __('global.misc.readMore') }}&hellip;
-            </a>
         </p>
     </article>
 {% endmacro %}

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -1,4 +1,4 @@
-{% from "components/caseStudies.njk" import caseStudyFeature %}
+{% from "components/caseStudies.njk" import caseStudyFeature with context %}
 {% from "components/ebulletin.njk" import ebulletinForm with context %}
 {% from "components/hero.njk" import homepageSuperHero %}
 {% from "components/icons.njk" import iconArrowLeft, iconArrowRight %}


### PR DESCRIPTION
Last few a11y tweaks mostly around "read more" link text.

- Disable carousel looping as it causes weird duplication of link text in a screen reader
- Remove "Read more" link text from news articles, article title link is enough and reduces confusion in screen readers
- Add more context to case study links so they make sense our of context e.g. "Read more about Bytes" rather than just "Bytes"