### PR TITLE
Scope error message

### DIFF
--- a/views/error.njk
+++ b/views/error.njk
@@ -34,7 +34,7 @@
                     <p><code>{{ sentry }}</code></p>
                 {% endif %}
 
-                {% if error %}
+                {% if error and appData.isNotProduction %}
                     <h4>Stack trace:</h4>
                     <pre>{{ error.stack }}</pre>
                     <h4>Raw error:</h4>

--- a/views/notfound.njk
+++ b/views/notfound.njk
@@ -35,7 +35,7 @@
                     <p><code>{{ sentry }}</code></p>
                 {% endif %}
 
-                {% if error %}
+                {% if error and appData.isNotProduction %}
                     <h4>Stack trace:</h4>
                     <pre>{{ error.stack }}</pre>
                     <h4>Raw error:</h4>


### PR DESCRIPTION
We have this check in `http-errors` but it doesn't catch all cases, so better to keep the check in the templates to avoid showing error stacks to real people.