### PR TITLE
Refactor breadcrumbs component, add tinted version

### DIFF
--- a/assets/sass/components/navigation.scss
+++ b/assets/sass/components/navigation.scss
@@ -44,46 +44,57 @@
 
 
 /* =========================================================================
-   Selection Trail
+   Breadcrumb Trail
    ========================================================================= */
 
-.selection-trail {
+.breadcrumb-trail {
     font-size: 16px;
     color: #6a6a6b;
     background-color: rgba(0,0,0,0.03);
+    padding: 1em ($spacingUnit / 2);
 
+    @include mq('medium') {
+        padding: 1em $spacingUnit;
+    }
+
+    .breadcrumb-trail__item {
+        display: inline-block;
+
+        &::after {
+            content: '›';
+            font-weight: normal;
+            color: #6a6a6b;
+            margin: 0 4px;
+        }
+
+        &:last-child::after {
+            content: '';
+            display: none;
+        }
+    }
+    .breadcrumb-trail__item,
+    .breadcrumb-trail__link {
+        color: inherit;
+    }
+    .breadcrumb-trail__link {
+        font-weight: bold;
+    }
+}
+
+.breadcrumb-trail--flush {
     margin: -($spacingUnit / 2);
     margin-top: -$spacingUnit;
     margin-bottom: $spacingUnit;
-    padding: 1em ($spacingUnit / 2);
 
     @include mq('medium') {
         margin: -$spacingUnit;
         margin-bottom: $spacingUnit;
-        padding: 1em $spacingUnit;
     }
 }
-.selection-trail__item {
-    display: inline-block;
 
-    &::after {
-        content: '›';
-        font-weight: normal;
-        color: #6a6a6b;
-        margin: 0 4px;
-    }
-
-    &:last-child::after {
-        content: '';
-        display: none;
-    }
-}
-.selection-trail__item,
-.selection-trail__link {
-    color: inherit;
-}
-.selection-trail__link {
-    font-weight: bold;
+.breadcrumb-trail--tinted {
+    color: #B20062;
+    background-color: #FFD8E8;
 }
 
 /* =========================================================================

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -1,6 +1,6 @@
 {% from "components/hero.njk" import hero %}
 {% from "components/programmes.njk" import programmeList with context %}
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% extends "layouts/main.njk" %}
 {% set pageAccent = 'pink' %}
@@ -14,7 +14,7 @@
         ) }}
 
         <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top nudge-up">
-            {{ selectionTrail(trail = activeBreadcrumbs) }}
+            {{ breadcrumbTrail(trail = activeBreadcrumbs) }}
             <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
 
             {% if programmes | length > 0 %}

--- a/controllers/strategic-investments/views/strategic-programme.njk
+++ b/controllers/strategic-investments/views/strategic-programme.njk
@@ -1,5 +1,5 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/nav.njk" import selectionTrail with context %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/content-tabs/macro.njk" import contentTabs %}
 {% from "components/media-object/macro.njk" import mediaObject with context %}
 {% from "components/promo-card/macro.njk" import promoCard with context %}
@@ -18,7 +18,7 @@
 
     <div class="nudge-up">
         <section class="content-box content-box--tinted u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
-            {{ selectionTrail(breadcrumbs) }}
+            {{ breadcrumbTrail(breadcrumbs, isTinted = true) }}
             <div class="s-prose u-constrained-content-wide">
                 {{ strategicProgramme.intro | safe }}
             </div>

--- a/views/common/informationPage.njk
+++ b/views/common/informationPage.njk
@@ -1,7 +1,7 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/nav.njk" import selectionTrail %}
-{% from "components/segment/macro.njk" import segment %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/caseStudies.njk" import caseStudyCollection with context %}
+{% from "components/segment/macro.njk" import segment %}
 
 {% extends "layouts/main.njk" %}
 
@@ -35,7 +35,7 @@
     {% endif %}
 
     {% macro primaryContent() %}
-        {{ selectionTrail(breadcrumbs) }}
+        {{ breadcrumbTrail(breadcrumbs) }}
 
         <div class="s-prose accent-content--{{ pageAccent }} u-constrained-content-wide js-annotate-links">
             {% if not heroImage %}

--- a/views/common/listingPage.njk
+++ b/views/common/listingPage.njk
@@ -1,6 +1,6 @@
 {% from "components/hero.njk" import hero %}
 {% from "components/miniature-hero/macro.njk" import miniatureHero %}
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% extends "layouts/main.njk" %}
 
@@ -14,7 +14,7 @@
 
     <main role="main" class="nudge-up">
         <section class="content-box u-inner-wide-only accent--blue a--border-top">
-            {{ selectionTrail(breadcrumbs) }}
+            {{ breadcrumbTrail(breadcrumbs) }}
             <div class=" s-prose">
                 {{ content.introduction | safe }}
             </div>

--- a/views/components/breadcrumb-trail/examples.njk
+++ b/views/components/breadcrumb-trail/examples.njk
@@ -1,0 +1,20 @@
+{% from "components/styleguide.njk" import sgExample %}
+{% from "./macro.njk" import breadcrumbTrail %}
+
+{% set trail = [{
+    "label": "Top-level",
+    "url": "#"
+}, {
+    "label": "Second-level",
+    "url": "#"
+}, {
+    "label": "Current"
+}] %}
+
+{% call sgExample('Defaults') %}
+    {{ breadcrumbTrail(trail, isFlush = false) }}
+{% endcall %}
+
+{% call sgExample('Tinted') %}
+    {{ breadcrumbTrail(trail, isFlush = false, isTinted = true) }}
+{% endcall %}

--- a/views/components/breadcrumb-trail/macro.njk
+++ b/views/components/breadcrumb-trail/macro.njk
@@ -1,0 +1,16 @@
+{% macro breadcrumbTrail(trail, isFlush = true, isTinted = false) %}
+    {% if trail | length > 0 %}
+        <ol class="breadcrumb-trail
+            {%- if isFlush %} breadcrumb-trail--flush{% endif -%}
+            {%- if isTinted %} breadcrumb-trail--tinted{% endif -%}">
+            {% for crumb in trail %}
+                <li class="breadcrumb-trail__item">
+                    {% set showUrl = crumb.url %}
+                    {%- if showUrl -%}<a class="breadcrumb-trail__link" href="{{ crumb.url }}">{%- endif -%}
+                    {{ crumb.label }}{% if crumb.count %} ({{ crumb.count }}){% endif %}
+                    {%- if showUrl -%}</a>{%- endif -%}
+                </li>
+            {% endfor %}
+        </ol>
+    {% endif %}
+{% endmacro %}

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -63,19 +63,6 @@
     </nav>
 {% endmacro %}
 
-{% macro selectionTrail(trail) %}
-    {% if trail | length > 0 %}
-    <ol class="selection-trail">
-        {% for crumb in trail %}
-        <li class="selection-trail__item">
-            {% set showUrl = crumb.url %}
-            {% if showUrl %}<a class="selection-trail__link" href="{{ crumb.url }}">{% endif %}{{ crumb.label }}{% if crumb.count %} ({{ crumb.count }}){% endif %}{% if showUrl %}</a>{% endif %}
-        </li>
-        {% endfor %}
-    </ol>
-    {% endif %}
-{% endmacro %}
-
 {% macro quickLinks(links, isSticky = false) %}
     <nav class="quicklinks quicklinks--sticky">
         <ul class="quicklinks__list">

--- a/views/pages/blog/listing.njk
+++ b/views/pages/blog/listing.njk
@@ -1,6 +1,6 @@
-{% from "components/nav.njk" import selectionTrail with context %}
-{% from "components/split-nav/macro.njk" import splitNav %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/news.njk" import blogTeaser with context %}
+{% from "components/split-nav/macro.njk" import splitNav %}
 
 {% set bodyClass = 'has-static-header' %}
 {% extends "layouts/main.njk" %}
@@ -10,7 +10,7 @@
 
     <main role="main" id="content">
         <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-            {{ selectionTrail(activeBreadcrumbs) }}
+            {{ breadcrumbTrail(activeBreadcrumbs) }}
 
             <div class="u-constrained-wide">
                 {% if entriesMeta %}

--- a/views/pages/blog/post.njk
+++ b/views/pages/blog/post.njk
@@ -1,4 +1,4 @@
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/content.njk" import flexibleContent %}
 
 {% set bodyClass = 'has-static-header' %}
@@ -41,7 +41,7 @@
 
     <main role="main">
         <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-            {{ selectionTrail(activeBreadcrumbs) }}
+            {{ breadcrumbTrail(activeBreadcrumbs) }}
 
             <article class="article">
                 <header class="article__header">

--- a/views/pages/funding/over10k.njk
+++ b/views/pages/funding/over10k.njk
@@ -1,6 +1,6 @@
 {% from "components/caseStudies.njk" import caseStudyCollection with context  %}
 {% from "components/hero.njk" import hero %}
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% extends "layouts/main.njk" %}
 
@@ -18,7 +18,7 @@
 
         <div class="nudge-up">
             <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                {{ selectionTrail(breadcrumbs) }}
+                {{ breadcrumbTrail(breadcrumbs) }}
 
                 <div class="s-prose">
                     <p>{{ copy.intro }}</p>

--- a/views/pages/funding/past-grants.njk
+++ b/views/pages/funding/past-grants.njk
@@ -1,5 +1,5 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/feedback.njk" import inlineFeedback with context %}
 
 {% extends "layouts/main.njk" %}
@@ -16,7 +16,7 @@
 
         <div class="nudge-up">
             <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                {{ selectionTrail(breadcrumbs) }}
+                {{ breadcrumbTrail(breadcrumbs) }}
 
                 <section class="s-prose u-constrained-content-wide">
                     <p>{{ copy.intro }}</p>

--- a/views/pages/funding/under10k.njk
+++ b/views/pages/funding/under10k.njk
@@ -1,6 +1,6 @@
 {% from "components/caseStudies.njk" import caseStudyCollection with context  %}
 {% from "components/hero.njk" import hero %}
-{% from "components/nav.njk" import selectionTrail %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% extends "layouts/main.njk" %}
 
@@ -16,7 +16,7 @@
 
         <div class="nudge-up">
             <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                {{ selectionTrail(breadcrumbs) }}
+                {{ breadcrumbTrail(breadcrumbs) }}
 
                 <div class="s-prose accent-content--{{ pageAccent }}">
                     <p>{{ copy.intro }}</p>


### PR DESCRIPTION
This PR refactors the breadcrumb and documents the breadcrumb trail component. Notably adding a "tinted" style for use on tinted content areas.

![image](https://user-images.githubusercontent.com/123386/43204066-df319658-9017-11e8-8bdc-8acf1b585814.png)
