### PR TITLE
Tweak browserlist to match what we support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
           "modules": false,
           "targets": {
             "browsers": [
-              "last 2 versions",
-              "ie >= 10"
+              ">0.5%",
+              "not ie 10",
+              "ie >= 11"
             ]
           }
         }
@@ -57,8 +58,9 @@
     ]
   },
   "browserslist": [
-    "last 2 versions",
-    "ie >= 10"
+    ">0.5%",
+    "not ie 10",
+    "ie >= 11"
   ],
   "nodemonConfig": {
     "verbose": true,


### PR DESCRIPTION
Tweak browserlist to match what we support. Uses percentage based guard and explicitly excludes IE 10. Shouldn't change much other than a slightly smaller browser bundle (~couple kb each for css and js).