### PR TITLE
Fix board link, new page doesn't exist yet

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,7 +408,7 @@ about:
         link: /about-big/our-people
       children:
       - label: Board
-        link: /about/our-people/board
+        link: /about-big/our-people/board
       - label: Senior management team
         link: /about/our-people/senior-management-team
       - label: England committee members


### PR DESCRIPTION
Fix board link, new page doesn't exist yet