### PR TITLE
Reduce reliance on setViewGlobal

### DIFF
--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -30,16 +30,6 @@ function getMetaTitle(base, pageTitle) {
     }
 }
 
-function getHtmlClasses({ locale, highContrast }) {
-    let parts = ['no-js', 'locale--' + locale];
-
-    if (highContrast) {
-        parts.push('contrast--high');
-    }
-
-    return parts.join(' ');
-}
-
 /**
  * buildUrl
  * URL helper, return canonical URL based on sectionName or pageName
@@ -145,13 +135,6 @@ function init(app) {
 
     setViewGlobal('getMetaTitle', getMetaTitle);
 
-    setViewGlobal('getHtmlClasses', () => {
-        return getHtmlClasses({
-            locale: getViewGlobal('locale'),
-            highContrast: getViewGlobal('highContrast')
-        });
-    });
-
     setViewGlobal('anchors', config.get('anchors'));
 
     setViewGlobal('buildUrl', (sectionName, pageName) => {
@@ -192,7 +175,6 @@ module.exports = {
     init,
     buildUrl,
     getCurrentUrl,
-    getHtmlClasses,
     getMetaTitle,
     getCurrentSection
 };

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const httpMocks = require('node-mocks-http');
-const { buildUrl, getCurrentUrl, getHtmlClasses, getMetaTitle, getCurrentSection } = require('./viewGlobals');
+const { buildUrl, getCurrentUrl, getMetaTitle, getCurrentSection } = require('./viewGlobals');
 
 describe('View Globals', () => {
     describe('#buildUrl', () => {
@@ -69,20 +69,6 @@ describe('View Globals', () => {
             expect(getCurrentUrl(withQuery('version=123&draft=2&something=else'))).to.equal(
                 '/some/example/url?something=else'
             );
-        });
-    });
-
-    describe('#getHtmlClasses', () => {
-        it('should return expected html classes based on locale', () => {
-            expect(getHtmlClasses({ locale: 'en' })).to.equal('no-js locale--en');
-            expect(getHtmlClasses({ locale: 'cy' })).to.equal('no-js locale--cy');
-        });
-
-        it('should return expected html classes if in high contrast mode', () => {
-            expect(getHtmlClasses({ locale: 'en', highContrast: true })).to.equal('no-js locale--en contrast--high');
-            expect(getHtmlClasses({ locale: 'cy', highContrast: true })).to.equal('no-js locale--cy contrast--high');
-            expect(getHtmlClasses({ locale: 'en', highContrast: false })).to.equal('no-js locale--en');
-            expect(getHtmlClasses({ locale: 'cy', highContrast: false })).to.equal('no-js locale--cy');
         });
     });
 

--- a/server.js
+++ b/server.js
@@ -52,6 +52,11 @@ Raven.config(SENTRY_DSN, {
 
 app.use(Raven.requestHandler());
 
+/**
+ * Set static app locals
+ */
+app.locals.navigationSections = routes.sections;
+
 viewEngineService.init(app);
 viewGlobalsService.init(app);
 

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -1,7 +1,7 @@
 {% from "components/icons.njk" import iconSearch %}
 
 {% macro navlinks(itemClass) %}
-    {% for id, section in routes %}
+    {% for id, section in navigationSections %}
         {% set currentSectionId = getCurrentSection(sectionId, pageId)  %}
         <li class="{% if currentSectionId === id %}is-selected{% endif %}{% if itemClass %} {{ itemClass }}{% if loop.last %} {{ itemClass }}--last{% endif %}{% endif %} qa-nav-link qa-nav-link--{{ id }}">
             <a href="{{ buildUrl(id) }}">{{ __(section.langTitlePath) }}</a>

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -1,7 +1,8 @@
 {% from "components/accessibility.njk" import accessibilityNav with context %}
 {% from "components/preview.njk" import previewBanner with context %}
 <!doctype html>
-<html lang="{{ locale }}" class="{{ getHtmlClasses() }}">
+<html lang="{{ locale }}"
+    class="no-js locale--{{ locale }}{% if isHighContrast %} contrast--high{% endif %}">
     <head>
         <title>{% block title %}{% endblock %}{{ __("global.brand.title") }}</title>
 

--- a/views/layouts/styleguide.njk
+++ b/views/layouts/styleguide.njk
@@ -1,11 +1,10 @@
 <!doctype html>
-<html lang="{{ locale }}" class="{{ getHtmlClasses() }}">
+<html lang="{{ locale }}" class="no-js">
 <head>
     <title>Style Guide | {{ __("global.brand.title") }}</title>
 
-    {% include "../includes/metadata.njk" %}
-    {% include "../includes/metaHeadJS.njk" %}
-    {% include "../includes/metaHeadCSS.njk" %}
+    {% include "includes/metadata.njk" %}
+    {% include "includes/metaHead.njk" %}
 
     <link rel="stylesheet" href="{{ 'stylesheets/styleguide.css' | getCachebustedPath }}"/>
 </head>

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -3,7 +3,7 @@
 {% from "components/hero.njk" import homepageSuperHero %}
 {% from "components/icons.njk" import iconArrowLeft, iconArrowRight %}
 {% from "components/news.njk" import articleTeaser with context %}
-{% from "components/social.njk" import socialLinks %}
+{% from "components/social.njk" import socialLinks with context %}
 
 {% extends "layouts/main.njk" %}
 


### PR DESCRIPTION
This is an attempt to remove the occasional race condition we see with values set using `setViewGlobal` in middleware. Switches `locale` and `highContrast` to use request locals instead.