### PR TITLE
Remove session cookie from default cloudfront config

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -603,6 +603,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -1434,6 +1499,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -1603,6 +1733,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 26
+    "Quantity": 28
   }
 }

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -46,10 +46,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "contrastMode",
-            "blf-alpha-session"
+            "contrastMode"
           ],
-          "Quantity": 2
+          "Quantity": 1
         }
       }
     },
@@ -109,10 +108,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -278,10 +276,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -448,10 +445,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -512,10 +508,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -573,10 +568,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -900,10 +894,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -961,10 +954,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1027,10 +1019,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1089,10 +1080,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1153,10 +1143,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1214,10 +1203,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1271,10 +1259,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -244,6 +244,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/apply/your-idea/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -461,6 +526,71 @@
           "Quantity": 0
         },
         "PathPattern": "/funding/funding-finder"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials"
       },
       {
         "TargetOriginId": "ELB_LIVE",
@@ -1009,6 +1139,71 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/tools/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
               "version",
               "token"
             ],
@@ -1019,9 +1214,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode"
+                "contrastMode",
+                "blf-alpha-session"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -1035,6 +1231,71 @@
           "Quantity": 0
         },
         "PathPattern": "/user/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/apply/your-idea/*"
       },
       {
         "TargetOriginId": "ELB_LIVE",
@@ -1096,6 +1357,71 @@
           "Quantity": 0
         },
         "PathPattern": "/welsh/funding/funding-finder"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials"
       },
       {
         "TargetOriginId": "ELB_LIVE",
@@ -1277,6 +1603,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 21
+    "Quantity": 26
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -603,6 +603,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -1434,6 +1499,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -1603,6 +1733,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 26
+    "Quantity": 28
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -244,6 +244,71 @@
         "AllowedMethods": {
           "Items": [
             "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/apply/your-idea/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
             "GET"
           ],
           "Quantity": 2,
@@ -461,6 +526,71 @@
           "Quantity": 0
         },
         "PathPattern": "/funding/funding-finder"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials"
       },
       {
         "TargetOriginId": "ELB-TEST",
@@ -1009,6 +1139,71 @@
           "QueryStringCacheKeys": {
             "Items": [
               "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/tools/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
               "version",
               "token"
             ],
@@ -1019,9 +1214,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode"
+                "contrastMode",
+                "blf-alpha-session"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -1035,6 +1231,71 @@
           "Quantity": 0
         },
         "PathPattern": "/user/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/apply/your-idea/*"
       },
       {
         "TargetOriginId": "ELB-TEST",
@@ -1096,6 +1357,71 @@
           "Quantity": 0
         },
         "PathPattern": "/welsh/funding/funding-finder"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH"
+          ],
+          "Quantity": 7,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version"
+            ],
+            "Quantity": 2
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-alpha-session"
+              ],
+              "Quantity": 2
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials"
       },
       {
         "TargetOriginId": "ELB-TEST",
@@ -1277,6 +1603,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 21
+    "Quantity": 26
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -46,10 +46,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "contrastMode",
-            "blf-alpha-session"
+            "contrastMode"
           ],
-          "Quantity": 2
+          "Quantity": 1
         }
       }
     },
@@ -109,10 +108,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -278,10 +276,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -448,10 +445,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -512,10 +508,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -573,10 +568,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -900,10 +894,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -961,10 +954,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1027,10 +1019,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1089,10 +1080,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1153,10 +1143,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -1214,10 +1203,9 @@
             "WhitelistedNames": {
               "Items": [
                 "contrastMode",
-                "blf-alpha-session",
                 "blf-ab-afa-v2"
               ],
-              "Quantity": 3
+              "Quantity": 2
             }
           }
         },
