### PR TITLE
Show banner on test site

### DIFF
--- a/views/components/preview.njk
+++ b/views/components/preview.njk
@@ -5,5 +5,10 @@
             Please do not share this page.
             <a href="{{ getCurrentUrl() }}">View original</a>
         </div>
+    {% elseif appData.isNotProduction and not appData.isDev %}
+        <div class="preview-banner">
+            ✋ This is a test environment.
+            <a href="{{ appData.config.get('siteDomain') }}{{ getCurrentUrl() }}">View this page on the live site</a>
+        </div>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
As we occasionally share test URLs with stakeholders it wouldn't hurt to show a similar banner to the one shown on for previews.

<img width="1205" alt="screen shot 2018-07-05 at 15 58 24" src="https://user-images.githubusercontent.com/123386/42331028-5be642e0-806c-11e8-9c03-3b4253ceb16d.png">
