### PR TITLE
Swap out XSS library for DOMpurify

### DIFF
--- a/controllers/about/ebulletin.js
+++ b/controllers/about/ebulletin.js
@@ -7,8 +7,7 @@ const rp = require('request-promise-native');
 const config = require('config');
 
 const { customEvent } = require('../../modules/analytics');
-const { purifyUserInput } = require('../../modules/validators');
-const { errorTranslator } = require('../../modules/validators');
+const { purifyUserInput, errorTranslator } = require('../../modules/validators');
 const { FORM_STATES } = require('../../modules/forms');
 const { getSecret } = require('../../modules/secrets');
 const cached = require('../../middleware/cached');

--- a/controllers/about/ebulletin.js
+++ b/controllers/about/ebulletin.js
@@ -5,9 +5,9 @@ const { body, validationResult } = require('express-validator/check');
 const { matchedData } = require('express-validator/filter');
 const rp = require('request-promise-native');
 const config = require('config');
-const xss = require('xss');
 
 const { customEvent } = require('../../modules/analytics');
+const { purifyUserInput } = require('../../modules/validators');
 const { errorTranslator } = require('../../modules/validators');
 const { FORM_STATES } = require('../../modules/forms');
 const { getSecret } = require('../../modules/secrets');
@@ -99,7 +99,7 @@ function init({ router, routeConfig }) {
         })
         .post(formValidators, (req, res) => {
             for (let key in req.body) {
-                req.body[key] = xss(req.body[key]);
+                req.body[key] = purifyUserInput(req.body[key]);
             }
 
             const formData = matchedData(req);

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const { get, set, some } = require('lodash');
 const { check, validationResult } = require('express-validator/check');
 const { sanitizeBody } = require('express-validator/filter');
-const xss = require('xss');
+const { purifyUserInput } = require('../../modules/validators');
 
 const app = require('../../server');
 const cached = require('../../middleware/cached');
@@ -21,7 +21,6 @@ const translationLabelBase = 'funding.guidance.order-free-materials.formFields.'
 
 function checkClean(fieldName) {
     return check(fieldName)
-        .escape()
         .trim();
 }
 
@@ -358,7 +357,7 @@ function init({ router, routeConfig }) {
         .post(validators, cached.csrfProtection, (req, res) => {
             // sanitise input
             for (let key in req.body) {
-                req.body[key] = xss(req.body[key]);
+                req.body[key] = purifyUserInput(req.body[key]);
             }
 
             // get form errors and translate them

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -20,8 +20,7 @@ const translateError = errorTranslator('global.forms');
 const translationLabelBase = 'funding.guidance.order-free-materials.formFields.';
 
 function checkClean(fieldName) {
-    return check(fieldName)
-        .trim();
+    return check(fieldName).trim();
 }
 
 function createField(props) {

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -4,7 +4,6 @@ const express = require('express');
 const config = require('config');
 const { sortBy } = require('lodash');
 const { body, validationResult } = require('express-validator/check');
-const xss = require('xss');
 const moment = require('moment');
 const Raven = require('raven');
 
@@ -16,6 +15,7 @@ const surveyService = require('../../services/surveys');
 const contentApi = require('../../services/content-api');
 
 const { homepageHero } = require('../../modules/images');
+const { purifyUserInput } = require('../../modules/validators');
 const regions = require('../../config/content/regions.json');
 
 const robotRoutes = require('./robots');
@@ -144,7 +144,7 @@ module.exports = (pages, sectionPath, sectionId) => {
             });
         } else {
             for (let key in req.body) {
-                req.body[key] = xss(req.body[key]);
+                req.body[key] = purifyUserInput(req.body[key]);
             }
 
             let responseData = {

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -1,8 +1,8 @@
-const xss = require('xss');
 const jwt = require('jsonwebtoken');
 const { validationResult } = require('express-validator/check');
 
 const mail = require('../../modules/mail');
+const { purifyUserInput } = require('../../modules/validators');
 const { JWT_SIGNING_TOKEN } = require('../../modules/secrets');
 const userService = require('../../services/user');
 const { userBasePath, userEndpoints, makeUserLink, makeErrorList, trackError } = require('./utils');
@@ -88,7 +88,7 @@ const sendResetEmail = (req, res) => {
             return requestResetForm(req, res);
         });
     } else {
-        const email = xss(req.body.username);
+        const email = purifyUserInput(req.body.username);
         userService
             .findByUsername(email)
             .then(user => {

--- a/modules/validators.js
+++ b/modules/validators.js
@@ -2,7 +2,7 @@
 
 const createDOMPurify = require('dompurify');
 const { JSDOM } = require('jsdom');
-const window = (new JSDOM('')).window;
+const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
 function purifyUserInput(input) {

--- a/modules/validators.js
+++ b/modules/validators.js
@@ -1,5 +1,14 @@
 'use strict';
 
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = (new JSDOM('')).window;
+const DOMPurify = createDOMPurify(window);
+
+function purifyUserInput(input) {
+    return DOMPurify.sanitize(input);
+}
+
 function errorTranslator(prefix) {
     return function(prop, replacementKeys = []) {
         return function(value, { req }) {
@@ -11,5 +20,6 @@ function errorTranslator(prefix) {
 }
 
 module.exports = {
-    errorTranslator
+    errorTranslator,
+    purifyUserInput
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5065,6 +5065,11 @@
         "domelementtype": "1.3.0"
       }
     },
+    "dompurify": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.3.tgz",
+      "integrity": "sha512-7dks9EA59zmQ9UBH7QJmGCHNxGJ7chzB5RJObT+h/TGBDtp4pTgunOeT0NidTA5MAq22muWrW3XfqtpvIsoSmw=="
+    },
     "domutils": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "cookie-parser": "~1.4.3",
     "csurf": "^1.9.0",
     "debug": "^3.1.0",
+    "dompurify": "^1.0.3",
     "express": "^4.15.5",
     "express-ab": "^0.7.1",
     "express-cache-controller": "^1.0.1",
@@ -120,7 +121,6 @@
     "uuid": "^3.1.0",
     "vary": "^1.1.1",
     "vue": "^2.4.4",
-    "xss": "^0.3.4",
     "yargs": "^11.0.0"
   },
   "devDependencies": {

--- a/services/user.js
+++ b/services/user.js
@@ -1,11 +1,11 @@
-const xss = require('xss');
 const { Op } = require('sequelize');
 const { Users } = require('../models');
+const { purifyUserInput } = require('../modules/validators');
 
 function getSanitizedUser({ username, password, level }) {
     return {
-        username: xss(username),
-        password: xss(password),
+        username: purifyUserInput(username),
+        password: purifyUserInput(password),
         level: level || 0
     };
 }
@@ -18,7 +18,7 @@ function findByUsername(username) {
     return Users.findOne({
         where: {
             username: {
-                [Op.eq]: xss(username)
+                [Op.eq]: purifyUserInput(username)
             }
         }
     });


### PR DESCRIPTION
We had a complaint that a user address for a material order came through like this:

	Address line 1: c&#x2F;o Foo Cottage

(was meant to be `c/o`).

It turned out that the `escape()` filter was adding this, not the `xss` library, but that package felt a little basic so thought I'd upgrade it here to `DOMpurify` which feels a bit better. 

I removed `escape()` and tested it by ordering with these fields:

`c/o Foo Cottage <script src="evil.js"></script><script>alert('lol');</script><marquee>foo</marquee>`

The `<script>`s were removed (though the `<marquee>` wasn't, but we don't display this input anywhre or store it), and the `c/o` remained the same – success.
