### PR TITLE
Refine search styles

### DIFF
--- a/assets/sass/components/global-header.scss
+++ b/assets/sass/components/global-header.scss
@@ -238,13 +238,13 @@ html:not(.contrast--high) body:not(.has-static-header) .global-nav {
     }
 }
 .global-search__input {
-    padding: 6px;
+    @include poppins();
+    font-size: 16px;
+    font-weight: normal;
+    border: none;
     width: 100%;
     margin-top: 0;
-    border: none;
-    @include poppins();
-    font-weight: 600;
-    font-size: 16px;
+    padding: 6px 32px 6px 12px;
 }
 .global-search__submit {
     border: 0;
@@ -253,6 +253,7 @@ html:not(.contrast--high) body:not(.has-static-header) .global-nav {
     top: 0;
     right: 0;
     cursor: pointer;
+    background-color: transparent;
 
     .icon {
         width: 21px;
@@ -266,6 +267,14 @@ html:not(.contrast--high) body:not(.has-static-header) .global-nav {
             fill: palette('charcoal');
         }
     }
+}
+
+/**
+ * Global search: Offset modifier (i.e. in global header)
+ * Gives search form contrast against light hero images and pages with no image.
+ */
+.global-search--offset {
+    box-shadow: 0 0 2px 1px rgba(0,0,0,0.2);
 }
 
 /* =========================================================================

--- a/assets/sass/globals/base.scss
+++ b/assets/sass/globals/base.scss
@@ -173,16 +173,16 @@ fieldset {
     min-width: 0;
 }
 
-input[type='text'],
-input[type='email'],
-input[type='search'] {
+[type='text'],
+[type='email'],
+[type='search'] {
     -webkit-appearance: none;
     appearance: none;
     border-radius: 0; // Normalise border-radius, notably for iOS.
 }
 
-input[type='search']::-webkit-search-decoration,
-input[type='search']::-webkit-search-cancel-button {
+[type='search']::-webkit-search-decoration,
+[type='search']::-webkit-search-cancel-button {
     display: none;
 }
 

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -19,9 +19,9 @@
     {% endif %}
 {% endmacro %}
 
-{% macro navSearchForm() %}
+{% macro navSearchForm(isOffset = false) %}
     {% set id = shortid() %}
-    <form class="global-search" role="search" action="/search">
+    <form class="global-search{% if isOffset %} global-search--offset{% endif %}" role="search" action="/search">
         <input type="hidden" name="lang" value="en-GB">
         <input type="hidden" name="type" value="All">
         <input type="hidden" name="order" value="r">

--- a/views/includes/header.njk
+++ b/views/includes/header.njk
@@ -22,7 +22,7 @@
                         {{ navLangLink() }}
                     </li>
                     <li class="global-nav__search">
-                        {{ navSearchForm() }}
+                        {{ navSearchForm(isOffset = true) }}
                     </li>
                 </ul>
             </nav>


### PR DESCRIPTION
Small bit of refinement to search styles to add a slight box-shadow to the search in the header to give contrast against lighter hero images and to allow for pages with no image.

<img width="1060" alt="screen shot 2018-05-22 at 16 41 26" src="https://user-images.githubusercontent.com/123386/40373714-67ce8f9a-5ddf-11e8-8163-d5eaa3f72ea0.png">
<img width="943" alt="screen shot 2018-05-22 at 16 44 18" src="https://user-images.githubusercontent.com/123386/40373715-67e9d458-5ddf-11e8-822a-19f90242ba17.png">
