### PR TITLE
Add per-email metrics to mailer

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,7 @@
 {
+    "aws": {
+      "region": "eu-west-1"
+    },
     "siteDomain": "www.biglotteryfund.org.uk",
     "meta": {
         "title": "The Big Lottery Fund",

--- a/controllers/apply/reaching-communities-form.js
+++ b/controllers/apply/reaching-communities-form.js
@@ -280,7 +280,7 @@ formModel.registerSuccessStep({
 
         return mail.generateAndSend([
             {
-                name: 'customer',
+                name: 'reaching_communities_customer',
                 sendTo: primaryAddress,
                 sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
                 subject: 'Thank you for getting in touch with the Big Lottery Fund!',
@@ -292,7 +292,7 @@ formModel.registerSuccessStep({
                 }
             },
             {
-                name: 'internal',
+                name: 'reaching_communities_internal',
                 sendTo: internalAddress,
                 sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
                 subject: 'New idea submission from website',

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -400,7 +400,7 @@ function init({ router, routeConfig }) {
                         .then(() => {
                             const customerEmail = mail.generateAndSend([
                                 {
-                                    name: 'customer',
+                                    name: 'material_customer',
                                     sendTo: req.body.yourEmail,
                                     subject: 'Thank you for your Big Lottery Fund order',
                                     templateName: 'emails/newMaterialOrder',
@@ -409,6 +409,7 @@ function init({ router, routeConfig }) {
                             ]);
 
                             const supplierEmail = mail.send({
+                                name: 'material_supplier',
                                 subject: `Order from Big Lottery Fund website - ${dateNow}`,
                                 text: orderText.text,
                                 sendTo: MATERIAL_SUPPLIER,

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -115,6 +115,7 @@ const sendResetEmail = (req, res) => {
                     let resetUrl = `${req.protocol}://${req.headers.host}${resetPath}?token=${token}`;
 
                     let sendEmail = mail.send({
+                        name: 'user_password_reset',
                         subject: 'Reset the password for your Big Lottery Fund website account',
                         text: `Please click the following link to reset your password: ${resetUrl}`,
                         sendTo: email,

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -32,6 +32,7 @@ const sendActivationEmail = (user, req, isBrandNewUser) => {
         let activatePath = makeUserLink('activate');
         let activateUrl = `${req.protocol}://${req.headers.host}${activatePath}?token=${token}`;
         let emailData = {
+            name: 'user_activate_account',
             subject: 'Activate your Big Lottery Fund website account',
             text: `Please click the following link to activate your account: ${activateUrl}`,
             sendFrom: 'Big Lottery Fund <noreply@blf.digital>',

--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -1,10 +1,12 @@
 const AWS = require('aws-sdk');
+const config = require('config');
 const responseTime = require('response-time');
 const appData = require('../modules/appData');
 
-AWS.config.update({ region: 'eu-west-1' });
-
-const cloudwatch = new AWS.CloudWatch({ apiVersion: '2010-08-01' });
+const cloudwatch = new AWS.CloudWatch({
+    apiVersion: '2010-08-01',
+    region: config.get('aws.region')
+});
 
 module.exports = responseTime(function(req, res, time) {
     if (appData.isNotProduction) {


### PR DESCRIPTION
Send per-email metrics to CloudFront to give us more granularity than the standard SES metrics which are just an aggregate.

<img width="1193" alt="screen shot 2018-04-24 at 12 27 54" src="https://user-images.githubusercontent.com/123386/39184338-ef6e8724-47ba-11e8-877a-2b576354b6be.png">

