### PR TITLE
Add project name to BC form

### DIFF
--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -57,6 +57,13 @@ const yourIdea = [
         legend: 'Your idea',
         fields: [
             {
+                name: 'project-name',
+                type: 'text',
+                size: 180,
+                isRequired: true,
+                label: 'What is the name of your project?'
+            },
+            {
                 name: 'project-idea',
                 type: 'textarea',
                 lengthHint: LENGTH_HINTS.FEW_PARAS,

--- a/cypress/integration/e2e_spec.js
+++ b/cypress/integration/e2e_spec.js
@@ -197,6 +197,10 @@ describe('e2e', function() {
         cy.get(submitSelector).click();
 
         // Step 2
+        cy.get('#field-project-name')
+            .invoke('val', lorem)
+            .trigger('change');
+
         cy.get('#field-project-idea')
             .invoke('val', loremLong)
             .trigger('change');


### PR DESCRIPTION
Adds a missing field to the form. Tested and confirmed works properly on dashboard.