### PR TITLE
Add FieldLevelEncryptionId to cloudfront config

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -5,6 +5,7 @@
     "MinTTL": 0,
     "MaxTTL": 31536000,
     "DefaultTTL": 86400,
+    "FieldLevelEncryptionId": "",
     "Compress": true,
     "SmoothStreaming": false,
     "AllowedMethods": {
@@ -73,6 +74,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -135,6 +137,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -189,6 +192,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -243,6 +247,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -311,6 +316,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -379,6 +385,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -447,6 +454,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -510,6 +518,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -564,6 +573,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -618,6 +628,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -680,6 +691,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -748,6 +760,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -816,6 +829,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -882,6 +896,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -936,6 +951,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -990,6 +1006,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1044,6 +1061,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1098,6 +1116,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1152,6 +1171,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1209,6 +1229,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1277,6 +1298,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1346,6 +1368,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1414,6 +1437,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1482,6 +1506,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1550,6 +1575,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1612,6 +1638,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1680,6 +1707,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1748,6 +1776,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1814,6 +1843,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -5,6 +5,7 @@
     "MinTTL": 0,
     "MaxTTL": 31536000,
     "DefaultTTL": 86400,
+    "FieldLevelEncryptionId": "",
     "Compress": true,
     "SmoothStreaming": false,
     "AllowedMethods": {
@@ -73,6 +74,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -135,6 +137,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -189,6 +192,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -243,6 +247,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -311,6 +316,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -379,6 +385,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -447,6 +454,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -510,6 +518,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -564,6 +573,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -618,6 +628,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -680,6 +691,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -748,6 +760,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -816,6 +829,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -882,6 +896,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -936,6 +951,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -990,6 +1006,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1044,6 +1061,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1098,6 +1116,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1152,6 +1171,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1209,6 +1229,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1277,6 +1298,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1346,6 +1368,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1414,6 +1437,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1482,6 +1506,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1550,6 +1575,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1612,6 +1638,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1680,6 +1707,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1748,6 +1776,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {
@@ -1814,6 +1843,7 @@
         "MinTTL": 0,
         "MaxTTL": 31536000,
         "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
         "Compress": true,
         "SmoothStreaming": false,
         "AllowedMethods": {

--- a/modules/__tests__/cloudfront.test.js
+++ b/modules/__tests__/cloudfront.test.js
@@ -71,6 +71,7 @@ describe('Cloudfront Helpers', () => {
                 MinTTL: 0,
                 MaxTTL: 31536000,
                 DefaultTTL: 86400,
+                FieldLevelEncryptionId: '',
                 SmoothStreaming: false,
                 Compress: true,
                 AllowedMethods: {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -94,6 +94,7 @@ const makeBehaviourItem = ({
         MinTTL: 0,
         MaxTTL: 31536000,
         DefaultTTL: 86400,
+        FieldLevelEncryptionId: '',
         Compress: true,
         SmoothStreaming: false,
         AllowedMethods: {


### PR DESCRIPTION
Just ran the update cloudfront script on TEST after too long and got this error `The parameter Field level encryption id is required`.

Looks like this is a recent schema change on the CloudFront end:

- https://github.com/boto/boto3/issues/1558
- https://github.com/ansible/ansible/issues/40724#issuecomment-397672401

This PR adds the missing field, which can be blank, which fixes the update script. I've already run this against test and confirmed it works.