### PR TITLE
UX improvements to RC form

### DIFF
--- a/assets/js/modules/forms.js
+++ b/assets/js/modules/forms.js
@@ -67,7 +67,7 @@ function handleAbandonmentMessage(formEl) {
     window.addEventListener('beforeunload', handleBeforeUnload);
 
     // Remove beforeunload if clicking on edit links
-    $('.js-application-form-review-edit').on('click', removeBeforeUnload);
+    $('.js-application-form-review-link').on('click', removeBeforeUnload);
 
     // Remove beforeunload if submitting the form
     formEl.addEventListener('submit', removeBeforeUnload);

--- a/assets/sass/components/forms.scss
+++ b/assets/sass/components/forms.scss
@@ -3,14 +3,16 @@
    ========================================================================= */
 
 .form-header {
-    margin-bottom: $spacingUnit;
+    margin-bottom: $spacingUnit * 2;
 
-    .form-header__actions,
+    .form-header__actions {
+        margin-bottom: $spacingUnit / 2;
+    }
+    .form-header__prefix,
     .form-header__title {
         margin-bottom: 3px;
     }
-    .form-header__subtitle {
-        margin: 0;
+    .form-header__prefix {
         font-size: 16px;
         font-weight: normal;
         color: palette('charcoal-note');

--- a/assets/sass/components/forms.scss
+++ b/assets/sass/components/forms.scss
@@ -53,7 +53,7 @@
 }
 
 .form-field {
-    margin-bottom: $spacingUnit;
+    margin-bottom: 1.5em;
 
     &:target {
         background-color: rgba(255, 255, 0, 0.5);
@@ -113,12 +113,15 @@
 }
 
 .ff-explanation {
-    font-size: 15px;
+    font-size: 16px;
+    margin-bottom: 10px;
+    color: palette('charcoal-note');
 }
 
 .ff-text,
 .ff-textarea {
     display: block;
+    padding: 6px 12px;
     border: 2px solid palette('charcoal');
     // prevent elements with size attributes overflowing on mobile
     max-width: 100%;
@@ -156,10 +159,10 @@
     margin-bottom: 5px;
 
     input[type='checkbox'] {
-        margin: 0 6px 0 0;
+        margin: 0 .5em 0 0;
 
         @include mq('medium-minor') {
-            margin-right: 10px;
+            margin-right: .75em;
             position: relative;
             top: -2px;
         }
@@ -170,18 +173,18 @@
     display: table-cell;
 }
 .ff-checkbox__caption {
-    font-size: 13px;
+    font-size: 14px;
     color: palette('charcoal-note');
     display: block;
 
     @include mq('medium-minor') {
-        display: inline-block;
-        margin-left: 3px;
+        font-size: 16px;
+        margin-bottom: 3px;
     }
 }
 
 .review-list {
-    margin-bottom: $spacingUnit * 2;
+    margin: $spacingUnit 0 ($spacingUnit * 2);
 
     > dd,
     > dt {
@@ -204,6 +207,7 @@
 
         > dt {
             width: 40%;
+            padding-right: 5px;
             clear: left;
         }
 

--- a/controllers/apply/reaching-communities-form.js
+++ b/controllers/apply/reaching-communities-form.js
@@ -127,8 +127,9 @@ formModel.registerStep({
                 {
                     type: 'text',
                     name: 'project-location',
-                    label: "In your own words, describe the location(s) that you'll be running your project(s) in",
-                    placeholder: 'eg. "Newcastle community centre" or "Alfreton, Derby and Ripley"',
+                    label: 'Project location',
+                    explanation:
+                        'In your own words, describe the locations that you’ll be running your project in. eg. “Newcastle community centre” or “Alfreton, Derby and Ripley”.',
                     isRequired: true,
                     size: 60,
                     validator: function(field) {
@@ -252,7 +253,7 @@ formModel.registerStep({
 });
 
 formModel.registerReviewStep({
-    title: 'Check this is right',
+    title: 'Check this is right before submitting your idea',
     proceedLabel: 'Submit'
 });
 

--- a/controllers/helpers/create-form-router.js
+++ b/controllers/helpers/create-form-router.js
@@ -50,41 +50,66 @@ function createFormRouter({ router, formModel }) {
             });
         }
 
+        function renderStepIfAllowed(req, res) {
+            if (currentStepNumber > 1 && isEmpty(getFormSession(req, currentStepNumber - 1))) {
+                res.redirect(req.baseUrl);
+            } else {
+                renderStep(req, res);
+            }
+        }
+
+        function handleSubmitStep({ isEditing = false } = {}) {
+            return [
+                step.getValidators(),
+                function(req, res) {
+                    // Save valid fields and merge with any existing data (if we are editing the step);
+                    const sessionProp = formModel.getSessionProp(currentStepNumber);
+                    const stepData = get(req.session, sessionProp, {});
+                    const bodyData = matchedData(req, { locations: ['body'] });
+                    set(req.session, sessionProp, Object.assign(stepData, bodyData));
+
+                    req.session.save(() => {
+                        const errors = validationResult(req);
+                        if (errors.isEmpty()) {
+                            if (isEditing === true || currentStepNumber === formSteps.length) {
+                                res.redirect(`${req.baseUrl}/review`);
+                            } else {
+                                res.redirect(`${req.baseUrl}/${currentStepNumber + 1}`);
+                            }
+                        } else {
+                            renderStep(req, res, errors.array());
+                        }
+                    });
+                }
+            ];
+        }
+
+        /**
+         * Step router
+         */
         router
             .route(`/${currentStepNumber}`)
             .all(cached.csrfProtection)
+            .get(renderStepIfAllowed)
+            .post(handleSubmitStep());
+
+        /**
+         * Step edit router
+         *
+         */
+        router
+            .route(`/${currentStepNumber}/edit`)
+            .all(cached.csrfProtection)
             .get(function(req, res) {
-                if (currentStepNumber > 1) {
-                    const previousStepData = getFormSession(req, currentStepNumber - 1);
-                    if (isEmpty(previousStepData)) {
-                        res.redirect(req.baseUrl);
-                    } else {
-                        renderStep(req, res);
-                    }
+                const formSession = getFormSession(req);
+                const completedSteps = Object.keys(formSession).filter(key => /^step-/.test(key)).length;
+                if (completedSteps < totalSteps - 1) {
+                    res.redirect(req.originalUrl.replace('/edit', ''));
                 } else {
-                    renderStep(req, res);
+                    renderStepIfAllowed(req, res);
                 }
             })
-            .post(step.getValidators(), function(req, res) {
-                // Save valid fields and merge with any existing data (if we are editing the step);
-                const sessionProp = formModel.getSessionProp(currentStepNumber);
-                const stepData = get(req.session, sessionProp, {});
-                const bodyData = matchedData(req, { locations: ['body'] });
-                set(req.session, sessionProp, Object.assign(stepData, bodyData));
-
-                req.session.save(() => {
-                    const errors = validationResult(req);
-                    if (!errors.isEmpty()) {
-                        return renderStep(req, res, errors.array());
-                    }
-
-                    if (currentStepNumber === formSteps.length) {
-                        res.redirect(`${req.baseUrl}/review`);
-                    } else {
-                        res.redirect(`${req.baseUrl}/${currentStepNumber + 1}`);
-                    }
-                });
-            });
+            .post(handleSubmitStep({ isEditing: true }));
     });
 
     /**

--- a/views/components/forms-new.njk
+++ b/views/components/forms-new.njk
@@ -39,7 +39,7 @@
         name="{{ field.name }}"
         {% if field.autocompleteName %}autocomplete="{{ field.autocompleteName }}"{% endif %}
         {% if field.placeholder %}placeholder="{{ field.placeholder | escape }}"{% endif %}
-        {% if field.size %}size="{{ field.size }}"{% endif %}
+        size="{% if field.size %}{{ field.size }}{% else %}40{% endif %}"
         value="{% if field.value %}{{ field.value }}{% endif %}"
         {% if field.isRequired %}required aria-required="true"{% endif %}
     />

--- a/views/components/forms-new.njk
+++ b/views/components/forms-new.njk
@@ -1,5 +1,20 @@
 {% macro getLabelClasses(field) %}ff-label{% if field.isRequired %} ff-label--required{% else %} ff-label--optional{% endif %}{% endmacro %}
 
+{% macro formHeader(title, stepProgress) %}
+    <div class="form-header">
+        {% if stepProgress.prevStepUrl %}
+            <div class="form-header__actions">
+                <a href="{{ stepProgress.prevStepUrl }}"
+                    class="js-application-form-review-link">← Back</a>
+            </div>
+        {% endif %}
+        <p class="form-header__prefix">
+            Step {{ stepProgress.currentStepNumber }} of {{ stepProgress.totalSteps }}
+        </p>
+        <h1 class="form-header__title">{{ title }}</h1>
+    </div>
+{% endmacro %}
+
 {% macro errorList(errors, shouldBeLinked)  %}
     {% if errors | length > 0 %}
         <ol class="error-list">

--- a/views/pages/apply/form.njk
+++ b/views/pages/apply/form.njk
@@ -1,32 +1,26 @@
-{% from "components/forms-new.njk" import errorList, formErrors, formField %}
+{% from "components/forms-new.njk" import errorList, formErrors, formField, formHeader %}
 
 {% extends "layouts/main.njk" %}
 
-{% block title %}Step {{ currentStepNumber }} of {{ totalSteps }} | {{ form.title }} | {% endblock %}
+{% block title %}Step {{ stepProgress.currentStepNumber }} of {{ stepProgress.totalSteps }} | {{ form.title }} | {% endblock %}
 
 {% set bodyClass = 'has-static-header' %}
 
 {% block content %}
+    {% set pageAccent = 'pink' %}
     <main role="main" id="content">
         <form action="" method="POST"
-            class="js-application-form content-box u-inner-wide-only accent--pink a--border-top">
-            <div class="form-header">
-                {% if prevStepUrl %}
-                    <div class="form-header__actions">
-                        <a href="{{ prevStepUrl }}">← Back</a>
-                    </div>
-                {% endif %}
-                <h1 class="form-header__title">{{ form.title }}</h1>
-                <h2 class="form-header__subtitle">
-                    Step {{ currentStepNumber }} of {{ totalSteps }}
-                </h2>
-            </div>
+            class="js-application-form content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+
+            {{ formHeader(form.title, stepProgress) }}
 
             {{ formErrors(errors = errors, title = "There was a problem with your submission") }}
 
             {% for fieldset in step.fieldsets %}
                 <fieldset class="form-fieldset u-constrained-content">
-                    <legend class="form-fieldset__legend t2 t--underline accent--pink">{{ fieldset.legend }}</legend>
+                    <legend class="form-fieldset__legend t2 t--underline accent--{{ pageAccent }}">
+                        {{ fieldset.legend }}
+                    </legend>
                     <div class="form-fieldset__fields">
                         {% for field in fieldset.fields %}
                             {% set fieldErrors = formHelpers.errorsForField(field, errors) %}

--- a/views/pages/apply/review.njk
+++ b/views/pages/apply/review.njk
@@ -22,7 +22,8 @@
                     {% for step in summary %}
                         <h3>
                             {{ step.name }}
-                            [<a href="{{ baseUrl }}/{{ loop.index }}" class="js-application-form-review-link"
+                            [<a href="{{ baseUrl }}/{{ loop.index }}/edit"
+                                class="js-application-form-review-link"
                                 aria-label="Edit {{ step.name }}">
                                 Edit
                             </a>]

--- a/views/pages/apply/review.njk
+++ b/views/pages/apply/review.njk
@@ -1,3 +1,5 @@
+{% from "components/forms-new.njk" import formHeader %}
+
 {% extends "layouts/main.njk" %}
 
 {% block title %}{{ stepConfig.title }} | {{ form.title }} | {% endblock %}
@@ -11,42 +13,40 @@
             class="js-application-form js-application-form-review
             content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
             <div class="u-constrained-content">
-                <div class="form-header">
-                    <h1 class="form-header__title">{{ form.title }}</h1>
-                    <h2 class="form-header__subtitle">
-                        Step {{ currentStepNumber }} of {{ totalSteps }}
-                    </h2>
-                    <h3 class="t2 spaced--t spaced--l">{{ stepConfig.title }}</h3>
-                </div>
 
-                {% for step in summary %}
-                    <h2 class="t2 t--underline accent--{{ pageAccent }}">
-                        {{ step.name }}
-                        [<a href="{{ baseUrl }}/{{ loop.index }}" class="js-application-form-review-edit">Edit</a>]
-                    </h2>
-                    {% for fieldset in step.fieldsets %}
-                    <dl class="review-list {% if fieldset.fields.length === 1 %}review-list--stacked{% endif %}">
-                        {% for field in fieldset.fields %}
-                            {% if field.value %}
-                                <dt>{{ field.label }}</dt>
-                                {% if field.type === 'textarea' %}
-                                    <dd class="s-prose" data-hj-suppress>
-                                        {{ field.value | striptags(true) | escape | nl2br }}
-                                    </dd>
-                                {% elseif field.type === 'checkbox' %}
+                {{ formHeader(form.title, stepProgress) }}
+
+                <section class="s-prose s-prose--long accent-content--{{ pageAccent }} u-constrained-wide">
+                    <h2>{{ stepConfig.title }}</h2>
+
+                    {% for step in summary %}
+                        <h3>
+                            {{ step.name }}
+                            [<a href="{{ baseUrl }}/{{ loop.index }}" class="js-application-form-review-link"
+                                aria-label="Edit {{ step.name }}">
+                                Edit
+                            </a>]
+                        </h3>
+                        {% for fieldset in step.fieldsets %}
+                        <dl class="review-list {% if fieldset.fields.length === 1 %}review-list--stacked{% endif %}">
+                            {% for field in fieldset.fields %}
+                                {% if field.value %}
+                                    <dt>{{ field.label }}</dt>
                                     <dd data-hj-suppress>
-                                        {{ field.value | joinIfArray(', ') }}
-                                    </dd>
-                                {% else %}
-                                    <dd data-hj-suppress>
-                                        {{ field.value }}
+                                        {% if field.type === 'textarea' %}
+                                            {{ field.value | striptags(true) | escape | nl2br }}
+                                        {% elseif field.type === 'checkbox' %}
+                                            {{ field.value | joinIfArray(', ') }}
+                                        {% else %}
+                                            {{ field.value }}
+                                        {% endif %}
                                     </dd>
                                 {% endif %}
-                            {% endif %}
+                            {% endfor %}
+                        </dl>
                         {% endfor %}
-                    </dl>
                     {% endfor %}
-                {% endfor %}
+                </section>
             </div>
 
             {% if csrfToken %}


### PR DESCRIPTION
A few tweaks the the RC application experience. Mainly around form spacing, and the edit workflow.

**Form spacing**

Improves spacing around all fields and adds a default size to text fields. Mainly to fix silly things like this where you can't see the full text you typed into the field:

<img width="292" alt="screen shot 2018-05-14 at 09 31 12" src="https://user-images.githubusercontent.com/123386/39986598-134f96d4-575a-11e8-8658-976c3f0c961f.png">

<img width="461" alt="screen shot 2018-05-14 at 09 30 46" src="https://user-images.githubusercontent.com/123386/39986604-15ff5450-575a-11e8-881e-bec1f37dbf2b.png">

**Review Step**

Factors `form-header` out into a shared component and adds a missing back link to the review step

**Editing**

This is the main change code wise. Fixes an issue when editing a step where you would be required to proceed through all subsequent steps again.

Adds a `/edit` variant of the URL which skips back to the review step after editing. Using a separate URL to make it easier to see in analytics.