### PR TITLE
Rework survey results

### DIFF
--- a/assets/js/vue-components/surveys.js
+++ b/assets/js/vue-components/surveys.js
@@ -1,14 +1,20 @@
 import $ from 'jquery';
 import Vue from 'vue';
 
+const statuses = {
+    NOT_ASKED: 'NOT_ASKED',
+    MESSAGE_BOX_SHOWN: 'MESSAGE_BOX_SHOWN',
+    SUBMISSION_SUCCESS: 'SUBMISSION_SUCCESS',
+    SUBMISSION_ERROR: 'SUBMISSION_ERROR'
+};
+
 function init() {
     new Vue({
         el: '#js-survey',
         data: {
+            statuses: statuses,
+            status: statuses.NOT_ASKED,
             lang: null,
-            survey: null,
-            status: 'NOT_SUBMITTED',
-            showMessageBox: false,
             response: {
                 choice: null,
                 message: null,
@@ -17,75 +23,66 @@ function init() {
         },
         created: function() {
             const localePrefix = window.AppConfig.localePrefix;
-            // normalise URLs (eg. treat a Welsh URL the same as default)
-            const uri = window.location.pathname.replace(/\/welsh(\/|$)/, '/');
-            $.get(`${localePrefix}/surveys?path=${uri}`).then(response => {
-                if (response.status === 'success') {
-                    this.lang = response.lang;
-                    this.survey = response.survey;
-                }
+            $.get(`${localePrefix}/survey`).then(response => {
+                this.lang = response;
             });
         },
         methods: {
-            storeResponse(choiceId) {
-                this.response.choice = choiceId;
+            storeResponse(choice) {
+                this.response.choice = choice;
 
                 $.ajax({
-                    url: `/survey/${this.survey.id}`,
+                    url: `/survey`,
                     type: 'POST',
                     dataType: 'json',
                     data: this.response
                 }).then(response => {
-                    if (response.status === 'error') {
-                        this.status = 'ERROR';
+                    if (response.status === 'success') {
+                        this.status = this.statuses.SUBMISSION_SUCCESS;
                     } else {
-                        this.status = 'SUCCESS';
+                        this.status = this.statuses.SUBMISSION_ERROR;
                     }
-                }, () => (this.status = 'ERROR'));
+                }, () => (this.status = this.statuses.SUBMISSION_ERROR));
             },
             selectChoice(choice) {
-                if (choice.allowMessage) {
-                    this.showMessageBox = true;
-                } else {
-                    this.storeResponse(choice.id);
+                if (choice === 'yes') {
+                    this.storeResponse(choice);
+                } else if (choice === 'no') {
+                    this.status = statuses.MESSAGE_BOX_SHOWN;
                 }
             },
             resetChoice() {
-                this.showMessageBox = false;
+                this.status = statuses.NOT_ASKED;
             }
         },
         template: `
-<aside role="complementary" class="survey" v-if="survey">
+<aside role="complementary" class="survey" v-if="lang">
     <div class="inner">
-        <div class="survey__choices" v-if="status === 'NOT_SUBMITTED' && !showMessageBox">
-            <p class="survey__choices-question">{{ survey.question }}</p>
+        <div class="survey__choices" v-if="status === statuses.NOT_ASKED">
+            <p class="survey__choices-question">{{ lang.question }}</p>
             <div class="survey__choices-actions">
                 <button class="btn btn--small survey__choice" type="button"
-                    v-for="choice in survey.choices"
-                    v-on:click="selectChoice(choice)"
-                >{{ choice.title }}</button>
+                    v-on:click="selectChoice('yes')"
+                >{{ lang.yes }}</button>
+                <button class="btn btn--small survey__choice" type="button"
+                    v-on:click="selectChoice('no')"
+                >{{ lang.no }}</button>
             </div>
         </div>
 
-        <p class="survey__response" v-if="status === 'SUCCESS'">
+        <p class="survey__response" v-if="status === statuses.SUBMISSION_SUCCESS">
             {{ lang.success }}
         </p>
 
-        <p class="survey__response" v-if="status === 'ERROR'">
+        <p class="survey__response" v-if="status === statuses.SUBMISSION_ERROR">
             {{ lang.error }}
         </p>
 
-        <div class="survey__extra"
-            v-for="choice in survey.choices"
-            v-if="status === 'NOT_SUBMITTED' && choice.allowMessage && showMessageBox"
-        >
-            <form class="survey__form" v-on:submit.prevent="storeResponse(choice.id)">
+        <div class="survey__extra" v-if="status === statuses.MESSAGE_BOX_SHOWN">
+            <form class="survey__form" v-on:submit.prevent="storeResponse('no')">
                 <div class="survey__form-fields">
-                    <label class="ff-label" for="survey-extra-msg">{{ lang.genericQuestion }}</label>
-                    <textarea class="ff-textarea spaced--s" id="survey-extra-msg"
-                        :placeholder="lang.genericPrompt"
-                        v-model="response.message"
-                    ></textarea>
+                    <label class="ff-label" for="survey-extra-msg">{{ lang.prompt }}</label>
+                    <textarea class="ff-textarea" id="survey-extra-msg" v-model="response.message"></textarea>
                 </div>
                 <div class="survey__form-actions">
                     <input type="submit" class="btn btn--small" :value="lang.submit" />
@@ -95,7 +92,7 @@ function init() {
         </div>
     </div>
 </aside>
-`
+        `
     });
 }
 

--- a/assets/sass/components/prompts.scss
+++ b/assets/sass/components/prompts.scss
@@ -74,6 +74,9 @@
 .survey__response {
     margin-bottom: 0;
 }
+.survey__form-fields {
+    margin-bottom: $spacingUnit;
+}
 .survey__form-actions {
     display: flex;
     align-items: center;

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -81,13 +81,18 @@ global:
       fundingSize: Maint yr ariannu
       totalAvailable: Cyfanswm ar gael
       applicationDeadline: Terfyn amser ymgeisio
-  surveys:
-    response:
-      success: Diolch am rannu'ch adborth gyda ni – rydym yn gwerthfawrogi'ch amser.
-      error: Mae'n flin gennym, cafwyd gwall wrth gofnodi'ch data. Rhowch gynnig arall
-        arni.
-    genericQuestion: Sut gallem fod wedi gwneud y dudalen hon yn well?
-    genericPrompt: Dywedwch wrthym sut y gallem wella'r dudalen hon...
+  survey:
+    question: A ddaethoch o hyd i'r hyn yr oeddech yn chwilio amdano?
+    prompt: Dywedwch wrthym sut y gallem wella'r dudalen hon…
+    yes: Do
+    no: Naddo
+    submit: Cyflwyno
+    cancel: Canslo
+    success: Diolch am rannu'ch adborth gyda ni – rydym yn gwerthfawrogi'ch amser.
+    error: Mae'n flin gennym, cafwyd gwall wrth gofnodi'ch data. Rhowch gynnig arall arni.
+  feedback:
+    success: Diolch am rannu'ch adborth gyda ni – rydym yn gwerthfawrogi'ch amser.
+    error: Mae'n flin gennym, cafwyd gwall wrth gofnodi'ch data. Rhowch gynnig arall arni.
 toplevel:
   home:
     title: Hafan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,12 +81,18 @@ global:
       fundingSize: Funding size
       totalAvailable: Total available
       applicationDeadline: Application deadline
-  surveys:
-    response:
-      success: Thank you for sharing your feedback with us - we appreciate your time.
-      error: We're sorry, there was an error recording your response. Please try again.
-    genericQuestion: How could we have made this page better?
-    genericPrompt: Tell us how we could improve this page...
+  survey:
+    question: Did you find what you were looking for?
+    prompt: Tell us how we could improve this page…
+    yes: Yes
+    no: No
+    submit: Submit
+    cancel: Cancel
+    success: Thank you for sharing your feedback with us - we appreciate your time.
+    error: We're sorry, there was an error recording your response. Please try again.
+  feedback:
+    success: Thank you for sharing your feedback with us - we appreciate your time.
+    error: We're sorry, there was an error recording your response. Please try again.
 toplevel:
   home:
     title: Home

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -60,6 +60,17 @@ router.route('/feedback-results').get(async (req, res, next) => {
 
 router.route('/survey-results').get(async (req, res, next) => {
     try {
+        const survey = await surveysService.getAllResponses({
+            path: req.query.path
+        });
+        res.render('tools/survey', { survey });
+    } catch (error) {
+        next(error);
+    }
+});
+
+router.route('/survey-results-original').get(async (req, res, next) => {
+    try {
         const surveys = await surveysService.findAll();
         res.render('tools/surveys', { surveys });
     } catch (error) {

--- a/controllers/toplevel/feedback.js
+++ b/controllers/toplevel/feedback.js
@@ -19,8 +19,8 @@ function init({ router }) {
     router.post('/feedback', validators, (req, res) => {
         const formErrors = validationResult(req);
         const formData = matchedData(req);
-        const messageSuccess = req.i18n.__('global.surveys.response.success');
-        const messageError = req.i18n.__('global.surveys.response.error');
+        const messageSuccess = req.i18n.__('global.feedback.success');
+        const messageError = req.i18n.__('global.feedback.error');
 
         if (formErrors.isEmpty()) {
             feedbackService

--- a/controllers/toplevel/index.js
+++ b/controllers/toplevel/index.js
@@ -1,19 +1,16 @@
 'use strict';
-const { body, validationResult } = require('express-validator/check');
 const config = require('config');
 const moment = require('moment');
 
 const { homepageHero } = require('../../modules/images');
 const { sMaxAge } = require('../../middleware/cached');
-const { purifyUserInput } = require('../../modules/validators');
-const contentApi = require('../../services/content-api');
-const surveyService = require('../../services/surveys');
 
 const dataRoute = require('./data');
 const feedbackRoute = require('./feedback');
 const homepageRoute = require('./homepage');
 const robotRoutes = require('./robots');
 const searchRoute = require('./search');
+const surveyRoute = require('./survey');
 
 module.exports = ({ router, pages }) => {
     /**
@@ -79,110 +76,10 @@ module.exports = ({ router, pages }) => {
         });
     });
 
-    // retrieve list of surveys
-    router.get('/surveys', sMaxAge('10m'), (req, res) => {
-        let path = req.query.path;
-        let surveyToShow = false;
-
-        // fetch all active surveys from the API so we can filter them
-        contentApi
-            .getSurveys({
-                locale: req.i18n.getLocale()
-            })
-            .then(surveys => {
-                // is there a path-specific survey here?
-                surveyToShow = surveys.find(s => s.surveyPath === path);
-
-                // if not, is there a site-wide survey?
-                if (!surveyToShow) {
-                    surveyToShow = surveys.find(s => s.global);
-                }
-
-                res.send({
-                    status: surveyToShow ? 'success' : 'error',
-                    lang: {
-                        success: req.i18n.__('global.surveys.response.success'),
-                        error: req.i18n.__('global.surveys.response.error'),
-                        submit: req.i18n.__('global.forms.submit'),
-                        cancel: req.i18n.__('global.forms.cancel'),
-                        genericQuestion: req.i18n.__('global.surveys.genericQuestion'),
-                        genericPrompt: req.i18n.__('global.surveys.genericPrompt')
-                    },
-                    survey: surveyToShow
-                });
-            })
-            .catch(() => {
-                res.send({
-                    status: 'error'
-                });
-            });
-    });
-
-    const surveyValidations = [
-        body('choice')
-            .exists()
-            .not()
-            .isEmpty()
-            .isInt()
-            .withMessage('Please supply a valid choice')
-    ];
-
-    // store survey responses
-    router.post('/survey/:id', surveyValidations, (req, res) => {
-        let surveyId = req.params.id;
-        const errors = validationResult(req);
-
-        if (!errors.isEmpty()) {
-            res.status(400);
-            res.send({
-                status: 'error',
-                err: 'Please supply all fields'
-            });
-        } else {
-            for (let key in req.body) {
-                req.body[key] = purifyUserInput(req.body[key]);
-            }
-
-            let responseData = {
-                survey_id: surveyId,
-                choice_id: req.body['choice'],
-                path: req.body.path
-            };
-
-            // add a message (if we got one)
-            if (req.body['message']) {
-                responseData.message = req.body['message'];
-            }
-
-            // include any additional survey data
-            if (req.body['metadata']) {
-                responseData.metadata = JSON.parse(req.body['metadata']);
-            }
-
-            /**
-             * Form was okay, let's store their submission,
-             * we could still fail at this point if the choice isn't valid for this ID
-             * (SQL constraint error)
-             */
-            surveyService
-                .createResponse(responseData)
-                .then(data => {
-                    res.send({
-                        status: 'success',
-                        surveyId: surveyId,
-                        data: data
-                    });
-                })
-                .catch(err => {
-                    // SQL error with data
-                    res.status(400);
-                    res.send({
-                        status: 'error',
-                        err: err
-                    });
-                });
-        }
-    });
+    /**
+     * Survey (Did you find what you were looking for?)
+     */
+    surveyRoute.init({ router });
 
     /**
      * Feedback

--- a/controllers/toplevel/survey.js
+++ b/controllers/toplevel/survey.js
@@ -1,0 +1,59 @@
+'use strict';
+const { body, validationResult } = require('express-validator/check');
+const { pick } = require('lodash');
+
+const { purifyUserInput } = require('../../modules/validators');
+const { sMaxAge } = require('../../middleware/cached');
+const surveyService = require('../../services/surveys');
+
+function init({ router }) {
+    router
+        .route('/survey')
+        .get(sMaxAge('10m'), (req, res) => {
+            // Expose lang config for client-side component
+            res.send(req.i18n.__('global.survey'));
+        })
+        .post(
+            [
+                body('choice')
+                    .exists()
+                    .not()
+                    .isEmpty()
+                    .isIn(['yes', 'no'])
+                    .withMessage('Please supply a valid choice'),
+                body('path').exists()
+            ],
+            async (req, res) => {
+                const errors = validationResult(req);
+
+                if (errors.isEmpty()) {
+                    for (let key in req.body) {
+                        req.body[key] = purifyUserInput(req.body[key]);
+                    }
+
+                    try {
+                        const responseData = pick(req.body, ['choice', 'path', 'message']);
+                        const result = await surveyService.createResponse(responseData);
+                        res.send({
+                            status: 'success',
+                            result: result
+                        });
+                    } catch (err) {
+                        res.status(400).send({
+                            status: 'error',
+                            err: err
+                        });
+                    }
+                } else {
+                    res.status(400).send({
+                        status: 'error',
+                        err: errors.array()
+                    });
+                }
+            }
+        );
+}
+
+module.exports = {
+    init
+};

--- a/cypress/integration/auth_spec.js
+++ b/cypress/integration/auth_spec.js
@@ -68,7 +68,7 @@ describe('authentication', function() {
             });
 
             cy.visit('/tools/survey-results');
-            cy.get('h1').should('contain', 'All survey results');
+            cy.get('h1').should('contain', 'Did you find what you were looking for?');
         });
     });
 });

--- a/models/index.js
+++ b/models/index.js
@@ -50,7 +50,12 @@ if (DB_HOST) {
     // add models
     db.Users = sequelize.import('../models/user.js');
     db.Feedback = sequelize.import('./feedback');
+
+    db.SurveyAnswer = sequelize.import('./survey');
+
+    // @TODO: Remove me after migrating to new schema
     db.SurveyResponse = sequelize.import('../models/surveys/response.js');
+
     db.Order = sequelize.import('../models/materials/order.js');
     db.OrderItem = sequelize.import('../models/materials/orderItem.js');
 

--- a/models/survey.js
+++ b/models/survey.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/* Did you find what you were looking for? */
+module.exports = function(sequelize, DataTypes) {
+    return sequelize.define(
+        'survey',
+        {
+            choice: {
+                type: DataTypes.ENUM('yes', 'no'),
+                allowNull: false
+            },
+            path: {
+                type: DataTypes.TEXT,
+                allowNull: false
+            },
+            message: {
+                type: DataTypes.TEXT
+            }
+        },
+        {
+            freezeTableName: true
+        }
+    );
+};

--- a/views/tools/survey.njk
+++ b/views/tools/survey.njk
@@ -1,0 +1,104 @@
+{% extends "layouts/tools.njk" %}
+
+{% block title %}Survey results{% endblock %}
+
+{% block extraHead %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
+{% endblock %}
+
+{% block content %}
+    <h1 class="mb-4">
+        Did you find what you were looking for?
+        <small class="badge badge-success">{{ survey.totals.percentageYes }}% said yes</small>
+    </h1>
+
+    <div style="height: 450px" class="border mb-4">
+        <canvas id="js-chart" width="400" height="400"></canvas>
+    </div>
+
+    <h2 class="mb-4">How can we improve this page?</h2>
+
+    <div class="border mb-5" style="max-height: 400px; overflow: auto">
+        <div class="list-group">
+            {% for response in survey.no.responses %}
+            <div class="list-group-item list-group-item-action flex-column align-items-start"
+                    id="msg-{{ response.id }}">
+                <div class="d-flex w-100 justify-content-between">
+                    <a href="?path={{ response.path }}">{{ response.path }}</a>
+                    <a href="#msg-{{ response.id }}">
+                        <small title="{{ response.createdAt }}">{{ timeFromNow(response.createdAt) }}</small>
+                    </a>
+                </div>
+                <p class="mb-3">{{ response.message }}</p>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+
+    <script>
+        const survey = {{ survey | dump(2) | safe }};
+        const ctx = document.getElementById('js-chart');
+
+        const config = {
+            type: 'line',
+            data: {
+                datasets: [{
+                    label: 'yes',
+                    backgroundColor: '#41c27f',
+                    borderColor: '#2a7f53',
+                    fill: false,
+                    data: survey.yes.voteData,
+                }, {
+                    label: 'no',
+                    backgroundColor: '#de1d19',
+                    borderColor: '#8e1310',
+                    fill: false,
+                    data: survey.no.voteData,
+                }],
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                title: {
+                    display: false,
+                    text: "Response distribution"
+                },
+                scales: {
+                    xAxes: [{
+                        type: "time",
+                        display: true,
+                        scaleLabel: {
+                            display: false,
+                            labelString: 'Date'
+                        },
+                        ticks: {
+                            major: {
+                                fontStyle: "bold",
+                                fontColor: "#FF0000"
+                            }
+                        },
+                        time: {
+                            round: 'day',
+                            unit: 'day'
+                        }
+                    }],
+                    yAxes: [{
+                        display: true,
+                        scaleLabel: {
+                            display: true,
+                            labelString: 'Number of responses'
+                        },
+                        ticks: {
+                            beginAtZero: true,
+                            stepSize: 1
+                        }
+                    }]
+                }
+            }
+        };
+
+        let myChart = new Chart(ctx, config);
+
+    </script>
+
+{% endblock %}


### PR DESCRIPTION
Now that we show the "did you find?" survey as a fixed bar on all pages the concept of having multiple surveys with different wording no longer matches with what we are actually asking people; which is a single question across the site.

This PR adds a new stripped down data model for survey answers along with a new tools screen with a single site-wide graph. In order to maintain the ability to have per page graphs you can pass a `?path` query parameter to see results for a single page.

Keeping the old screen and data around for now but there is a task to write a migration script to clean things up afterwards.

It does mean removing the need for the CMS endpoint for managing the surveys (sorry matt 😢) but it doesn't feel like we need the complexity in practice.