### PR TITLE
Standardise word breaking to work in IE

### DIFF
--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -78,7 +78,15 @@ $constrainedWide: 42em;
     a[href^='tel:'] {
         color: palette('green');
         font-weight: bold;
-        word-break: break-word;
+        word-break: break-all;
+    }
+
+    // fix word-break in IE when used in tables
+    td {
+        a[href^='mailto:'],
+        a[href^='tel:'] {
+            display: table-cell;
+        }
     }
 
     a[href^='tel:'] {


### PR DESCRIPTION
Turns out `word-break: break-word;` is non-standard / Webkit only. We'd had a report that email addresses in IE weren't wrapping properly like this:

![image](https://user-images.githubusercontent.com/394376/39810757-24ea05a8-537e-11e8-8784-69d93bda9a43.png)

The `table-cell` thing is a bit of a hack (thanks StackOverflow) to force IE to play nice.