### PR TITLE
Add explicit no-store to status endpoint

### DIFF
--- a/controllers/toplevel/status.js
+++ b/controllers/toplevel/status.js
@@ -1,23 +1,20 @@
 'use strict';
 const moment = require('moment');
 const appData = require('../../modules/appData');
-const cached = require('../../middleware/cached');
 
 const LAUNCH_DATE = moment();
 
-module.exports = [
-    cached.noCache,
-    (req, res) => {
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+module.exports = (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    res.setHeader('Cache-Control', 'no-store,no-cache,max-age=0');
 
-        res.json({
-            APP_ENV: appData.environment,
-            DEPLOY_ID: appData.deployId,
-            COMMIT_ID: appData.commitId,
-            BUILD_NUMBER: appData.buildNumber,
-            START_DATE: LAUNCH_DATE.format('dddd, MMMM Do YYYY, h:mm:ss a'),
-            UPTIME: LAUNCH_DATE.toNow(true)
-        });
-    }
-];
+    res.json({
+        APP_ENV: appData.environment,
+        DEPLOY_ID: appData.deployId,
+        COMMIT_ID: appData.commitId,
+        BUILD_NUMBER: appData.buildNumber,
+        START_DATE: LAUNCH_DATE.format('dddd, MMMM Do YYYY, h:mm:ss a'),
+        UPTIME: LAUNCH_DATE.toNow(true)
+    });
+};


### PR DESCRIPTION
Noticed that the status endpoint was occasionally returning stale responses. This endpoint is mounted really early, before any middleware. Because of this the `cached` middleware has not been initialised yet resulting in the status endpoint having no cache-control header. The default in cloudfront when there is no explicit cache-control is 24 hours. This PR adds an explicit header manually to fix this.