### PR TITLE
Share breadcrumb logic across controllers

### DIFF
--- a/controllers/funding/10k.js
+++ b/controllers/funding/10k.js
@@ -1,6 +1,6 @@
 'use strict';
-const { get } = require('lodash');
 const contentApi = require('../../services/content-api');
+const { injectBreadcrumbs, injectCopy } = require('../../middleware/inject-content');
 
 function injectCaseStudies(caseStudySlugs) {
     return async function(req, res, next) {
@@ -13,27 +13,15 @@ function injectCaseStudies(caseStudySlugs) {
 }
 
 function init10k({ router, routeConfig, caseStudySlugs }) {
-    router.get(routeConfig.path, injectCaseStudies(caseStudySlugs), (req, res) => {
-        const copy = req.i18n.__(routeConfig.lang);
-
-        const breadcrumbs = [
-            {
-                label: req.i18n.__('global.nav.funding'),
-                url: req.baseUrl
-            },
-            {
-                label: copy.title
-            }
-        ];
-
-        res.render(routeConfig.template, {
-            copy: copy,
-            title: copy.title,
-            description: copy.description || false,
-            breadcrumbs: breadcrumbs,
-            caseStudies: get(res.locals, 'caseStudies', [])
-        });
-    });
+    router.get(
+        routeConfig.path,
+        injectCopy(routeConfig),
+        injectBreadcrumbs,
+        injectCaseStudies(caseStudySlugs),
+        (req, res) => {
+            res.render(routeConfig.template);
+        }
+    );
 }
 
 function init({ router, under10kConfig, over10kConfig }) {

--- a/views/pages/funding/past-grants.njk
+++ b/views/pages/funding/past-grants.njk
@@ -2,7 +2,9 @@
 {% from "components/forms-new.njk" import formErrors, formField %}
 {% from "components/hero.njk" import hero %}
 {% from "components/icons.njk" import iconSearch %}
+{% from "components/nav.njk" import selectionTrail %}
 {% from "components/surveys.njk" import inlineFeedback with context %}
+
 
 {% extends "layouts/main.njk" %}
 
@@ -18,6 +20,8 @@
 
         <div class="nudge-up">
             <div class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
+                {{ selectionTrail(breadcrumbs) }}
+
                 <section class="u-separator s-prose s-prose--long u-constrained-content-wide">
                     <p>{{ copy.intro }}</p>
                     {{ inlineFeedback(


### PR DESCRIPTION
A bit of work to share breadcrumb logic across controllers. This requires some `inject*` middleware to be stacked a bit, not sure if it's too much.

- Adds `injectCopy` middleware which handles setting `copy`, `title` and `description` properties
- Adds `injectBreadcrumbs` middleware which stacks with `injectCopy` and/or `injectListingContent` to build breadcrumbs
- Updates routes to use new middleware

End result is that all the new pages under `/funding` get a consistent breadcrumb. Thoughts welcome, does this make sense?