### PR TITLE
Refactor materials form to use new mailer helpers

### DIFF
--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -1,6 +1,7 @@
-const Raven = require('raven');
+const flash = require('req-flash');
 const moment = require('moment');
-const { get, set, some } = require('lodash');
+const Raven = require('raven');
+const { get, set, some, sumBy, values } = require('lodash');
 const { check, validationResult } = require('express-validator/check');
 const { sanitizeBody } = require('express-validator/filter');
 const { purifyUserInput } = require('../../modules/validators');
@@ -238,6 +239,8 @@ function modifyItems(req, orderKey, code) {
 }
 
 function init({ router, routeConfig }) {
+    router.use(flash());
+
     // handle adding/removing items
     router
         .route(routeConfig.path + '/item/:id')

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const express = require('express');
+const flash = require('req-flash');
 
 const auth = require('../../middleware/authed');
 const cached = require('../../middleware/cached');
@@ -13,7 +14,7 @@ const { userBasePath, userEndpoints, emailPasswordValidations, formValidations }
 
 const router = express.Router();
 
-router.use(toolsSecurityHeaders());
+router.use(toolsSecurityHeaders(), flash());
 
 // serve a logged-in user's dashboard
 router.get(userEndpoints.dashboard, cached.noCache, auth.requireAuthed, dashboard.dashboard);
@@ -28,8 +29,9 @@ router
 // login users
 router
     .route(userEndpoints.login)
-    .get(auth.requireUnauthed, cached.csrfProtection, login.loginForm)
-    .post(cached.csrfProtection, login.attemptAuth);
+    .all(cached.csrfProtection)
+    .get(auth.requireUnauthed, login.loginForm)
+    .post(login.attemptAuth);
 
 // logout users
 router.get(userEndpoints.logout, cached.noCache, (req, res) => {

--- a/middleware/locales.js
+++ b/middleware/locales.js
@@ -24,13 +24,6 @@ module.exports = function(app) {
         // get a11y contrast preferences
         let contrastPref = req.cookies[config.get('cookies.contrast')];
         res.locals.isHighContrast = contrastPref && contrastPref === 'high';
-
-        if (req.flash('showOverlay')) {
-            setViewGlobal('showOverlay', true);
-        } else {
-            setViewGlobal('showOverlay', false);
-        }
-
         next();
     }
 

--- a/middleware/session.js
+++ b/middleware/session.js
@@ -1,11 +1,11 @@
-const cookieParser = require('cookie-parser');
 const config = require('config');
+const cookieParser = require('cookie-parser');
 const session = require('express-session');
-const flash = require('req-flash');
 const SequelizeStore = require('connect-session-sequelize')(session.Store);
-const models = require('../models');
+
 const { SESSION_SECRET } = require('../modules/secrets');
 const appData = require('../modules/appData');
+const models = require('../models');
 
 module.exports = function(app) {
     if (!appData.isDev) {
@@ -32,5 +32,5 @@ module.exports = function(app) {
         store: store
     };
 
-    return [cookieParser(SESSION_SECRET), session(sessionConfig), flash()];
+    return [cookieParser(SESSION_SECRET), session(sessionConfig)];
 };

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -38,11 +38,12 @@ function getSecret(name) {
 }
 
 const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url');
-const DB_NAME = process.env.CUSTOM_DB ? process.env.CUSTOM_DB : config.get('database');
 const DB_HOST = process.env.mysqlHost || getSecret('mysql.host');
-const DB_USER = process.env.mysqlUser || getSecret('mysql.user');
+const DB_NAME = process.env.CUSTOM_DB ? process.env.CUSTOM_DB : config.get('database');
 const DB_PASS = process.env.mysqlPassword || getSecret('mysql.password');
+const DB_USER = process.env.mysqlUser || getSecret('mysql.user');
 const JWT_SIGNING_TOKEN = process.env.jwtSigningToken || getSecret('user.jwt.secret');
+const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
 const SENTRY_DSN = process.env.SENTRY_DSN || getSecret('sentry.dsn');
 const SESSION_SECRET = process.env.sessionSecret || getSecret('session.secret');
 
@@ -61,12 +62,13 @@ module.exports = {
     getSecretFromRawParameters,
     getSecret,
     CONTENT_API_URL,
-    DB_NAME,
     DB_HOST,
-    DB_USER,
+    DB_NAME,
     DB_PASS,
+    DB_USER,
     HUB_EMAILS,
     JWT_SIGNING_TOKEN,
+    MATERIAL_SUPPLIER,
     SENTRY_DSN,
     SESSION_SECRET
 };

--- a/modules/validators.js
+++ b/modules/validators.js
@@ -1,12 +1,22 @@
 'use strict';
 
-const createDOMPurify = require('dompurify');
 const { JSDOM } = require('jsdom');
+const { mapValues } = require('lodash');
+const createDOMPurify = require('dompurify');
+
 const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
 function purifyUserInput(input) {
     return DOMPurify.sanitize(input);
+}
+
+/**
+ * Middleware wrapper around purifyUserInput
+ */
+function purify(req, res, next) {
+    req.body = mapValues(req.body, purifyUserInput);
+    next();
 }
 
 function errorTranslator(prefix) {
@@ -21,5 +31,6 @@ function errorTranslator(prefix) {
 
 module.exports = {
     errorTranslator,
-    purifyUserInput
+    purifyUserInput,
+    purify
 };

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -242,13 +242,13 @@
     </article>
 
     {# JS-powered overlay #}
-    <div class="overlay{% if orderStatus === 'success' or orderStatus === 'failure' %} overlay--visible{% endif %}" id="js-overlay">
+    <div class="overlay{% if orderStatus === formHelpers.FORM_STATES.SUBMISSION_SUCCESS or orderStatus === formHelpers.FORM_STATES.SUBMISSION_ERROR %} overlay--visible{% endif %}" id="js-overlay">
         <div class="overlay__content">
-            {% if orderStatus == 'success' %}
+            {% if orderStatus == formHelpers.FORM_STATES.SUBMISSION_SUCCESS %}
                 <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.success.title }}</h2>
                 <h3 class="t2 accent--{{ pageAccent }} a--text">{{ copy.orderSubmitted.success.subtitle }}</h3>
                 <p>{{ copy.orderSubmitted.success.body | safe }}</p>
-            {% elseif orderStatus == 'failure' %}
+            {% elseif orderStatus == formHelpers.FORM_STATES.SUBMISSION_ERROR %}
                 <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.title }}</h2>
                 <h3 class="t2 accent--{{ pageAccent }} a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
             {% endif %}

--- a/views/pages/funding/guidance/order-free-materials.njk
+++ b/views/pages/funding/guidance/order-free-materials.njk
@@ -242,13 +242,13 @@
     </article>
 
     {# JS-powered overlay #}
-    <div class="overlay{% if showOverlay %} overlay--visible{% endif %}" id="js-overlay">
+    <div class="overlay{% if orderStatus === 'success' or orderStatus === 'failure' %} overlay--visible{% endif %}" id="js-overlay">
         <div class="overlay__content">
             {% if orderStatus == 'success' %}
                 <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.success.title }}</h2>
                 <h3 class="t2 accent--{{ pageAccent }} a--text">{{ copy.orderSubmitted.success.subtitle }}</h3>
                 <p>{{ copy.orderSubmitted.success.body | safe }}</p>
-            {% elseif orderStatus == 'fail' %}
+            {% elseif orderStatus == 'failure' %}
                 <h2 class="t2 accent--pink a--text">{{ copy.orderSubmitted.failure.title }}</h2>
                 <h3 class="t2 accent--{{ pageAccent }} a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
             {% endif %}


### PR DESCRIPTION
This PR refactors the materials form to use the new mailer helpers and reduce the reliance on session flash.

- Scopes `flash` middleware to specific routes. Avoids session being set on cached pages
- Refactors materials form to reduce use of session flash and view globals. Re-renders template with status rather than performing redundant redirects
- Refactor materials form to use new `mail.generateAndSend` method

Also rejigged the order of the promises as previously we were firing off the customer email without doing anything with the promise. The email would send but leads to some weird parallelism.

Refactored order is: Store summary in database -> then send both emails in a `Promise.all`, allows us to have a single `catch` to collect any errors in that process.