### PR TITLE
Programmes uk wide

### DIFF
--- a/controllers/funding/materials.js
+++ b/controllers/funding/materials.js
@@ -1,6 +1,6 @@
 'use strict';
 const { validationResult } = require('express-validator/check');
-const { get, map, mapValues, reduce, some } = require('lodash');
+const { map, reduce, some } = require('lodash');
 const { purify } = require('../../modules/validators');
 const { sanitizeBody } = require('express-validator/filter');
 const flash = require('req-flash');

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -28,11 +28,8 @@ const programmeFilters = {
                 return programme;
             }
 
-            return (
-                !programme.content.area ||
-                get(programme.content, 'area.value') === 'ukWide' ||
-                get(programme.content, 'area.value') === locationValue
-            );
+            const area = get(programme.content, 'area');
+            return area.value === locationValue;
         };
     },
     filterByMinAmount(minAmount) {

--- a/controllers/funding/programmes.test.js
+++ b/controllers/funding/programmes.test.js
@@ -87,33 +87,24 @@ describe('Programme utilities', () => {
         });
 
         describe('#filterByLocation', () => {
-            it('should filter programmes by England, including UK-Wide', () => {
+            it('should filter programmes by England', () => {
                 const res = mockProgrammes.filter(programmeFilters.filterByLocation('england'));
-                expect(res.map(item => item.content.title)).to.eql([
-                    'National Lottery Awards for All England',
-                    'Awards from the UK Portfolio'
-                ]);
+                expect(res.map(item => item.content.title)).to.eql(['National Lottery Awards for All England']);
             });
 
-            it('should filter programmes by Northern Ireland, including UK-Wide', () => {
+            it('should filter programmes by Northern Ireland', () => {
                 const res = mockProgrammes.filter(programmeFilters.filterByLocation('northernIreland'));
-                expect(res.map(item => item.content.title)).to.eql([
-                    'Empowering Young People',
-                    'Awards from the UK Portfolio'
-                ]);
+                expect(res.map(item => item.content.title)).to.eql(['Empowering Young People']);
             });
 
-            it('should filter programmes by Wales, including UK-Wide', () => {
+            it('should filter programmes by Wales', () => {
                 const res = mockProgrammes.filter(programmeFilters.filterByLocation('wales'));
-                expect(res.map(item => item.content.title)).to.eql([
-                    'People and Places: Large Grants',
-                    'Awards from the UK Portfolio'
-                ]);
+                expect(res.map(item => item.content.title)).to.eql(['People and Places: Large Grants']);
             });
 
-            it('should filter programmes by Scotland, including UK-Wide', () => {
+            it('should filter programmes by Scotland', () => {
                 const res = mockProgrammes.filter(programmeFilters.filterByLocation('scotland'));
-                expect(res.map(item => item.content.title)).to.eql(['Our Place', 'Awards from the UK Portfolio']);
+                expect(res.map(item => item.content.title)).to.eql(['Our Place']);
             });
         });
 

--- a/modules/viewGlobals.js
+++ b/modules/viewGlobals.js
@@ -1,5 +1,4 @@
 'use strict';
-const config = require('config');
 const shortid = require('shortid');
 
 const formHelpers = require('./forms');


### PR DESCRIPTION
https://github.com/biglotteryfund/blf-alpha/issues/899

I think we can safely update the programme filter logic to not include uk-wide programmes when filtered by regions. The three that go are: Awards from the UK Portfolio, Forces in Mind, and other lottery funders. They will still be shown on the main listing and if you explicitly filter by uk-wide (`?location=ukWide`) but will be not shown on region filters.