### PR TITLE
Add timings middleware

### DIFF
--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -1,0 +1,44 @@
+const AWS = require('aws-sdk');
+const responseTime = require('response-time');
+
+AWS.config.update({ region: 'eu-west-1' });
+
+const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
+
+module.exports = responseTime(function(req, res, time) {
+    if (req.method === 'GET') {
+        cloudwatch.putMetricData({
+            MetricData: [
+                {
+                    MetricName: 'RESPONSE_TIME_GET',
+                    Dimensions: [
+                        {
+                            Name: 'RESPONSE_TIME',
+                            Value: 'TIME_IN_MS'
+                        }
+                    ],
+                    Unit: 'Milliseconds',
+                    Value: time
+                }
+            ],
+            Namespace: 'SITE/TRAFFIC'
+        });
+    } else if (req.method === 'POST') {
+        cloudwatch.putMetricData({
+            MetricData: [
+                {
+                    MetricName: 'RESPONSE_TIME_POST',
+                    Dimensions: [
+                        {
+                            Name: 'RESPONSE_TIME',
+                            Value: 'TIME_IN_MS'
+                        }
+                    ],
+                    Unit: 'Milliseconds',
+                    Value: time
+                }
+            ],
+            Namespace: 'SITE/TRAFFIC'
+        });
+    }
+});

--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -1,11 +1,16 @@
 const AWS = require('aws-sdk');
 const responseTime = require('response-time');
