### PR TITLE
Clean up components list

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -98,7 +98,6 @@
         // eg. 80% of the max
         width: #{$widestScreen / 100 * 80};
         @if not $skipMargins {
-            height: 100%;
             margin-left: auto;
             margin-right: auto;
         }

--- a/controllers/pattern-library/views/components.njk
+++ b/controllers/pattern-library/views/components.njk
@@ -1,200 +1,23 @@
 {% extends "./layout.njk" %}
 
-{% from "components/styleguide.njk" import sgSectionHeader, sgBlock, sgComponent %}
-
-{% from "components/data.njk" import statsGrid %}
-{% from "components/hero.njk" import miniatureHero with context %}
-{% from "components/programmes.njk" import programmeCard with context %}
-{% from "components/nav.njk" import selectionTrail %}
-{% from "components/segment.njk" import segment %}
-{% from "components/tabs.njk" import tabs %}
+{% from "components/styleguide.njk" import sgSectionHeader, sgComponent %}
 
 {% block content %}
 
 {{ sgSectionHeader('Components') }}
 
+<div class="u-inner u-margin-bottom-l">
+    <div class="segment-links">
+        <ul>
+            {% for slug in componentSlugs  %}
+                <li><a href="#sg-pattern-{{ slug }}">{{ slug }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>
+
 {% for slug in componentSlugs  %}
     {{ sgComponent(slug) }}
 {% endfor %}
-
-{% set sgContent %}
-    <ul class="unstyled grid grid--2-up grid--padded grid--equal grid--wide-only">
-        <li class="grid__item">
-            {{ miniatureHero(
-                titleText = 'Example Miniature Hero',
-                imagePath = 'home/case-study-1-medium.jpg',
-                imageCaption = 'Three people working together on laptops',
-                linkUrl = '#',
-                accent = 'pink-mid'
-            )}}
-        </li>
-        <li class="grid__item">
-            {{ miniatureHero(
-                titleText = 'Example Miniature Hero',
-                imagePath = 'home/case-study-2-medium.jpg',
-                imageCaption = 'Two cooks in chefs\' clothing with another man smiling',
-                linkUrl = '#',
-                accent = 'blue'
-            )}}
-        </li>
-    </ul>
-{% endset %}
-{{ sgBlock('Miniature Heroes', sgContent) }}
-
-{% set sgContent %}
-    {{ statsGrid([
-        {
-            value: '42',
-            title: 'The meaning of life, the universe, and everything',
-            prefix: '',
-            suffix: '',
-            showNumberBeforeTitle: true
-        },
-        {
-            value: '9m',
-            title: 'in Beijing',
-            prefix: 'There are',
-            suffix: 'bicycles',
-            showNumberBeforeTitle: true
-        },
-        {
-            value: '500 miles',
-            title: 'I would walk',
-            prefix: '',
-            suffix: '',
-            showNumberBeforeTitle: false
-        }
-    ]) }}
-{% endset %}
-{{ sgBlock('Stats Grid', sgContent) }}
-
-{% set sgContent %}
-    {{ programmeCard(
-        accent = "pink",
-        programme = {
-            "title": "Helping Working Families",
-            "linkUrl": "/funding/programmes/helping-working-families",
-            "photo": "https://media.biglotteryfund.org.uk/media/awards-for-all-england.jpg",
-            "organisationTypes": [
-                "Voluntary or community organisation"
-            ],
-            "description": "Projects co-produced with working families affected by poverty.",
-            "area": {
-                "label": "Wales",
-                "value": "wales"
-            },
-            "fundingSize": {
-                "minimum": 10001,
-                "maximum": 500000
-            },
-            "fundingSizeDescription": "Approx. £500,000 per project",
-            "totalAvailable": "£6 million",
-            "applicationDeadline": "Midday 15 March 2018"
-        }
-    ) }}
-{% endset %}
-{% set sgNotes %}
-    <p>Individual funding programme summary card</p>
-{% endset %}
-{{ sgBlock('Programme Card', sgContent, sgNotes) }}
-
-{% set sgContent %}
-    {{
-        selectionTrail(
-            trail = [{
-                "label": "Funding Programmes"
-            }, {
-                "label": "Awards over £10,000",
-                "url": "#"
-            }, {
-                "label":"Wales",
-                "count": 3
-            }]
-        )
-    }}
-{% endset %}
-{% set sgNotes %}
-    <p>Breadcrumb-trail-esque device for showing selected programme filters.</p>
-{% endset %}
-{{ sgBlock('Selection Trail', sgContent, sgNotes) }}
-
-
-
-{% set sgContent %}
-    <div class="content-box inner--wide-only accent--turquoise a--border-top">
-        {{ __('funding.guidance.order-free-materials.body') | safe }}
-    </div>
-{% endset %}
-{{ sgBlock('Content Box', sgContent) }}
-
-{% set sgContent %}
-    <div class="content-box content-box--tinted inner--wide-only accent--pink a--border-top">
-        <p>Empowering Young People is a grants programme designed to support projects in Northern Ireland that give young people aged 8 to 25 the ability to overcome the challenges they face.</p>
-        <p><strong>Grant size</strong>: £30,000 to £500,000<br />
-        <strong>Grant duration</strong>: 2 to 5 Years</p>
-    </div>
-{% endset %}
-{% set sgNotes %}
-    <p>Tinted variant of a content box. Used to give focus to important blocks of copy on text heavy pages.</p>
-{% endset %}
-{{ sgBlock('Content Box: Tinted', sgContent, sgNotes) }}
-
-{% set sgContent %}
-    {% set segmentContent %}
-        <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ab vitae minus quidem beatae dolor voluptatibus incidunt at placeat excepturi, ad nisi, commodi, maxime distinctio delectus! Doloribus ullam deleniti odio cumque.</p>
-    {% endset %}
-    {{ segment(
-        title = "Segment Title",
-        text = segmentContent,
-        color = 'blue',
-        imagePath = 'contact/1.jpg'
-    ) }}
-{% endset %}
-{% set sgNotes %}
-    <p>Content segment. A content box with an attached image.</p>
-{% endset %}
-{{ sgBlock('Content Segment', sgContent, sgNotes) }}
-
-
-{% set sgContent %}
-    {% set tab1 %}
-        <div class="content-box content-box--borderless s-prose">
-            <p>This is the content for tab 1. This is a <a href="#tab2">link to tab 2</a></p>
-        </div>
-    {% endset %}
-    {% set tab2 %}
-        <div class="content-box content-box--borderless s-prose">
-            <p>This is the content for tab 2.</p>
-        </div>
-    {% endset %}
-    {% set tab3 %}
-        <div class="content-box content-box--borderless s-prose">
-            <p>This is the content for tab 3.</p>
-        </div>
-    {% endset %}
-    {{
-        tabs(
-            id = 'tabs',
-            content = [{
-                id: 'tab1',
-                title: 'Tab 1',
-                content: tab1,
-                active: true
-            }, {
-                id: 'tab2',
-                title: 'Tab 2',
-                content: tab2
-            }, {
-                id: 'tab3',
-                title: 'Tab 3',
-                content: tab3
-            }]
-        )
-    }}
-{% endset %}
-{% set sgNotes %}
-    <p>Generic tabbed content component. On small screens tabs are displayed in an accordion pattern.</p>
-{% endset %}
-{{ sgBlock('Tabs', sgContent, sgNotes) }}
 
 {% endblock %}

--- a/controllers/pattern-library/views/layout.njk
+++ b/controllers/pattern-library/views/layout.njk
@@ -60,6 +60,7 @@
         }
         .sg-usage-notes {
             border: 1px solid #e9e9e9;
+            margin-bottom: 20px;
         }
         .sg-usage-notes__title,
         .sg-usage-notes__content {

--- a/controllers/pattern-library/views/typography.njk
+++ b/controllers/pattern-library/views/typography.njk
@@ -1,126 +1,60 @@
 {% extends "./layout.njk" %}
 
-{% from "components/styleguide.njk" import sgSectionHeader, sgBlock %}
+{% from "components/styleguide.njk" import sgSectionHeader, sgExample, sgUsage %}
 
 {% block content %}
 
-{# ================================ #}
-{# Typography                       #}
-{# ================================ #}
+<div class="u-inner">
+    {{ sgSectionHeader('Typography') }}
 
-{{ sgSectionHeader('Typography') }}
+    {% call sgExample('Typographic Scale') %}
+        {% for n in range(1, 9) %}
+            <h2 class="t{{ n }}">T{{ n }} Typographic Style</h2>
+        {% endfor %}
+    {% endcall %}
 
-{% set sgContent %}
-    {% for n in range(1, 9) %}
-        <h2 class="t{{ n }}">T{{ n }} Typographic Style</h2>
-    {% endfor %}
-{% endset %}
-{{ sgBlock('Typographic Scale', sgContent) }}
+    {{ sgSectionHeader('Typography Helpers') }}
 
+    {% call sgExample('Title with underline') %}
+        <h2 class="t2 t--underline accent--pink a--text">Title with underline</h2>
+    {% endcall %}
 
-{% set sgContent %}
-    <h2 class="t2 t--underline accent--pink a--text">Title with underline</h2>
-{% endset %}
-{{ sgBlock('Typography: Modifiers', sgContent) }}
+    {{ sgSectionHeader('Buttons') }}
 
+    {% call sgExample('Default buttons') %}
+        <p><button class="btn" type="button">Default Button</button></p>
+        <p><button class="btn accent--pink a--btn" type="button">Default Button</button></p>
+        <p><button class="btn accent--cyan a--btn" type="button">Default Button</button></p>
+    {% endcall %}
 
-{% set sgContent %}
-    <h2 class="t2 accent--cyan overlay-text">
-        <span>T2 typographic style with overlay text</span>
-    </h2>
-    <br />{# TODO: Should overlay-text have some default margin? #}
-    <h2 class="t6 accent--cyan overlay-text">
-        <span>T6 typographic style with overlay text</span>
-    </h2>
-{% endset %}
-{{ sgBlock('Overlay text', sgContent) }}
+    {% call sgUsage() %}
+        Buttons can be themed by adding an accent class to the button, e.g. <code>accent--pink a--btn</code>
+    {% endcall %}
 
-{% set sgContent %}
-    <div class="s-prose u-constrained-content-wide">
-        <p>When you have a project idea you want to put to us please give us a call to talk it through. We’ll be able to tell you if it’s something that we’d fund.</p>
+    {% call sgExample('Medium button') %}
+        <p><button class="btn btn--medium" type="button">Medium Button</button></p>
+    {% endcall %}
 
-        <h3 class="t4">Before you get in touch, make sure you have:</h3>
+    {% call sgExample('Small button') %}
+        <p><button class="btn btn--small" type="button">Small Button</button></p>
+    {% endcall %}
 
-        <ul>
-            <li>checked your <a href="#check-eligibility">eligibility</a></li>
-            <li>read our guidance on <a href="#how-to-succeed">how to succeed</a></li>
-            <li>thought through what you want to tell us - this chat will be part of the way we assess your project</li>
-        </ul>
+    {% call sgExample('Outline button') %}
+        <p><button class="btn btn--medium btn--outline" type="button">Outline Button</button></p>
+    {% endcall %}
 
-        <p>You can reach us by phoning <a href="tel:03001230735">0300 123 0735</a> or e-mailing <a href="mailto:wales@biglotteryfund.org.uk">wales@biglotteryfund.org.uk</a> Monday to Friday, 9.00am to 5.00pm (not including public holidays) to book an appointment to speak to one of our team, who will call you back within three working days.</p>
-    </div>
-{% endset %}
-{% set sgNotes %}
-    <p>
-        Prose styles. Adds additional typographic treatment to long blocks of text: emboldens links, formats telephone and email links, indents and adds bullets to lists.
-    </p>
-{% endset %}
-{{ sgBlock('Prose Text', sgContent, sgNotes) }}
+    {% call sgExample('Button group') %}
+        <div class="o-button-group">
+            <button class="btn btn--medium" type="button">Button One</button>
+            <button class="btn btn--medium" type="button">Button Two</button>
+        </div>
+    {% endcall %}
 
-{{ sgSectionHeader('Typography Helpers') }}
-
-{% set sgContent -%}
-    <p class="u-note">Use this helper for small credit or note text</p>
-{%- endset %}
-{% set sgNotes %}<code>{{ sgContent | trim }}</code>{% endset %}
-{{ sgBlock('Credit', sgContent, sgNotes) }}
-
-{# ================================ #}
-{# Buttons                          #}
-{# ================================ #}
-
-{{ sgSectionHeader('Buttons') }}
-
-{% set sgContent %}
-    <p><button class="btn" type="button">Default Button</button></p>
-    <p><button class="btn accent--pink a--btn" type="button">Default Button</button></p>
-    <p><button class="btn accent--cyan a--btn" type="button">Default Button</button></p>
-{% endset %}
-{% set sgNotes %}
-    <p>
-        Default buttons.
-        Buttons can be themed by adding an accent class to the button, e.g. <code>accent--pink a--btn</code>.
-    </p>
-{% endset %}
-{{ sgBlock('Default Button', sgContent, sgNotes) }}
-
-{% set sgContent %}
-    <p><button class="btn btn--outline" type="button">Outline Button</button></p>
-    <p><button class="btn btn--outline accent--pink a--btn" type="button">Default Button</button></p>
-    <p><button class="btn btn--outline accent--cyan a--btn" type="button">Default Button</button></p>
-{% endset %}
-{% set sgNotes %}
-    <p>
-        Outline buttons.
-        Like default buttons, outline buttons can be themed by adding an accent class to the button.
-    </p>
-{% endset %}
-{{ sgBlock('Outline Buttons', sgContent, sgNotes) }}
-
-{% set sgContent %}
-    <p><button class="btn btn--medium" type="button">Medium Button</button></p>
-{% endset %}
-{{ sgBlock('Medium Buttons', sgContent) }}
-
-{% set sgContent %}
-    <p><button class="btn btn--small" type="button">Small Button</button></p>
-{% endset %}
-{{ sgBlock('Small Buttons', sgContent) }}
-
-
-{% set sgContent %}
-    <div class="o-button-group">
-        <button class="btn btn--medium" type="button">Button One</button>
-        <button class="btn btn--medium" type="button">Button Two</button>
-    </div>
-{% endset %}
-{% set sgNotes %}
-    <p>
+    {% call sgUsage() %}
         Group a set of buttons together.
         On small screens buttons within a group will be displayed stacked and full-width.
         On wider screens buttons are evenly horizontally spaced.
-    </p>
-{% endset %}
-{{ sgBlock('Button Groups', sgContent, sgNotes) }}
+    {% endcall %}
+</div>
 
 {% endblock %}

--- a/views/components/styleguide.njk
+++ b/views/components/styleguide.njk
@@ -7,35 +7,9 @@
     </div>
 {% endmacro %}
 
-{% macro sgBlock(title, content, notes, fullWidth = false) %}
-    <section class="sg-block">
-        <header class="sg-block__header inner">
-            <h3 class="sg-block__title accent--soft-grey t4 t--underline js-sg-pattern-title"
-                id="sg-pattern-{{ title | slugify }}">{{ title }}</h3>
-        </header>
-        <div class="sg-block__body{% if not fullWidth %} inner{% endif %}">
-            <div class="sg-block__content">
-                {{ content | safe }}
-            </div>
-        </div>
-        {% if notes %}
-        <div class="sg-block__extra inner">
-            <div class="sg-block__notes">
-                <div class="sg-usage-notes">
-                    <h4 class="sg-usage-notes__title">Usage Notes</h4>
-                    <div class="sg-usage-notes__content">
-                        {{ notes | safe }}
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% endif %}
-    </section>
-{% endmacro %}
-
 {% macro sgComponent(slug, showDetailLink = true) %}
-    <section class="sg-block">
-        <header class="sg-block__header inner">
+    <section class="sg-block u-inner">
+        <header class="sg-block__header">
             <h3 class="sg-block__title accent--soft-grey t4 t--underline js-sg-pattern-title"
                 id="sg-pattern-{{ slug }}">
                 {{ slug }}
@@ -44,7 +18,7 @@
                 <p><small><a href="?component={{ slug }}">View standalone</a></small></p>
             {% endif %}
         </header>
-        <div class="sg-block__body inner">
+        <div class="sg-block__body">
             <div class="sg-block__content">
                 {# Include examples file for a given component slug #}
                 {% include "components/" + slug + "/examples.njk" ignore missing %}


### PR DESCRIPTION
Cleans up the component list templates to remove some old macros and imports and to add a skip-link nav to the listing page:

<img width="975" alt="screen shot 2018-07-23 at 10 13 00" src="https://user-images.githubusercontent.com/123386/43068127-74671878-8e61-11e8-9f0d-fbcf5890704c.png">
