### PR TITLE
Fix redirect crash

### DIFF
--- a/middleware/redirects.js
+++ b/middleware/redirects.js
@@ -39,8 +39,9 @@ function redirectLinkNoise(req, res, next) {
     const cleanedUrl = cleanLinkNoise(req.originalUrl);
     if (cleanedUrl !== req.originalUrl) {
         res.redirect(301, cleanedUrl);
+    } else {
+        next();
     }
-    next();
 }
 
 const removeTrailingSlashes = slashes(false);


### PR DESCRIPTION
Looking over server logs there were lots of these messages:

```[29/May/2018:10:08:17 +0000] GET /research/research-round-up/%7E/%7E/link.aspx HTTP/1.1 301 70 - 0.586 ms "-"
Error: Can't set headers after they are sent.
    at validateHeader (_http_outgoing.js:491:11)
    at ServerResponse.setHeader (_http_outgoing.js:498:3)
    at ServerResponse.header (/var/www/biglotteryfund/node_modules/express/lib/response.js:767:10)
    at ServerResponse.send (/var/www/biglotteryfund/node_modules/express/lib/response.js:170:12)
    at done (/var/www/biglotteryfund/node_modules/express/lib/response.js:1004:10)
    at /var/www/biglotteryfund/node_modules/nunjucks/src/environment.js:23:23
    at RawTask.call (/var/www/biglotteryfund/node_modules/asap/asap.js:40:19)
    at flush (/var/www/biglotteryfund/node_modules/asap/raw.js:50:29)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
[ N 2018-05-29 10:08:19.3409 6234/T5 age/Cor/CoreMain.cpp:1062 ]: Checking whether to disconnect long-running connections for process 20851, application /var/www/biglotteryfund (production)```

That URI (`/research/research-round-up/%7E/%7E/link.aspx`) causes the error above and crashes the app server(!) which, luckily, restarts. 

I did some digging and tracked it down to this: the `link.aspx` gets removed from the URL and redirected, but because of the logic it also calls `next()` which goes on to proxy the page. This results in the "headers already sent" error (and then the app crashing).

This change makes the `next()` handler either/or (eg. it only kicks in if we don't redirect), stopping the double request and the error.