### PR TITLE
Update location of help text

### DIFF
--- a/assets/sass/components/forms.scss
+++ b/assets/sass/components/forms.scss
@@ -35,6 +35,9 @@
     font-weight: bold;
     margin-bottom: $spacingUnit;
 }
+.form-fieldset__intro {
+    margin-bottom: 1.5em;
+}
 .form-fieldset__fields {
     margin-bottom: $spacingUnit;
 }
@@ -70,11 +73,7 @@
         background-color: rgba(255, 255, 0, 0.5);
     }
 }
-.form-field__help {
-    margin-top: $spacingUnit / 2;
-    font-size: 18px;
-    color: #4a4a4a;
-}
+
 .form-field__errors {
     margin-top: $spacingUnit / 3;
 }
@@ -115,6 +114,7 @@
     }
 }
 
+.ff-help,
 .ff-explanation {
     font-size: 18px;
     margin-bottom: 10px;
@@ -126,6 +126,7 @@
     display: block;
     font-style: italic;
     color: palette('charcoal-note');
+    margin-bottom: 10px;
 }
 
 .ff-text,

--- a/views/components/forms-new.njk
+++ b/views/components/forms-new.njk
@@ -42,11 +42,23 @@
     {% endif %}
 {% endmacro %}
 
+{% macro fieldHelpText(field) %}
+    {% if field.lengthHint %}
+        <small class="ff-length-hint">
+            <strong>Suggested answer length:</strong> {{ field.lengthHint.text }}
+        </small>
+    {% endif %}
+    {% if field.explanation %}
+        <div class="ff-help s-prose">{{ field.explanation | safe }}</div>
+    {% endif %}
+    {% if field.helpText %}
+        <div class="ff-help s-prose">{{ field.helpText | safe }}</div>
+    {% endif %}
+{% endmacro %}
+
 {% macro inputText(field, type="text") %}
     <label class="{{ getLabelClasses(field) }}" for="field-{{ field.name }}">{{ field.label }}</label>
-    {% if field.explanation %}
-        <div class="ff-explanation s-prose">{{ field.explanation | safe }}</div>
-    {% endif %}
+    {{ fieldHelpText(field) }}
     <input
         class="ff-text"
         type="{{ type }}"
@@ -62,9 +74,7 @@
 
 {% macro inputTextarea(field) %}
     <label class="{{ getLabelClasses(field) }}" for="field-{{ field.name }}">{{ field.label }}</label>
-    {% if field.explanation %}
-        <div class="ff-explanation s-prose">{{ field.explanation | safe }}</div>
-    {% endif %}
+    {{ fieldHelpText(field) }}
     <textarea
         class="ff-textarea"
         id="field-{{ field.name }}"
@@ -156,16 +166,6 @@
                 </div>
             {% endif %}
         </div>
-        {% if field.helpText %}
-            <div class="form-field__help s-prose">
-                {{ field.helpText | safe }}
-            </div>
-        {% endif %}
-        {% if field.lengthHint %}
-            <small class="ff-length-hint">
-                <strong>Suggested answer length:</strong> {{ field.lengthHint.text }}
-            </small>
-        {% endif %}
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
Update location of help text so that it is above the field. Research so far is pointing to a preference for that but we'll keep an eye on things in case we see evidence to the contrary.

![image](https://user-images.githubusercontent.com/123386/42022376-1d00e858-7ab5-11e8-9dbd-81c29c6d896b.png)
