### PR TITLE
Centralise injectCopy method

### DIFF
--- a/controllers/about/ebulletin.js
+++ b/controllers/about/ebulletin.js
@@ -9,7 +9,6 @@ const config = require('config');
 const { customEvent } = require('../../modules/analytics');
 const { FORM_STATES } = require('../../modules/forms');
 const { getSecret } = require('../../modules/secrets');
-const { injectCopy } = require('../../middleware/inject-content');
 const { purifyUserInput, errorTranslator } = require('../../modules/validators');
 const cached = require('../../middleware/cached');
 
@@ -94,7 +93,7 @@ function init({ router, routeConfig }) {
     router
         .route(routeConfig.path)
         .all(cached.noCache)
-        .get(injectCopy(routeConfig), (req, res) => {
+        .get((req, res) => {
             renderForm({ res });
         })
         .post(formValidators, (req, res) => {

--- a/controllers/about/profiles.js
+++ b/controllers/about/profiles.js
@@ -1,10 +1,10 @@
 'use strict';
-const { injectCopy, injectProfiles } = require('../../middleware/inject-content');
+const { injectProfiles } = require('../../middleware/inject-content');
 const { shouldServe } = require('../../modules/pageLogic');
 
 function serveProfiles({ router, routeConfig, profilesSection }) {
     if (shouldServe(routeConfig)) {
-        router.get(routeConfig.path, injectCopy(routeConfig), injectProfiles(profilesSection), (req, res) => {
+        router.get(routeConfig.path, injectProfiles(profilesSection), (req, res) => {
             const profiles = res.locals.profiles;
             if (profiles.length > 0) {
                 res.render(routeConfig.template, { profiles });

--- a/controllers/common.js
+++ b/controllers/common.js
@@ -3,7 +3,7 @@
 const { forEach, isEmpty } = require('lodash');
 const { getOr } = require('lodash/fp');
 
-const { injectBreadcrumbs, injectCopy, injectListingContent } = require('../middleware/inject-content');
+const { injectBreadcrumbs, injectListingContent } = require('../middleware/inject-content');
 const { isBilingual, shouldServe } = require('../modules/pageLogic');
 const { isWelsh } = require('../modules/urls');
 
@@ -64,9 +64,9 @@ function init({ router, pages }) {
     forEach(pages, page => {
         if (shouldServe(page)) {
             if (page.static) {
-                router.get(page.path, injectCopy(page), injectBreadcrumbs, handleStaticPage(page));
+                router.get(page.path, injectBreadcrumbs, handleStaticPage(page));
             } else if (page.useCmsContent) {
-                router.get(page.path, injectCopy(page), injectListingContent, injectBreadcrumbs, handleCmsPage(page));
+                router.get(page.path, injectListingContent, injectBreadcrumbs, handleCmsPage(page));
             }
         }
     });

--- a/controllers/funding/10k.js
+++ b/controllers/funding/10k.js
@@ -1,6 +1,6 @@
 'use strict';
 const contentApi = require('../../services/content-api');
-const { injectBreadcrumbs, injectCopy } = require('../../middleware/inject-content');
+const { injectBreadcrumbs } = require('../../middleware/inject-content');
 
 function injectCaseStudies(caseStudySlugs) {
     return async function(req, res, next) {
@@ -13,15 +13,9 @@ function injectCaseStudies(caseStudySlugs) {
 }
 
 function init10k({ router, routeConfig, caseStudySlugs }) {
-    router.get(
-        routeConfig.path,
-        injectCopy(routeConfig),
-        injectBreadcrumbs,
-        injectCaseStudies(caseStudySlugs),
-        (req, res) => {
-            res.render(routeConfig.template);
-        }
-    );
+    router.get(routeConfig.path, injectBreadcrumbs, injectCaseStudies(caseStudySlugs), (req, res) => {
+        res.render(routeConfig.template);
+    });
 }
 
 function init({ router, routeConfigs }) {

--- a/controllers/funding/funding.js
+++ b/controllers/funding/funding.js
@@ -1,9 +1,9 @@
 'use strict';
 const { find, get } = require('lodash');
-const { injectCopy, injectFundingProgrammes } = require('../../middleware/inject-content');
+const { injectFundingProgrammes } = require('../../middleware/inject-content');
 
 function init({ router, routeConfig }) {
-    router.get(routeConfig.path, injectCopy(routeConfig), injectFundingProgrammes, (req, res) => {
+    router.get(routeConfig.path, injectFundingProgrammes, (req, res) => {
         const { copy, fundingProgrammes } = res.locals;
 
         /**

--- a/controllers/funding/programmes.js
+++ b/controllers/funding/programmes.js
@@ -2,7 +2,7 @@
 const { map } = require('lodash');
 
 const { heroImages } = require('../../modules/images');
-const { injectCopy, injectFundingProgramme, injectFundingProgrammes } = require('../../middleware/inject-content');
+const { injectFundingProgramme, injectFundingProgrammes } = require('../../middleware/inject-content');
 const { isBilingual } = require('../../modules/pageLogic');
 const { localify, normaliseQuery } = require('../../modules/urls');
 const { programmeFilters, reformatQueryString } = require('./programmes-helpers');
@@ -47,7 +47,7 @@ function initLegacyFundingFinder({ router, routeConfig }) {
  * Route: Programmes Listing
  */
 function initProgrammesList({ router, routeConfig }) {
-    router.get(routeConfig.path, injectCopy(routeConfig), injectFundingProgrammes, (req, res, next) => {
+    router.get(routeConfig.path, injectFundingProgrammes, (req, res, next) => {
         const { copy, fundingProgrammes } = res.locals;
         const globalCopy = req.i18n.__('global');
 

--- a/controllers/toplevel/data.js
+++ b/controllers/toplevel/data.js
@@ -1,10 +1,9 @@
 'use strict';
 const Raven = require('raven');
 const contentApi = require('../../services/content-api');
-const { injectCopy } = require('../../middleware/inject-content');
 
 function init({ router, routeConfig }) {
-    router.get(routeConfig.path, injectCopy(routeConfig), (req, res, next) => {
+    router.get(routeConfig.path, (req, res, next) => {
         const locale = req.i18n.getLocale();
         return Promise.all([contentApi.getStatBlocks(locale), contentApi.getStatRegions(locale)])
             .then(responses => {

--- a/controllers/toplevel/homepage.js
+++ b/controllers/toplevel/homepage.js
@@ -2,7 +2,6 @@
 const { get } = require('lodash');
 const Raven = require('raven');
 const { heroImages } = require('../../modules/images');
-const { injectCopy } = require('../../middleware/inject-content');
 const contentApi = require('../../services/content-api');
 
 async function injectHomepageContent(req, res, next) {
@@ -18,7 +17,7 @@ async function injectHomepageContent(req, res, next) {
 }
 
 function init({ router, routeConfig }) {
-    router.get(routeConfig.path, injectCopy(routeConfig), injectHomepageContent, (req, res) => {
+    router.get(routeConfig.path, injectHomepageContent, (req, res) => {
         res.render(routeConfig.template, {
             news: get(res.locals, 'newsArticles', []),
             heroImage: get(res.locals, 'heroImages', heroImages.fallbackSuperheroImage)

--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ const viewGlobalsService = require('./modules/viewGlobals');
 
 const { defaults: cachedMiddleware, sMaxAge } = require('./middleware/cached');
 const { defaultSecurityHeaders, stripCSPHeader } = require('./middleware/securityHeaders');
-const { injectHeroImage } = require('./middleware/inject-content');
+const { injectCopy, injectHeroImage } = require('./middleware/inject-content');
 const { noCache } = require('./middleware/cached');
 const bodyParserMiddleware = require('./middleware/bodyParser');
 const i18nMiddleware = require('./middleware/i18n');
@@ -218,7 +218,7 @@ forEach(routes.sections, (section, sectionId) => {
      * Middleware to add a section ID to requests with a known section
      * (eg. to mark a section as current in the nav)
      */
-    router.use(function (req, res, next) {
+    router.use(function(req, res, next) {
         res.locals.sectionId = sectionId;
         next();
     });
@@ -227,8 +227,9 @@ forEach(routes.sections, (section, sectionId) => {
      * Page specific middleware
      */
     forEach(section.pages, (page, pageId) => {
-        router.route(page.path)
-            .all(injectHeroImage(page.heroSlug), (req, res, next) => {
+        router
+            .route(page.path)
+            .all(injectCopy(page), injectHeroImage(page.heroSlug), (req, res, next) => {
                 res.locals.pageId = pageId;
                 next();
             })


### PR DESCRIPTION
Spotted that we can happily centralise the `injectCopy` middleware so it's referenced once up-front rather than dotting it around the place.