### PR TITLE
Add Funding to programmes breadcrumb

### DIFF
--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -85,16 +85,19 @@ function initProgrammesList(router, options) {
                     .filter(programmeFilters.filterByMinAmount(minAmountParam))
                     .filter(programmeFilters.filterByMaxAmount(maxAmountParam));
 
+                templateData.activeBreadcrumbs.push({
+                    label: req.i18n.__('global.nav.funding'),
+                    url: req.baseUrl
+                });
+
                 if (!minAmountParam && !maxAmountParam && !locationParam) {
-                    templateData.activeBreadcrumbs = [
-                        {
-                            label: req.i18n.__(options.lang + '.breadcrumbAll')
-                        }
-                    ];
+                    templateData.activeBreadcrumbs.push({
+                        label: req.i18n.__(options.lang + '.breadcrumbAll')
+                    });
                 } else {
                     templateData.activeBreadcrumbs.push({
                         label: req.i18n.__(options.lang + '.title'),
-                        url: req.originalUrl.split('?').shift()
+                        url: req.baseUrl + req.path
                     });
 
                     if (parseInt(minAmountParam, 10) === 10000) {


### PR DESCRIPTION
Now that we have breadcrumb trails on more pages it's worth making sure they are conceptually the same everywhere. Adds a "Funding" top-level link to the programmes breadcrumb to mark that it is part of that section.

Before:
<img width="1017" alt="screen shot 2018-05-14 at 11 04 29" src="https://user-images.githubusercontent.com/123386/39991467-8d1ece28-5767-11e8-9db3-941c16453805.png">

After:
<img width="1000" alt="screen shot 2018-05-14 at 11 07 08" src="https://user-images.githubusercontent.com/123386/39991466-8d02f270-5767-11e8-9c49-a6d7bab39be3.png">