### PR TITLE
Improve micro-survey UX

### DIFF
--- a/assets/js/vue-components/surveys.js
+++ b/assets/js/vue-components/surveys.js
@@ -1,7 +1,7 @@
 /* global ga */
 import $ from 'jquery';
 import Vue from 'vue';
-import { VueConfig } from './vue-config';
+import { withDefaults } from './vue-config';
 import { storageAvailable } from '../helpers/storage';
 
 const CAN_STORE = storageAvailable('localStorage');
@@ -57,10 +57,11 @@ const showSurvey = survey => {
     }
 
     new Vue(
-        Object.assign({}, VueConfig, {
+        withDefaults({
             el: mountEl,
             data: {
                 survey: survey,
+                isShown: false,
                 isActivated: false,
                 isComplete: undefined,
                 showMessageBox: false,
@@ -70,35 +71,40 @@ const showSurvey = survey => {
                     message: undefined
                 }
             },
+            mounted: function() {
+                setTimeout(() => {
+                    this.isShown = true;
+                }, 3000);
+            },
             methods: {
-                toggleSurvey: function() {
+                toggleSurvey() {
                     this.isActivated = !this.isActivated;
                 },
-                blockSurvey: function() {
+                blockSurvey() {
                     logSurveyTaken(this.survey.id);
                     this.surveyBlocked = true;
                 },
-                toggleMessage: function(choice) {
+                toggleMessage(choice) {
                     if (choice.allowMessage) {
                         this.showMessageBox = true;
                     } else {
                         this.formData.choice = choice.id;
                     }
                 },
-                messageOnFocus: function() {
+                messageOnFocus() {
                     if (hasiOSBug()) {
                         $('body').addClass('is-ios-editing-survey');
                     }
                 },
-                messageOnBlur: function() {
+                messageOnBlur() {
                     if (hasiOSBug()) {
                         $('body').removeClass('is-ios-editing-survey');
                     }
                 },
-                updateChoice: function(choice) {
+                updateChoice(choice) {
                     this.formData.choice = choice.id;
                 },
-                submitSurvey: function(e) {
+                submitSurvey(e) {
                     let self = this;
                     let data = this.formData;
 

--- a/assets/sass/components/survey.scss
+++ b/assets/sass/components/survey.scss
@@ -4,7 +4,7 @@
 
 /**
  * iOS 11 has a bug where if an input is inside a position fixed element the
- * cursor will disapear of the screen when entering text. Why???
+ * cursor will disapear off the screen when entering text. Why???
  * https://stackoverflow.com/questions/46339063/ios-11-safari-bootstrap-modal-text-area-outside-of-cursor/46954486#46954486
  * https://bugs.webkit.org/show_bug.cgi?id=176896
  */
@@ -14,33 +14,36 @@ body.is-ios-editing-survey {
 }
 
 .survey {
-    color: #ffffff;
-    background-color: #4a4a4a;
-
     width: 100%;
     position: fixed;
     bottom: 0;
     right: 0;
     z-index: 100;
-    padding: $spacingUnit / 2;
+    transition: transform 300ms ease-in-out;
+    transform: translateY(100%);
 
-    @include mq(small) {
-        padding-left: $spacingUnit;
-        padding-right: $spacingUnit;
+    &.is-shown {
+        transform: translateY(0%);
     }
 
-    @include mq('tablet') {
-        width: 60%;
+    .survey__form {
+        color: white;
+        background-color: #4a4a4a;
+        max-width: 720px;
+        margin: 0 auto;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
 
     .survey__header {
+        color: white;
+        width: 100%;
         margin-bottom: 0;
         text-decoration: underline;
         cursor: pointer;
         display: block;
-        color: #ffffff;
+        padding: $spacingUnit / 2;
+        position: relative;
     }
-
     .survey__arrow {
         width: 25px;
         display: inline-block;
@@ -61,18 +64,19 @@ body.is-ios-editing-survey {
             }
         }
     }
+    &:hover,
     &.is-active {
         .survey__arrow svg {
             transform: rotate(0deg);
         }
     }
-
     .survey__close-icon {
         $iconRadius: 25px;
         $iconOffset: 7px;
         position: absolute;
         right: $iconOffset;
         top: $iconOffset;
+        z-index: 1;
         border-radius: 100%;
         border: 1px solid white;
         height: $iconRadius;
@@ -94,6 +98,11 @@ body.is-ios-editing-survey {
         }
     }
 
+    .survey__content {
+        padding: $spacingUnit / 2;
+        padding-top: 0;
+    }
+
     .survey__btn {
         $bg: #747474;
         background-color: $bg;
@@ -107,10 +116,6 @@ body.is-ios-editing-survey {
         &:last-child {
             margin-right: 0;
         }
-    }
-
-    .survey__form-items {
-        margin-top: $spacingUnit / 2;
     }
 
     .survey__extra {

--- a/views/components/surveys.njk
+++ b/views/components/surveys.njk
@@ -2,7 +2,7 @@
 
 {% macro showSurvey() %}
     <aside role="complementary" class="survey u-dont-print"
-        v-bind:class="{ 'is-active': isActivated }"
+        v-bind:class="{ 'is-active': isActivated, 'is-shown': isShown }"
         id="js-survey-container"
         v-if="!surveyBlocked"
         v-cloak>
@@ -15,60 +15,61 @@
             <fieldset>
                 <legend class="survey__header t6"
                     v-on:click="toggleSurvey()">
-                    <% survey.question %> <span class="survey__arrow js-survey-arrow">
-                    {{ iconArrowDown() }}
+                    <% survey.question %>
+                    <span class="survey__arrow js-survey-arrow">{{ iconArrowDown() }}</span>
+                    <span class="survey__close-icon"
+                        v-on:click="blockSurvey()">
+                        {{ iconClose() }}
                     </span>
                 </legend>
 
-                <span class="survey__close-icon"
-                    v-on:click="blockSurvey()">
-                    {{ iconClose() }}
-                </span>
 
-                <p class="survey__response"
-                    v-if="isComplete">
-                    <span v-if="isComplete == 'success'">{{ __('global.surveys.response.success') }}</span>
-                    <span v-if="isComplete == 'error'">{{ __('global.surveys.response.error') }}</span>
-                </p>
+                <div class="survey__content" v-if="isActivated || isComplete">
+                    <p class="survey__response"
+                        v-if="isComplete">
+                        <span v-if="isComplete == 'success'">{{ __('global.surveys.response.success') }}</span>
+                        <span v-if="isComplete == 'error'">{{ __('global.surveys.response.error') }}</span>
+                    </p>
 
-                <div class="survey__form-items" v-if="isActivated && !isComplete">
-                    <button
-                        v-for="choice in survey.choices"
-                        class="btn btn--small survey__btn survey__btn--choice"
-                        :type="(choice.allowMessage) ? 'button' : 'submit'"
-                        v-on:click="toggleMessage(choice)"
-                        v-if="!showMessageBox"
-                    >
-                        <% choice.title %>
-                    </button>
+                    <div class="survey__form-items" v-if="isActivated && !isComplete">
+                        <button
+                            v-for="choice in survey.choices"
+                            class="btn btn--small survey__btn survey__btn--choice"
+                            :type="(choice.allowMessage) ? 'button' : 'submit'"
+                            v-on:click="toggleMessage(choice)"
+                            v-if="!showMessageBox"
+                        >
+                            <% choice.title %>
+                        </button>
 
-                    <div class="survey__extra"
-                        v-for="choice in survey.choices"
-                        v-if="choice.allowMessage && showMessageBox"
-                    >
-                        <div class="survey__extra-message">
-                            <label for="survey-extra-msg"
-                                class="survey__label">
-                                {{ __('global.surveys.genericQuestion') }}
-                            </label>
-                            <textarea
-                                class="survey__textbox"
-                                id="survey-extra-msg"
-                                placeholder="{{ __('global.surveys.genericPrompt') }}"
-                                v-model="formData.message"
-                                v-on:focus="messageOnFocus"
-                                v-on:blur="messageOnBlur"
-                            >
-                            </textarea>
-                        </div>
-                        {# submit the survey as a "no" #}
-                        <div class="survey__extra-submit">
-                            <button type="submit"
-                                class="btn btn--small survey__btn"
-                                v-on:click="updateChoice(choice)"
-                            >
-                                {{ __('global.forms.submit') }}
-                            </button>
+                        <div class="survey__extra"
+                            v-for="choice in survey.choices"
+                            v-if="choice.allowMessage && showMessageBox"
+                        >
+                            <div class="survey__extra-message">
+                                <label for="survey-extra-msg"
+                                    class="survey__label">
+                                    {{ __('global.surveys.genericQuestion') }}
+                                </label>
+                                <textarea
+                                    class="survey__textbox"
+                                    id="survey-extra-msg"
+                                    placeholder="{{ __('global.surveys.genericPrompt') }}"
+                                    v-model="formData.message"
+                                    v-on:focus="messageOnFocus"
+                                    v-on:blur="messageOnBlur"
+                                >
+                                </textarea>
+                            </div>
+                            {# submit the survey as a "no" #}
+                            <div class="survey__extra-submit">
+                                <button type="submit"
+                                    class="btn btn--small survey__btn"
+                                    v-on:click="updateChoice(choice)"
+                                >
+                                    {{ __('global.forms.submit') }}
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
There were a few UX issues that were bugging me with the micro survey

- It appears immediately before you get a chance to get your bearings likely prompting people to immediately dismiss (backed up by number of RC recording of people dismissing)
- The click area to toggle the survey was too small
- The size/positioning of the survey felt awkwards

Refines the survey to include a short delay before showing, increase tap/hit areas and tidy up the size and positioning.

![micro-survey](https://user-images.githubusercontent.com/123386/39915049-cb5e89aa-54fe-11e8-940b-024b9fd61017.gif)
