### PR TITLE
Prevent direct access to the dashboard

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -19,7 +19,7 @@ const restrictAccess = (req, res, next) => {
     const shouldServe = appData.isDev || isCloudfront;
 
     if (!shouldServe) {
-        return res.redirect('/');
+        return res.redirect('/error-unauthorised');
     } else {
         return next();
     }
@@ -45,7 +45,6 @@ function init({ router }) {
                 formTitle = applications[0].formTitle;
 
                 if (req.query.download) {
-
                     // build a link to the application page
                     let urlBase = getFullUrl(req);
                     urlBase = urlBase.split('?')[0]; // remove querystring

--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -1,15 +1,32 @@
 'use strict';
 const XLSX = require('xlsx');
+const config = require('config');
 
 const applicationService = require('../../services/applications');
 const { purifyUserInput } = require('../../modules/validators');
 const { getFullUrl } = require('../../modules/urls');
+const appData = require('../../modules/appData');
+const { getSecret } = require('../../modules/secrets');
+
+const TEST_DOMAIN = process.env.TEST_DOMAIN || getSecret('test.domain');
+
+const restrictAccess = (req, res, next) => {
+    // these endpoints should only be available either in DEV,
+    // or on Cloudfront-hosted environments (eg. TEST/LIVE domains)
+    // which have WAF-protected status (eg. IP whitelisting)
+    const cloudfrontDomains = [config.get('siteDomain'), TEST_DOMAIN];
+    const isCloudfront = cloudfrontDomains.indexOf(req.get('host')) !== -1;
+    const shouldServe = appData.isDev || isCloudfront;
+
+    if (!shouldServe) {
+        return res.redirect('/');
+    } else {
+        return next();
+    }
+};
 
 function init({ router }) {
-    // @TODO
-    // domain must be www.biglotteryfund.org.uk or test.blf.digital (eg. CF-protected)
-    // and then WAF rules can protect us
-    router.route('/applications/:formId?/:applicationId?').get(async (req, res, next) => {
+    router.route('/applications/:formId?/:applicationId?').get(restrictAccess, async (req, res, next) => {
         try {
             let forms, applications, formTitle, applicationData;
             const formId = purifyUserInput(req.params.formId);


### PR DESCRIPTION
This is a bit of a sticking plaster until we move to VPC / complete #1103 but it's still worth doing.

This change means the app will no longer serve the application dashboard if accessed via anything other than the two Cloudfront-powered (and therefore WAF-protected) domains (or in DEV mode). This means direct access via IP/EC2 hostnames will no longer work, and therefore access is only available for an approved IP whitelist.