### PR TITLE
Rename classnames (fixup todos)

### DIFF
--- a/assets/js/vue-components/feedback.js
+++ b/assets/js/vue-components/feedback.js
@@ -32,7 +32,7 @@ const FeedbackForm = {
             <form v-if="!statusMessage" v-on:submit.prevent="handleSubmit">
                 <label class="ff-label" for="field-message">{{ fieldLabel }}</label>
                 <textarea
-                    class="ff-textarea spaced"
+                    class="ff-textarea u-margin-bottom"
                     id="field-message"
                     name="message"
                     v-model="feedback"

--- a/assets/js/vue-components/surveys.js
+++ b/assets/js/vue-components/surveys.js
@@ -82,7 +82,7 @@ function init() {
             <form class="survey__form" v-on:submit.prevent="storeResponse(choice.id)">
                 <div class="survey__form-fields">
                     <label class="ff-label" for="survey-extra-msg">{{ lang.genericQuestion }}</label>
-                    <textarea class="ff-textarea spaced--s" id="survey-extra-msg"
+                    <textarea class="ff-textarea" id="survey-extra-msg"
                         :placeholder="lang.genericPrompt"
                         v-model="response.message"
                     ></textarea>

--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -363,3 +363,25 @@ $btnConf: (
         }
     }
 }
+
+.o-button-group-flex {
+    @include mq('medium') {
+        display: flex;
+        flex-flow: row wrap;
+        margin: -10px 0 $spacingUnit -10px;
+        justify-content: center;
+    }
+
+    .btn {
+        display: block;
+        width: 100%;
+        margin-bottom: $spacingUnit;
+
+        @include mq('medium') {
+            width: auto;
+            flex: 1 1 auto;
+            margin: 10px 0 0 10px;
+            max-width: $constrained;
+        }
+    }
+}

--- a/assets/sass/components/prompts.scss
+++ b/assets/sass/components/prompts.scss
@@ -74,6 +74,9 @@
 .survey__response {
     margin-bottom: 0;
 }
+.survey__form-fields {
+    margin-bottom: $spacingUnit;
+}
 .survey__form-actions {
     display: flex;
     align-items: center;

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -54,17 +54,16 @@
     }
 }
 
-// @TODO: Rename all uses to u-padded
-.padded,
+.u-bordered {
+    border: 1px solid palette('border');
+}
+
 .u-padded {
     padding: $spacingUnit ($spacingUnit / 2);
 
     @include mq('medium') {
         padding: $spacingUnit;
     }
-}
-.u-padded-top {
-    padding-top: $spacingUnit;
 }
 
 .u-margin-bottom {
@@ -79,9 +78,4 @@
 
 .u-margin-top {
     margin-top: $spacingUnit;
-}
-
-.u-outline {
-    border: 1px solid palette('border');
-    padding: $spacingUnit;
 }

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -75,29 +75,18 @@
     padding-top: $spacingUnit;
 }
 
