### PR TITLE
Remove dud Guardian link handler

### DIFF
--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -33,13 +33,6 @@ const legacyRedirects = [
         '/england/global-content/programmes/england/reaching-communities-england'
     ),
 
-    // Broken link in https://www.theguardian.com/society/2018/apr/03/travel-training-young-people-learning-disability-cuts-council-costs
-    // @TODO: Can we auto strip spaces in URLs?
-    aliasFor(
-        '/global-content/programmes/england/commissioning-better-outcomes-and-social-outcomes-fund',
-        '/global-%20content/programmes/england/commissioning-better-%20outcomes-%20and-social-%20outcomes-fund'
-    ),
-
     aliasFor('/about/customer-service/accessibility', '/about-big/our-approach/accessibility'),
 
     // Migrated Programme Pages [LIVE]


### PR DESCRIPTION
I managed to get the Guardian to update the broken link (cower in awe at my control of the press) – we can stop supporting this dodgy URL now.