+const appData = require('../modules/appData');
 
 AWS.config.update({ region: 'eu-west-1' });
 
 const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
 
 module.exports = responseTime(function(req, res, time) {
+    if (appData.isDev) {
+        return;
+    }
+
     if (req.method === 'GET') {
         cloudwatch.putMetricData({
             MetricData: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -758,7 +758,7 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "assign-symbols": {
@@ -4776,7 +4776,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -4973,7 +4973,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU=",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "diffie-hellman": {
@@ -5134,7 +5134,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -5286,7 +5286,7 @@
     "email-validator": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-1.1.1.tgz",
-      "integrity": "sha1-sH8757rB3AmbxD519q45n1UtWoA="
+      "integrity": "sha512-vkcJJZEb7JXDY883Nx1Lkmb6noM3j1SfSt8L9tVFhZPnPQiFq+Nkd5evc77+tRVS4ChTUSr34voThsglI/ja/A=="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -8029,7 +8029,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8054,7 +8054,7 @@
     "graphlib": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha1-av4a/MUUhVXseZ5JkFZ5W9aTjIc=",
+      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -8071,7 +8071,7 @@
     "growl": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "gulp": {
@@ -13056,7 +13056,7 @@
     "nock": {
       "version": "9.1.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-9.1.6.tgz",
-      "integrity": "sha1-Fjla9MRbD9hNGkqWaBVOFvpmJNs=",
+      "integrity": "sha512-DuKF+1W/FnMO6MXIGgCIWcM95bETjBbmFdR4v7dAj1zH9a9XhOjAa//PuWh98XIXxcZt7wdiv0JlO0AA0e2kqQ==",
       "dev": true,
       "requires": {
         "chai": "3.5.0",
@@ -13929,7 +13929,7 @@
     "nyc": {
       "version": "11.4.1",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.4.1.tgz",
-      "integrity": "sha1-E/335+8i0CfGHRdHWPaXimj09eU=",
+      "integrity": "sha512-5eCZpvaksFVjP2rt1r60cfXmt3MUtsQDw8bAzNqNEr4WLvUMLgiVENMf/B9bE9YAX0mGVvaGA3v9IS9ekNqB1Q==",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -18681,7 +18681,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
       }
@@ -19105,7 +19105,7 @@
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -19660,6 +19660,15 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
+    },
+    "response-time": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+      "requires": {
+        "depd": "1.1.1",
+        "on-headers": "1.0.1"
+      }
     },
     "responselike": {
       "version": "1.0.2",
@@ -20637,7 +20646,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
         },
         "restore-cursor": {
@@ -20706,7 +20715,7 @@
     "snyk-go-plugin": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/snyk-go-plugin/-/snyk-go-plugin-1.4.5.tgz",
-      "integrity": "sha1-v0YmVsqt4GA5cLaOdW9LOJw66qo=",
+      "integrity": "sha512-uuPXt/NDROmG/pnQveOdur/ToG3h4W64F8r+3L7ZCMPikkRkieoCMGpfMYhEgG+oMlO1bzAsf+YGvMfY0o96Kg==",
       "requires": {
         "graphlib": "2.1.5",
         "toml": "2.3.3"
@@ -20715,7 +20724,7 @@
     "snyk-gradle-plugin": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.2.0.tgz",
-      "integrity": "sha1-71rqXRMpBcvwMVxy2dlrJKpKdd0=",
+      "integrity": "sha512-FucMRR+Rc6LBaSIYxiBl+jvb7R00SgA0QfMT+RGxLIZlDk1lagvA/jIkv+mRadwHVSV/ShIFSZLmS7agfPclVg==",
       "requires": {
         "clone-deep": "0.3.0"
       }
@@ -20747,12 +20756,12 @@
     "snyk-mvn-plugin": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.1.1.tgz",
-      "integrity": "sha1-FcExMaNo3eSHdj3pNVetX7lXL/4="
+      "integrity": "sha512-CkOAkOYVpEXm/c0peKNpEhbSIqb6SxNM28L5Rt5XZOkZ00Ud3uhz26+AicZVgvhe3in8A2CzOIAPyMUL2ueW4A=="
     },
     "snyk-nuget-plugin": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.3.9.tgz",
-      "integrity": "sha1-vNxQPq/p8+60Akt1be1NDDsmXRI=",
+      "integrity": "sha512-F38Amr8AxbalFfUmjLM+57P2Gq2vUh9dWsP7oE2DPXO/f7tW00jwyWhJ5D39Zx+elBoXDxWYvAp14IJnxV18Ag==",
       "requires": {
         "debug": "3.1.0",
         "es6-promise": "4.2.4",
@@ -20763,7 +20772,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           },
@@ -20778,14 +20787,14 @@
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk="
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
         }
       }
     },
     "snyk-php-plugin": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/snyk-php-plugin/-/snyk-php-plugin-1.3.2.tgz",
-      "integrity": "sha1-UcGRcd7gzTUVinqoNf4CqX3ISrg=",
+      "integrity": "sha512-EVN5ilP2PJ5EEBWUvSjzI1kHTRyJxqCQXm5Bb2Kkl4z1cNCFO9ScxjwUDO7cJmQCDQUhHGflDd611ToWmlEYnQ==",
       "requires": {
         "debug": "3.1.0"
       },
@@ -20793,7 +20802,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           },
@@ -20842,7 +20851,7 @@
     "snyk-python-plugin": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.5.6.tgz",
-      "integrity": "sha1-zjHwtofyPRJ/evORgOopAbKJH+w="
+      "integrity": "sha512-YHDi+tEffbqOVp66sFxEYLSIcHcr/ORkxnqulyM7m1jOqzdgb8Rq/460DyGhm09wMEEdvvgt6v+Ld+QGM8GzYw=="
     },
     "snyk-resolve": {
       "version": "1.0.0",
@@ -20917,7 +20926,7 @@
     "snyk-sbt-plugin": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.2.3.tgz",
-      "integrity": "sha1-VhV4bxmCXuZKy1CxoEGEO0qcTg8=",
+      "integrity": "sha512-R8L2+wzB7Zc8BZPmszAoQDjtl9tjLjE6Pf3Mu6tjv22+2rbyADlyfHg7FR+vmQXVFtOuJa43p1orXoaZGatE0g==",
       "requires": {
         "debug": "2.6.9"
       },
@@ -22539,7 +22548,7 @@
     "toml": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
-      "integrity": "sha1-jWg9cpV3yyhiMd/HqK/+WNMXKPs="
+      "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
     "topo": {
       "version": "2.0.2",
@@ -22689,7 +22698,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-is": {
@@ -25025,7 +25034,7 @@
     "yargs": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
-      "integrity": "sha1-wFKTEAbF7udGEOX8A1S+39CKIBs=",
+      "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
       "requires": {
         "cliui": "4.0.0",
         "decamelize": "1.2.0",
@@ -25049,7 +25058,7 @@
         "cliui": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
-          "integrity": "sha1-dD1GUOBfNtHtJXW1ljjYcyK/u8w=",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -25081,7 +25090,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "req-flash": "0.0.3",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
+    "response-time": "^2.3.2",
     "sequelize": "^4.8.0",
     "serve-favicon": "^2.4.3",
     "shortid": "^2.2.8",

--- a/server.js
+++ b/server.js
@@ -21,6 +21,7 @@ const { serveRedirects } = require('./modules/redirects');
 const routes = require('./controllers/routes');
 
 const favicon = require('serve-favicon');
+const timingsMiddleware = require('./middleware/timings');
 const bodyParserMiddleware = require('./middleware/bodyParser');
 const cachedMiddleware = require('./middleware/cached');
 const loggerMiddleware = require('./middleware/logger');
@@ -52,14 +53,6 @@ Raven.config(SENTRY_DSN, {
 
 app.use(Raven.requestHandler());
 
-/**
- * Set static app locals
- */
-app.locals.navigationSections = routes.sections;
-
-viewEngineService.init(app);
-viewGlobalsService.init(app);
-
 app.use(loggerMiddleware);
 app.use(cachedMiddleware.defaultVary);
 app.use(cachedMiddleware.defaultCacheControl);
@@ -72,6 +65,15 @@ app.use(
     })
 );
 
+/**
+ * Set static app locals
+ */
+app.locals.navigationSections = routes.sections;
+
+viewEngineService.init(app);
+viewGlobalsService.init(app);
+
+app.use(timingsMiddleware);
 app.use(previewMiddleware);
 app.use(defaultSecurityHeaders());
 app.use(bodyParserMiddleware);


### PR DESCRIPTION
Adds a middleware which logs response time to CloudFront. Logs separate metrics for GET and POST requests. Response time is counted from when middleware is mounted to when headers are sent. So not perfect but a reasonable approximation of app response time.

Adding this to help us debug average latency metrics, keen to see the difference between GET and POST requests.