### PR TITLE
Remove t--tracking modifier

### DIFF
--- a/assets/sass/globals/typography.scss
+++ b/assets/sass/globals/typography.scss
@@ -64,13 +64,6 @@ h6,
 }
 
 /**
- * Modifier to add extra tracking to .t headings
- */
-.t--tracking {
-    letter-spacing: 2px;
-}
-
-/**
  * Caption within headings
  */
 .t-caption {

--- a/views/components/caseStudies.njk
+++ b/views/components/caseStudies.njk
@@ -21,7 +21,7 @@
                         <p>{{ quoteText }}</p>
                     </div>
                     <div class="pullquote__meta">
-                        <cite class="pullquote__citation t2 t--tracking">{{ quoteName }}</cite>
+                        <cite class="pullquote__citation t2">{{ quoteName }}</cite>
                         <div class="pullquote__aside">
                             {% if quoteNameCaption %}
                                 <p class="t8 u-weight-normal">{{ quoteNameCaption }}</p>

--- a/views/pages/toplevel/styleguide.njk
+++ b/views/pages/toplevel/styleguide.njk
@@ -28,7 +28,6 @@
 
 {% set sgContent %}
     <h2 class="t2 t--underline accent--pink a--text">Title with underline</h2>
-    <h2 class="t3 t--tracking">Title with tracking</h2>
 {% endset %}
 {{ sgBlock('Typography: Modifiers', sgContent) }}
 


### PR DESCRIPTION
Spotted whilst fixing the (broken) styleguide, that we only use `t--tracking` in a single questionable place, so [putting the sheep back where they belong](http://www.paulshawletterdesign.com/2017/01/typophillics-no-1/)