### PR TITLE
Dynamically set webpack public path

### DIFF
--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,0 +1,4 @@
+// https://medium.com/@aviv.rosental/portable-bundle-with-webpack-d2eed216cd4c
+var script = document.getElementById('js-script-main');
+var src = script.getAttribute('src');
+__webpack_public_path__ = src.substr(0, src.lastIndexOf('/') + 1); // eslint-disable-line

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,11 @@
+const scripts = document.getElementsByTagName('script');
+const currentScript = scripts[scripts.length - 1];
+const scriptDomain = currentScript.src
+    .split('/')
+    .slice(0, -1)
+    .join('/');
+__webpack_public_path__ = `${scriptDomain}/`; // eslint-disable-line
+
 import raven from './bootstraps/raven';
 import common from './bootstraps/common';
 import { featureIsEnabled } from './helpers/features';

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,11 +1,4 @@
-const scripts = document.getElementsByTagName('script');
-const currentScript = scripts[scripts.length - 1];
-const scriptDomain = currentScript.src
-    .split('/')
-    .slice(0, -1)
-    .join('/');
-__webpack_public_path__ = `${scriptDomain}/`; // eslint-disable-line
-
+import './config';
 import raven from './bootstraps/raven';
 import common from './bootstraps/common';
 import { featureIsEnabled } from './helpers/features';

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -5,6 +5,7 @@
 
 <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=HTMLPictureElement,Promise,Array.prototype.find"></script>
 <script id="script-config">
+
 (function() {
     var AppConfig = {
         environment: '{{ appData.environment }}',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,8 +45,7 @@ module.exports = [
         output: {
             filename: '[name].js',
             chunkFilename: '[name].bundle.js',
-            path: path.resolve(__dirname, buildSummary.buildDir, 'javascripts'),
-            publicPath: `${buildSummary.publicDir}/javascripts/`
+            path: path.resolve(__dirname, buildSummary.buildDir, 'javascripts')
         },
         devtool: buildSummary.isProduction ? 'source-map' : 'eval-source-map',
         resolve: {


### PR DESCRIPTION
This is supposedly the documented way to avoid https://github.com/biglotteryfund/blf-alpha/issues/1021, either that or set the CDN domain statically at build time. Either way feels a bit…hacky so going to take a look at alternatives. Raising this PR for reference.

See https://webpack.js.org/guides/public-path/