-// @TODO: Rename to u-margin-bottom-*
-.spaced {
+.u-margin-bottom {
     margin-bottom: $spacingUnit;
 }
-
-.spaced--s {
+.u-margin-bottom-s {
     margin-bottom: $spacingUnit / 2;
 }
-
-.spaced--l {
+.u-margin-bottom-l {
     margin-bottom: $spacingUnit * 2;
 }
 
-.spaced--x-l {
-    margin-bottom: $spacingUnit * 3;
-}
-
-.spaced--t {
+.u-margin-top {
     margin-top: $spacingUnit;
-}
-
-.spaced--t--l {
-    margin-top: $spacingUnit * 2;
 }
 
 .u-outline {

--- a/assets/sass/globals/layout.scss
+++ b/assets/sass/globals/layout.scss
@@ -45,14 +45,6 @@
     margin-right: $spacingUnit / 2;
 }
 
-// @TODO better name
-.central-gap {
-    @include mq('tablet') {
-        margin-left: 20%;
-        margin-right: 20%;
-    }
-}
-
 .nudge-up {
     @include mq('tablet') {
         top: -25px;

--- a/views/components/forms.njk
+++ b/views/components/forms.njk
@@ -24,7 +24,7 @@
                placeholder="{{ placeholderText }}"{% if charLimit %} data-char-limit="{{ charLimit }}"{% endif %}>
     {% endif %}
     {% if showErrorsBelowFields %}
-        <p class="spaced--t error t6">
+        <p class="t6 error u-margin-top">
             {% if error %}{{ error.msg }}{% else %}&nbsp;{% endif %}
         </p>
     {% endif %}
@@ -95,7 +95,7 @@
                     hasOther = true
                 ) }}
             {% endif %}
-            {% if error %}<p class="error t6 spaced--t">{{ error.msg }}</p>{% endif %}
+            {% if error %}<p class="error t6 u-margin-top">{{ error.msg }}</p>{% endif %}
         </div>
     </fieldset>
 
@@ -103,6 +103,6 @@
         <label for="{{ otherId }}" class="u-visually-hidden">{{ __('global.forms.other') }}</label>
         <input type="text" name="{{ fieldName }}Other" id="{{ otherId }}" placeholder="{{ __('global.forms.other') }}" />
     {% endif %}
-    {% if error %}<p class="error t6 spaced--t">{{ error.msg }}</p>{% endif %}
+    {% if error %}<p class="error t6 u-margin-top">{{ error.msg }}</p>{% endif %}
     {% if allowOther %}</div>{% endif %}
 {% endmacro %}

--- a/views/pages/apply/error.njk
+++ b/views/pages/apply/error.njk
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="content-box inner inner--wide-only accent--pink a--border-top">
-        <div class="u-constrained-content s-prose spaced">
+        <div class="s-prose u-constrained-content u-margin-bottom">
             <div class="form-message">
                 <h1 class="t1 form-message__title">{{ stepConfig.title }}</h1>
             </div>

--- a/views/pages/apply/reaching-communities-startpage.njk
+++ b/views/pages/apply/reaching-communities-startpage.njk
@@ -24,7 +24,7 @@
                 Apply for a grant over £10,000
             </h1>
 
-            <div class="u-constrained-content s-prose spaced--l">
+            <div class="u-constrained-content s-prose u-margin-bottom-l">
                 <h2 class="t2 t--underline accent--{{ pageAccent }}">Find out how we can help you</h2>
                 <p>
                     You can apply for over £10,000 to support communities to take action
@@ -35,7 +35,7 @@
                 {{ startButton(startUrl) }}
             </div>
 
-            <div class="u-constrained-content s-prose spaced--l">
+            <div class="u-constrained-content s-prose u-margin-bottom-l">
                 <h2 class="t2 t--underline accent--{{ pageAccent }}">Before you start</h2>
                 <h3 class="t4">We can fund</h3>
                 <ul>

--- a/views/pages/apply/success.njk
+++ b/views/pages/apply/success.njk
@@ -9,7 +9,7 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box inner inner--wide-only accent--pink a--border-top">
-            <div class="u-constrained-content s-prose spaced">
+            <div class="u-constrained-content s-prose u-margin-bottom">
                 <div class="form-message">
                     <h1 class="t1 form-message__title">{{ stepConfig.title }}</h1>
                 </div>

--- a/views/pages/funding/logos.njk
+++ b/views/pages/funding/logos.njk
@@ -76,7 +76,7 @@
 {% endmacro %}
 
 {% macro logoBlock(logoId, logoFilename, logoName, logoLocale = 'en', onlyEps = false, accent = false) %}
-    <div class="u-outline">
+    <div class="u-padded u-bordered">
         {{ downloadBlock(logoId) }}
         {% set accentClass = '' %}
         {% if accent %}
@@ -104,7 +104,7 @@
 {% endmacro %}
 
 {% set logosMonolingual %}
-    <div class="padded">
+    <div class="u-padded">
         <ul class="unstyled grid grid--wide-only grid--equal grid--2-up grid--padded">
             <li class="grid__item">
                 <div class="grid__item__inner accent--turquoise">
@@ -152,7 +152,7 @@
 {# Wales #}
 
 {% set logosBilingual %}
-    <div class="padded">
+    <div class="u-padded">
         <ul class="unstyled grid grid--wide-only grid--equal grid--2-up grid--padded">
             <li class="grid__item">
                 <div class="grid__item__inner accent--turquoise">

--- a/views/pages/funding/logos.njk
+++ b/views/pages/funding/logos.njk
@@ -86,17 +86,20 @@
         {% if not onlyEps %}<a href="{{ logoPath(logoLocale, logoFilename, 'jpg', '-large') | trim}}" target="_blank" class="js-logo-trigger" data-logo-type="print" data-logo-id="{{ logoId }}">{% endif %}
             <img src="{{ logoPath(logoLocale, logoFilename, 'png') | trim }}" alt="The Big Lottery Fund logo, in {% if logoLocale == 'en' %}English{% else %}Welsh and English{% endif %}, coloured {{ logoName }}">
         {% if not onlyEps %}</a>{% endif %}
-        {% if not onlyEps %}
-            <a href="{{ logoPath(logoLocale, logoFilename, 'jpg', '-small') | trim }}" class="{{ accentClass }}spaced--s btn btn--block btn--small js-logo-trigger" target="_blank" data-logo-type="digital" data-logo-id="{{ logoId }}">
-                {{ makeLogoTitle(logoName, 'small') }}
+
+        <div class="o-button-group-block">
+            {% if not onlyEps %}
+                <a href="{{ logoPath(logoLocale, logoFilename, 'jpg', '-small') | trim }}" class="{{ accentClass }} btn btn--small js-logo-trigger" target="_blank" data-logo-type="digital" data-logo-id="{{ logoId }}">
+                    {{ makeLogoTitle(logoName, 'small') }}
+                </a>
+                <a href="{{ logoPath(logoLocale, logoFilename, 'jpg', '-large') | trim }}" class="{{ accentClass }} btn btn--small js-logo-trigger" target="_blank" data-logo-type="print" data-logo-id="{{ logoId }}">
+                    {{ makeLogoTitle(logoName, 'large') }}
+                </a>
+            {% endif %}
+            <a href="{{ logoPath(logoLocale, logoFilename, 'eps') | trim }}" class="{{ accentClass }} btn btn--small js-logo-trigger" target="_blank" data-logo-type="vector" data-logo-id="{{ logoId }}">
+                {{ makeLogoTitle(logoName, 'eps') }}
             </a>
-            <a href="{{ logoPath(logoLocale, logoFilename, 'jpg', '-large') | trim }}" class="{{ accentClass }}spaced--s btn btn--block btn--small js-logo-trigger" target="_blank" data-logo-type="print" data-logo-id="{{ logoId }}">
-                {{ makeLogoTitle(logoName, 'large') }}
-            </a>
-        {% endif %}
-        <a href="{{ logoPath(logoLocale, logoFilename, 'eps') | trim }}" class="{{ accentClass }}spaced--s btn btn--block btn--small js-logo-trigger" target="_blank" data-logo-type="vector" data-logo-id="{{ logoId }}">
-            {{ makeLogoTitle(logoName, 'eps') }}
-        </a>
+        </div>
     </div>
 {% endmacro %}
 

--- a/views/pages/funding/order-free-materials.njk
+++ b/views/pages/funding/order-free-materials.njk
@@ -164,7 +164,7 @@
                 </div>
 
                 <div class="inner accent--{{ pageAccent }} a--border-top p" id="your-details">
-                    <div class="padded">
+                    <div class="u-padded">
                         <h3 class="t2">{{ copy.enterDeliveryAddress }}</h3>
 
                         <form class="form-materials" method="post">

--- a/views/pages/funding/order-free-materials.njk
+++ b/views/pages/funding/order-free-materials.njk
@@ -194,7 +194,6 @@
                             {{ textField(formFields.yourProjectName) }}
 
                             <div class="grid grid--padded grid--top grid-row">
-
                                 <div class="grid__item grid-col-6 grid-col-3--m">
                                     {{ radios(
                                         fieldName = formFields.yourReason.name,
@@ -217,14 +216,17 @@
                                     ) }}
 
                                     <input type="submit"{% if orders.length == 0 %} disabled="disabled"{% endif %}
-                                           v-bind:disabled="isEmpty() && {{ orders.length }} === 0"
-                                           value="{{ __('global.forms.submit') }}"
-                                           class="btn spaced--t--l"
-                                           id="js-submit-material-order">
+                                        v-bind:disabled="isEmpty() && {{ orders.length }} === 0"
+                                        value="{{ __('global.forms.submit') }}"
+                                        class="btn u-margin-top"
+                                        id="js-submit-material-order">
                                 </div>
                             </div>
-                            <h4 class="spaced--t spaced--s">{{ copy.dataProtection.title }}</h4>
-                            <aside class="t8">{{ copy.dataProtection.text | safe }}</aside>
+
+                            <div class="s-prose u-margin-top">
+                                <h4>{{ copy.dataProtection.title }}</h4>
+                                <div class="t8">{{ copy.dataProtection.text | safe }}</div>
+                            </div>
                         </form>
                     </div>
                 </div>

--- a/views/pages/funding/over10k.njk
+++ b/views/pages/funding/over10k.njk
@@ -25,35 +25,24 @@
                     <h2>{{ copy.callToAction }}</h2>
                 </div>
 
-                <ul class="u-list-unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
-                <li class="grid__item">
+                <div class="o-button-group-flex">
                     <a href="{{ localify('/funding/programmes?min=10000&location=england') }}"
-                        class="btn accent--{{ pageAccent }} a--btn btn--block btn--small"
+                        class="btn accent--{{ pageAccent }} a--btn btn--small"
                         id="qa-button-england">{{ copy.locations.england }}</a>
-                </li>
-                <li class="grid__item">
                     <a href="{{ localify('/funding/programmes?min=10000&location=scotland') }}"
-                        class="btn accent--{{ pageAccent }} a--btn btn--block btn--small"
+                        class="btn accent--{{ pageAccent }} a--btn btn--small"
                         id="qa-button-scotland">{{ copy.locations.scotland }}</a>
-                </li>
-                <li class="grid__item">
                     <a href="{{ localify('/funding/programmes?min=10000&location=wales') }}"
-                        class="btn accent--{{ pageAccent }} a--btn btn--block btn--small"
+                        class="btn accent--{{ pageAccent }} a--btn btn--small"
                         id="qa-button-wales">{{ copy.locations.wales }}</a>
-                </li>
-                <li class="grid__item">
                     <a href="{{ localify('/funding/programmes?min=10000&location=northernIreland') }}"
-                        class="btn accent--{{ pageAccent }} a--btn btn--block btn--small"
+                        class="btn accent--{{ pageAccent }} a--btn btn--small"
                         id="qa-button-northernIreland">{{ copy.locations.northernIreland }}</a>
-                </li>
-                </ul>
-                <div class="central-gap">
                     <a href="{{ localify('/funding/programmes/awards-from-the-uk-portfolio') }}"
-                    class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">
+                        class="btn accent--{{ pageAccent }} a--btn btn--small">
                         {{ copy.locations.ukWide }}
                     </a>
                 </div>
-
             </div>
 
             {# Case Studies #}
@@ -63,11 +52,13 @@
                 accent = pageAccent
             ) }}
 
-            <div class="inner">
-                <div class="central-gap spaced">
-                    <a href="{{ localify('/funding/past-grants') }}" class="btn btn--outline accent--turquoise btn--a btn--block btn--small">{{ copy.browseAll }}</a>
-                </div>
+            <div class="inner u-margin-bottom u-constrained">
+                <a href="{{ localify('/funding/past-grants') }}"
+                    class="btn btn--small btn--outline btn--block accent--{{ pageAccent }} a--btn">
+                    {{ copy.browseAll }}
+                </a>
             </div>
+
         </div>
     </main>
 {% endblock %}

--- a/views/pages/funding/under10k.njk
+++ b/views/pages/funding/under10k.njk
@@ -29,32 +29,24 @@
 
                     <h2>{{ copy.callToAction }}</h2>
 
-                    <ul class="u-list-unstyled grid grid--padded grid--equal grid--4-up grid--wide-only">
-                    <li class="grid__item">
+                    <div class="o-button-group-flex">
                         <a href="{{ localify('/funding/programmes/national-lottery-awards-for-all-england') }}"
                             class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">
                             {{ copy.locations.england }}
                         </a>
-                    </li>
-                    <li class="grid__item">
                         <a href="{{ localify('/funding/programmes/national-lottery-awards-for-all-scotland') }}"
                             class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">
                             {{ copy.locations.scotland }}
                         </a>
-                    </li>
-                    <li class="grid__item">
                         <a href="{{ localify('/funding/programmes/national-lottery-awards-for-all-wales') }}"
                             class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">
                             {{ copy.locations.wales }}
                         </a>
-                    </li>
-                    <li class="grid__item">
                         <a href="{{ localify('/funding/programmes/awards-for-all-northern-ireland') }}"
                             class="btn accent--{{ pageAccent }} a--btn btn--block btn--small">
                             {{ copy.locations.northernIreland }}
                         </a>
-                    </li>
-                    </ul>
+                    </div>
 
                     <p>{{ copy.ukWideInfo | safe }}</p>
                 </div>
@@ -67,10 +59,11 @@
                 accent = pageAccent
             ) }}
 
