### PR TITLE
Prune default cookies

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 require('dotenv').config();
 
 const has = require('lodash/has');

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 const fs = require('fs');
 const path = require('path');
 const util = require('util');

--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-
 'use strict';
-
 const fs = require('fs');
 const assert = require('assert');
 const AWS = require('aws-sdk');

--- a/bin/scraper
+++ b/bin/scraper
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 const path = require('path');
 const moment = require('moment');
 const fs = require('fs');

--- a/bin/update-cloudfront
+++ b/bin/update-cloudfront
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-
 const fs = require('fs');
 const path = require('path');
 const prompt = require('prompt');

--- a/bin/www
+++ b/bin/www
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+'use strict';
 const app = require('../server');
 const debug = require('debug')('blf-alpha:server');
 const http = require('http');

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -48,10 +48,9 @@
           "Items": [
             "contrastMode",
             "blf-alpha-session",
-            "_csrf",
             "blf-ab-afa-v2"
           ],
-          "Quantity": 4
+          "Quantity": 3
         }
       }
     },
@@ -113,10 +112,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -284,10 +282,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -456,10 +453,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -522,10 +518,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -851,10 +846,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -914,10 +908,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -982,10 +975,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1046,10 +1038,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1112,10 +1103,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1171,10 +1161,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -47,10 +47,9 @@
         "WhitelistedNames": {
           "Items": [
             "contrastMode",
-            "blf-alpha-session",
-            "blf-ab-afa-v2"
+            "blf-alpha-session"
           ],
-          "Quantity": 3
+          "Quantity": 2
         }
       }
     },
@@ -111,10 +110,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -281,10 +279,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -452,10 +449,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -517,10 +513,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -845,10 +840,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -907,10 +901,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -974,10 +967,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1037,10 +1029,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1102,10 +1093,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1160,10 +1150,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -531,6 +531,67 @@
         "PathPattern": "/funding/programmes"
       },
       {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
         "TargetOriginId": "LEGACY",
         "ViewerProtocolPolicy": "allow-all",
         "MinTTL": 0,
@@ -1141,6 +1202,67 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [],
             "Quantity": 0
           },
@@ -1168,6 +1290,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 19
+    "Quantity": 21
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -531,6 +531,67 @@
         "PathPattern": "/funding/programmes"
       },
       {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
         "TargetOriginId": "LEGACY",
         "ViewerProtocolPolicy": "allow-all",
         "MinTTL": 0,
@@ -1141,6 +1202,67 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session",
+                "blf-ab-afa-v2"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [],
             "Quantity": 0
           },
@@ -1168,6 +1290,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 19
+    "Quantity": 21
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -48,10 +48,9 @@
           "Items": [
             "contrastMode",
             "blf-alpha-session",
-            "_csrf",
             "blf-ab-afa-v2"
           ],
-          "Quantity": 4
+          "Quantity": 3
         }
       }
     },
@@ -113,10 +112,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -284,10 +282,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -456,10 +453,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -522,10 +518,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -851,10 +846,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -914,10 +908,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -982,10 +975,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1046,10 +1038,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1112,10 +1103,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },
@@ -1171,10 +1161,9 @@
               "Items": [
                 "contrastMode",
                 "blf-alpha-session",
-                "_csrf",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 4
+              "Quantity": 3
             }
           }
         },

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -47,10 +47,9 @@
         "WhitelistedNames": {
           "Items": [
             "contrastMode",
-            "blf-alpha-session",
-            "blf-ab-afa-v2"
+            "blf-alpha-session"
           ],
-          "Quantity": 3
+          "Quantity": 2
         }
       }
     },
@@ -111,10 +110,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -281,10 +279,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -452,10 +449,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -517,10 +513,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -845,10 +840,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -907,10 +901,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -974,10 +967,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1037,10 +1029,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1102,10 +1093,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1160,10 +1150,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
-                "blf-ab-afa-v2"
+                "blf-alpha-session"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },

--- a/config/default.json
+++ b/config/default.json
@@ -23,7 +23,6 @@
     "cookies": {
         "contrast": "contrastMode",
         "session": "blf-alpha-session",
-        "csrf": "_csrf",
         "abTestAwardsForAll": "blf-ab-afa-v2"
     },
     "anchors": {

--- a/config/default.json
+++ b/config/default.json
@@ -14,6 +14,7 @@
         }
     },
     "features": {
+      "enableAbTests": true,
       "useHotjar": true,
       "useRemoteAssets": true
     },
@@ -22,8 +23,7 @@
     },
     "cookies": {
         "contrast": "contrastMode",
-        "session": "blf-alpha-session",
-        "abTestAwardsForAll": "blf-ab-afa-v2"
+        "session": "blf-alpha-session"
     },
     "anchors": {
         "contactPress": "press",
@@ -33,14 +33,6 @@
     "googleAnalyticsCode": "UA-98908627-1",
     "legacyDomain": "https://wwwlegacy.biglotteryfund.org.uk",
     "ebulletinApiEndpoint": "https://apiconnector.com/v2",
-    "abTests": {
-        "enabled": true,
-        "tests": {
-            "awardsForAll": {
-                "percentage": 50
-            }
-        }
-    },
     "social": {
         "instagram": "https://www.instagram.com/big_lottery_fund",
         "twitterAccounts": {

--- a/config/development.json
+++ b/config/development.json
@@ -1,8 +1,6 @@
 {
   "features": {
+    "enableAbTests": true,
     "useRemoteAssets": false
-  },
-  "abTests": {
-    "enabled": true
   }
 }

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -182,17 +182,6 @@ function initProgrammeDetail(router) {
 }
 
 function initProgrammeDetailAwardsForAll(router, options) {
-    const testFn = ab.test('blf-afa-rollout-england', {
-        cookie: {
-            name: config.get('cookies.abTestAwardsForAll'),
-            maxAge: moment.duration(4, 'weeks').asMilliseconds()
-        },
-        id: options.experimentId
-    });
-
-    const percentageForTest = config.get('abTests.tests.awardsForAll.percentage');
-    const percentages = splitPercentages(percentageForTest);
-
     const getSlug = urlPath => last(urlPath.split('/'));
 
     function renderVariantA(req, res, next) {
@@ -235,6 +224,16 @@ function initProgrammeDetailAwardsForAll(router, options) {
             });
     }
 
+    const testFn = ab.test('blf-afa-rollout-england', {
+        cookie: {
+            name: options.abTest.cookie,
+            maxAge: moment.duration(4, 'weeks').asMilliseconds()
+        },
+        id: options.abTest.experimentId
+    });
+
+    const percentages = splitPercentages(options.abTest.percentage);
+
     router.get(options.path, cached.noCache, testFn(null, percentages.A), renderVariantA);
     router.get(options.path, cached.noCache, testFn(null, percentages.B), renderVariantB);
 
@@ -256,11 +255,13 @@ function initProgrammeDetailAwardsForAll(router, options) {
 
 function init({ router, routeConfig }) {
     initProgrammesList(router, routeConfig.programmes);
-    if (config.get('abTests.enabled')) {
+
+    if (config.get('features.enableAbTests')) {
         [routeConfig.programmeDetailAfaScotland].forEach(route => {
             initProgrammeDetailAwardsForAll(router, route);
         });
     }
+
     initProgrammeDetail(router);
 }
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -206,7 +206,11 @@ sections.funding.addRoutes({
     programmeDetailAfaScotland: dynamicRoute({
         path: '/programmes/national-lottery-awards-for-all-scotland',
         applyUrl: 'https://apply.biglotteryfund.org.uk/?cn=sc',
-        experimentId: 'EcAwbF34R5mbCaWW-y_rFQ'
+        abTest: {
+            cookie: 'blf-ab-afa-v2',
+            percentage: 50,
+            experimentId: 'EcAwbF34R5mbCaWW-y_rFQ'
+        }
     }),
     buildingBetterOpportunities: cmsRoute({
         path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding',


### PR DESCRIPTION
This does some work to reduce the cookies we whitelist by default in CloudFront. The two main changes are:

- Remove the unused `_csrf` cookie, we don't handle CSRF this way
- Move A/B test cookies to be configured at the route level, and only whitelist the cookie for the route that uses it.

I've tried to make the commits as readable as possible to make it easier to see the changes to the cloudfront output.