### PR TITLE
Set maxWorkers for jest command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "startDev": "export DEBUG=blf-alpha:*,express-session,connect:session-sequelize; nodemon --inspect ./bin/www",
-    "test": "eslint . && jest",
+    "test": "eslint . && jest --maxWorkers=4",
     "test-cypress": "wait-on http://localhost:8090 && cypress run",
     "pretest-ci": "npm run build",
     "test-ci": "./bin/start-test-server & concurrently --success --raw 'npm test' 'npm run test-cypress'",


### PR DESCRIPTION
Noticed jest tests were slower than expected. This seems to improve things by a good 20 seconds.

https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server