### PR TITLE
Refactor legacy proxy code, always use canonical link

### DIFF
--- a/cypress/integration/4_legacy_suite.js
+++ b/cypress/integration/4_legacy_suite.js
@@ -44,12 +44,12 @@ describe('Legacy pages', () => {
         const urlPath = '/funding/funding-guidance/applying-for-funding/aims-and-outcomes';
         cy.checkRedirect({
             from: urlPath,
-            to: `http://webarchive.nationalarchives.gov.uk/*/https://www.biglotteryfund.org.uk${urlPath}`,
+            to: `http://webarchive.nationalarchives.gov.uk/https://www.biglotteryfund.org.uk${urlPath}`,
             isRelative: false
         });
     });
 
-    it('Should redirect ~/link.aspx urls', () => {
+    it('should redirect ~/link.aspx urls', () => {
         cy.checkRedirect({
             from: '/~/link.aspx?_id=50fab7d4b5a248f8a8c8f5d4d33f9e0f&_z=z',
             to: '/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding'

--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -1,5 +1,9 @@
 'use strict';
+const config = require('config');
 const slashes = require('connect-slashes');
+
+const { customEvent } = require('../modules/analytics');
+const { isWelsh, removeWelsh } = require('../modules/urls');
 
 /**
  * Clean link noise
@@ -39,10 +43,28 @@ function redirectLinkNoise(req, res, next) {
 
 const removeTrailingSlashes = slashes(false);
 
+/**
+ * Redirect archived links to the national archives
+ */
+function redirectArchived(req, res) {
+    const fullUrl = `https://${config.get('siteDomain')}${req.originalUrl}`;
+    customEvent('redirect', 'National Archives', req.originalUrl);
+    res.redirect(301, `http://webarchive.nationalarchives.gov.uk/${fullUrl}`);
+}
+
+function redirectNoWelsh(req, res, next) {
+    if (isWelsh(req.originalUrl)) {
+        res.redirect(removeWelsh(req.originalUrl));
+    } else {
+        next();
+    }
+}
+
 module.exports = {
-    all: [redirectNonWww, redirectLinkNoise, removeTrailingSlashes],
+    common: [redirectNonWww, redirectLinkNoise, removeTrailingSlashes],
     cleanLinkNoise,
     redirectNonWww,
     removeTrailingSlashes,
-    redirectLinkNoise
+    redirectArchived,
+    redirectNoWelsh
 };

--- a/modules/assets.test.js
+++ b/modules/assets.test.js
@@ -5,7 +5,7 @@ const expect = chai.expect;
 
 const { getCachebustedPath, getCachebustedRealPath, getImagePath } = require('./assets');
 
-describe.only('assets', () => {
+describe('assets', () => {
     it('should get cachebusted url path for an asset', () => {
         const result = getCachebustedPath('stylesheets/style.css');
         expect(result).to.match(/^\/assets\/build\/\w+\/stylesheets\/style.css$/);

--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -1,8 +1,7 @@
 'use strict';
-const Raven = require('raven');
 const config = require('config');
 const { get } = require('lodash');
-const rp = require('request-promise-native');
+const request = require('request-promise-native');
 const absolution = require('absolution');
 const jsdom = require('jsdom');
 const { JSDOM } = jsdom;
@@ -12,10 +11,59 @@ const { isWelsh, makeWelsh, removeWelsh } = require('../modules/urls');
 
 const legacyUrl = config.get('legacyDomain');
 
-const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) => {
+/**
+ * 1. Convert all links in the document to be absolute
+ *    (only really useful on non-prod envs)
+ * 2. Fix meta tags in HTML which use the wrong CNAME
+ */
+function cleanBody(body) {
+    const prodDomain = 'https://www.biglotteryfund.org.uk';
+    return absolution(body, prodDomain).replace(/wwwlegacy/g, 'www');
+}
+
+function getCanonicalUrl(dom) {
+    const metaIdentifier = dom.window.document.querySelector('meta[name="identifier"]');
+    return metaIdentifier && metaIdentifier.getAttribute('content');
+}
+
+/**
+ * Append language link
+ * Alwas append a language link if there isn't one on the page.
+ */
+function appendLanguageLink(req, res, dom) {
+    const pageIsWelsh = isWelsh(req.path);
+    const regionNav = dom.window.document.getElementById('regionNav');
+    const hasWelshLink = regionNav.querySelectorAll('[hreflang="cy"]').length > 0;
+    const hasEnglishLink = regionNav.querySelectorAll('[hreflang="en"]').length > 0;
+
+    const injectLink = (localeToAppend, nav) => {
+        const linkPath = localeToAppend === 'cy' ? makeWelsh(req.path) : removeWelsh(req.path);
+        const linkText = localeToAppend === 'cy' ? 'Cymraeg' : 'English';
+        const listItem = dom.window.document.createElement('li');
+        listItem.setAttribute('id', 'ctl12_langLi');
+        listItem.setAttribute('class', 'last');
+        listItem.innerHTML = `
+            <a href="${linkPath}"
+                id="ctl12_welshLanguage"
+                lang="${localeToAppend}"
+                hreflang="${localeToAppend}"
+                data-blf-alpha="true">
+                ${linkText}
+            </a>`;
+        nav.appendChild(listItem);
+    };
+
+    if (!pageIsWelsh && !hasWelshLink) {
+        injectLink('cy', regionNav);
+    } else if (pageIsWelsh && !hasEnglishLink) {
+        injectLink('en', regionNav);
+    }
+}
+
+function proxyLegacyPage({ req, res, domModifications, followRedirect = true }) {
     res.cacheControl = { maxAge: 0 };
 
-    return rp({
+    return request({
         url: legacyUrl + req.path,
         qs: req.query,
         strictSSL: false,
@@ -24,112 +72,51 @@ const proxyLegacyPage = ({ req, res, domModifications, followRedirect = true }) 
         maxRedirects: 1,
         resolveWithFullResponse: true
     }).then(response => {
-        let body = response.body;
-        // convert all links in the document to be absolute
-        // (only really useful on non-prod envs)
-        body = absolution(body, 'https://www.biglotteryfund.org.uk');
-
-        // fix meta tags in HTML which use the wrong CNAME
-        body = body.replace(/wwwlegacy/g, 'www');
-
-        // parse the DOM
+        let body = cleanBody(response.body);
         let dom = new JSDOM(body);
 
-        if (appData.isDev) {
-            let titleText = dom.window.document.title;
-            dom.window.document.title = '[PROXIED] ' + titleText;
-        }
-
-        const regionNav = dom.window.document.getElementById('regionNav');
-        const pageIsWelsh = isWelsh(req.path);
-        const hasWelshLink = regionNav.querySelectorAll('[hreflang="cy"]').length > 0;
-        const hasEnglishLink = regionNav.querySelectorAll('[hreflang="en"]').length > 0;
-
-        const appendLanguageLink = (localeToAppend, nav) => {
-            const linkPath = localeToAppend === 'cy' ? makeWelsh(req.path) : removeWelsh(req.path);
-            const linkText = localeToAppend === 'cy' ? 'Cymraeg' : 'English';
-            const listItem = dom.window.document.createElement('li');
-            listItem.setAttribute('id', 'ctl12_langLi');
-            listItem.setAttribute('class', 'last');
-            listItem.innerHTML = `
-                <a href="${linkPath}"
-                   id="ctl12_welshLanguage"
-                   lang="${localeToAppend}"
-                   hreflang="${localeToAppend}"
-                   data-blf-alpha="true">
-                   ${linkText}
-               </a>`;
-            nav.appendChild(listItem);
-        };
-
-        // some pages aren't welsh but *do* have the link
-        // other pages aren't welsh but don't (due to cookies etc)
-        if (!pageIsWelsh && !hasWelshLink) {
-            appendLanguageLink('cy', regionNav);
-        } else if (pageIsWelsh && !hasEnglishLink) {
-            appendLanguageLink('en', regionNav);
-        }
-
-        // rewrite main ASP.net form to point to this page
-        // (currently it's rewritten above to the external one)
-        const form = dom.window.document.getElementById('form1');
-        if (form) {
-            form.setAttribute('action', req.path);
-        }
-
         /**
-         * Are we in an A/B test and do we have a Google Experiments ID
+         * Always redirect to canonical link
+         * Sitecore serves the content of vanity URLs rather
+         * than redirecting, so to avoid duplicate content and make it
+         * easier to replace old URLs we attempt to look up the canonical URL
+         * from the page and redirect to that.
          */
-        const experimentId = get(res.locals, 'ab.id');
-        const variantId = get(res.locals, 'ab.variantId');
-        if (experimentId) {
-            // create GA snippet for tracking experiment
-            const gaCode = `
-                <script src="//www.google-analytics.com/cx/api.js"></script>
-                <script>
-                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                            (i[r].q=i[r].q||[]).push(arguments);},i[r].l=1*new Date();a=s.createElement(o),
-                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m);
-                    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-                    ga('create', '${config.get('googleAnalyticsCode')}', {
-                        'cookieDomain': 'none'
-                    });
-                    ga('set', 'expId', '${experimentId}');
-                    ga('set', 'expVar', ${variantId});
-                    cxApi.setChosenVariation(${variantId}, '${experimentId}');
-                    ga('send', 'pageview');
-                </script>`;
-
-            // insert GA experiment code into the page
-            const script = dom.window.document.createElement('div');
-            script.innerHTML = gaCode;
-            dom.window.document.body.appendChild(script);
-
-            // try to kill the google tag manager (useful for non-prod envs)
-            const scripts = dom.window.document.scripts;
-            let gtm = [].find.call(scripts, s => s.innerHTML.indexOf('www.googletagmanager.com/gtm.js') !== -1);
-            if (gtm) {
-                gtm.innerHTML = '';
+        const canonicalUrl = getCanonicalUrl(dom);
+        if (canonicalUrl && canonicalUrl !== req.path) {
+            res.redirect(301, canonicalUrl);
+        } else {
+            if (appData.isDev) {
+                dom.window.document.title = '[PROXIED] ' + dom.window.document.title;
             }
-        }
 
-        // Remove live chat widget as document.write causes issue when proxying.
-        const liveChat = dom.window.document.getElementById('askLiveCall');
-        if (liveChat) {
-            liveChat.parentNode.removeChild(liveChat);
-        }
+            appendLanguageLink(req, res, dom);
 
-        // Allow custom overrides on a per-page basis
-        if (domModifications) {
-            dom = domModifications(dom);
-        }
+            // rewrite main ASP.net form to point to this page
+            // (currently it's rewritten above to the external one)
+            const form = dom.window.document.getElementById('form1');
+            if (form) {
+                form.setAttribute('action', req.path);
+            }
 
-        res.set('X-BLF-Legacy', true);
-        res.send(dom.serialize());
+            // Remove live chat widget as document.write causes issue when proxying.
+            const liveChat = dom.window.document.getElementById('askLiveCall');
+            if (liveChat) {
+                liveChat.parentNode.removeChild(liveChat);
+            }
+
+            // Allow custom overrides on a per-page basis
+            if (domModifications) {
+                dom = domModifications(dom);
+            }
+
+            res.set('X-BLF-Legacy', true);
+            res.send(dom.serialize());
+        }
     });
-};
+}
 
-const proxyPassthrough = (req, res, next) => {
+function proxyPassthrough(req, res, next) {
     return proxyLegacyPage({
         req,
         res,
@@ -152,16 +139,16 @@ const proxyPassthrough = (req, res, next) => {
         // either it wasn't a redirect, or Sitecore said no
         return next();
     });
-};
+}
 
-const postToLegacyForm = (req, res, next) => {
+function postToLegacyForm(req, res, next) {
     res.cacheControl = { maxAge: 0 };
 
     // work out if we need to serve english/welsh page
     let localePath = req.i18n.getLocale() === 'cy' ? config.get('i18n.urlPrefix.cy') : '';
     let pagePath = localePath + req.path;
 
-    return rp
+    return request
         .post({
             uri: legacyUrl + pagePath,
             form: req.body,
@@ -180,37 +167,10 @@ const postToLegacyForm = (req, res, next) => {
                 next();
             }
         });
-};
-
-const redirectUglyLink = (req, res) => {
-    const handleError = err => {
-        Raven.captureException(err);
-        res.redirect('/');
-    };
-
-    const livePagePath = `${legacyUrl}${req.originalUrl}`;
-    rp({
-        url: livePagePath,
-        strictSSL: false,
-        jar: true,
-        resolveWithFullResponse: false,
-        maxRedirects: 1
-    })
-        .then(response => {
-            let dom = new JSDOM(response);
-            let metaIdentifier = dom.window.document.querySelector('meta[name="identifier"]');
-            let intendedUrl = metaIdentifier.getAttribute('content');
-            if (!metaIdentifier || !intendedUrl) {
-                return handleError(new Error('Unable to find meta identifier URL'));
-            }
-            res.redirect(301, intendedUrl);
-        })
-        .catch(handleError);
-};
+}
 
 module.exports = {
     proxyLegacyPage,
     proxyPassthrough,
-    postToLegacyForm,
-    redirectUglyLink
+    postToLegacyForm
 };

--- a/modules/redirects.js
+++ b/modules/redirects.js
@@ -1,8 +1,6 @@
 'use strict';
-const config = require('config');
 const app = require('../server');
-const { customEvent } = require('../modules/analytics');
-const { isWelsh, makeWelsh, removeWelsh } = require('../modules/urls');
+const { makeWelsh } = require('../modules/urls');
 
 function serveRedirects({ redirects, makeBilingual = false }) {
     redirects.forEach(redirect => {
@@ -18,25 +16,6 @@ function serveRedirects({ redirects, makeBilingual = false }) {
     });
 }
 
-/**
- * Redirect archived links to the national archives
- */
-function redirectArchived(req, res) {
-    const fullUrl = `https://${config.get('siteDomain')}${req.originalUrl}`;
-    customEvent('redirect', 'National Archives', req.originalUrl);
-    res.redirect(301, `http://webarchive.nationalarchives.gov.uk/*/${fullUrl}`);
-}
-
-function redirectNoWelsh(req, res, next) {
-    if (isWelsh(req.originalUrl)) {
-        res.redirect(removeWelsh(req.originalUrl));
-    } else {
-        next();
-    }
-}
-
 module.exports = {
-    serveRedirects,
-    redirectArchived,
-    redirectNoWelsh
+    serveRedirects
 };


### PR DESCRIPTION
This PR refactors the legacy proxy code to always use canonical link. Moves the `~/link.aspx` / `meta[identifier]` logic up into the main `proxyLegacyPage` function and cleans that up so we always attempt to redirect to the canonical path if it's different to the current path.

Should fix a lot of the issues with vanity URLs. 🤞 