### PR TITLE
Icon size

### DIFF
--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -3,10 +3,22 @@
    ========================================================================= */
 
 $btnConf: (
-    'default': ('fontSize': 18px, 'desiredHeight': 59px),
-    'medium': ('fontSize': 16px, 'desiredHeight': 42px),
-    'small': ('fontSize': 16px, 'desiredHeight': 36px),
-    'mini': ('fontSize': 13px, 'desiredHeight': 30px)
+    'default': (
+        'fontSize': 18px,
+        'desiredHeight': 59px
+    ),
+    'medium': (
+        'fontSize': 16px,
+        'desiredHeight': 42px
+    ),
+    'small': (
+        'fontSize': 16px,
+        'desiredHeight': 36px
+    ),
+    'mini': (
+        'fontSize': 13px,
+        'desiredHeight': 30px
+    )
 );
 
 @mixin getBtnVertPadding($conf) {
@@ -77,7 +89,7 @@ $btnConf: (
         vertical-align: middle;
         display: inline-block;
         line-height: 1;
-        margin-right: .5em;
+        margin-right: 0.5em;
     }
 }
 
@@ -247,7 +259,7 @@ $btnConf: (
 /**
  * Service start button
  */
- .start-button {
+.start-button {
     margin: 1.5em 0;
 
     .btn .icon {

--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -252,8 +252,6 @@ $btnConf: (
 
     .btn .icon {
         fill: currentColor;
-        width: 14px;
-        height: 14px;
         margin-left: 2px;
     }
 }

--- a/assets/sass/components/overlay-text.scss
+++ b/assets/sass/components/overlay-text.scss
@@ -16,7 +16,7 @@
     .overlay-text__inner {
         color: white;
         display: inline;
-        padding: .2em .3em;
+        padding: 0.2em 0.3em;
         // allows multi-line wrapped text to work
         box-decoration-break: clone;
     }

--- a/assets/sass/components/overlay-text.scss
+++ b/assets/sass/components/overlay-text.scss
@@ -9,6 +9,10 @@
     line-height: 1.5;
     margin: 0;
 
+    .icon {
+        vertical-align: middle;
+    }
+
     .overlay-text__inner {
         color: white;
         display: inline;

--- a/views/components/buttons.njk
+++ b/views/components/buttons.njk
@@ -5,7 +5,7 @@
         <a class="btn" href="{{ url }}">
             {{ label }}
             <span class="btn__icon">
-                {{ iconArrowRight() }}
+                {{ iconArrowRight('small') }}
             </span>
         </a>
     </div>

--- a/views/components/icons.njk
+++ b/views/components/icons.njk
@@ -1,8 +1,8 @@
-{% macro icon(slug, title, viewbox) %}
+{% macro icon(slug, title, viewbox, variant = 'small') %}
     {% set id = uuid() %}
     <svg
         role="img"
-        class="icon icon--{{ slug }}"
+        class="icon icon--{{ variant }} icon--{{ slug }}"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="{{ viewbox }}" width="32" height="32"
         aria-labelledby="aria-{{ slug }}-title-{{ id }}"
@@ -12,14 +12,14 @@
     </svg>
 {% endmacro %}
 
-{% macro iconArrowLeft() %}
-    {% call icon('arrow-left', 'Arrow pointing left', viewbox="0 0 512 512") %}
+{% macro iconArrowLeft(variant = 'small') %}
+    {% call icon('arrow-left', 'Arrow pointing left', viewbox="0 0 512 512", variant = variant) %}
         <path d="M327.3 98.9l-2.1 1.8-156.5 136c-5.3 4.6-8.6 11.5-8.6 19.2 0 7.7 3.4 14.6 8.6 19.2L324.9 411l2.6 2.3c2.5 1.7 5.5 2.7 8.7 2.7 8.7 0 15.8-7.4 15.8-16.6V112.6c0-9.2-7.1-16.6-15.8-16.6-3.3 0-6.4 1.1-8.9 2.9z"></path>
     {% endcall %}
 {% endmacro %}
 
-{% macro iconArrowRight() %}
-    {% call icon('arrow-right', 'Arrow pointing right', viewbox="0 0 512 512") %}
+{% macro iconArrowRight(variant = 'small') %}
+    {% call icon('arrow-right', 'Arrow pointing right', viewbox="0 0 512 512", variant = variant) %}
         <path d="M184.7 413.1l2.1-1.8 156.5-136c5.3-4.6 8.6-11.5 8.6-19.2 0-7.7-3.4-14.6-8.6-19.2L187.1 101l-2.6-2.3C182 97 179 96 175.8 96c-8.7 0-15.8 7.4-15.8 16.6v286.8c0 9.2 7.1 16.6 15.8 16.6 3.3 0 6.4-1.1 8.9-2.9z"></path>
     {% endcall %}
 {% endmacro %}
@@ -57,18 +57,11 @@
     </svg>
 {% endmacro %}
 
-{% macro iconPrint(variant = 'medium') %}
-    <svg
-        role="img"
-        class="icon icon--{{ variant }} icon--print"
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 32 32" width="32" height="32"
-        aria-labelledby="aria-nav-title"
-    >
-        <title id="aria-nav-title">Printer</title>
+{% macro iconPrint(variant = 'small') %}
+    {% call icon('print', 'Print', viewbox="0 0 32 32", variant = variant) %}
         <path d="M8 2h16v4h-16v-4z"></path>
         <path d="M30 8h-28c-1.1 0-2 0.9-2 2v10c0 1.1 0.9 2 2 2h6v8h16v-8h6c1.1 0 2-0.9 2-2v-10c0-1.1-0.9-2-2-2zM4 14c-1.105 0-2-0.895-2-2s0.895-2 2-2 2 0.895 2 2-0.895 2-2 2zM22 28h-12v-10h12v10z"></path>
-    </svg>
+    {% endcall %}
 {% endmacro %}
 
 {% macro iconFacebook() %}


### PR DESCRIPTION
Spotted when sharing the components list that the overlay text icon had gone all big. This PR fixes that and makes the default size for the arrow icons small.

<img width="968" alt="screen shot 2018-07-27 at 12 39 47" src="https://user-images.githubusercontent.com/123386/43318823-465eed16-919a-11e8-9c3b-b930422a2b22.png">
<img width="977" alt="screen shot 2018-07-27 at 12 39 40" src="https://user-images.githubusercontent.com/123386/43318824-46759c3c-919a-11e8-9240-1d864f000b74.png">
