### PR TITLE
Add max timeout to legacy proxy requests

### DIFF
--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -87,7 +87,7 @@ function proxyLegacyPage({ req, res, followRedirect = true }) {
         followRedirect: followRedirect,
         maxRedirects: 1,
         resolveWithFullResponse: true,
-        timeout: ms('30s')
+        timeout: ms('45s')
     }).then(response => {
         const contentType = response.headers['content-type'];
 

--- a/modules/legacy.js
+++ b/modules/legacy.js
@@ -3,6 +3,7 @@ const { get } = require('lodash');
 const absolution = require('absolution');
 const config = require('config');
 const jsdom = require('jsdom');
+const ms = require('ms');
 const request = require('request-promise-native');
 
 const { isWelsh, makeWelsh, removeWelsh } = require('../modules/urls');
@@ -59,10 +60,25 @@ function appendLanguageLink(dom, originalUrlPath) {
     }
 }
 
-function proxyLegacyPage({ req, res, domModifications, followRedirect = true }) {
-    res.cacheControl = { maxAge: 0 };
+function cleanDom(dom, originalUrlPath) {
+    appendLanguageLink(dom, originalUrlPath);
 
-    const originalUrlPath = req.baseUrl + req.path;
+    // rewrite main ASP.net form to point to this page
+    // (currently it's rewritten above to the external one)
+    const form = dom.window.document.getElementById('form1');
+    if (form) {
+        form.setAttribute('action', originalUrlPath);
+    }
+
+    // Remove live chat widget as document.write causes issue when proxying.
+    const liveChat = dom.window.document.getElementById('askLiveCall');
+    if (liveChat) {
+        liveChat.parentNode.removeChild(liveChat);
+    }
+}
+
+function proxyLegacyPage({ req, res, followRedirect = true }) {
+    res.cacheControl = { maxAge: 0 };
 
     return request({
         url: legacyUrl + req.originalUrl,
@@ -70,44 +86,33 @@ function proxyLegacyPage({ req, res, domModifications, followRedirect = true }) 
         jar: true,
         followRedirect: followRedirect,
         maxRedirects: 1,
-        resolveWithFullResponse: true
+        resolveWithFullResponse: true,
+        timeout: ms('30s')
     }).then(response => {
-        let body = cleanBody(response.body);
-        let dom = new JSDOM(body);
+        const contentType = response.headers['content-type'];
 
-        /**
-         * Always redirect to canonical link
-         * Sitecore serves the content of vanity URLs rather
-         * than redirecting, so to avoid duplicate content and make it
-         * easier to replace old URLs we attempt to look up the canonical URL
-         * from the page and redirect to that.
-         */
-        const canonicalUrl = getCanonicalUrl(dom);
-        if (canonicalUrl && canonicalUrl !== originalUrlPath) {
-            res.redirect(301, canonicalUrl);
+        if (/^text\/html/.test(contentType)) {
+            const originalUrlPath = req.baseUrl + req.path;
+            const body = cleanBody(response.body);
+            const dom = new JSDOM(body);
+
+            /**
+             * Always redirect to canonical link
+             * Sitecore serves the content of vanity URLs rather
+             * than redirecting, so to avoid duplicate content and make it
+             * easier to replace old URLs we attempt to look up the canonical URL
+             * from the page and redirect to that.
+             */
+            const canonicalUrl = getCanonicalUrl(dom);
+            if (canonicalUrl && canonicalUrl !== originalUrlPath) {
+                res.redirect(301, canonicalUrl);
+            } else {
+                cleanDom(dom, originalUrlPath);
+                res.set('X-BLF-Legacy', true);
+                res.send(dom.serialize());
+            }
         } else {
-            appendLanguageLink(dom, originalUrlPath);
-
-            // rewrite main ASP.net form to point to this page
-            // (currently it's rewritten above to the external one)
-            const form = dom.window.document.getElementById('form1');
-            if (form) {
-                form.setAttribute('action', originalUrlPath);
-            }
-
-            // Remove live chat widget as document.write causes issue when proxying.
-            const liveChat = dom.window.document.getElementById('askLiveCall');
-            if (liveChat) {
-                liveChat.parentNode.removeChild(liveChat);
-            }
-
-            // Allow custom overrides on a per-page basis
-            if (domModifications) {
-                dom = domModifications(dom);
-            }
-
-            res.set('X-BLF-Legacy', true);
-            res.send(dom.serialize());
+            res.send(response.body);
         }
     });
 }


### PR DESCRIPTION
This morning we saw long-hanging legacy page requests. As legacy pages were hanging for so long other requests started to back-up. Net effect on new pages was minimal but this PR sets some stricter timeouts to avoid any domino effect if this happens in the future.

This is a long way of saying we need to set a max timeout on proxied legacy pages. Under normal traffic the p95 response times for legacy pages are around 20 seconds. Setting a timeout of **30 seconds** is a good starting point.

This guard only applies to `GET` requests so should not affect past-grant searches where most of the time is spent in `POST`s but I will do some more investigation into this before merging.

I've also added a guard to only perform modifications on `text/html` content types. In practice I don't think we actively proxy any non-html content as most assets are sent straight to legacy servers when behind cloudfront but in local/non-cloudfront environments it adds extra overhead, so better to add the check to be explicit. Also removes custom `domModifications` as we never use it.
