### PR TITLE
Conditional loading of third-parties

### DIFF
--- a/assets/js/bootstraps/analytics.js
+++ b/assets/js/bootstraps/analytics.js
@@ -47,6 +47,13 @@ export const init = () => {
     });
 
     /**
+     * Anonymise IPs
+     * https://developers.google.com/analytics/devguides/collection/analyticsjs/ip-anonymization
+     * https://support.google.com/analytics/answer/2763052?hl=en
+     */
+    ga('set', 'anonymizeIp', true);
+
+    /**
      * Use Beacon transport mechanism if available
      * https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits
      */

--- a/assets/js/helpers/features.js
+++ b/assets/js/helpers/features.js
@@ -15,7 +15,20 @@ function createFeature(config) {
     };
 }
 
+export const isDoNotTrack =
+    window.doNotTrack === '1' || window.navigator.doNotTrack === '1' || window.navigator.msDoNotTrack === '1';
+
 export const FEATURES = [
+    createFeature({
+        id: 'analytics',
+        description: 'Enable Google Analytics',
+        isEnabled: !window.AppConfig.blockAnalytics && !isDoNotTrack
+    }),
+    createFeature({
+        id: 'hotjar',
+        description: 'Enable HotJar',
+        isEnabled: !isDoNotTrack
+    }),
     createFeature({
         id: 'review-abandonment-message',
         description: 'Show abandonment message on the review step',

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,6 +2,7 @@
 
 import raven from './bootstraps/raven';
 import common from './bootstraps/common';
+import { featureIsEnabled } from './helpers/features';
 
 raven.init();
 
@@ -13,12 +14,30 @@ vueSplit().then(vueComponents => {
 });
 
 /**
- * If we are in the live environment then load analytics
- * @see metaHeadJS.njk for where App.blockAnalytics is set
+ * Load analytics if enabled
  */
 const analyticsSplit = () => import(/* webpackChunkName: "analytics" */ './bootstraps/analytics');
-if (!window.AppConfig.blockAnalytics) {
+if (featureIsEnabled('analytics')) {
     analyticsSplit().then(analytics => {
         analytics.init();
     });
+}
+
+/**
+ * Load HotJar if enabled
+ */
+if (featureIsEnabled('hotjar')) {
+    (function(h, o, t, j, a, r) {
+        h.hj =
+            h.hj ||
+            function() {
+                (h.hj.q = h.hj.q || []).push(arguments);
+            };
+        h._hjSettings = { hjid: 828894, hjsv: 6 };
+        a = o.getElementsByTagName('head')[0];
+        r = o.createElement('script');
+        r.async = 1;
+        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+        a.appendChild(r);
+    })(window, document, 'https://static.hotjar.com/c/hotjar-', '.js?sv=');
 }

--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,7 @@
         }
     },
     "features": {
+      "useHotjar": true,
       "useRemoteAssets": true
     },
     "imgix": {
@@ -54,6 +55,5 @@
     },
     "database": "website-dev",
     "database-test": "website-test",
-    "emailSender": "noreply@biglotteryfund.org.uk",
-    "hotjarEnabled": false
+    "emailSender": "noreply@biglotteryfund.org.uk"
 }

--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -79,7 +79,7 @@ function defaultSecurityHeaders() {
         directives.connectSrc = directives.connectSrc.concat(['ws://127.0.0.1:35729/livereload']);
     }
 
-    if (config.get('hotjarEnabled')) {
+    if (config.get('features.useHotjar')) {
         directives.connectSrc = directives.connectSrc.concat(['wss://*.hotjar.com']);
         directives.defaultSrc = directives.defaultSrc.concat(['*.hotjar.com']);
     }

--- a/views/includes/metaFooterJS.njk
+++ b/views/includes/metaFooterJS.njk
@@ -7,15 +7,3 @@
 
 <script async src="https://www.google-analytics.com/analytics.js"></script>
 <script async src="/assets/autotrack/autotrack.js"></script>
-{% if appData.config.get('hotjarEnabled') %}
-    <script>
-        (function(h,o,t,j,a,r){
-            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-            h._hjSettings={hjid:828894,hjsv:6};
-            a=o.getElementsByTagName('head')[0];
-            r=o.createElement('script');r.async=1;
-            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-            a.appendChild(r);
-        })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
-    </script>
-{% endif %}


### PR DESCRIPTION
Makes a couple of changes to how third-parties are loaded:

- Moves third-parties to use the client-side `createFeature` method, and adds an initial check for `doNotTrack`. The services we use respect this header on their end too, but might as well be belt-and-braces about it.
- Sets the `anonymizeIp` flag for analytics