### PR TITLE
View globals prune

### DIFF
--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -3,7 +3,7 @@
 const config = require('config');
 const moment = require('moment');
 
-const { buildUrl, getAbsoluteUrl } = require('../modules/urls');
+const { buildUrl, getCurrentUrl, getAbsoluteUrl } = require('../modules/urls');
 
 /**
  * Get normalised page title for metadata
@@ -47,6 +47,13 @@ module.exports = {
          */
         res.locals.getAbsoluteUrl = function(urlPath) {
             return getAbsoluteUrl(req, urlPath);
+        };
+
+        /**
+         * Current URL helper
+         */
+        res.locals.getCurrentUrl = function(requestedLocale) {
+            return getCurrentUrl(req, requestedLocale);
         };
 
         /**

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -3,7 +3,7 @@
 const config = require('config');
 const moment = require('moment');
 
-const { buildUrl } = require('../modules/urls');
+const { buildUrl, getAbsoluteUrl } = require('../modules/urls');
 
 /**
  * Get normalised page title for metadata
@@ -41,6 +41,13 @@ module.exports = {
          ***********************************************/
 
         res.locals.getMetaTitle = getMetaTitle;
+
+        /**
+         * Abosolute URL helper
+         */
+        res.locals.getAbsoluteUrl = function(urlPath) {
+            return getAbsoluteUrl(req, urlPath);
+        };
 
         /**
          * View helper for building URLs from route names

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -6,49 +6,61 @@ const moment = require('moment');
 const { buildUrl } = require('../modules/urls');
 
 /**
+ * Get normalised page title for metadata
+ */
+function getMetaTitle(base, pageTitle) {
+    return pageTitle ? `${pageTitle} | ${base}` : base;
+}
+
+/**
  * Set request locals
  * - Local properties that depend on the request
  * - Local methods for use in views that depend on the request
  */
