### PR TITLE
Shhh! Secrets

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -45,7 +45,5 @@
   "googleAnalyticsCode": "UA-98908627-1",
   "legacyDomain": "https://wwwlegacy.biglotteryfund.org.uk",
   "ebulletinApiEndpoint": "https://apiconnector.com/v2",
-  "database": "website-dev",
-  "database-test": "website-test",
   "emailSender": "noreply@biglotteryfund.org.uk"
 }

--- a/config/production.json
+++ b/config/production.json
@@ -1,4 +1,3 @@
 {
-    "googleAnalyticsCode": "UA-637620-2",
-    "database": "website"
+  "googleAnalyticsCode": "UA-637620-2"
 }

--- a/controllers/about/ebulletin.js
+++ b/controllers/about/ebulletin.js
@@ -8,7 +8,7 @@ const config = require('config');
 
 const { customEvent } = require('../../modules/analytics');
 const { FORM_STATES } = require('../../modules/forms');
-const { getSecret } = require('../../modules/secrets');
+const { DOTMAILER_API } = require('../../modules/secrets');
 const { purifyUserInput, errorTranslator } = require('../../modules/validators');
 const cached = require('../../middleware/cached');
 
@@ -47,8 +47,8 @@ function subscribeToNewsletter(formData) {
         uri: ENDPOINT,
         method: 'POST',
         auth: {
-            user: getSecret('dotmailer.api.user'),
-            pass: getSecret('dotmailer.api.password'),
+            user: DOTMAILER_API.user,
+            pass: DOTMAILER_API.password,
             sendImmediately: true
         },
         json: true,

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -2,7 +2,6 @@
 const express = require('express');
 
 const { injectMerchandise } = require('../../controllers/funding/materials-helpers');
-const { TOOLS_CMS_ADMIN_URL, TOOLS_ANALYTICS_DASHBOARD_URL, TOOLS_DATASTUDIO_URL } = require('../../modules/secrets');
 const { toolsSecurityHeaders } = require('../../middleware/securityHeaders');
 const auth = require('../../middleware/authed');
 const cached = require('../../middleware/cached');
@@ -40,10 +39,7 @@ router.route('/').get((req, res) => {
         { label: 'View a list of all published pages', href: '/tools/pages' },
         { label: 'View micro-survey results', href: '/tools/survey-results' },
         { label: 'View feedback results', href: '/tools/feedback-results' },
-        { label: 'View recent materials order stats', href: '/tools/order-stats' },
-        { label: 'View the Reaching Communities & Partnerships data dashboard', href: TOOLS_DATASTUDIO_URL },
-        { label: 'Access Google Analytics dashboard', href: TOOLS_ANALYTICS_DASHBOARD_URL },
-        { label: 'Log in to the CMS', href: TOOLS_CMS_ADMIN_URL }
+        { label: 'View recent materials order stats', href: '/tools/order-stats' }
     ];
 
     res.render('tools/index', { links });

--- a/middleware/preview.js
+++ b/middleware/preview.js
@@ -1,6 +1,5 @@
 'use strict';
-const { getSecret } = require('../modules/secrets');
-const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');
+const { PREVIEW_DOMAIN } = require('../modules/secrets');
 
 /**
  * Adds a PREVIEW_MODE object to locals if this request came from a preview domain

--- a/modules/__tests__/secrets.test.js
+++ b/modules/__tests__/secrets.test.js
@@ -23,9 +23,13 @@ describe('Get secrets', () => {
         expect(getSecretFromRawParameters(mockParameters, 'some.parameter')).toBe('some-value');
     });
 
-    it('should throw an error for unknown properties', () => {
-        expect(() => getSecretFromRawParameters(mockParameters, 'does.not.exist')).toThrowError(
-            'Could not find property does.not.exist in secrets'
+    it('should return undefined for unknown values', () => {
+        expect(getSecretFromRawParameters(mockParameters, 'does.not.exist')).toBe(undefined);
+    });
+
+    it('should throw an error for unknown properties when shouldThrowIfMissing is true', () => {
+        expect(() => getSecretFromRawParameters(mockParameters, 'does.not.exist', true)).toThrowError(
+            'Secret missing: does.not.exist'
         );
     });
 });

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -1,7 +1,6 @@
 'use strict';
 const fs = require('fs');
-const { flow, get, isEmpty, keyBy, mapValues } = require('lodash/fp');
-const config = require('config');
+const { flow, get, keyBy, mapValues } = require('lodash/fp');
 
 function getRawParameters() {
     let rawParameters;
@@ -19,47 +18,43 @@ function parseSecrets(rawParameters) {
     return mapKeyedValues(rawParameters);
 }
 
-function getSecretFromRawParameters(rawParameters, name) {
+function getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing = false) {
     const secrets = parseSecrets(rawParameters);
     const secret = get(name)(secrets);
-    if (secret) {
+
+    if (shouldThrowIfMissing === true && typeof secret === 'undefined') {
+        throw new Error(`Secret missing: ${name}`);
+    } else {
         return secret;
-    } else {
-        throw new Error(`Could not find property ${name} in secrets`);
     }
 }
 
-function getSecret(name) {
+function getSecret(name, shouldThrowIfMissing = false) {
     const rawParameters = getRawParameters();
-    if (process.env.CI === true || isEmpty(rawParameters)) {
-        console.warn(`Secret "${name}" not found: are you in CI or DEVELOPMENT mode?`);
-        return;
-    } else {
-        return getSecretFromRawParameters(rawParameters, name);
-    }
+    return getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing);
 }
 
+/* =========================================================================
+   Secret Constants
+   ========================================================================= */
+
+/**
+ * Required: Without these the app won't start
+ */
+const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || getSecret('db.connection-uri', true);
+const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url', true);
+const SESSION_SECRET = process.env.SESSION_SECRET || getSecret('session.secret', true);
+const JWT_SIGNING_TOKEN = process.env.JWT_SIGNING_TOKEN || getSecret('user.jwt.secret', true);
 const APPLICATIONS_SERVICE_ENDPOINT =
-    process.env.APPLICATIONS_SERVICE_ENDPOINT || getSecret('applications-service.endpoint');
+    process.env.APPLICATIONS_SERVICE_ENDPOINT || getSecret('applications-service.endpoint', true);
 
-const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url');
-
-const DB_HOST = process.env.mysqlHost || getSecret('mysql.host');
-const DB_NAME = process.env.CUSTOM_DB ? process.env.CUSTOM_DB : config.get('database');
-const DB_PASS = process.env.mysqlPassword || getSecret('mysql.password');
-const DB_USER = process.env.mysqlUser || getSecret('mysql.user');
-
-// @TODO: Update parameter store to always pass connection URI
-const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || `mysql://${DB_USER}:${DB_PASS}@${DB_HOST}/${DB_NAME}`;
-
-const JWT_SIGNING_TOKEN = process.env.jwtSigningToken || getSecret('user.jwt.secret');
+/**
+ * Additional: Without these the app will start but some funcitonality will be unavailable
+ */
 const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
+const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');
 const SENTRY_DSN = process.env.SENTRY_DSN || getSecret('sentry.dsn');
-const SESSION_SECRET = process.env.sessionSecret || getSecret('session.secret');
-const TOOLS_CMS_ADMIN_URL = getSecret('tools.cms-admin-url');
-const TOOLS_ANALYTICS_DASHBOARD_URL = getSecret('tools.analytics-dashboard-url');
-const TOOLS_DATASTUDIO_URL = getSecret('tools.datastudio-url');
-
+const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecret('dotmailer.api.password') };
 const HUB_EMAILS = {
     northWest: getSecret('emails.hubs.northwest'),
     northEastCumbria: getSecret('emails.hubs.northeastcumbria'),
@@ -77,12 +72,11 @@ module.exports = {
     APPLICATIONS_SERVICE_ENDPOINT,
     CONTENT_API_URL,
     DB_CONNECTION_URI,
+    DOTMAILER_API,
     HUB_EMAILS,
     JWT_SIGNING_TOKEN,
     MATERIAL_SUPPLIER,
+    PREVIEW_DOMAIN,
     SENTRY_DSN,
-    SESSION_SECRET,
-    TOOLS_CMS_ADMIN_URL,
-    TOOLS_ANALYTICS_DASHBOARD_URL,
-    TOOLS_DATASTUDIO_URL
+    SESSION_SECRET
 };


### PR DESCRIPTION
This PR does some work to clean up our secrets to:

- remove unused secrets
- reduce console noise
- fix inconsistencies in camelCase vs WHATEVER_CASE_THIS_IS for environment variables

It flattens the DB connection credentials into a single `db.connection-uri` secret and adds a flag to mark if a secret is a hard requirements (i.e. we should throw a fatal error) and no longer logs out a warning in CI for optional secrets.

I've already updated parameter store with the new values so this is safe to merge assuming the changes look OK.