-            <div class="inner">
-                <div class="central-gap spaced">
-                    <a href="{{ localify('/funding/past-grants') }}" class="btn btn--outline accent--{{ pageAccent }} btn--block btn--small">{{ copy.browseFundedProjects }}</a>
-                </div>
+            <div class="inner u-margin-bottom u-constrained">
+                <a href="{{ localify('/funding/past-grants') }}"
+                    class="btn btn--small btn--outline btn--block accent--{{ pageAccent }} a--btn">
+                    {{ copy.browseFundedProjects }}
+                </a>
             </div>
         </div>
     </main>

--- a/views/pages/toplevel/data.njk
+++ b/views/pages/toplevel/data.njk
@@ -30,7 +30,7 @@
                     <div id="js-map-panes" class="js-paneset">
                         {% for region in statRegions %}
                             <section id="region-{{ region.slug }}" class="tab__pane{% if loop.first %} pane--active{% endif %}">
-                                <article class="map-info accent--{{ pageAccent }} a--border-top padded region--{{ region.slug }}--b-t">
+                                <article class="map-info accent--{{ pageAccent }} a--border-top u-padded region--{{ region.slug }}--b-t">
                                     <h3 class="t2 t--underline region--{{ region.slug }}--b-b">{{ region.title }}</h3>
 
                                     <p class="map-info__stat">

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -98,7 +98,7 @@
 
         <section class="inner--wide-only u-margin-bottom">
             <ul class="unstyled grid grid--wide-only grid--equal">
