### PR TITLE
IE fixes

### DIFF
--- a/assets/sass/components/survey.scss
+++ b/assets/sass/components/survey.scss
@@ -38,6 +38,7 @@ body.is-ios-editing-survey {
         text-decoration: underline;
         cursor: pointer;
         display: block;
+        color: #ffffff;
     }
 
     .survey__arrow {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
       ]
     ]
   },
+  "browserslist": [
+    "last 2 versions",
+    "ie >= 10"
+  ],
   "nodemonConfig": {
     "verbose": true,
     "ignore": [


### PR DESCRIPTION
This comment came in via a survey:

>The "Did you find what you were looking for" link has black text on a very dark grey background when viewed in IE 11.

![image](https://user-images.githubusercontent.com/394376/39517763-bdb68fb2-4df8-11e8-93d4-241b1273d344.png)

As you can see, the flexbox columns above the survey are broken too – this is because none of our CSS seems to have any older browser prefixes anymore.

I added a `browserslist` key which matches our `babel` browser config and is used by `postcss`/`autoprefixer`. This now renders like so in IE10 onwards:

![image](https://user-images.githubusercontent.com/394376/39517814-ee2afc5a-4df8-11e8-8f4b-2efff7a509e0.png)
