### PR TITLE
Remove (most) overrides from ebulletin form

### DIFF
--- a/assets/sass/components/forms.scss
+++ b/assets/sass/components/forms.scss
@@ -232,44 +232,25 @@
 /* =========================================================================
    Custom Form: Ebulletin
    ========================================================================= */
+// @TODO: can we define this a general modifier? Slim? Tinted?
 
 .form-ebulletin {
-    .form-field--type-text .ff-label,
-    .form-field--type-email .ff-label {
-        @include visually-hidden();
+    .form-field {
+        margin-bottom: .5em;
     }
 
-    .form-fieldset--details {
-        .form-fieldset__fields {
-            display: flex;
-            flex-flow: row wrap;
-        }
-
-        .form-field {
-            flex: 1 1 100%;
-            margin-bottom: $spacingUnit / 2;
-        }
-
-        .form-field--firstName,
-        .form-field--lastName {
-            flex: 0 0 50%;
-        }
-        .form-field--firstName {
-            padding-right: 5px;
-        }
-        .form-field--lastName {
-            padding-left: 5px;
-        }
+    &,
+    .ff-label {
+        font-size: 18px;
     }
 
-    .ff-text {
+    .ff-text,
+    .ff-textarea {
         display: block;
         width: 100%;
+        padding: .35em;
         font-size: 16px;
-        border: none;
-        border-bottom: 2px solid palette('pink');
-        background-color: transparent;
-        padding: 3px 3px 6px;
+        border: 1px solid rgba(0,0,0,0.2);
     }
 }
 

--- a/views/components/ebulletin.njk
+++ b/views/components/ebulletin.njk
@@ -67,7 +67,6 @@
                     name: 'firstName',
                     autocompleteName: 'given-name',
                     label: __('toplevel.ebulletin.fields.firstName'),
-                    placeholder: __('toplevel.ebulletin.fields.firstName') + ' *',
                     isRequired: true
                 }) }}
 
@@ -76,7 +75,6 @@
                     name: 'lastName',
                     autocompleteName: 'family-name',
                     label: __('toplevel.ebulletin.fields.lastName'),
-                    placeholder: __('toplevel.ebulletin.fields.lastName') + ' *',
                     isRequired: true
                 }) }}
 
@@ -85,7 +83,6 @@
                     name: 'organisation',
                     autocompleteName: 'organization',
                     label: __('toplevel.ebulletin.fields.organisation'),
-                    placeholder: __('toplevel.ebulletin.fields.organisation'),
                     isRequired: false
                 }) }}
 
@@ -94,7 +91,7 @@
                     name: 'email',
                     autocompleteName: 'email',
                     label: __('toplevel.ebulletin.fields.emailAddress'),
-                    placeholder: __('toplevel.ebulletin.fields.emailAddress') + ' *',
+                    placeholder: 'yourname@example.com',
                     isRequired: true
                 }) }}
             </div>


### PR DESCRIPTION
Makes the e-bulletin form fields look like the rest of our form fields. No more placeholders-as-labels!

Makes some concessions to the fact that the form is on a tinted background and in a constrained space. There is probably a case to turn this into a more general modifier or two but for now I'm just happy to make this form less special.

<img width="995" alt="screen shot 2018-05-17 at 15 50 46" src="https://user-images.githubusercontent.com/123386/40186783-d6e84eac-59ed-11e8-9bae-1470df55586a.png">

![image](https://user-images.githubusercontent.com/123386/40186902-1f71f07e-59ee-11e8-88e9-67bc8d6c8921.png)
