### PR TITLE
Model about page in the CMS

### DIFF
--- a/assets/sass/components/media.scss
+++ b/assets/sass/components/media.scss
@@ -61,10 +61,6 @@
         position: relative;
         top: -$spacingUnit; // Optical alignment
     }
-}
-.media-aside__text {
-    font-weight: bold;
-    margin-bottom: 0;
 
     @include mq('medium-minor', 'max') {
         @include fullwidth();
@@ -73,7 +69,16 @@
         background-color: palette('turquoise');
         margin-top: 1em;
         margin-bottom: 1em;
+
+        a {
+            color: inherit;
+        }
     }
+
+}
+.media-aside__text {
+    font-weight: bold;
+    margin-bottom: 0;
 
     @include mq('medium') {
         font-size: 32px;

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -172,12 +172,10 @@ sections.research.addRoutes({
  * About Routes
  */
 sections.about.addRoutes({
-    root: staticRoute({
+    root: cmsRoute({
         path: '/',
         template: 'pages/toplevel/about',
-        lang: 'about.landing',
-        heroSlug: 'mental-health-foundation',
-        sMaxAge: '30m'
+        lang: 'about.landing'
     }),
     seniorManagement: customRoute({
         path: '/our-people/senior-management-team',

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const Raven = require('raven');
 
 const { heroImages } = require('../modules/images');
-const { localify, removeWelsh } = require('../modules/urls');
+const { localify, removeWelsh, stripTrailingSlashes } = require('../modules/urls');
 const contentApi = require('../services/content-api');
 
 function getPreviewStatus(entry) {
@@ -95,7 +95,7 @@ async function injectListingContent(req, res, next) {
         res.locals.timings.start('inject-content');
         const content = await contentApi.getListingPage({
             locale: req.i18n.getLocale(),
-            path: req.baseUrl + req.path,
+            path: stripTrailingSlashes(req.baseUrl + req.path),
             previewMode: res.locals.PREVIEW_MODE || false
         });
 

--- a/views/common/informationPage.njk
+++ b/views/common/informationPage.njk
@@ -2,6 +2,7 @@
 {% from "components/hero.njk" import hero %}
 {% from "components/nav.njk" import selectionTrail %}
 {% from "components/segment.njk" import segment with context %}
+{% from "components/media.njk" import mediaAside %}
 
 {% extends "layouts/main.njk" %}
 
@@ -84,6 +85,15 @@
                                 imagePath = image,
                                 id = contentSegment.anchor | default('segment-' + loop.index, true),
                                 imageIsAbsolute = true
+                            ) }}
+                        {% elseif  contentSegment.type === 'pullQuote' %}
+                            {{ mediaAside(
+                                quoteText = contentSegment.quoteText,
+                                linkText = contentSegment.linkText,
+                                linkHref = contentSegment.linkUrl,
+                                imageUrl = contentSegment.quoteImage,
+                                imageCaption =  contentSegment.quoteImageCaption,
+                                accentColor = themes.next()
                             ) }}
                         {% endif %}
                     {% endfor %}

--- a/views/common/informationPage.njk
+++ b/views/common/informationPage.njk
@@ -12,9 +12,10 @@
 {% endif %}
 
 {% macro segmentLinks(segments) %}
-    {% if segments.length > 0 %}
+    {% set segmentsToShow = segments | filter('type', 'segment')  %}
+    {% if segmentsToShow.length > 0 %}
         <ul>
-            {% for segment in segments %}
+            {% for segment in segmentsToShow %}
                 <li><a href="#segment-{{ loop.index }}">{{ segment.title }}</a></li>
             {% endfor %}
         </ul>
@@ -71,18 +72,20 @@
                 <div class="inner--wide-only u-constrained-content-wide">
                     {% set themes = cycler('blue', 'pink-dark', 'orange', 'green', 'turquoise', 'pink', 'cyan') %}
                     {% for contentSegment in content.segments %}
-                        {% set image = false %}
-                        {% if contentSegment.photo %}
-                            {% set image = contentSegment.photo %}
+                        {% if contentSegment.type === 'segment' %}
+                            {% set image = false %}
+                            {% if contentSegment.photo %}
+                                {% set image = contentSegment.photo %}
+                            {% endif %}
+                            {{ segment(
+                                title = contentSegment.title,
+                                text = contentSegment.content,
+                                color = themes.next(),
+                                imagePath = image,
+                                id = contentSegment.anchor | default('segment-' + loop.index, true),
+                                imageIsAbsolute = true
+                            ) }}
                         {% endif %}
-                        {{ segment(
-                            title = contentSegment.title,
-                            text = contentSegment.content,
-                            color = themes.next(),
-                            imagePath = image,
-                            id = 'segment-' + loop.index,
-                            imageIsAbsolute = true
-                        ) }}
                     {% endfor %}
                 </div>
             {% endif %}

--- a/views/pages/toplevel/about.njk
+++ b/views/pages/toplevel/about.njk
@@ -8,71 +8,42 @@
 {% set socialImage = heroImage %}
 
 {% block content %}
-    {% set pageAccent = 'pink' %}
-
     <main role="main">
-        {{
-            hero(
-                accent = pageAccent,
-                titleText = title,
-                image = heroImage
-            )
-        }}
+        {% set pageAccent = content.themeColour  %}
+        {{ hero(
+            titleText = title,
+            image = heroImage,
+            accent = pageAccent
+        ) }}
 
         <div class="nudge-up">
             <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
-
-                {# Intro #}
                 <div class="s-prose s-prose--long u-constrained-content-wide">
-                    <p>{{ copy.intro.opening | safe }}</p>
-                    <p><a href="{{ localify('/funding') }}">{{ copy.intro.learnApply }}</a></p>
+                    {{ content.introduction | safe }}
                 </div>
 
-                {# What We Do #}
-                <div class="s-prose s-prose--long u-constrained-content-wide">
-                    <h2 class="t2 t--underline accent--{{ pageAccent }}">{{ copy.whatWeDo.title }}</h2>
-                    {% for paragraph in copy.whatWeDo.paragraphs %}
-                        <p>{{ paragraph | safe }}</p>
+                {# Content segments #}
+                {% if content.segments.length > 0 %}
+                    {% for segment in content.segments %}
+                        <div id="{{ segment.anchor | default('segment-' + loop.index, true) }}">
+                            {% if segment.type === 'segment' %}
+                                <div class="s-prose s-prose--long u-constrained-content-wide">
+                                    <h2 class="t2 t--underline accent--{{ pageAccent }}">{{ segment.title }}</h2>
+                                    {{ segment.content | safe }}
+                                </div>
+                            {% elseif  segment.type === 'pullQuote' %}
+                                {{ mediaAside(
+                                    quoteText = segment.quoteText,
+                                    linkText = segment.linkText,
+                                    linkHref = segment.linkUrl,
+                                    imageUrl = segment.quoteImage,
+                                    imageCaption =  segment.quoteImageCaption,
+                                    accentColor = pageAccent
+                                ) }}
+                            {% endif %}
+                        </div>
                     {% endfor %}
-                </div>
-
-                {# Annual Report #}
-                {{ mediaAside(
-                    quoteText = copy.asideAnnualReport.quoteText,
-                    linkText = copy.asideAnnualReport.linkText,
-                    linkHref = copy.asideAnnualReport.linkHref,
-                    imageUrl = "/assets/images/about/pennine-lancashire.jpg",
-                    imageCaption = copy.asideAnnualReport.imageCaption,
-                    accentColor = pageAccent
-                ) }}
-
-                {# How Funding Is Used #}
-                <div class="s-prose s-prose--long u-constrained-content-wide">
-                    <h2 class="t2 t--underline accent--{{ pageAccent }}">{{ copy.howOurFundingIsUsed.title }}</h2>
-                    {% for paragraph in copy.howOurFundingIsUsed.paragraphs %}
-                        <p>{{ paragraph | safe }}</p>
-                    {% endfor %}
-                </div>
-
-                {# People In The Lead #}
-                {{ mediaAside(
-                    quoteText = copy.asidePeopleInTheLead.quoteText,
-                    linkText = copy.asidePeopleInTheLead.linkText,
-                    linkHref = copy.asidePeopleInTheLead.linkHref,
-                    imageUrl = "/assets/images/about/dawn.jpg",
-                    imageCaption = copy.asidePeopleInTheLead.imageCaption,
-                    accentColor = pageAccent,
-                    isReversed = true
-                ) }}
-
-                {# Our Structure #}
-                <div class="s-prose s-prose--long u-constrained-content-wide">
-                    <h2 class="t2 t--underline accent--{{ pageAccent }}">{{ copy.ourStructure.title }}</h2>
-                    {% for paragraph in copy.ourStructure.paragraphs %}
-                        <p>{{ paragraph | safe }}</p>
-                    {% endfor %}
-                    <p><a href="{{ localify('/about-big/our-people') }}">{{ copy.ourStructure.learnGovernance }}</a></p>
-                </div>
+                {% endif %}
             </section>
         </div>
     </main>


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/72

Models the about page in the CMS. Has a couple of key trade-offs:

- Uses the same _content model_ as information pages, but has a custom template. As a result thumbnails added to segments on the about page are ignored. 
- ~Relies on a new `pullQuote` content type. This has been modelled in the shared `contentSegments` matrix field but we don't currently support pull quotes on general information pages; this might get confusing.~ Added support for them on information pages…they look OK! Still something to consider.