### PR TITLE
Add overflow table styles for small screens

### DIFF
--- a/assets/sass/scaffolding/scope-prose.scss
+++ b/assets/sass/scaffolding/scope-prose.scss
@@ -186,7 +186,7 @@ $constrainedWide: 42em;
         font-size: 90%;
         box-sizing: border-box;
         width: 100%;
-        max-width: 40em;
+        max-width: 48em;
         border-collapse: separate;
         border-spacing: 0;
         table-layout: fixed;
@@ -238,6 +238,7 @@ $constrainedWide: 42em;
         td {
             padding: 1em;
             text-align: left;
+            word-wrap: break-word;
 
             > p {
                 margin: 0;
@@ -246,6 +247,18 @@ $constrainedWide: 42em;
 
         td {
             vertical-align: top;
+        }
+    }
+
+    .table-container {
+        width: 100%;
+        overflow-y: auto;
+        margin: 0 0 1em;
+
+        @include mq('medium', 'max') {
+            table {
+                width: auto;
+            }
         }
     }
 


### PR DESCRIPTION
Add overflow table styles for small screens. Relies on tables being wrapped with an extra div. Currently needs to be added manually where needed but may look at an automatic way of doing this for CMS content.