### PR TITLE
Add startDebug command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "scripts": {
     "start": "node ./bin/www",
     "startDev": "export DEBUG=blf-alpha:*,express-session,connect:session-sequelize; nodemon ./bin/www",
-    "startTest": "./bin/start-test-server",
+    "startDebug": "export DEBUG=blf-alpha:* && nodemon --inspect ./bin/www",
     "lint": "eslint .",
     "test-deps": "snyk test",
     "test-client": "mocha assets/**/*.test.js --bail --exit",
     "test-server": "nyc --include={middleware,modules,services}/**/*.js --all mocha {controllers,middleware,modules,services}/{**/*,*}.test.js --bail --exit",
     "test-unit": "npm run test-client && npm run test-server",
-    "test-cypress": "npm run startTest & wait-on http://localhost:8090 && cypress run && fkill :8090",
+    "test-cypress": "./bin/start-test-server & wait-on http://localhost:8090 && cypress run && fkill :8090",
     "test": "npm run test-unit && npm run test-cypress",
     "build": "gulp build && webpack",
     "build-production": "export NODE_ENV=production && npm run build && gulp manifest",
@@ -67,8 +67,7 @@
       "assets",
       "public"
     ],
-    "ext": "js,json,yml",
-    "exec": "bin/www"
+    "ext": "js,json,yml"
   },
   "dependencies": {
     "absolution": "^1.0.0",


### PR DESCRIPTION
Adds a `startDebug` command to aid with node debugging in Chrome devtools or directly in IDE.

TIL: Node debugging in VS Code is really good.