### PR TITLE
Add data protection page to the footer

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -31,14 +31,16 @@ global:
       href: "/welsh/about-big/publications/corporate-documents"
     - label: Polisi Preifatrwydd
       href: "/welsh/about/customer-service/privacy-policy"
+    - label: Diogelu Data
+      href: "/welsh/about/customer-service/data-protection"
+    - label: Cwcis
+      href: "/welsh/about/customer-service/cookies"
     - label: Telerau
       href: "/welsh/about/customer-service/terms-of-use"
     - label: Cyswllt
       href: "/welsh/contact"
     - label: Swyddi
       href: "/welsh/jobs"
-    - label: Cwcis
-      href: "/welsh/about/customer-service/cookies"
     - label: Map o'r wefan
       href: "/welsh/sitemap"
     - label: Hygyrchedd

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,14 +31,16 @@ global:
       href: "/about-big/publications/corporate-documents"
     - label: Privacy Policy
       href: "/about/customer-service/privacy-policy"
+    - label: Data Protection
+      href: "/about/customer-service/data-protection"
+    - label: Cookies
+      href: "/about/customer-service/cookies"
     - label: Terms
       href: "/about/customer-service/terms-of-use"
     - label: Contact
       href: "/contact"
     - label: Jobs
       href: "/jobs"
-    - label: Cookies
-      href: "/about/customer-service/cookies"
     - label: Site map
       href: "/sitemap"
     - label: Accessibility


### PR DESCRIPTION
Add data protection page to the footer. Re-ordered the links to group data protection / privacy / cookies together.