### PR TITLE
A few bits of cleanup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,4 @@
 {
-    "staticExpiration": 1,
-    "assetVirtualDir": "assets",
     "siteDomain": "www.biglotteryfund.org.uk",
     "meta": {
         "title": "The Big Lottery Fund",

--- a/config/default.json
+++ b/config/default.json
@@ -14,8 +14,7 @@
       "useRemoteAssets": true
     },
     "imgix": {
-      "mediaDomain": "biglotteryfund-assets.imgix.net",
-      "mediaDomainOriginal": "big-lottery-fund-media-trial.imgix.net"
+      "mediaDomain": "biglotteryfund-assets.imgix.net"
     },
     "cookies": {
         "contrast": "contrastMode",

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -69,7 +69,7 @@ function defaultSecurityHeaders() {
         defaultSrc: defaultSecurityDomains,
         childSrc: ['www.google.com'],
         styleSrc: ['fonts.googleapis.com'],
-        imgSrc: ['stats.g.doubleclick.net', config.get('imgix.mediaDomain'), config.get('imgix.mediaDomainOriginal')],
+        imgSrc: ['stats.g.doubleclick.net', config.get('imgix.mediaDomain')],
         connectSrc: [],
         reportUri: 'https://sentry.io/api/226416/csp-report/?sentry_key=53aa5923a25c43cd9a645d9207ae5b6c'
     };

--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -7,7 +7,7 @@ AWS.config.update({ region: 'eu-west-1' });
 const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
 
 module.exports = responseTime(function(req, res, time) {
-    if (appData.isDev) {
+    if (appData.isNotProduction) {
         return;
     }
 

--- a/modules/assets.js
+++ b/modules/assets.js
@@ -9,11 +9,10 @@ try {
 } catch (e) {} // eslint-disable-line no-empty
 
 const CURRENT_VERSION = assets.version || 'latest';
-const ASSET_VIRTUAL_DIR = config.get('assetVirtualDir');
 const USE_REMOTE_ASSETS = config.get('features.useRemoteAssets');
 
 function getCachebustedPath(urlPath) {
-    const baseUrl = USE_REMOTE_ASSETS ? 'https://media.biglotteryfund.org.uk/assets' : `/${ASSET_VIRTUAL_DIR}`;
+    const baseUrl = USE_REMOTE_ASSETS ? 'https://media.biglotteryfund.org.uk/assets' : `/assets`;
     return `${baseUrl}/build/${CURRENT_VERSION}/${urlPath}`;
 }
 
@@ -25,7 +24,7 @@ function getImagePath(urlPath) {
     if (/^http(s?):\/\//.test(urlPath)) {
         return urlPath;
     } else {
-        return `/${ASSET_VIRTUAL_DIR}/images/${urlPath}`;
+        return `/assets/images/${urlPath}`;
     }
 }
 

--- a/modules/viewEngine.js
+++ b/modules/viewEngine.js
@@ -7,19 +7,6 @@ const assets = require('./assets');
 const appData = require('./appData');
 
 /**
- * Define common app locals
- * @see https://expressjs.com/en/api.html#app.locals
- */
-function initAppLocals(app) {
-    /**
-     * Is this page bilingual?
-     * i.e. do we have a Welsh translation
-     * Default to true unless overriden by a route
-     */
-    app.locals.isBilingual = true;
-}
-
-/**
  * Add custom Nunjucks filters
  * @see https://mozilla.github.io/nunjucks/api.html#addfilter
  */
@@ -85,8 +72,6 @@ function initFilters(templateEnv) {
 }
 
 function init(app) {
-    initAppLocals(app);
-
     const templateEnv = nunjucks.configure('views', {
         autoescape: true,
         express: app,

--- a/server.js
+++ b/server.js
@@ -57,13 +57,13 @@ app.use(loggerMiddleware);
 app.use(cachedMiddleware.defaultVary);
 app.use(cachedMiddleware.defaultCacheControl);
 
+/**
+ * Static asset paths
+ * Mount early to avoid being processed by any middleware
+ * @see https://expressjs.com/en/4x/api.html#express.static
+ */
 app.use(favicon(path.join('public', '/favicon.ico')));
-app.use(
-    `/${config.get('assetVirtualDir')}`,
-    express.static(path.join(__dirname, './public'), {
-        maxAge: config.get('staticExpiration')
-    })
-);
+app.use('/assets', express.static(path.join(__dirname, './public')));
 
 /**
  * Set static app locals


### PR DESCRIPTION
A few bits of cleanup following on from recent PRs

- Limit CloudWatch metrics to production now we've confirmed they are sending
- Remove config for an old imgix domain
- Prune some redundant config
- Cleaned up `app.locals` so they are defined in a single place
- Re-ordered the middleware so they are all mounted together (/status and /assets before *all* middleware)
- Streamlined how the application routes are initialised using `lodash`