### PR TITLE
Remove aliases/redirects from pagelist

### DIFF
--- a/controllers/tools/pagelist.js
+++ b/controllers/tools/pagelist.js
@@ -1,31 +1,19 @@
 'use strict';
-const { renderError } = require('../http-errors');
 const appData = require('../../modules/appData');
 const routeHelpers = require('../helpers/route-helpers');
 
+const countRoutes = routeList => routeList.filter(route => route.live === true).length;
+
 function init({ router }) {
-    router.get('/pages', async (req, res) => {
+    router.get('/pages', async (req, res, next) => {
         try {
             const canonicalRoutes = await routeHelpers.getCanonicalRoutes({ includeDraft: appData.isNotProduction });
-            const redirectRoutes = await routeHelpers.getCombinedRedirects({ includeDraft: appData.isNotProduction });
-            const vanityRoutes = await routeHelpers.getVanityRedirects();
-
-            const countRoutes = routeList => routeList.filter(route => route.live === true).length;
-
-            const totals = {
-                canonical: countRoutes(canonicalRoutes),
-                redirects: countRoutes(redirectRoutes),
-                vanity: countRoutes(vanityRoutes)
-            };
-
             res.render('pages/tools/pagelist', {
-                totals,
                 canonicalRoutes,
-                redirectRoutes,
-                vanityRoutes
+                totalCanonicalRoutes: countRoutes(canonicalRoutes)
             });
         } catch (err) {
-            renderError(err);
+            next(err);
         }
     });
 

--- a/views/pages/tools/pagelist.njk
+++ b/views/pages/tools/pagelist.njk
@@ -7,21 +7,12 @@
 {% block content %}
     <h1 class="border-bottom pb-2 mb-4">Page list</h1>
 
-    <section class="mb-4">
-        <h2 class="mb-4">Totals</h2>
-        <ul class="list-unstyled">
-            <li><strong>{{ totals.canonical }}</strong> live canonical URLs</li>
-            <li><strong>{{ totals.vanity }}</strong> live vanity URLs</li>
-            <li><strong>{{ totals.redirects }}</strong> live redirect URLs</li>
-        </ul>
-    </section>
-
     {% macro statusBadge(message, state) %}
         <span class="badge badge-{{ state }}">{{ message }}</span>
     {% endmacro %}
 
     <section>
-        <h2 class="mb-4">Canonical URLs</h2>
+        <h2 class="mb-4">Canonical URLs (<strong>{{ totalCanonicalRoutes }}</strong> live URLs)</h2>
 
         <p><button class="btn btn-primary" id="js-open-links">Open all English canonical pages?</button></p>
         <ul class="list-unstyled">
@@ -36,56 +27,6 @@
                                 {{statusBadge('Draft', 'warning')}}
                             {% endif %}
                         </h3>
-                        <p>
-                            <a href="{{ route.path }}">English</a> |
-                            <a href="/welsh{{ route.path }}">Welsh</a>
-                        </p>
-                    </article>
-                </li>
-            {% endfor %}
-        </ul>
-    </section>
-
-    <section>
-        <h2 class="mb-4">Vanity URLs</h2>
-        <ul class="list-unstyled">
-            {% for route in vanityRoutes %}
-                <li>
-                    <article class="border-top py-2">
-                        <h3 class="h6">
-                            <a href={{ route.path}} title="{{ route.title }}">
-                                {{ route.path }}
-                            </a>
-                            {% if route.live %}
-                                {{statusBadge('Live', 'success')}}
-                            {% else %}
-                                {{statusBadge('Draft', 'warning')}}
-                            {% endif %}
-                        </h3>
-                        <p><em>→ {{ route.destination }}</em></p>
-                    </article>
-                </li>
-            {% endfor %}
-        </ul>
-    </section>
-
-    <section>
-        <h2 class="mb-4">Legacy Redirects</h2>
-        <ul class="list-unstyled">
-            {% for route in redirectRoutes %}
-                <li>
-                    <article class="border-top py-2">
-                        <h3 class="h6">
-                            <a href={{ route.path}} title="{{ route.title }}">
-                                {{ route.path }}
-                            </a>
-                            {% if route.live %}
-                                {{statusBadge('Live', 'success')}}
-                            {% else %}
-                                {{statusBadge('Draft', 'warning')}}
-                            {% endif %}
-                        </h3>
-                        <p><em>→ {{ route.destination }}</em></p>
                         <p>
                             <a href="{{ route.path }}">English</a> |
                             <a href="/welsh{{ route.path }}">Welsh</a>


### PR DESCRIPTION
This PR removes aliases/redirects from the page list tool. Particularly as most vanity URLs will come from the CMS it's less useful or accurate to repeat them here.