### PR TITLE
Use common-tags to make testing multi-line text easier

### DIFF
--- a/cypress/integration/e2e_spec.js
+++ b/cypress/integration/e2e_spec.js
@@ -1,23 +1,20 @@
+const { oneLine, stripIndents } = require('common-tags');
 describe('e2e', function() {
-    const lorem = `
+    const lorem = oneLine`
         Lorem, ipsum dolor sit amet consectetur adipisicing elit.
         Praesentium quidem nihil, similique voluptatibus tempore quasi,
         cumque laborum officia voluptatem laboriosam tempora.
-    `.replace(/\s{2,}/g, ' ');
+    `;
 
-    const loremLong = `
-        Lorem, ipsum dolor sit amet consectetur adipisicing elit.
-        Praesentium quidem nihil, similique voluptatibus tempore quasi,
-        cumque laborum officia voluptatem laboriosam tempora.
+    const loremLong = stripIndents`
+        Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium quidem nihil, similique voluptatibus tempore quasi, cumque laborum officia voluptatem laboriosam tempora.
 
-        Repudiandae doloremque necessitatibus earum molestias error
-        enim quisquam eligendi impedit quidem nulla rerum dolor aut
-        veniam facilis recusandae, laudantium repellendus,
-        soluta neque consequatur tenetur maiores nostrum asperiores.
+        - Repudiandae doloremque necessitatibus
+        - Laudantium repellendus
+        - Soluta neque consequatur tenetur maiores.
 
-        Enim provident necessitatibus ipsa ad autem aliquam ducimus minima delectus exercitationem,
-        minus blanditiis molestias quas eaque ullam ab aperiam assumenda.
-    `.replace(/\s{2,}/g, ' ');
+        Enim provident necessitatibus ipsa ad autem aliquam ducimus minima delectus exercitationem, minus blanditiis molestias quas eaque ullam ab aperiam assumenda.
+    `;
 
     it('should perform  common interactions', () => {
         cy.visit('/');
@@ -196,33 +193,39 @@ describe('e2e', function() {
         cy.get('#field-current-work')
             .invoke('val', lorem)
             .trigger('change');
+
         cy.get(submitSelector).click();
 
         // Step 2
         cy.get('#field-project-idea')
-            .invoke('val', lorem)
+            .invoke('val', loremLong)
             .trigger('change');
+
         cy.get('#field-project-impact')
             .invoke('val', lorem)
             .trigger('change');
+
         cy.get(submitSelector).click();
 
         // Step 3
         cy.get('#field-project-activities-a')
             .invoke('val', lorem)
             .trigger('change');
+
         cy.get(submitSelector).click();
 
         // Step 4
         cy.get('#field-social-connections')
             .invoke('val', lorem)
             .trigger('change');
+
         cy.get(submitSelector).click();
 
         // Step 5
         cy.get('#field-project-evaluation')
             .invoke('val', lorem)
             .trigger('change');
+
         cy.get(submitSelector).click();
 
         // Step 6

--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,13 +3733,10 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
-      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.18.0"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -4614,6 +4611,15 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
           "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
+        },
+        "common-tags": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
+          "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.18.0"
+          }
         },
         "cross-spawn": {
           "version": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-env": "^1.7.0",
     "chai": "^4.1.2",
+    "common-tags": "^1.8.0",
     "concurrently": "^3.5.0",
     "cssnano": "^3.10.0",
     "cypress": "^3.0.2",


### PR DESCRIPTION
Update the e2e tests to use `common-tags` to make testing multi-line text more accurate rather than relying on a regex. Also uses long text with some basic formatting for an answer on the building connections test to make sure we have more accurate test data.