### PR TITLE
Fix "other" field data storage for material orders

### DIFF
--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -10,7 +10,13 @@ const Raven = require('raven');
 const { FORM_STATES } = require('../../modules/forms');
 const { injectListingContent } = require('../../middleware/inject-content');
 const { MATERIAL_SUPPLIER } = require('../../modules/secrets');
-const { materialFields, makeOrderText, postcodeArea, injectMerchandise } = require('./materials-helpers');
+const {
+    materialFields,
+    makeOrderText,
+    postcodeArea,
+    injectMerchandise,
+    normaliseUserInput
+} = require('./materials-helpers');
 const appData = require('../../modules/appData');
 const cached = require('../../middleware/cached');
 const mail = require('../../modules/mail');
@@ -125,21 +131,13 @@ function storeOrderSummary({ orderItems, orderDetails }) {
         []
     );
 
-    const preparedOrderDetails = mapValues(orderDetails, (value, key) => {
-        const field = get(materialFields, key);
-
-        if (field) {
-            const otherValue = get(orderDetails, field.name + 'Other');
-            return field.allowOther && otherValue ? otherValue : value;
-        } else {
-            return value;
-        }
-    });
+    const preparedOrderDetails = normaliseUserInput(orderDetails);
+    const getFieldValue = fieldName => preparedOrderDetails.find(d => d.key === fieldName).value;
 
     return ordersService.storeOrder({
-        grantAmount: preparedOrderDetails.yourGrantAmount,
-        orderReason: preparedOrderDetails.yourReason,
-        postcodeArea: postcodeArea(preparedOrderDetails.yourPostcode),
+        grantAmount: getFieldValue('yourGrantAmount'),
+        orderReason: getFieldValue('yourReason'),
+        postcodeArea: postcodeArea(getFieldValue('yourPostcode')),
         items: preparedOrderItems
     });
 }

--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -132,7 +132,11 @@ function storeOrderSummary({ orderItems, orderDetails }) {
     );
 
     const preparedOrderDetails = normaliseUserInput(orderDetails);
-    const getFieldValue = fieldName => preparedOrderDetails.find(d => d.key === fieldName).value;
+    const getFieldValue = fieldName => {
+        // some fields are optional and won't be here
+        let field = preparedOrderDetails.find(d => d.key === fieldName);
+        return field ? field.value : null;
+    };
 
     return ordersService.storeOrder({
         grantAmount: getFieldValue('yourGrantAmount'),
@@ -196,7 +200,7 @@ function initForm({ router, routeConfig }) {
                         quantity: item.quantity
                     };
                 });
-                
+
                 const orderText = makeOrderText(itemsToEmail, details);
 
                 storeOrderSummary({


### PR DESCRIPTION
Noticed this when testing the material form.

There's an edge case when this happens:

![image](https://user-images.githubusercontent.com/394376/40110192-4472e8a8-58f7-11e8-81a6-5d2ebbfe8ddb.png)

(eg. the user types into one of the fields with an "other" option without selecting the "other" radio button)

When this happens, the order info we send to the suppliers correctly merges/replaces the `yourReason` and `yourReasonOther` fields into one, but this doesn't happen for the version we store internally so we just get `NULL` for this in the database. While this only effects people who just click straight into the field it's still a bug so this PR fixes it.

I guess alternatively this could be fixed client-side by automatically selecting the "other" radio button when the user types in the text field, but the JS code for that would be quite fiddly (what happens if they clear the "other" field / select another one etc?). But the code this PR deletes never worked anyway for this case (the field values it was looking for already had `Other` prepended).