### PR TITLE
Add before unload message to review page

### DIFF
--- a/assets/js/bootstraps/common.js
+++ b/assets/js/bootstraps/common.js
@@ -8,7 +8,7 @@ const global = require('../modules/global');
 const tabs = require('../modules/tabs');
 import heroImages from '../modules/heroImages';
 const logos = require('../modules/logos');
-const forms = require('../modules/forms');
+import forms from '../modules/forms';
 import carousel from '../modules/carousel';
 
 function init() {

--- a/assets/js/helpers/features.js
+++ b/assets/js/helpers/features.js
@@ -1,0 +1,35 @@
+import find from 'lodash/find';
+
+function createFeature(config) {
+    let override = null;
+    try {
+        override = window.localStorage.getItem(`app.features.${config.id}`);
+    } catch (e) {} // eslint-disable-line no-empty
+
+    const isEnabled = override !== null ? override === 'true' : config.isEnabled;
+
+    return {
+        id: config.id,
+        description: config.description,
+        isEnabled: isEnabled
+    };
+}
+
+export const FEATURES = [
+    createFeature({
+        id: 'review-abandonment-message',
+        description: 'Show abandonment message on the review step',
+        isEnabled: window.AppConfig.isNotProduction
+    })
+];
+
+window.AppConfig.features = FEATURES;
+
+export function featureIsEnabled(featureId) {
+    const match = find(FEATURES, feature => feature.id === featureId);
+    if (match) {
+        return match.isEnabled;
+    } else {
+        throw new Error(`Feature ${featureId} not found`);
+    }
+}

--- a/assets/js/modules/forms.js
+++ b/assets/js/modules/forms.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const $ = require('jquery');
+import $ from 'jquery';
+import { featureIsEnabled } from '../helpers/features';
 
 // Materials form logic
 function initLegacyForms() {
@@ -54,7 +55,7 @@ function handleAbandonmentMessage(formEl) {
         return confirmationMessage; // Gecko, WebKit, Chrome <34
     }
 
-    if (abandonmentMessage) {
+    if (featureIsEnabled('review-abandonment-message') && abandonmentMessage) {
         window.addEventListener('beforeunload', handleBeforeUnload);
 
         // Remove beforeunload if clicking on edit links
@@ -99,6 +100,6 @@ function init() {
     initApplicationForms();
 }
 
-module.exports = {
-    init: init
+export default {
+    init
 };

--- a/controllers/apply/forms/create-form-router.js
+++ b/controllers/apply/forms/create-form-router.js
@@ -89,7 +89,7 @@ module.exports = function(router, formModel) {
                 res.render('pages/apply/review', {
                     csrfToken: req.csrfToken(),
                     form: formModel,
-                    review: formModel.getReviewStep(),
+                    stepConfig: formModel.getReviewStep(),
                     summary: formModel.getStepsWithValues(formData),
                     baseUrl: req.baseUrl
                 });

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -228,7 +228,8 @@ formModel.registerStep({
 
 formModel.registerReviewStep({
     title: 'Check this is right',
-    proceedLabel: 'Submit'
+    proceedLabel: 'Submit',
+    abandonmentMessage: 'Your idea has not been submitted. Are you sure you want to leave this page?'
 });
 
 formModel.registerSuccessStep({

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -228,8 +228,7 @@ formModel.registerStep({
 
 formModel.registerReviewStep({
     title: 'Check this is right',
-    proceedLabel: 'Submit',
-    abandonmentMessage: 'Your idea has not been submitted. Are you sure you want to leave this page?'
+    proceedLabel: 'Submit'
 });
 
 formModel.registerSuccessStep({

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -8,6 +8,7 @@
 (function() {
     var AppConfig = {
         environment: '{{ appData.environment }}',
+        isNotProduction: {{ appData.isNotProduction }},
         locale: '{{ locale }}',
         localePrefix: '{{ localePrefix }}',
         isModernBrowser:

--- a/views/pages/apply/review.njk
+++ b/views/pages/apply/review.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/main.njk" %}
 
-{% block title %}Review | {{ form.title }} | {% endblock %}
+{% block title %}{{ stepConfig.title }} | {{ form.title }} | {% endblock %}
 
 {% set bodyClass = 'has-static-header' %}
 
@@ -9,13 +9,14 @@
     <main role="main" id="content">
         <form action="" method="POST"
             class="js-application-form js-application-form-review
-            content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+            content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top"
+            data-abandonment-message="{{ stepConfig.abandonmentMessage }}">
             <div class="u-constrained-content">
-                <h1 class="t1">{{ review.title }}</h1>
+                <h1 class="t1">{{ stepConfig.title }}</h1>
                 {% for step in summary %}
                     <h2 class="t2 t--underline accent--{{ pageAccent }}">
                         {{ step.name }}
-                        [<a href="{{ baseUrl }}/{{ loop.index }}">Edit</a>]
+                        [<a href="{{ baseUrl }}/{{ loop.index }}" class="js-application-form-review-edit">Edit</a>]
                     </h2>
                     {% for fieldset in step.fieldsets %}
                     <dl class="review-list {% if fieldset.fields.length === 1 %}review-list--stacked{% endif %}">
@@ -46,7 +47,7 @@
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             {% endif %}
 
-            <input class="btn btn--next" type="submit" value="{{ review.proceedLabel }}" />
+            <input class="btn btn--next" type="submit" value="{{ stepConfig.proceedLabel }}" />
         </form>
     </main>
 {% endblock %}

--- a/views/pages/apply/review.njk
+++ b/views/pages/apply/review.njk
@@ -9,8 +9,7 @@
     <main role="main" id="content">
         <form action="" method="POST"
             class="js-application-form js-application-form-review
-            content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top"
-            data-abandonment-message="{{ stepConfig.abandonmentMessage }}">
+            content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
             <div class="u-constrained-content">
                 <h1 class="t1">{{ stepConfig.title }}</h1>
                 {% for step in summary %}


### PR DESCRIPTION
<img width="461" alt="screen shot 2018-04-12 at 17 59 44" src="https://user-images.githubusercontent.com/123386/38729306-79f14c06-3f0a-11e8-9b4b-731bd82a0077.png">

Adds a `beforeunload` message to the review screen. Needs a bit of thought. This approach is a bit heavy handed and has plenty of caveats: can't change the message, need to jump through hoops to only trigger in certain contexts, browsers don't guarantee they will show it.