### PR TITLE
Don't explicitly capture exception for programme 404s

### DIFF
--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -168,8 +168,7 @@ function handleProgrammeDetail(slug) {
                     throw new Error('NoContent');
                 }
             })
-            .catch(err => {
-                err.statusCode !== '404' && Raven.captureException(err);
+            .catch(() => {
                 next();
             });
     };
@@ -229,8 +228,7 @@ function initProgrammeDetailAwardsForAll(router, options) {
                     throw new Error('NoContent');
                 }
             })
-            .catch(err => {
-                err.statusCode !== '404' && Raven.captureException(err);
+            .catch(() => {
                 next();
             });
     }


### PR DESCRIPTION
Aims to reduce some of the noise from https://sentry.io/big-lottery-fund/biglotteryfund/issues/417893284/

If you went to a welsh url for a page that wasn't translated we were logging the error even when we redirected you. Rather than explicitly capturing exceptions we can pass through and let the main 404 handler catch it if needed.