@@ -1271,10 +1259,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "contrastMode",
-                "blf-alpha-session"
+                "contrastMode"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const config = require('config');
 const { get } = require('lodash');
 
 /**
@@ -93,6 +93,19 @@ function dynamicRoute(props) {
         live: true
     };
     return Object.assign({}, defaults, dynamicDefaults, props);
+}
+
+/**
+ * Session route
+ * Route type where session is required
+ */
+function sessionRoute(props) {
+    const sessionDefaults = {
+        cookies: [config.get('cookies.session')],
+        static: false,
+        live: true
+    };
+    return Object.assign({}, sessionDefaults, defaults, props);
 }
 
 /**
@@ -192,6 +205,7 @@ module.exports = {
     basicRoute,
     staticRoute,
     dynamicRoute,
+    sessionRoute,
     wildcardRoute,
     cmsRoute,
     legacyRoute,

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -109,21 +109,6 @@ function sessionRoute(props) {
 }
 
 /**
- * Wildcard route
- * Extends from dynamic route, used when we require wildcard parameters
- * e.g. /some/route/:dynamicId
- * Used on the Free Materials form
- */
-function wildcardRoute(props) {
-    const wildcardDefaults = {
-        static: false,
-        live: true,
-        isWildcard: true
-    };
-    return Object.assign({}, defaults, wildcardDefaults, props);
-}
-
-/**
  * CMS route
  * Triggers CMS content handler in 'routeCommon'
  * e.g. Programme detail pages
@@ -206,7 +191,6 @@ module.exports = {
     staticRoute,
     dynamicRoute,
     sessionRoute,
-    wildcardRoute,
     cmsRoute,
     legacyRoute,
     archived,

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -3,13 +3,14 @@
 const path = require('path');
 const { archivedRoutes, legacyRedirects, vanityRedirects } = require('./aliases');
 const {
-    createSection,
     basicRoute,
-    staticRoute,
-    dynamicRoute,
-    wildcardRoute,
     cmsRoute,
-    legacyRoute
+    createSection,
+    dynamicRoute,
+    legacyRoute,
+    sessionRoute,
+    staticRoute,
+    wildcardRoute
 } = require('./route-types');
 
 const sections = {
@@ -158,7 +159,7 @@ sections.funding.addRoutes({
         lang: 'funding.guidance.managing-your-funding',
         aliases: ['/funding/funding-guidance/managing-your-funding/help-with-publicity', '/welcome', '/publicity']
     }),
-    freeMaterials: wildcardRoute({
+    freeMaterials: sessionRoute({
         path: '/funding-guidance/managing-your-funding/ordering-free-materials',
         template: 'pages/funding/guidance/order-free-materials',
         lang: 'funding.guidance.order-free-materials',
@@ -339,7 +340,7 @@ sections.apply.addRoutes({
     root: dynamicRoute({
         path: '/'
     }),
-    yourIdea: dynamicRoute({
+    yourIdea: sessionRoute({
         path: '/your-idea/*',
         isPostable: true
     })
@@ -377,7 +378,7 @@ const otherUrls = [
     basicRoute({
         path: '/styleguide'
     }),
-    basicRoute({
+    sessionRoute({
         path: '/tools/*',
         isPostable: true
     }),
@@ -394,7 +395,7 @@ const otherUrls = [
         path: '/survey/*',
         isPostable: true
     }),
-    basicRoute({
+    sessionRoute({
         path: '/user/*',
         isPostable: true,
         queryStrings: ['token']

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -9,8 +9,7 @@ const {
     dynamicRoute,
     legacyRoute,
     sessionRoute,
-    staticRoute,
-    wildcardRoute
+    staticRoute
 } = require('./route-types');
 
 const sections = {

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -173,6 +173,10 @@ sections.funding.addRoutes({
             '/yourgrant'
         ]
     }),
+    freeMaterialsActions: sessionRoute({
+        path: '/funding-guidance/managing-your-funding/ordering-free-materials/*',
+        isPostable: true
+    }),
     helpWithPublicity: staticRoute({
         path: '/funding-guidance/managing-your-funding/social-media',
         template: 'pages/funding/guidance/help-with-publicity',

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -182,12 +182,13 @@ const makeBehaviourItem = ({
  */
 function generateBehaviours({ routesConfig, origins }) {
     const urlsToSupport = generateUrlList(routesConfig);
-    const cookiesInUse = map(config.get('cookies'), val => val);
+
+    const defaultCookies = [config.get('cookies.contrast')];
 
     const defaultBehaviour = makeBehaviourItem({
         originId: origins.newSite,
         isPostable: true,
-        cookiesInUse: cookiesInUse
+        cookiesInUse: defaultCookies
     });
 
     // Serve legacy static files
@@ -215,7 +216,7 @@ function generateBehaviours({ routesConfig, origins }) {
 
     // direct all custom routes (eg. with non-standard config) to Express
     const primaryBehaviours = urlsToSupport.map(url => {
-        const routeCookies = has(url, 'abTest.cookie') ? concat(cookiesInUse, [url.abTest.cookie]) : cookiesInUse;
+        const cookiesInUse = has(url, 'abTest.cookie') ? concat(defaultCookies, [url.abTest.cookie]) : defaultCookies;
 
         return makeBehaviourItem({
             originId: origins.newSite,
@@ -223,7 +224,7 @@ function generateBehaviours({ routesConfig, origins }) {
             isPostable: url.isPostable,
             queryStringWhitelist: url.queryStrings,
             allowAllQueryStrings: url.allowAllQueryStrings,
-            cookiesInUse: routeCookies
+            cookiesInUse: cookiesInUse
         });
     });
 

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -53,9 +53,6 @@ function generateUrlList(routes) {
             let url = section.path + page.path;
 
             if (pageNeedsCustomRouting(page)) {
-                if (page.isWildcard) {
-                    url += '*';
-                }
                 // create route mapping for canonical URLs
                 urls.push(makeUrlObject(page, url));
                 urls.push(makeUrlObject(page, makeWelsh(url)));

--- a/modules/cloudfront.test.js
+++ b/modules/cloudfront.test.js
@@ -15,7 +15,6 @@ describe('Cloudfront Helpers', () => {
                     monkey: {
                         path: '/monkey/dishwasher',
                         live: true,
-                        isWildcard: false,
                         isPostable: true,
                         aliases: ['/green/orangutan/fridge'],
                         queryStrings: ['foo', 'bar']


### PR DESCRIPTION
Building on from https://github.com/biglotteryfund/blf-alpha/pull/928 this PR removes the session cookie from the default cloudfront config.

In place it adds a new `sessionRoute` route-type which allows us to whitelist certain routes for use with session cookies. 

The one part that needs some extra handling is the `/item/:id` route in the materials form as there is currently not a wildcard route to cover it. Needs a bit of adjustment to work.

💭Thoughts very welcome.