### PR TITLE
Localise recent programmes on funding page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -273,6 +273,10 @@ toplevel:
       href: "/welsh/funding/search-past-grants"
     - label: Cymorth rheoli’ch grant
       href: "/welsh/funding/funding-guidance/managing-your-funding"
+    recentProgrammes:
+    - "national-lottery-awards-for-all-wales"
+    - "people-and-places-medium-grants"
+    - "people-and-places-large-grants"
   research:
     title: Ymchwil
     intro: Cael gwybod mwy am beth rydym yn ei ddysgu o’r prosiectau a ariannwn.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,6 +351,10 @@ toplevel:
       href: "/funding/search-past-grants"
     - label: Help with managing your grant
       href: "/funding/funding-guidance/managing-your-funding"
+    recentProgrammes:
+    - "reaching-communities-england"
+    - "national-lottery-awards-for-all-england"
+    - "empowering-young-people"
   research:
     title: Research
     intro: Find out more about what we’re learning from the projects we fund.

--- a/controllers/funding/funding.js
+++ b/controllers/funding/funding.js
@@ -1,12 +1,24 @@
-const { find } = require('lodash');
+const { find, get } = require('lodash');
 const { sMaxAge } = require('../../middleware/cached');
 const injectHeroImage = require('../../middleware/inject-hero');
 const contentApi = require('../../services/content-api');
 
 function init({ router, routeConfig }) {
     router.get(routeConfig.path, sMaxAge(routeConfig.sMaxAge), injectHeroImage(routeConfig), (req, res) => {
+        const lang = req.i18n.__(routeConfig.lang);
+
+        /**
+         * "Latest" programmes
+         * Hardcoded for now but we may want to fetch these dynamically.
+         */
+        function getLatestProgrammes(programmes) {
+            const findBySlug = slug => find(programmes, p => p.urlPath === `funding/programmes/${slug}`);
+            const programmeSlugs = get(lang, 'recentProgrammes', []);
+            const latestProgrammes = programmeSlugs.map(findBySlug);
+            return latestProgrammes;
+        }
+
         function renderLandingPage(programmes) {
-            const lang = req.i18n.__(routeConfig.lang);
             res.render(routeConfig.template, {
                 copy: lang,
                 title: lang.title,
@@ -19,17 +31,7 @@ function init({ router, routeConfig }) {
                 locale: req.i18n.getLocale()
             })
             .then(programmes => {
-                /**
-                 * "Latest" programmes
-                 * @todo Hardcoded for now but we may want to fetch these dynamically.
-                 */
-                const findBySlug = slug => find(programmes, p => p.urlPath === `funding/programmes/${slug}`);
-                const latestProgrammes = [
-                    findBySlug('reaching-communities-england'),
-                    findBySlug('national-lottery-awards-for-all-england'),
-                    findBySlug('empowering-young-people')
-                ];
-
+                const latestProgrammes = getLatestProgrammes(programmes);
                 renderLandingPage(latestProgrammes);
             })
             .catch(() => {


### PR DESCRIPTION
Eagle eyed Dave Symons and team spotted that on the welsh version of `/funding` we show england programmes, which are not translated. Byproduct of the fact we hard code the "recent" programmes. It might be worth fetching these dynamically from the CMS using the publish date or similar, but for now I've updated the page to pull in equivalent welsh programmes. Using the same programmes listed on `/wales`