### PR TITLE
Only send timings for get/post

### DIFF
--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -14,23 +14,26 @@ module.exports = responseTime(function(req, res, time) {
     }
 
     const method = req.method.toUpperCase();
-    const isLegacy = res.getHeader('X-BLF-Legacy') === 'true';
-    const metricPrefix = isLegacy ? 'RESPONSE_TIME_LEGACY' : 'RESPONSE_TIME';
 
-    const metric = {
-        MetricName: `${metricPrefix}_${method}`,
-        Dimensions: [
-            {
-                Name: 'RESPONSE_TIME',
-                Value: 'TIME_IN_MS'
-            }
-        ],
-        Unit: 'Milliseconds',
-        Value: time
-    };
+    if (method === 'GET' || method === 'POST') {
+        const isLegacy = res.getHeader('X-BLF-Legacy') === 'true';
+        const metricPrefix = isLegacy ? 'RESPONSE_TIME_LEGACY' : 'RESPONSE_TIME';
 
-    CloudWatch.putMetricData({
-        MetricData: [metric],
-        Namespace: 'SITE/TRAFFIC'
-    }).send();
+        const metric = {
+            MetricName: `${metricPrefix}_${method}`,
+            Dimensions: [
+                {
+                    Name: 'RESPONSE_TIME',
+                    Value: 'TIME_IN_MS'
+                }
+            ],
+            Unit: 'Milliseconds',
+            Value: time
+        };
+
+        CloudWatch.putMetricData({
+            MetricData: [metric],
+            Namespace: 'SITE/TRAFFIC'
+        }).send();
+    }
 });


### PR DESCRIPTION
Little bit of noise from `HEAD` and `OPTIONS` calls so limiting to `GET` and `POST`