### PR TITLE
Fixup proxied manage funding

### DIFF
--- a/controllers/common.js
+++ b/controllers/common.js
@@ -46,32 +46,35 @@ function handleStaticPage(page) {
 }
 
 function handleCmsPage(page) {
-    return (req, res) => {
+    return (req, res, next) => {
         const content = res.locals.content;
+        if (content) {
+            const viewData = {
+                content: content,
+                title: content.displayTitle || content.title,
+                heroImage: content.hero,
+                breadcrumbs: res.locals.breadcrumbs,
+                isBilingual: isBilingual(content.availableLanguages)
+            };
 
-        const viewData = {
-            content: content,
-            title: content.displayTitle || content.title,
-            heroImage: content.hero,
-            breadcrumbs: res.locals.breadcrumbs,
-            isBilingual: isBilingual(content.availableLanguages)
-        };
-
-        if (page.lang) {
-            viewData.copy = req.i18n.__(page.lang);
-        }
-
-        const template = (() => {
-            if (page.template) {
-                return page.template;
-            } else if (content.children) {
-                return 'common/listingPage';
-            } else {
-                return 'common/informationPage';
+            if (page.lang) {
+                viewData.copy = req.i18n.__(page.lang);
             }
-        })();
 
-        res.render(template, viewData);
+            const template = (() => {
+                if (page.template) {
+                    return page.template;
+                } else if (content.children) {
+                    return 'common/listingPage';
+                } else {
+                    return 'common/informationPage';
+                }
+            })();
+
+            res.render(template, viewData);
+        } else {
+            next();
+        }
     };
 }
 

--- a/cypress/integration/legacy_spec.js
+++ b/cypress/integration/legacy_spec.js
@@ -1,7 +1,16 @@
 describe('Legacy pages', () => {
     it('should pass unknown routes to the legacy site', () => {
-        cy.visit('/about-big/publications/corporate-documents');
-        cy.title().should('include', 'Corporate documents: About - Big Lottery Fund');
+        cy.request('/about-big/publications/corporate-documents').then(response => {
+            expect(response.headers['x-blf-legacy']).to.eq('true');
+            expect(response.body).to.include('Corporate documents: About - Big Lottery Fund');
+        });
+
+        cy
+            .request('/funding/funding-guidance/managing-your-funding/about-equalities/evidence-collection-tools')
+            .then(response => {
+                expect(response.headers['x-blf-legacy']).to.eq('true');
+                expect(response.body).to.include('Evidence collection tools: Funding - Big Lottery Fund');
+            });
     });
 
     it('should redirect old funding finder', () => {

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -67,8 +67,12 @@ async function injectListingContent(req, res, next) {
             path: req.baseUrl + req.path,
             previewMode: res.locals.PREVIEW_MODE || false
         });
-        res.locals.content = content;
-        res.locals.breadcrumbs = buildContentBreadcrumbs(req, res);
+
+        if (content) {
+            res.locals.content = content;
+            res.locals.breadcrumbs = buildContentBreadcrumbs(req, res);
+        }
+
         res.locals.timings.end('inject-content');
         next();
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -202,6 +202,25 @@ routes.archivedRoutes.filter(shouldServe).forEach(route => {
 });
 
 /**
+ * Legacy Redirects
+ * Redirecy legacy URLs to new locations
+ * For these URLs handle both english and welsh variants
+ */
+serveRedirects({
+    redirects: routes.legacyRedirects.filter(shouldServe),
+    makeBilingual: true
+});
+
+/**
+ * Vanity URLs
+ * Sharable short-urls redirected to canonical URLs.
+ */
+serveRedirects({
+    redirects: routes.vanityRedirects.filter(shouldServe)
+});
+
+
+/**
  * Initialise section routes
  * - Creates a new router for each section
  * - Apply shared middleware
@@ -261,24 +280,6 @@ forEach(routes.sections, (section, sectionId) => {
     cymreigio(section.path).forEach(urlPath => {
         app.use(urlPath, router);
     });
-});
-
-/**
- * Legacy Redirects
- * Redirecy legacy URLs to new locations
- * For these URLs handle both english and welsh variants
- */
-serveRedirects({
-    redirects: routes.legacyRedirects.filter(shouldServe),
-    makeBilingual: true
-});
-
-/**
- * Vanity URLs
- * Sharable short-urls redirected to canonical URLs.
- */
-serveRedirects({
-    redirects: routes.vanityRedirects.filter(shouldServe)
 });
 
 app.use(timings.end('routing'));

--- a/server.js
+++ b/server.js
@@ -219,7 +219,6 @@ serveRedirects({
     redirects: routes.vanityRedirects.filter(shouldServe)
 });
 
-
 /**
  * Initialise section routes
  * - Creates a new router for each section


### PR DESCRIPTION
https://sentry.io/big-lottery-fund/biglotteryfund/issues/555790658/

Fixes links under `/manage-your-funding` which aren't handled by the CMS. Notably this section `/funding/funding-guidance/managing-your-funding/about-equalities/evidence-collection-tools`.

As we pass anything under `/funding-guidance` to the CMS we need to guard against missing content for routes that are not found in the CMS. By passing to next we can make sure to pass down to later route handlers, notably `proxyLegacy`.