### PR TITLE
Switch back to npm install over npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 before_install:
 - npm i -g npm@6
 install:
-- npm ci
+- npm install
 cache:
   directories:
     - "$HOME/.npm"


### PR DESCRIPTION
Switches back to `npm install` over the newer `npm ci`

> The new npm ci command installs from your lock-file ONLY. If your package.json and your lock-file are out of sync then it will report an error.It works **by throwing away your node_modules and recreating it from scratch**. Beyond guaranteeing you that you’ll only get what is in your lock-file it’s also much faster (2x-10x!) than npm install

In some contexts `npm ci` is preferable, but as we are relying on caching of `node_modules` it is currently much slower than a plain `npm install` as `npm ci` relies on throwing away the `node_modules` directory first, negating any cache.