### PR TITLE
Strawman: Add inline feedback to form success pages

### DIFF
--- a/controllers/apply/reaching-communities-form.js
+++ b/controllers/apply/reaching-communities-form.js
@@ -258,6 +258,10 @@ formModel.registerReviewStep({
 
 formModel.registerSuccessStep({
     title: 'We have received your idea',
+    feedback: {
+        promptLabel: 'Can you spare a minute to give us some feedback?',
+        fieldLabel: 'How was your experience of submitting an idea?'
+    },
     message: `
 <h2 class="t2 t--underline accent--pink">What happens next?</h2>
 <p>Thank you for submitting your idea. A local funding officer will contact you within fifteen working days.</p>

--- a/views/components/surveys.njk
+++ b/views/components/surveys.njk
@@ -1,5 +1,21 @@
 {% from "components/icons.njk" import iconArrowDown, iconClose %}
 
+{% macro inlineFeedback(description, promptLabel, fieldLabel) %}
+    <details class="inline-feedback u-dont-print js-only" id="js-feedback">
+        <summary
+            data-ga-on="click"
+            data-ga-event-category="{{ description }}"
+            data-ga-event-action="Toggle survey"
+        >{{ promptLabel }}</summary>
+        <feedback-form
+            description="{{ description }}"
+            field-label="{{ fieldLabel }}"
+            submit-label=" {{ __('global.forms.submit') }}"
+        />
+    </details>
+{% endmacro %}
+
+
 {% macro showSurvey() %}
     <aside role="complementary" class="survey u-dont-print"
         v-bind:class="{ 'is-active': isActivated, 'is-shown': isShown }"

--- a/views/pages/apply/success.njk
+++ b/views/pages/apply/success.njk
@@ -1,5 +1,9 @@
+{% from "components/surveys.njk" import inlineFeedback with context %}
+
 {% extends "layouts/main.njk" %}
+
 {% block title %}Success | {{ form.title }} | {% endblock %}
+
 {% set bodyClass = 'has-static-header' %}
 
 {% block content %}
@@ -12,6 +16,14 @@
 
                 {{ stepConfig.message | safe }}
             </div>
+
+            {% if stepConfig.feedback %}
+                {{ inlineFeedback(
+                    title = form.title,
+                    promptLabel = stepConfig.feedback.promptLabel,
+                    fieldLabel = stepConfig.feedback.fieldLabel
+                )  }}
+            {% endif %}
         </div>
     </main>
 {% endblock %}

--- a/views/pages/apply/success.njk
+++ b/views/pages/apply/success.njk
@@ -17,7 +17,7 @@
                 {{ stepConfig.message | safe }}
             </div>
 
-            {% if stepConfig.feedback %}
+            {% if stepConfig.feedback and appData.isNotProduction %}
                 {{ inlineFeedback(
                     title = form.title,
                     promptLabel = stepConfig.feedback.promptLabel,

--- a/views/pages/funding/past-grants.njk
+++ b/views/pages/funding/past-grants.njk
@@ -1,26 +1,10 @@
-{% from "components/hero.njk" import hero %}
 {% from "components/caseStudies.njk" import caseStudyCollection with context  %}
 {% from "components/forms-new.njk" import formErrors, formField %}
+{% from "components/hero.njk" import hero %}
 {% from "components/icons.njk" import iconSearch %}
+{% from "components/surveys.njk" import inlineFeedback with context %}
 
 {% extends "layouts/main.njk" %}
-
-{% set socialImage = heroImage %}
-
-{% macro inlineFeedback() %}
-    <details class="inline-feedback u-dont-print js-only" id="js-feedback">
-        <summary
-            data-ga-on="click"
-            data-ga-event-category="Past grants"
-            data-ga-event-action="Toggle survey"
-        >{{ copy.survey.prompt }}</summary>
-        <feedback-form
-            description="Past grants"
-            field-label="{{ copy.survey.label }}"
-            submit-label=" {{ __('global.forms.submit') }}"
-        />
-    </details>
-{% endmacro %}
 
 {% block content %}
     {% set pageAccent = 'pink' %}
@@ -36,7 +20,11 @@
             <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
                 <section class="u-separator s-prose s-prose--long u-constrained-content-wide">
                     <p>{{ copy.intro }}</p>
-                    {{ inlineFeedback() }}
+                    {{ inlineFeedback(
+                        title = "Past Grants",
+                        promptLabel = copy.survey.prompt,
+                        fieldLabel = copy.survey.label
+                    )  }}
                 </section>
 
                 <p>{{ copy.optionsIntro }}</p>


### PR DESCRIPTION
Strawman PR for discussion but it might be interesting to put the inline feedback form on success pages given we've seen a reasonable take up for it.

<img width="984" alt="screen shot 2018-05-11 at 16 02 42" src="https://user-images.githubusercontent.com/123386/39931345-0734d610-5535-11e8-8b8f-1b7b1dcadfe5.png">
