### PR TITLE
Add headersSent check to stripCSPHeader

### DIFF
--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -104,7 +104,10 @@ function toolsSecurityHeaders() {
 }
 
 function stripCSPHeader(req, res, next) {
-    res.removeHeader('Content-Security-Policy');
+    if (!res.headersSent) {
+        res.removeHeader('Content-Security-Policy');
+    }
+
     next();
 }
 


### PR DESCRIPTION
Got a little spike of https://sentry.io/big-lottery-fund/biglotteryfund/issues/533236486/ overnight. This is treating the symptom rather than the cause but it makes sense to check for `headersSent` before modifying headers.