### PR TITLE
Use npm 6 for travis, test new npm ci command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: node_js
 node_js:
 - '8'
+before_install:
+- npm i -g npm@6
+install:
+- npm ci
 cache:
   directories:
+    - "$HOME/.npm"
     - node_modules
-before_script:
-- npm install
 script:
 - npm run lint
 - npm run build-production


### PR DESCRIPTION
Update to npm 6. Particularly to test the new `npm ci` command. https://medium.com/npm-inc/announcing-npm-6-5d0b1799a905 / https://docs.npmjs.com/cli/ci

> Optimization for CI. `npm ci` makes using npm within your continuous integration/continuous deployment (CI/CD) workflow an additional 2x–3x faster.

🤞 