### PR TITLE
Normalise feedback key

### DIFF
--- a/services/feedback.js
+++ b/services/feedback.js
@@ -8,7 +8,7 @@ function findAll() {
     return Feedback.findAll({
         order: [['updatedAt', 'DESC']]
     }).then(results => {
-        return groupBy('description')(results);
+        return groupBy(result => result.description.toLowerCase())(results);
     });
 }
 


### PR DESCRIPTION
As part of https://github.com/biglotteryfund/blf-alpha/pull/1009 and the previous changes to pass a description through to the feedback partial I altered the case of the description. This results in this view in the feedback overview:

<img width="1175" alt="screen shot 2018-05-24 at 15 47 27" src="https://user-images.githubusercontent.com/123386/40493082-e5258c10-5f69-11e8-8dfe-5281911ab513.png">

This almost certainly points to a need for a stricter unique ID to group feedback on, but for now I've opted to normalise this by lower casing the description.