### PR TITLE
Centralise common date formats

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -8,6 +8,11 @@
         "description": "The Big Lottery Fund gives grants to organisations in the UK to help improve their communities. The money awarded comes from the UK National Lottery.",
         "themeColour": "#ec008c"
     },
+    "dateFormats": {
+      "short": "D MMMM, YYYY",
+      "full": "dddd D MMMM YYYY",
+      "fullTimestamp": "dddd D MMM YYYY (hh:mm a)"
+    },
     "i18n": {
         "urlPrefix": {
             "cy": "/welsh"

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -69,8 +69,9 @@ module.exports = {
          * @see https://momentjs.com/docs/#/displaying/format/
          */
         res.locals.formatDate = function(dateString, format) {
-            moment.locale(locale);
-            return moment(dateString).format(format);
+            return moment(dateString)
+                .locale(locale)
+                .format(format);
         };
 
         /**
@@ -78,8 +79,9 @@ module.exports = {
          * @param {String} dateString
          */
         res.locals.timeFromNow = function(dateString) {
-            moment.locale(locale);
-            return moment(dateString).fromNow();
+            return moment(dateString)
+                .locale(locale)
+                .fromNow();
         };
 
         next();

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -73,6 +73,15 @@ module.exports = {
             return moment(dateString).format(format);
         };
 
+        /**
+         * View helper to represent date as relative time
+         * @param {String} dateString
+         */
+        res.locals.timeFromNow = function(dateString) {
+            moment.locale(locale);
+            return moment(dateString).fromNow();
+        };
+
         next();
     },
     getMetaTitle

--- a/modules/filters.js
+++ b/modules/filters.js
@@ -42,10 +42,6 @@ function mailto(str) {
     return `<a href="mailto:${str}">${str}</a>`;
 }
 
-function timeFromNow(str) {
-    return moment(str).fromNow();
-}
-
 function numberWithCommas(str) {
     return str.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
@@ -67,6 +63,5 @@ module.exports = {
     makePhoneLink,
     numberWithCommas,
     pluralise,
-    slugify,
-    timeFromNow
+    slugify
 };

--- a/server.js
+++ b/server.js
@@ -106,11 +106,7 @@ function initAppLocals() {
     /**
      * Common date formats
      */
-    app.locals.DATE_FORMATS = {
-        short: 'D MMMM, YYYY',
-        full: 'dddd D MMMM YYYY',
-        fullTimestamp: 'dddd D MMM YYYY (hh:mm a)'
-    };
+    app.locals.DATE_FORMATS = config.get('dateFormats');
 
     /**
      * Is this page bilingual?

--- a/server.js
+++ b/server.js
@@ -104,6 +104,15 @@ function initAppLocals() {
     app.locals.metadata = config.get('meta');
 
     /**
+     * Common date formats
+     */
+    app.locals.DATE_FORMATS = {
+        short: 'D MMMM, YYYY',
+        full: 'dddd D MMMM YYYY',
+        fullTimestamp: 'dddd D MMM YYYY (hh:mm a)'
+    };
+
+    /**
      * Is this page bilingual?
      * i.e. do we have a Welsh translation
      * Default to true unless overriden by a route

--- a/views/components/news.njk
+++ b/views/components/news.njk
@@ -25,7 +25,7 @@
         </header>
         <footer class="blog-teaser__meta">
             <time class="blog-teaser__pubdate" pubdate datetime="{{ entry.postDate.date }}">
-                {{ formatDate(entry.postDate.date, 'D MMMM, YYYY') }}
+                {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
             </time>
             {% if entry.category -%}
                 in <a href="{{ entry.category.link }}">{{ entry.category.title }}</a>

--- a/views/pages/blog/post.njk
+++ b/views/pages/blog/post.njk
@@ -16,7 +16,7 @@
         {% endif %}
         <p class="article-meta__pubdate">
             <time pubdate datetime="{{ entry.postDate.date }}">
-                {{ formatDate(entry.postDate.date, 'Do MMMM, YYYY') }}
+                {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
             </time>
         </p>
     </div>

--- a/views/pages/tools/feedback-results.njk
+++ b/views/pages/tools/feedback-results.njk
@@ -15,10 +15,10 @@
                             id="msg-{{ response.id }}">
                         <div class="d-flex w-100 justify-content-between">
                             <h3 class="h6">
-                                {{ formatDate(response.createdAt, 'ddd DD MMM YYYY (hh:mm a)') }}
+                                {{ formatDate(response.createdAt, DATE_FORMATS.fullTimestamp) }}
                             </h3>
                             <a href="#msg-{{ response.id }}">
-                                <small title="{{ response.createdAt }}">{{ response.createdAt | timeFromNow }}</small>
+                                <small title="{{ response.createdAt }}">{{ timeFromNow(response.createdAt) }}</small>
                             </a>
                         </div>
                         <p class="mb-0">{{ response.message }}</p>

--- a/views/pages/tools/surveys.njk
+++ b/views/pages/tools/surveys.njk
@@ -19,7 +19,7 @@
                 <span class="badge badge-info">{{ s.status }}</span>
             </h2>
             <a href="#survey-{{ s.id }}">
-                <small class="text-muted" title="{{ s.dateCreated.date }}">Created {{ s.dateCreated.date | timeFromNow }}</small>
+                <small class="text-muted" title="{{ s.dateCreated.date }}">Created {{ timeFromNow(s.dateCreated.date) }}</small>
             </a>
         </nav>
         <p class="lead">
@@ -57,11 +57,11 @@
                                             {% if response.path %}
                                                 {{ response.path }}
                                             {% else %}
-                                                {{ formatDate(response.createdAt, 'ddd DD MMM YYYY (hh:mm a)') }}
+                                                {{ formatDate(response.createdAt, DATE_FORMATS.fullTimestamp) }}
                                             {% endif %}
                                         </h6>
                                         <a href="#msg-{{ response.id }}">
-                                            <small title="{{ response.createdAt }}">{{ response.createdAt | timeFromNow }}</small>
+                                            <small title="{{ response.createdAt }}">{{ timeFromNow(response.createdAt) }}</small>
                                         </a>
                                     </div>
                                     <p class="mb-3">{{ response.message }}</p>


### PR DESCRIPTION
Prompted by my own comment on https://github.com/biglotteryfund/blf-alpha/pull/930

There's clearly a need for some kind of format sharing as I'd already managed to use different date formats for the blog!

Not sure if this the right _place_ for this stuff to live, does this feel OK? Too verbose?