### PR TITLE
Add the commit hash to Sentry to group release errors together

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,6 +51,7 @@ const timingsMiddleware = require('./middleware/timings');
  */
 Raven.config(SENTRY_DSN, {
     environment: appData.environment,
+    release: appData.commitId,
     autoBreadcrumbs: true,
     dataCallback(data) {
         // Clear installed node_modules


### PR DESCRIPTION
From the Sentry docs:

> This will annotate each event with the version of your application, as well as automatically create a release entity in the system the first time it's seen.

