### PR TITLE
Add middleware to clean link noise

### DIFF
--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,6 +1,23 @@
 'use strict';
 const slashes = require('connect-slashes');
 
+/**
+ * Clean link noise
+ * Strips trailing /~/~/~/link.apsx noise from old Sitecore genrated URLs
+ */
+function cleanLinkNoise(originalUrl) {
+    const re = /(~\/)*link.aspx$/;
+    if (re.test(originalUrl)) {
+        return originalUrl.replace(re, '');
+    } else {
+        return originalUrl;
+    }
+}
+
+/**************************************
+ * Middlewares
+ **************************************/
+
 function redirectNonWww(req, res, next) {
     const host = req.headers.host;
     const domainProd = 'biglotteryfund.org.uk';
@@ -12,10 +29,20 @@ function redirectNonWww(req, res, next) {
     }
 }
 
+function redirectLinkNoise(req, res, next) {
+    const cleanedUrl = cleanLinkNoise(req.originalUrl);
+    if (cleanedUrl !== req.originalUrl) {
+        res.redirect(301, cleanedUrl);
+    }
+    next();
+}
+
 const removeTrailingSlashes = slashes(false);
 
 module.exports = {
-    all: [redirectNonWww, removeTrailingSlashes],
+    all: [redirectNonWww, redirectLinkNoise, removeTrailingSlashes],
+    cleanLinkNoise,
     redirectNonWww,
-    removeTrailingSlashes
+    removeTrailingSlashes,
+    redirectLinkNoise
 };

--- a/middleware/redirects.test.js
+++ b/middleware/redirects.test.js
@@ -2,9 +2,27 @@
 const chai = require('chai');
 const expect = chai.expect;
 const httpMocks = require('node-mocks-http');
-const redirects = require('./redirects');
+const { cleanLinkNoise, redirectNonWww } = require('./redirects');
 
 describe('redirects', () => {
+    describe('cleanLinkNoise', () => {
+        it('should clean link noise from the URL', () => {
+            expect(cleanLinkNoise('/funding/programmes/reaching-communities-england')).to.equal(
+                '/funding/programmes/reaching-communities-england'
+            );
+
+            expect(cleanLinkNoise('/~/link.aspx')).to.equal('/');
+
+            expect(
+                cleanLinkNoise('/research/health-and-well-being/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/link.aspx')
+            ).to.equal('/research/health-and-well-being/');
+
+            expect(cleanLinkNoise('/welsh/england/funding/funding-guidance/applying-for-funding/~/link.aspx')).to.equal(
+                '/welsh/england/funding/funding-guidance/applying-for-funding/'
+            );
+        });
+    });
+
     describe('redirectNonWww', () => {
         it('should redirect on non www production domain ', () => {
             const req = httpMocks.createRequest({
@@ -13,7 +31,7 @@ describe('redirects', () => {
                 }
             });
             const res = httpMocks.createResponse();
-            redirects.redirectNonWww(req, res, () => {});
+            redirectNonWww(req, res, () => {});
             expect(res.statusCode).to.equal(301);
         });
 
@@ -24,7 +42,7 @@ describe('redirects', () => {
                 }
             });
             const res = httpMocks.createResponse();
-            redirects.redirectNonWww(req, res, () => {});
+            redirectNonWww(req, res, () => {});
             expect(res.statusCode).to.equal(200);
         });
     });


### PR DESCRIPTION
We've been getting a number of the same Sentry errors with some weird links in e.g. https://sentry.io/big-lottery-fund/biglotteryfund/issues/526760330/events/?cursor=1523672210000%3A0%3A0

Seems to mostly be from Bing, but somewhere along the line some the old site is generating a bunch of URLs that look like this: `https://www.biglotteryfund.org.uk/research/making-the-most-of-funding/impact-and-outcomes/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/link.aspx`.

Rather than muting the error, which might suppress some genuine things, I've opted to add a middleware to clean up these URL. If the URL **ends with** `link.aspx` and includes any number of `/~` characters then we strip it and redirect.

Sound reasonable?