### PR TITLE
Update blog posts to use new flexible content

### DIFF
--- a/assets/sass/globals/base.scss
+++ b/assets/sass/globals/base.scss
@@ -1,10 +1,15 @@
 /* =========================================================================
-   Base: Global element level styles
+   Base & Element level Styles
    ========================================================================= */
 
 [v-cloak] {
     display: none;
 }
+
+/* =========================================================================
+   Sectioning content
+   https://w3c.github.io/html/sections
+   ========================================================================= */
 
 html {
     box-sizing: border-box;
@@ -43,6 +48,11 @@ h6 {
     font-family: font-stack('display');
     margin: 0 0 20px 0;
 }
+
+/* =========================================================================
+   Grouping content
+   https://w3c.github.io/html/grouping-content
+   ========================================================================= */
 
 ul,
 ol,
@@ -104,6 +114,24 @@ details[open] summary {
     margin-bottom: .5em;
 }
 
+code,
+pre {
+    overflow-x: auto;
+    white-space: pre-wrap;
+    font-family: Hack, Consolas, monospace;
+    font-size: 14px;
+    padding: 10px;
+    border-radius: 2px;
+    color: palette('pale');
+    background-color: palette('charcoal');
+}
+
+pre {
+    padding: 1em;
+    max-height: 25em;
+    box-shadow: inset 0 0 30px rgba(0,0,0,1);
+}
+
 /*  =========================================================================
     Embedded content
     http://developers.whatwg.org/embedded-content-1
@@ -120,7 +148,7 @@ video {
     max-width: 100%;
 }
 
-/* Non-fluid images if you specify `width` attribute. */
+/* Fluid images if you omit the `width` attribute. */
 img:not([width]) {
     width: 100%;
 }
@@ -130,7 +158,8 @@ iframe {
 }
 
 /* =========================================================================
-   Normalise form defaults
+   Form Defaults
+   https://w3c.github.io/html/sec-forms.html
    ========================================================================= */
 
 legend {

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -258,12 +258,7 @@ $constrainedWide: 42em;
     }
 
     figure {
-        margin-left: -($spacingUnit);
-        margin-right: -($spacingUnit);
-
-        @include mq(tablet) {
-            margin: 1em 0 2em;
-        }
+        margin: 1em 0 2em;
 
         img {
             width: auto;

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -269,22 +269,4 @@ $constrainedWide: 42em;
             @include text-caption();
         }
     }
-
-    code,
-    pre {
-        overflow-x: auto;
-        white-space: pre-wrap;
-        font-family: Hack, Consolas, monospace;
-        font-size: 14px;
-        padding: 10px;
-        border-radius: 2px;
-        color: palette('pale');
-        background-color: palette('charcoal');
-    }
-
-    pre {
-        padding: 1em;
-        max-height: 25em;
-        box-shadow: inset 0 0 30px rgba(0,0,0,1);
-    }
 }

--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -265,15 +265,14 @@ $constrainedWide: 42em;
             margin: 1em 0 2em;
         }
 
-        &.auto-width {
-            img {
-                width: auto;
-            }
+        img {
+            width: auto;
+            margin-bottom: 5px;
         }
-    }
 
-    figcaption {
-        @include text-caption();
+        figcaption {
+            @include text-caption();
+        }
     }
 
     code,

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -236,10 +236,12 @@ sections.about.addRoutes({
  */
 sections.blog.addRoutes({
     root: customRoute({
-        path: '/'
+        path: '/',
+        live: false
     }),
     articles: customRoute({
-        path: '/*'
+        path: '/*',
+        live: false
     })
 });
 

--- a/views/components/content.njk
+++ b/views/components/content.njk
@@ -1,0 +1,34 @@
+{% from "components/media.njk" import mediaAside %}
+
+{% macro flexibleContent(flexibleContent) %}
+    {% if flexibleContent.length > 0 %}
+        {% set mediaAsideCounter = 0 %}
+        {% for part in flexibleContent %}
+            {% if part.type === 'contentArea' %}
+                <div class="s-prose s-prose--long u-constrained-content-wide
+                    accent-content--{{ pageAccent }}">
+                    {{ part.content | safe }}
+                </div>
+            {% elseif  part.type === 'inlineFigure' %}
+                <div class="s-prose s-prose--long">
+                    <figure>
+                        <img src="{{ part.photo }}" alt="{{ part.caption }}">
+                        <figcaption>{{ part.photoCaption }}</figcaption>
+                    </figure>
+                </div>
+
+            {% elseif  part.type === 'mediaAside' %}
+                {% set mediaAsideCounter = mediaAsideCounter + 1 %}
+                {{ mediaAside(
+                    quoteText = part.quoteText,
+                    linkText = part.linkText,
+                    linkHref = part.linkUrl,
+                    imageUrl = part.photo,
+                    imageCaption =  part.photoCaption,
+                    accentColor = pageAccent,
+                    isReversed = mediaAsideCounter % 2 == 0
+                ) }}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endmacro %}

--- a/views/components/content.njk
+++ b/views/components/content.njk
@@ -1,12 +1,11 @@
 {% from "components/media.njk" import mediaAside %}
 
-{% macro flexibleContent(flexibleContent) %}
+{% macro flexibleContent(flexibleContent, accent) %}
     {% if flexibleContent.length > 0 %}
         {% set mediaAsideCounter = 0 %}
         {% for part in flexibleContent %}
             {% if part.type === 'contentArea' %}
-                <div class="s-prose s-prose--long u-constrained-content-wide
-                    accent-content--{{ pageAccent }}">
+                <div class="s-prose s-prose--long u-constrained-content-wide accent-content--{{ accent }}">
                     {{ part.content | safe }}
                 </div>
             {% elseif  part.type === 'inlineFigure' %}
@@ -25,7 +24,7 @@
                     linkHref = part.linkUrl,
                     imageUrl = part.photo,
                     imageCaption =  part.photoCaption,
-                    accentColor = pageAccent,
+                    accentColor = accent,
                     isReversed = mediaAsideCounter % 2 == 0
                 ) }}
             {% endif %}