-module.exports = function(req, res, next) {
-    const locale = req.i18n.getLocale();
-    const localePrefix = res.locals.localePrefix;
+module.exports = {
+    middleware: function(req, res, next) {
+        const locale = req.i18n.getLocale();
+        const localePrefix = res.locals.localePrefix;
 
-    /**
-     * High-contrast mode
-     */
-    const contrastPref = req.cookies[config.get('cookies.contrast')];
-    res.locals.isHighContrast = contrastPref && contrastPref === 'high';
+        /**
+         * High-contrast mode
+         */
+        const contrastPref = req.cookies[config.get('cookies.contrast')];
+        res.locals.isHighContrast = contrastPref && contrastPref === 'high';
 
-    /**
-     * Add the request object as a local variable
-     * for URL rewriting in templates
-     * (eg. locale versions, high-contrast redirect etc)
-     * @TODO: Remove the need for this
-     */
-    res.locals.request = req;
+        /**
+         * Add the request object as a local variable
+         * for URL rewriting in templates
+         * (eg. locale versions, high-contrast redirect etc)
+         * @TODO: Remove the need for this
+         */
+        res.locals.request = req;
 
-    /***********************************************
-     * Global view methods
-     ***********************************************/
+        /***********************************************
+         * Global view methods
+         ***********************************************/
 
-    /**
-     * View helper for building URLs from route names
-     */
-    res.locals.buildUrl = function(sectionName, pageName) {
-        return buildUrl(localePrefix)(sectionName, pageName);
-    };
+        res.locals.getMetaTitle = getMetaTitle;
 
-    /**
-     * View helper for formatting date in the current locale
-     * @param {String} dateString
-     * @param {String} format
-     * @see https://momentjs.com/docs/#/displaying/format/
-     */
-    res.locals.formatDate = function(dateString, format) {
-        moment.locale(locale);
-        return moment(dateString).format(format);
-    };
+        /**
+         * View helper for building URLs from route names
+         */
+        res.locals.buildUrl = function(sectionName, pageName) {
+            return buildUrl(localePrefix)(sectionName, pageName);
+        };
 
-    next();
+        /**
+         * View helper for formatting date in the current locale
+         * @param {String} dateString
+         * @param {String} format
+         * @see https://momentjs.com/docs/#/displaying/format/
+         */
+        res.locals.formatDate = function(dateString, format) {
+            moment.locale(locale);
+            return moment(dateString).format(format);
+        };
+
+        next();
+    },
+    getMetaTitle
 };

--- a/middleware/locals.test.js
+++ b/middleware/locals.test.js
@@ -1,0 +1,12 @@
+'use strict';
+/* eslint-env mocha */
+const chai = require('chai');
+const expect = chai.expect;
+const { getMetaTitle } = require('./locals');
+
+describe('locals middleware', () => {
+    it('should return meta title for page', () => {
+        expect(getMetaTitle('Big Lottery Fund', 'Example')).to.equal('Example | Big Lottery Fund');
+        expect(getMetaTitle('Big Lottery Fund')).to.equal('Big Lottery Fund');
+    });
+});

--- a/middleware/redirects.test.js
+++ b/middleware/redirects.test.js
@@ -1,3 +1,4 @@
+'use strict';
 /* eslint-env mocha */
 const chai = require('chai');
 const expect = chai.expect;

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -68,8 +68,12 @@ function getFullUrl(req) {
 }
 
 function getAbsoluteUrl(req, urlPath) {
-    const baseUrl = getBaseUrl(req);
-    return `${baseUrl}${urlPath}`;
+    if (urlPath.indexOf('://') === -1) {
+        const baseUrl = getBaseUrl(req);
+        return `${baseUrl}${urlPath}`;
+    } else {
+        return urlPath;
+    }
 }
 
 /**

--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -6,27 +6,7 @@ const querystring = require('querystring');
 const shortid = require('shortid');
 
 const { getBaseUrl, isWelsh, makeWelsh, removeWelsh, stripTrailingSlashes } = require('./urls');
-const { heroImages } = require('./images');
-const appData = require('./appData');
 const formHelpers = require('./forms');
-
-const metadata = {
-    title: config.get('meta.title'),
-    description: config.get('meta.description'),
-    themeColour: config.get('meta.themeColour')
-};
-
-/**
- * getMetaTitle
- * Get normalised page title for metadata
- */
-function getMetaTitle(base, pageTitle) {
-    if (pageTitle) {
-        return `${pageTitle} | ${base}`;
-    } else {
-        return base;
-    }
-}
 
 /**
  * getCurrentUrl
@@ -83,17 +63,7 @@ function init(app) {
         app.get('engineEnv').addGlobal(name, value);
     };
 
-    const getViewGlobal = name => {
-        return app.get('engineEnv').getGlobal(name);
-    };
-
-    setViewGlobal('appData', appData);
-
-    setViewGlobal('metadata', metadata);
-
     setViewGlobal('shortid', () => shortid());
-
-    setViewGlobal('getMetaTitle', getMetaTitle);
 
     setViewGlobal('anchors', config.get('anchors'));
 
@@ -122,13 +92,10 @@ function init(app) {
     });
 
     setViewGlobal('formHelpers', formHelpers);
-
-    setViewGlobal('heroImages', heroImages);
 }
 
 module.exports = {
     init,
     getCurrentUrl,
-    getMetaTitle,
     getCurrentSection
 };

--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -1,53 +1,9 @@
 'use strict';
 
 const config = require('config');
-const { URL } = require('url');
-const querystring = require('querystring');
 const shortid = require('shortid');
 
-const { getBaseUrl, isWelsh, makeWelsh, removeWelsh, stripTrailingSlashes } = require('./urls');
 const formHelpers = require('./forms');
-
-/**
- * getCurrentUrl
- * Look up the current URL and rewrite to another locale
- */
-function getCurrentUrl(req, requestedLocale) {
-    const urlPath = req.originalUrl;
-    const baseUrl = getBaseUrl(req);
-
-    const isCurrentUrlWelsh = isWelsh(urlPath);
-    const isCyWithEnRequested = isCurrentUrlWelsh && requestedLocale === 'en';
-    const isEnWithCyRequested = !isCurrentUrlWelsh && requestedLocale === 'cy';
-
-    // Rewrite URL to requested language
-    let urlPathForRequestedLocale = urlPath;
-    if (isEnWithCyRequested) {
-        urlPathForRequestedLocale = makeWelsh(urlPath);
-    } else if (isCyWithEnRequested) {
-        urlPathForRequestedLocale = removeWelsh(urlPath);
-    }
-
-    // Remove any trailing slashes (eg. /welsh/ => /welsh)
-    const cleanedUrlPath = stripTrailingSlashes(urlPathForRequestedLocale);
-
-    const fullUrl = baseUrl + cleanedUrlPath;
-
-    const parsedUrl = new URL(fullUrl);
-    const parsedPathname = parsedUrl.pathname;
-    const parsedQuery = parsedUrl.search.replace(/^\?/, '');
-
-    // Remove draft and version parameters
-    const originalQuery = querystring.parse(parsedQuery);
-    delete originalQuery.version;
-    delete originalQuery.draft;
-
-    // Reconstruct clean URL
-    const newCleanQuery = querystring.stringify(originalQuery);
-    const newCleanUrl = newCleanQuery.length > 0 ? `${parsedPathname}?${newCleanQuery}` : parsedPathname;
-
-    return newCleanUrl;
-}
 
 function getCurrentSection(sectionId, pageId) {
     const isHomepage = sectionId === 'toplevel' && pageId === 'home';
@@ -66,8 +22,6 @@ function init(app) {
     setViewGlobal('shortid', () => shortid());
 
     setViewGlobal('anchors', config.get('anchors'));
-
-    setViewGlobal('getCurrentUrl', getCurrentUrl);
 
     setViewGlobal('getCurrentSection', getCurrentSection);
 
@@ -96,6 +50,5 @@ function init(app) {
 
 module.exports = {
     init,
-    getCurrentUrl,
     getCurrentSection
 };

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -5,58 +5,9 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const httpMocks = require('node-mocks-http');
-const { getCurrentUrl, getMetaTitle, getCurrentSection } = require('./viewGlobals');
+const { getCurrentSection } = require('./viewGlobals');
 
 describe('View Globals', () => {
-    describe('#getCurrentUrl', () => {
-        it('should return expected url for en locale', () => {
-            const req = httpMocks.createRequest({
-                method: 'GET',
-                url: '/some/example/url/',
-                headers: {
-                    Host: 'biglotteryfund.org.uk',
-                    'X-Forwarded-Proto': 'https'
-                }
-            });
-            expect(getCurrentUrl(req, 'en')).to.equal('/some/example/url');
-            expect(getCurrentUrl(req, 'cy')).to.equal('/welsh/some/example/url');
-        });
-
-        it('should correct url if in cy locale', () => {
-            const req = httpMocks.createRequest({
-                method: 'GET',
-                url: '/welsh/some/example/url/',
-                headers: {
-                    Host: 'biglotteryfund.org.uk',
-                    'X-Forwarded-Proto': 'https'
-                }
-            });
-
-            expect(getCurrentUrl(req, 'en')).to.equal('/some/example/url');
-            expect(getCurrentUrl(req, 'cy')).to.equal('/welsh/some/example/url');
-        });
-
-        it('should strip version and draft query parameters', () => {
-            function withQuery(query) {
-                return httpMocks.createRequest({
-                    method: 'GET',
-                    url: `/some/example/url?${query}`,
-                    headers: {
-                        Host: 'biglotteryfund.org.uk',
-                        'X-Forwarded-Proto': 'https'
-                    }
-                });
-            }
-            expect(getCurrentUrl(withQuery('version=123'))).to.equal('/some/example/url');
-            expect(getCurrentUrl(withQuery('draft=123'))).to.equal('/some/example/url');
-            expect(getCurrentUrl(withQuery('version=123&something=else'))).to.equal('/some/example/url?something=else');
-            expect(getCurrentUrl(withQuery('draft=2&something=else'))).to.equal('/some/example/url?something=else');
-            expect(getCurrentUrl(withQuery('version=123&draft=2&something=else'))).to.equal(
-                '/some/example/url?something=else'
-            );
-        });
-    });
-
     describe('#getCurrentSection', () => {
         it('should return navigation section for a given page', () => {
             expect(getCurrentSection('toplevel', 'home')).to.equal('toplevel');

--- a/modules/viewGlobals.test.js
+++ b/modules/viewGlobals.test.js
@@ -57,16 +57,6 @@ describe('View Globals', () => {
         });
     });
 
-    describe('#getMetaTitle', () => {
-        it('should return combined meta title when page title is set', () => {
-            expect(getMetaTitle('Big Lottery Fund', 'Example')).to.equal('Example | Big Lottery Fund');
-        });
-
-        it('should return base title if no page title is set', () => {
-            expect(getMetaTitle('Big Lottery Fund')).to.equal('Big Lottery Fund');
-        });
-    });
-
     describe('#getCurrentSection', () => {
         it('should return navigation section for a given page', () => {
             expect(getCurrentSection('toplevel', 'home')).to.equal('toplevel');

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 'use strict';
 const { forEach } = require('lodash');
+const config = require('config');
 const express = require('express');
 const favicon = require('serve-favicon');
 const i18n = require('i18n-2');
@@ -19,6 +20,7 @@ if (appData.isDev) {
 
 const { cymreigio } = require('./modules/urls');
 const { getSectionsForNavigation } = require('./controllers/route-helpers');
+const { heroImages } = require('./modules/images');
 const { proxyPassthrough, postToLegacyForm } = require('./modules/legacy');
 const { renderError, renderNotFound, renderUnauthorised } = require('./controllers/http-errors');
 const { SENTRY_DSN } = require('./modules/secrets');
@@ -92,6 +94,16 @@ app.use('/assets', express.static(path.join(__dirname, './public')));
  */
 function initAppLocals() {
     /**
+     * Environment metadata
+     */
+    app.locals.appData = appData;
+
+    /**
+     * Metadata (e.g. global title, description)
+     */
+    app.locals.metadata = config.get('meta');
+
+    /**
      * Is this page bilingual?
      * i.e. do we have a Welsh translation
      * Default to true unless overriden by a route
@@ -102,6 +114,11 @@ function initAppLocals() {
      * Navigation sections for top-level nav
      */
     app.locals.navigationSections = getSectionsForNavigation();
+
+    /**
+     * Common hero images
+     */
+    app.locals.heroImages = heroImages;
 }
 
 initAppLocals();
@@ -143,7 +160,7 @@ app.use(bodyParserMiddleware);
 app.use(sessionMiddleware(app));
 app.use(passportMiddleware());
 app.use(redirectsMiddleware.common);
-app.use(localsMiddleware);
+app.use(localsMiddleware.middleware);
 app.use(previewMiddleware);
 
 // Mount tools controller

--- a/views/components/accessibility.njk
+++ b/views/components/accessibility.njk
@@ -20,7 +20,7 @@
                 {% if isHighContrast %}
                     {% set modeToSwitchTo = 'standard'  %}
                 {% endif %}
-                <a href="/contrast/{{ modeToSwitchTo }}?url={{ getCurrentUrl(request) | urlencode}}"
+                <a href="/contrast/{{ modeToSwitchTo }}?url={{ getCurrentUrl() | urlencode}}"
                     data-on="click"
                     data-event-category="Change contrast"
                     data-event-action="Click"

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -12,9 +12,9 @@
 {% macro navLangLink() %}
     {% if isBilingual %}
         {% if locale == 'en' %}
-            <a class="qa-lang-switcher" href="{{ getCurrentUrl(request, 'cy') }}">Cymraeg</a>
+            <a class="qa-lang-switcher" href="{{ getCurrentUrl('cy') }}">Cymraeg</a>
         {% else %}
-            <a class="qa-lang-switcher" href="{{ getCurrentUrl(request, 'en') }}">English</a>
+            <a class="qa-lang-switcher" href="{{ getCurrentUrl('en') }}">English</a>
         {% endif %}
     {% endif %}
 {% endmacro %}

--- a/views/components/preview.njk
+++ b/views/components/preview.njk
@@ -3,7 +3,7 @@
         <div class="preview-banner">
             ✋ You are viewing a draft (last updated {{ status.lastUpdated }}).
             Please do not share this page.
-            <a href="{{ getCurrentUrl(request) }}">View original</a>
+            <a href="{{ getCurrentUrl() }}">View original</a>
         </div>
     {% endif %}
 {% endmacro %}

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -11,7 +11,7 @@
 <meta property="og:type" content="website">
 <meta property="og:title" content="{{ metaTitle }}">
 <meta property="og:description" content="{% if description %}{{ description }}{% else %}{{ metadata.description }}{% endif %}">
-<meta property="og:url" content="{{ getCurrentUrl(request) }}">
+<meta property="og:url" content="{{ getCurrentUrl() }}">
 
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@{{ appData.config.get('social.twitterAccounts.' + locale) }}" />
@@ -50,8 +50,8 @@
 
 {% if isBilingual %}
     {% if locale == 'en' %}
-        <link rel="alternate" hreflang="cy" href="{{ getCurrentUrl(request, 'cy') }}" />
+        <link rel="alternate" hreflang="cy" href="{{ getCurrentUrl('cy') }}" />
     {% else %}
-        <link rel="alternate" hreflang="en" href="{{ getCurrentUrl(request, 'en') }}" />
+        <link rel="alternate" hreflang="en" href="{{ getCurrentUrl('en') }}" />
     {% endif %}
 {% endif %}

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -1,5 +1,4 @@
 {% set metaTitle = getMetaTitle(__("global.brand.title"), title) %}
-{% macro makeAbsoluteImage(path) %}{% if path.indexOf('://') === -1 %}{{ request.protocol }}://{{ request.headers.host }}{% endif %}{{ path }}{% endmacro %}
 <!-- deploy {{ appData.deployId }} (build #{{ appData.buildNumber }}) -->
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,11 +17,11 @@
 <meta name="twitter:site" content="@{{ appData.config.get('social.twitterAccounts.' + locale) }}" />
 
 {% if socialImage %}
-<meta property="twitter:image" content="{{ makeAbsoluteImage(socialImage.default) }}">
-<meta property="og:image" content="{{ makeAbsoluteImage(socialImage.default) }}">
+<meta property="twitter:image" content="{{ getAbsoluteUrl(socialImage.default) }}">
+<meta property="og:image" content="{{ getAbsoluteUrl(socialImage.default) }}">
 {% else %}
-<meta property="twitter:image" content="{{ makeAbsoluteImage("social/twitter.jpg" | getImagePath) }}">
-<meta property="og:image" content="{{ makeAbsoluteImage("social/facebook.jpg" | getImagePath) }}">
+<meta property="twitter:image" content="{{ getAbsoluteUrl("social/twitter.jpg" | getImagePath) }}">
+<meta property="og:image" content="{{ getAbsoluteUrl("social/facebook.jpg" | getImagePath) }}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 {% endif %}

--- a/views/layouts/profiles.njk
+++ b/views/layouts/profiles.njk
@@ -31,7 +31,7 @@
             </div>
             <div class="page-section__supplementary accent--{{ pageAccent }} a--border-top">
                 <aside class="content-box">
-                    {{ nestedMenu(navigation, getCurrentUrl(request)) }}
+                    {{ nestedMenu(navigation, getCurrentUrl()) }}
                 </aside>
 
                 {% set quickLinksList = [] %}


### PR DESCRIPTION
More pruning of view globals in favour of locals. Main changes are:

- Move a few properties to the global `app.locals` block
- Replace inline makeAbsoluteImage method with identical getAbsoluteUrl
- Rework getCurrentUrl to not need request in template