-                <li class="grid__item grid__item--large accent--{{ pageAccent }} a--border-top padded">
+                <li class="grid__item grid__item--large accent--{{ pageAccent }} a--border-top u-padded">
                     {# Twitter Feed #}
                     {% set twitterAccount = appData.config.get('social.twitterAccounts.' + locale)  %}
                     <a class="twitter-timeline" data-dnt="true" data-chrome="noheader" data-tweet-limit="3"

--- a/views/pages/toplevel/home.njk
+++ b/views/pages/toplevel/home.njk
@@ -27,7 +27,7 @@
             {# case studies #}
             <div class="carousel js-carousel
                 swiper-container
-                accent--{{ pageAccent }} a--border-top spaced--l"
+                accent--{{ pageAccent }} a--border-top u-margin-bottom-l"
                 data-name="Case-studies carousel">
                 <div class="carousel__controls js-only">
                     <button class="btn--carousel btn--carousel--round btn--carousel--prev js-carousel-prev"
@@ -61,9 +61,9 @@
                 </ul>
             </div>
 
-            <div class="central-gap">
+            <div class="inner u-constrained u-margin-bottom">
                 <a href="{{ localify('/funding/past-grants') }}"
-                    class="btn btn--block accent--{{ pageAccent }} a--btn spaced">
+                    class="btn btn--block accent--{{ pageAccent }} a--btn">
                     {{ copy.browseFundedProjects }}
                 </a>
             </div>
@@ -96,7 +96,7 @@
         </section>
         {% endif %}
 
-        <section class="inner--wide-only spaced">
+        <section class="inner--wide-only u-margin-bottom">
             <ul class="unstyled grid grid--wide-only grid--equal">
                 <li class="grid__item grid__item--large accent--{{ pageAccent }} a--border-top padded">
                     {# Twitter Feed #}


### PR DESCRIPTION
Renamed `spaced` and `padded` classnames with `u-` prefixes and more explicit names. Also removes central gap in favour of either using existing utilities to constrain content or with the addition of a `o-button-group-flex` class for the most common use case.