### PR TITLE
Add some default imagery in case the CMS goes down

### DIFF
--- a/controllers/toplevel/homepage.js
+++ b/controllers/toplevel/homepage.js
@@ -1,5 +1,6 @@
 const Raven = require('raven');
 const contentApi = require('../../services/content-api');
+const images = require('../../modules/images');
 
 function init({ router, routeConfig }) {
     router.get(routeConfig.path, (req, res) => {
@@ -25,7 +26,14 @@ function init({ router, routeConfig }) {
             })
             .catch(err => {
                 Raven.captureException(err);
-                serveHomepage();
+                const fallbackHeroes = {
+                    default: images.heroImages.larcheBelfast,
+                    candidates: [
+                        images.heroImages.passion4Fusion,
+                        images.heroImages.streetDreams
+                    ]
+                };
+                serveHomepage(fallbackHeroes);
             });
     });
 }


### PR DESCRIPTION
If the CMS is unavailable, we serve the homepage with an empty `heroes` configuration. This adds in some hard-coded ones so the homepage doesn't look blank.