--- a/views/pages/blog/post.njk
+++ b/views/pages/blog/post.njk
@@ -57,7 +57,7 @@
                                 {{ entry.body | safe }}
                             </div>
                         {% else %}
-                            {{ flexibleContent(entry.flexibleContent) }}
+                            {{ flexibleContent(entry.flexibleContent, pageAccent) }}
                         {% endif %}
                     </div>
                 </div>

--- a/views/pages/blog/post.njk
+++ b/views/pages/blog/post.njk
@@ -52,7 +52,13 @@
                         {{ articleMeta(entry) }}
                     </footer>
                     <div class="article__body">
-                        {{ flexibleContent(entry.flexibleContent) }}
+                        {% if entry.body %}
+                            <div class="s-prose s-prose--long">
+                                {{ entry.body | safe }}
+                            </div>
+                        {% else %}
+                            {{ flexibleContent(entry.flexibleContent) }}
+                        {% endif %}
                     </div>
                 </div>
                 {% if entry.tags.length > 0 %}

--- a/views/pages/blog/post.njk
+++ b/views/pages/blog/post.njk
@@ -1,4 +1,5 @@
 {% from "components/nav.njk" import selectionTrail %}
+{% from "components/content.njk" import flexibleContent %}
 
 {% set bodyClass = 'has-static-header' %}
 {% extends "layouts/main.njk" %}
@@ -50,8 +51,8 @@
                     <footer class="article__meta accent--{{ pageAccent }} a--border-color">
                         {{ articleMeta(entry) }}
                     </footer>
-                    <div class="article__body s-prose s-prose--long">
-                        {{ entry.body | safe }}
+                    <div class="article__body">
+                        {{ flexibleContent(entry.flexibleContent) }}
                     </div>
                 </div>
                 {% if entry.tags.length > 0 %}

--- a/views/pages/toplevel/about.njk
+++ b/views/pages/toplevel/about.njk
@@ -1,5 +1,5 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/media.njk" import mediaAside %}
+{% from "components/content.njk" import flexibleContent %}
 
 {% extends "layouts/main.njk" %}
 
@@ -14,28 +14,7 @@
 
         <div class="nudge-up">
             <section class="content-box inner--wide-only accent--{{ pageAccent }} a--border-top">
-                {% if entry.flexibleContent.length > 0 %}
-                    {% set mediaAsideCounter = 0 %}
-                    {% for part in entry.flexibleContent %}
-                        {% if part.type === 'contentArea' %}
-                            <div class="s-prose s-prose--long u-constrained-content-wide
-                                accent-content--{{ pageAccent }}">
-                                {{ part.content | safe }}
-                            </div>
-                        {% elseif  part.type === 'mediaAside' %}
-                            {% set mediaAsideCounter = mediaAsideCounter + 1 %}
-                            {{ mediaAside(
-                                quoteText = part.quoteText,
-                                linkText = part.linkText,
-                                linkHref = part.linkUrl,
-                                imageUrl = part.photo,
-                                imageCaption =  part.photoCaption,
-                                accentColor = pageAccent,
-                                isReversed = mediaAsideCounter % 2 == 0
-                            ) }}
-                        {% endif %}
-                    {% endfor %}
-                {% endif %}
+                {{ flexibleContent(entry.flexibleContent) }}
             </section>
         </div>
     </main>


### PR DESCRIPTION
Extends upon https://github.com/biglotteryfund/blf-alpha/pull/997 as a way of confirming that the new `flexibleContent` fields are, well, flexible.

Updates the blog post template to use a flexible content field and adds a content type of `inlineFigure` for adding a photo with a caption as a dedicated content block.