### PR TITLE
Fix some styleguide regressions

### DIFF
--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -173,10 +173,36 @@ module.exports = ({ router, pages }) => {
     feedbackRoute.init({ router });
 
     router.get('/styleguide', (req, res) => {
+
+        const demoStats = [
+            {
+                value: '42',
+                title: 'The meaning of life, the universe, and everything',
+                prefix: '',
+                suffix: '',
+                showNumberBeforeTitle: true
+            },
+            {
+                value: '9m',
+                title: 'in Beijing',
+                prefix: 'There are',
+                suffix: 'bicycles',
+                showNumberBeforeTitle: true
+            },
+            {
+                value: '500 miles',
+                title: 'I would walk',
+                prefix: '',
+                suffix: '',
+                showNumberBeforeTitle: false
+            }
+        ];
+
         res.render('pages/toplevel/styleguide', {
             title: 'Styleguide',
             description: 'Styleguide',
-            superHeroImages: homepageHero
+            superHeroImages: homepageHero,
+            demoStats: demoStats
         });
     });
 

--- a/views/pages/toplevel/styleguide.njk
+++ b/views/pages/toplevel/styleguide.njk
@@ -162,7 +162,7 @@
         <li class="grid__item">
             {{ miniatureHero(
                 titleText = 'Example Miniature Hero',
-                imagePath = 'funding/tell-the-world.jpg',
+                imagePath = 'home/case-study-1-medium.jpg',
                 imageCaption = 'Three people working together on laptops',
                 linkUrl = '#',
                 accent = 'pink-mid'
@@ -171,7 +171,7 @@
         <li class="grid__item">
             {{ miniatureHero(
                 titleText = 'Example Miniature Hero',
-                imagePath = 'funding/local-press.jpg',
+                imagePath = 'home/case-study-2-medium.jpg',
                 imageCaption = 'Two cooks in chefs\' clothing with another man smiling',
                 linkUrl = '#',
                 accent = 'blue'
@@ -184,7 +184,7 @@
 
 
 {% set sgContent %}
-    {{ statsGrid(__('toplevel.data.data')) }}
+    {{ statsGrid(demoStats) }}
 {% endset %}
 {{ sgBlock('Stats Grid', sgContent) }}
 
@@ -242,7 +242,7 @@
 
 {% set sgContent %}
     <div class="content-box inner--wide-only accent--turquoise a--border-top">
-        {{ __('funding.guidance.getting-press-coverage.body') | safe }}
+        {{ __('funding.guidance.order-free-materials.body') | safe }}
     </div>
 {% endset %}
 {{ sgBlock('Content Box', sgContent) }}


### PR DESCRIPTION
We had a few regressions from deleted stuff (eg. hardcoded translations and image files). Well spotted by @LynseyJReynolds.

![image](https://user-images.githubusercontent.com/394376/40793023-41307e50-64f3-11e8-9577-7b591208227a.png)

![image](https://user-images.githubusercontent.com/394376/40793030-4560653a-64f3-11e8-96ed-9a09b88a0514.png)
