### PR TITLE
Mount static assets earlier to avoid extra middleware processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "startDev": "export DEBUG=blf-alpha:*; nodemon ./bin/www",
+    "startDev": "export DEBUG=blf-alpha:*,express-session,connect:session-sequelize; nodemon ./bin/www",
     "startTest": "./bin/start-test-server",
     "lint": "eslint .",
     "test-deps": "snyk test",

--- a/server.js
+++ b/server.js
@@ -52,23 +52,13 @@ Raven.config(SENTRY_DSN, {
 
 app.use(Raven.requestHandler());
 
-// Configure views
 viewEngineService.init(app);
 viewGlobalsService.init(app);
 
-// Add global middlewares
 app.use(loggerMiddleware);
-app.use(previewMiddleware);
 app.use(cachedMiddleware.defaultVary);
 app.use(cachedMiddleware.defaultCacheControl);
-app.use(defaultSecurityHeaders());
-app.use(bodyParserMiddleware);
-app.use(sessionMiddleware(app));
-app.use(passportMiddleware());
-app.use(redirectsMiddleware.all);
-app.use(localesMiddleware(app));
 
-// Configure static files
 app.use(favicon(path.join('public', '/favicon.ico')));
 app.use(
     `/${config.get('assetVirtualDir')}`,
@@ -76,6 +66,14 @@ app.use(
         maxAge: config.get('staticExpiration')
     })
 );
+
+app.use(previewMiddleware);
+app.use(defaultSecurityHeaders());
+app.use(bodyParserMiddleware);
+app.use(sessionMiddleware(app));
+app.use(passportMiddleware());
+app.use(redirectsMiddleware.all);
+app.use(localesMiddleware(app));
 
 // Mount load balancer status route
 app.get('/status', require('./controllers/toplevel/status'));


### PR DESCRIPTION
Added a bit of debugging logging for sessions and noticed a lot of noise. Looks like it was static assets triggering a bunch of extra middlewares. This PR moves the mounting of static files earlier in the process. As middlewares are order dependent this avoids some unwanted processing.