### PR TITLE
Set logger name for raven-node

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,6 +50,7 @@ const timingsMiddleware = require('./middleware/timings');
  * @see https://docs.sentry.io/clients/node/config/
  */
 Raven.config(SENTRY_DSN, {
+    logger: 'server',
     environment: appData.environment,
     autoBreadcrumbs: true,
     dataCallback(data) {


### PR DESCRIPTION
The node Sentry client has a default logger value of `default` which doesn't show up as a tag, making it hard to filter by all server errors. Adding in an explicit logger value to make filtering easier.