### PR TITLE
Fix feedback and add test

### DIFF
--- a/cypress/integration/flow_spec.js
+++ b/cypress/integration/flow_spec.js
@@ -46,4 +46,22 @@ describe('Core funding flow', function() {
             cy.get($el.attr('href')).should('be.visible');
         });
     });
+
+    it.only('should allow feedback submissions', () => {
+        cy.visit('/funding/past-grants');
+        cy.get('#js-feedback').as('feedbackForm');
+        cy
+            .get('@feedbackForm')
+            .find('summary')
+            .click();
+        cy
+            .get('@feedbackForm')
+            .find('textarea')
+            .type('Test feedback');
+        cy
+            .get('@feedbackForm')
+            .find('form')
+            .submit();
+        cy.get('@feedbackForm').should('contain', 'Thank you for sharing');
+    });
 });

--- a/views/pages/apply/success.njk
+++ b/views/pages/apply/success.njk
@@ -19,7 +19,7 @@
 
             {% if stepConfig.feedback and appData.isNotProduction %}
                 {{ inlineFeedback(
-                    title = form.title,
+                    description = form.title,
                     promptLabel = stepConfig.feedback.promptLabel,
                     fieldLabel = stepConfig.feedback.fieldLabel
                 )  }}

--- a/views/pages/funding/past-grants.njk
+++ b/views/pages/funding/past-grants.njk
@@ -25,7 +25,7 @@
                 <section class="u-separator s-prose s-prose--long u-constrained-content-wide">
                     <p>{{ copy.intro }}</p>
                     {{ inlineFeedback(
-                        title = "Past Grants",
+                        description = "Past Grants",
                         promptLabel = copy.survey.prompt,
                         fieldLabel = copy.survey.label
                     )  }}


### PR DESCRIPTION
Not sure how I missed this but there was a problem with submissions on inline-feedback due to a typo in a variable name. This PR fixes the typo and adds a smoke test for inline feedback to avoid future regressions.