### PR TITLE
Add prev/next links to programme pages

### DIFF
--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -1,5 +1,5 @@
 'use strict';
-const { map } = require('lodash');
+const { includes, map } = require('lodash');
 
 const { heroImages } = require('../../modules/images');
 const { injectCopy, injectFundingProgramme, injectFundingProgrammes } = require('../../middleware/inject-content');
@@ -131,9 +131,16 @@ function initProgrammeDetail({ router, routeConfig }) {
     router.get('/programmes/:slug', injectFundingProgramme, (req, res, next) => {
         const entry = res.locals.fundingProgramme;
         if (entry.contentSections.length > 0) {
+            // Limit to certain programme pages before we roll out more widely.
+            const showNextSectionLink =
+                includes(entry.path, 'young-start') ||
+                includes(entry.path, 'reaching-communities-england') ||
+                includes(entry.path, 'partnerships-england');
+
             res.render(routeConfig.template, {
                 title: entry.summary.title,
                 entry: res.locals.fundingProgramme,
+                showNextSectionLink: showNextSectionLink,
                 isBilingual: isBilingual(entry.availableLanguages),
                 heroImage: entry.hero || heroImages.fallbackHeroImage
             });

--- a/views/pages/funding/programme-detail.njk
+++ b/views/pages/funding/programme-detail.njk
@@ -36,27 +36,51 @@
                 </div>
             </section>
 
-            {% macro tabContent(content, pageAccent) %}
-                <div class="content-box content-box--frameless">
-                    <div class="s-prose s-prose--long u-constrained-content-wide accent-content--{{ pageAccent }} js-content">
-                        {{ content | safe }}
-                    </div>
-                </div>
+            {% macro nextPrevNav(entry, loopIdx) %}
+                {% set zeroIndexed = loopIdx - 1 %}
+                {% set nextSection = entry.contentSections[zeroIndexed + 1] %}
+                {% set prevSection = entry.contentSections[zeroIndexed - 1] %}
+                {% if nextSection or prevSection and showNextSectionLink %}
+                    <nav class="split-nav">
+                        {% if prevSection %}
+                            <a class="split-nav__prev" href="#section-{{ loopIdx - 1 }}">
+                                {{ prevSection.title }}
+                            </a>
+                        {% endif %}
+                        {% if nextSection %}
+                            <a class="split-nav__next" href="#section-{{ loopIdx + 1 }}">
+                                {{ nextSection.title }}
+                            </a>
+                        {% endif %}
+                    </nav>
+                {% endif %}
             {% endmacro %}
-
-            {% set tabItems = [] %}
-            {% for section in entry.contentSections -%}
-                {% set newTab = {
-                    "id": "section-" + loop.index,
-                    "title": section.title,
-                    "content": tabContent(section.body, pageAccent),
-                    "active": loop.index === 1
-                } %}
-                {% set tabItems = (tabItems.push(newTab), tabItems) %}
-            {%- endfor %}
 
             <div class="inner--wide-only">
                 {% if entry.contentSections.length > 1 %}
+
+                    {% set tabItems = [] %}
+                    {% for section in entry.contentSections -%}
+
+                        {% set tabContent -%}
+                            <div class="content-box content-box--frameless">
+                                <div class="s-prose s-prose--long u-constrained-content-wide
+                                    accent-content--{{ pageAccent }} js-content">
+                                    {{ section.body | safe }}
+                                </div>
+
+                                {{ nextPrevNav(entry, loop.index) }}
+                            </div>
+                        {%- endset %}
+
+                        {% set tabItems = (tabItems.push({
+                            "id": "section-" + loop.index,
+                            "title": section.title,
+                            "content": tabContent,
+                            "active": loop.index === 1
+                        }), tabItems) %}
+                    {%- endfor %}
+
                     {{
                         tabs(
                             id = entry.title | slugify,


### PR DESCRIPTION
Adds prev/next section links to programme pages. Limits to reaching communities for now to allow us to test it before rolling out more widely.

![image](https://user-images.githubusercontent.com/123386/40923240-2f1f2376-680c-11e8-888e-5c26d203c114.png)
