### PR TITLE
Split RC emails

### DIFF
--- a/controllers/apply/forms/create-form-model.js
+++ b/controllers/apply/forms/create-form-model.js
@@ -113,7 +113,7 @@ function createFormModel({ id, title, shortCode }) {
         },
         orderStepsForInternalUse: function(stepData) {
             // rank steps by their internal order (if provided), falling back to original (source) order
-            const stepGroups = groupBy(stepData, s => (s.internalOrder) ? 'ordered' : 'unordered');
+            const stepGroups = groupBy(stepData, s => (s.internalOrder ? 'ordered' : 'unordered'));
             return sortBy(stepGroups.ordered, 'internalOrder').concat(stepGroups.unordered);
         },
         registerReviewStep: function(review) {

--- a/controllers/apply/forms/create-form-model.js
+++ b/controllers/apply/forms/create-form-model.js
@@ -1,5 +1,5 @@
 const shortid = require('shortid');
-const { find, flatMap, has, get } = require('lodash');
+const { find, flatMap, has, get, sortBy, groupBy } = require('lodash');
 
 /**
  * For a given field attach some additional computed properties
@@ -110,6 +110,11 @@ function createFormModel({ id, title, shortCode }) {
                 }
             }
             return obj;
+        },
+        orderStepsForInternalUse: function(stepData) {
+            // rank steps by their internal order (if provided), falling back to original (source) order
+            const stepGroups = groupBy(stepData, s => (s.internalOrder) ? 'ordered' : 'unordered');
+            return sortBy(stepGroups.ordered, 'internalOrder').concat(stepGroups.unordered);
         },
         registerReviewStep: function(review) {
             reviewStep = review;

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -7,6 +7,45 @@ const app = require('../../../server');
 const appData = require('../../../modules/appData');
 const mail = require('../../../modules/mail');
 
+const DEFAULT_EMAIL = HUB_EMAILS.england;
+
+const PROJECT_LOCATIONS = [
+    {
+        label: 'North East & Cumbria',
+        value: 'North East & Cumbria',
+        explanation: 'covering Newcastle, Cumbria and the north-east of England',
+        email: HUB_EMAILS.northEastCumbria
+    },
+    {
+        label: 'North West',
+        value: 'North West',
+        explanation: 'covering Greater Manchester, Lancashire, Cheshire and Merseyside',
+        email: HUB_EMAILS.northWest
+    },
+    {
+        label: 'Yorkshire and the Humber',
+        value: 'Yorkshire and the Humber',
+        explanation: 'covering Yorkshire, north and north-east Lincolnshire',
+        email: HUB_EMAILS.yorksHumber
+    },
+    {
+        label: 'South West',
+        value: 'South West',
+        explanation: 'covering Exeter, Bristol and the south-west of England',
+        email: HUB_EMAILS.southWest
+    },
+    {
+        label: 'London, South-East and East of England',
+        value: 'London and South East',
+        email: HUB_EMAILS.londonSouthEast
+    },
+    {
+        label: 'East and West Midlands',
+        value: 'Midlands',
+        email: HUB_EMAILS.midlands
+    }
+];
+
 const formModel = createFormModel({
     id: 'reaching-communities-idea',
     title: 'Reaching Communities & Partnerships',
@@ -59,45 +98,6 @@ formModel.registerStep({
         }
     ]
 });
-
-const DEFAULT_EMAIL = HUB_EMAILS.england;
-
-const PROJECT_LOCATIONS = [
-    {
-        label: 'North East & Cumbria',
-        value: 'North East & Cumbria',
-        explanation: 'covering Newcastle, Cumbria and the north-east of England',
-        email: HUB_EMAILS.northEastCumbria
-    },
-    {
-        label: 'North West',
-        value: 'North West',
-        explanation: 'covering Greater Manchester, Lancashire, Cheshire and Merseyside',
-        email: HUB_EMAILS.northWest
-    },
-    {
-        label: 'Yorkshire and the Humber',
-        value: 'Yorkshire and the Humber',
-        explanation: 'covering Yorkshire, north and north-east Lincolnshire',
-        email: HUB_EMAILS.yorksHumber
-    },
-    {
-        label: 'South West',
-        value: 'South West',
-        explanation: 'covering Exeter, Bristol and the south-west of England',
-        email: HUB_EMAILS.southWest
-    },
-    {
-        label: 'London, South-East and East of England',
-        value: 'London and South East',
-        email: HUB_EMAILS.londonSouthEast
-    },
-    {
-        label: 'East and West Midlands',
-        value: 'Midlands',
-        email: HUB_EMAILS.midlands
-    }
-];
 
 formModel.registerStep({
     name: 'Project location',

--- a/controllers/apply/forms/reaching-communities-form.js
+++ b/controllers/apply/forms/reaching-communities-form.js
@@ -101,6 +101,7 @@ const PROJECT_LOCATIONS = [
 
 formModel.registerStep({
     name: 'Project location',
+    internalOrder: 3,
     fieldsets: [
         {
             legend: 'Where will your project take place?',
@@ -140,6 +141,7 @@ formModel.registerStep({
 
 formModel.registerStep({
     name: 'Your organisation',
+    internalOrder: 2,
     fieldsets: [
         {
             legend: 'Your organisation',
@@ -176,6 +178,7 @@ formModel.registerStep({
 
 formModel.registerStep({
     name: 'Your details',
+    internalOrder: 1,
     fieldsets: [
         {
             legend: 'Your details',

--- a/controllers/apply/reaching-communities.js
+++ b/controllers/apply/reaching-communities.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const createFormRouter = require('./forms/create-form-router');
-const formModel = require('./forms/reaching-communities-form');
+const formModel = require('./reaching-communities-form');
 
 const router = express.Router();
 

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -439,7 +439,7 @@ function init({ router, routeConfig }) {
                         if (!errorRenderingTemplate) {
                             // Next, convert this string into inline-styled HTML
                             mail
-                                .renderHtmlEmail(html)
+                                .inlineCss(html)
                                 .then(inlinedHtml => {
                                     mail.send({
                                         subject: `Thank you for your Big Lottery Fund order`,

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -76,6 +76,7 @@ const send = ({ subject, text, sendTo, sendMode, html, sendFrom }) => {
                     feature: 'email'
                 }
             });
+            return Promise.reject(error);
         });
     } else {
         debug(`[skipped] sending mail`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -758,7 +758,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assign-symbols": {
@@ -2825,11 +2825,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
-    },
     "clean-stack": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
@@ -3427,7 +3422,8 @@
     "commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+      "dev": true
     },
     "common-tags": {
       "version": "1.4.0",
@@ -3963,11 +3959,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
-    },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
     },
     "cssnano": {
       "version": "3.10.0",
@@ -4785,7 +4776,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -4982,7 +4973,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
       "dev": true
     },
     "diffie-hellman": {
@@ -5143,7 +5134,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -5295,7 +5286,7 @@
     "email-validator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
-      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
+      "integrity": "sha1-sH8757rB3AmbxD519q45n1UtWoA="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -8038,7 +8029,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8063,7 +8054,7 @@
     "graphlib": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -8080,7 +8071,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "gulp": {
@@ -13065,7 +13056,7 @@
     "nock": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
+      "integrity": "sha1-Fjla9MRbD9hNGkqWaBVOFvpmJNs=",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -13938,7 +13929,7 @@
     "nyc": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
+      "integrity": "sha1-E/335+8i0CfGHRdHWPaXimj09eU=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -18690,7 +18681,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
         "asap": "2.0.6"
       }
@@ -19114,7 +19105,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -20646,7 +20637,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "restore-cursor": {
@@ -20715,7 +20706,7 @@
     "snyk-go-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz",
-      "integrity": "sha512-uuPXt/NDROmG/pnQveOdur/ToG3h4W64F8r+3L7ZCMPikkRkieoCMGpfMYhEgG+oMlO1bzAsf+YGvMfY0o96Kg==",
+      "integrity": "sha1-v0YmVsqt4GA5cLaOdW9LOJw66qo=",
       "requires": {
         "graphlib": "2.1.5",
         "toml": "2.3.3"
@@ -20724,7 +20715,7 @@
     "snyk-gradle-plugin": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
-      "integrity": "sha512-FucMRR+Rc6LBaSIYxiBl+jvb7R00SgA0QfMT+RGxLIZlDk1lagvA/jIkv+mRadwHVSV/ShIFSZLmS7agfPclVg==",
+      "integrity": "sha1-71rqXRMpBcvwMVxy2dlrJKpKdd0=",
       "requires": {
         "clone-deep": "0.3.0"
       }
@@ -20756,12 +20747,12 @@
     "snyk-mvn-plugin": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz",
-      "integrity": "sha512-CkOAkOYVpEXm/c0peKNpEhbSIqb6SxNM28L5Rt5XZOkZ00Ud3uhz26+AicZVgvhe3in8A2CzOIAPyMUL2ueW4A=="
+      "integrity": "sha1-FcExMaNo3eSHdj3pNVetX7lXL/4="
     },
     "snyk-nuget-plugin": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
-      "integrity": "sha512-F38Amr8AxbalFfUmjLM+57P2Gq2vUh9dWsP7oE2DPXO/f7tW00jwyWhJ5D39Zx+elBoXDxWYvAp14IJnxV18Ag==",
+      "integrity": "sha1-vNxQPq/p8+60Akt1be1NDDsmXRI=",
       "requires": {
         "debug": "3.1.0",
         "es6-promise": "4.2.4",
@@ -20772,7 +20763,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           },
@@ -20787,14 +20778,14 @@
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk="
         }
       }
     },
     "snyk-php-plugin": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
-      "integrity": "sha512-EVN5ilP2PJ5EEBWUvSjzI1kHTRyJxqCQXm5Bb2Kkl4z1cNCFO9ScxjwUDO7cJmQCDQUhHGflDd611ToWmlEYnQ==",
+      "integrity": "sha1-UcGRcd7gzTUVinqoNf4CqX3ISrg=",
       "requires": {
         "debug": "3.1.0"
       },
@@ -20802,7 +20793,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "requires": {
             "ms": "2.0.0"
           },
@@ -20851,7 +20842,7 @@
     "snyk-python-plugin": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
-      "integrity": "sha512-YHDi+tEffbqOVp66sFxEYLSIcHcr/ORkxnqulyM7m1jOqzdgb8Rq/460DyGhm09wMEEdvvgt6v+Ld+QGM8GzYw=="
+      "integrity": "sha1-zjHwtofyPRJ/evORgOopAbKJH+w="
     },
     "snyk-resolve": {
       "version": "1.0.0",
@@ -20926,7 +20917,7 @@
     "snyk-sbt-plugin": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
-      "integrity": "sha512-R8L2+wzB7Zc8BZPmszAoQDjtl9tjLjE6Pf3Mu6tjv22+2rbyADlyfHg7FR+vmQXVFtOuJa43p1orXoaZGatE0g==",
+      "integrity": "sha1-VhV4bxmCXuZKy1CxoEGEO0qcTg8=",
       "requires": {
         "debug": "2.6.9"
       },
@@ -22548,7 +22539,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
     },
     "topo": {
       "version": "2.0.2",
@@ -22698,7 +22689,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-is": {
@@ -25016,15 +25007,6 @@
         "lodash": "4.17.4"
       }
     },
-    "xss": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-0.3.4.tgz",
-      "integrity": "sha512-JFy2ZKgTrEk7BAXm66WoJfOc4WonXue+IMfv1wqnwv4Scz6J+ttuYyZegjbiCGiJJ0teQuTZ6Z0d5AXF5/byXQ==",
-      "requires": {
-        "commander": "2.12.2",
-        "cssfilter": "0.0.10"
-      }
-    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -25043,7 +25025,7 @@
     "yargs": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
+      "integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
       "requires": {
         "cliui": "4.0.0",
         "decamelize": "1.2.0",
@@ -25067,7 +25049,7 @@
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -25099,7 +25081,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",

--- a/views/emails/applicationSummaryInternal.njk
+++ b/views/emails/applicationSummaryInternal.njk
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+    <head>
+        <link rel="stylesheet" type="text/css" href="{{ 'stylesheets/emails.css' | getCachebustedRealPath }}">
+        <link href="//fonts.googleapis.com/css?family=Poppins:300,500" rel="stylesheet">
+        <meta charset="UTF-8">
+    </head>
+    <body>
+
+        <p>A customer has submitted an idea from the Reaching Communities web form.</p>
+        <p>The details they provided are included below:</p>
+
+        <h2 class="space-above">Customer information</h2>
+        {% for step in summary %}
+            <h4 class="data__step">{{ step.name }}</h4>
+            {% for fieldset in step.fieldsets %}
+                {% for field in fieldset.fields %}
+                    {% if field.value %}
+                        <h5 class="data__label">{{ field.label }}</h5>
+                        {% if field.type === 'textarea' %}
+                            <p>{{ field.value | striptags(true) | escape | nl2br }}</p>
+                        {% elseif field.type === 'checkbox' %}
+                            <p>{{ field.value | joinIfArray(', ') }}</p>
+                        {% else %}
+                            <p>{{ field.value }}</p>
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
+        {% endfor %}
+
+    </body>
+</html>


### PR DESCRIPTION
For [this card](https://trello.com/c/eHu2AcPR/30-could-the-applicant-location-legal-group-name-be-at-the-start-of-the-form-when-printed-instead-of-at-the-end-helps-with-identifi).

The idea here is that the email that gets sent internally should structure the customer's idea summary differently to the one the internal hub team gets (eg. put their contact/location details first). 

It was also fairly likely we were going to change the emails to send two different messages (rather than a BCC) so this change helps us get there.

We have a some nested Promises going on here as we have to generate the HTML string first, then send it as an email, but I think it's fairly readable. 