### PR TITLE
Language switcher

### DIFF
--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -252,9 +252,20 @@ $btnConf: (
     color: currentColor;
     background-color: transparent;
     border: 2px solid currentColor;
-    padding: 10px 20px;
+    padding: 8px 20px 9px;
 
     margin-right: 0.5em;
+
+    .icon--tick {
+        vertical-align: middle;
+        width: 16px;
+        height: 16px;
+        margin-right: 2px;
+        // Optical alignment
+        margin-left: -2px;
+        position: relative;
+        top: -1px;
+    }
 
     &.is-current {
         pointer-events: none;

--- a/assets/sass/components/buttons.scss
+++ b/assets/sass/components/buttons.scss
@@ -233,17 +233,41 @@ $btnConf: (
 }
 
 /* =========================================================================
-   Button Utilities
+   Language Controls
    ========================================================================= */
 
-// forces full-width
-.btn--block {
-    display: block;
-}
+.language-control {
+    @include poppins();
+    font-size: 14px;
+    font-weight: 500;
+    text-align: center;
+    text-decoration: none;
+    border: none;
+    border-radius: 50px;
+    -webkit-appearance: none;
+    display: inline-block;
+    vertical-align: top;
+    line-height: 1;
 
-.btn--block-full {
-    display: block;
-    width: 100%;
+    color: currentColor;
+    background-color: transparent;
+    border: 2px solid currentColor;
+    padding: 10px 20px;
+
+    margin-right: 0.5em;
+
+    &.is-current {
+        pointer-events: none;
+    }
+
+    &:not(.is-current) {
+        @include on-interact {
+            text-decoration: none;
+            color: palette('charcoal');
+            background-color: white;
+            border-color: white;
+        }
+    }
 }
 
 /* =========================================================================
@@ -261,6 +285,20 @@ $btnConf: (
         fill: currentColor;
         margin-left: 2px;
     }
+}
+
+/* =========================================================================
+   Button Utilities
+   ========================================================================= */
+
+// forces full-width
+.btn--block {
+    display: block;
+}
+
+.btn--block-full {
+    display: block;
+    width: 100%;
 }
 
 /* =========================================================================

--- a/assets/sass/components/global-footer.scss
+++ b/assets/sass/components/global-footer.scss
@@ -2,7 +2,7 @@
    Global Footer
    ========================================================================== */
 
-.footer {
+.global-footer {
     font-size: 14px;
     color: palette('off-white');
     background-color: palette('charcoal');
@@ -20,35 +20,84 @@
             text-decoration: underline;
         }
     }
-}
-.footer__inner {
-    padding: 0;
 
-    @include mq('medium') {
-        padding: 60px 0;
-    }
-}
-
-.footer-links {
-    @include mq('small') {
-        columns: 2;
-    }
-
-    li {
-        margin: 0;
+    .global-footer__inner {
         padding: 0;
-        border-bottom: 1px solid lighten(palette('charcoal'), 10%);
 
-        @include mq('medium') {
-            border-bottom: none;
-            margin-bottom: $spacingUnit / 1.5;
+        @include mq('medium-minor') {
+            width: calc(100% - #{$spacingUnit});
+            max-width: $maxWidth;
+            margin: 0 auto;
+            padding: 60px 0;
+            display: flex;
         }
     }
 
-    a {
-        @include mq('medium', 'max') {
-            padding: $spacingUnit ($spacingUnit / 2);
+    .global-footer__section-title {
+        @include poppins();
+        font-size: 14px;
+        font-weight: bold;
+        text-transform: uppercase;
+        margin-bottom: 0.75em;
+    }
+
+    .global-footer__address,
+    .global-footer__language {
+        margin-bottom: $spacingUnit;
+    }
+
+    .global-footer__meta,
+    .global-footer__quicklinks {
+        padding: $spacingUnit / 2;
+        padding-bottom: $spacingUnit;
+
+        @include mq('medium-minor') {
+            padding: 0;
+            flex: 1 1 auto;
+        }
+    }
+
+    .global-footer__meta {
+        @include mq('medium-minor', 'max') {
+            background-color: darken(palette('charcoal'), 3%);
+        }
+    }
+
+    .global-footer__quicklinks {
+        @include mq('medium-minor') {
+            order: 1;
+        }
+    }
+
+    .global-footer__quicklinks-list {
+        li {
+            margin: 0;
+            padding: 0;
+            border-bottom: 1px solid lighten(palette('charcoal'), 10%);
+
+            &:last-child {
+                border-bottom: none;
+            }
+        }
+
+        a {
             display: block;
+            padding: 1em 0;
+        }
+
+        @include mq('medium-minor') {
+            li {
+                border-bottom: none;
+            }
+
+            a {
+                display: inline-block;
+                padding: 0 0 0.5em 0;
+            }
+        }
+
+        @include mq('medium-major') {
+            columns: 2;
         }
     }
 }

--- a/assets/sass/components/global-header-next.scss
+++ b/assets/sass/components/global-header-next.scss
@@ -25,6 +25,16 @@
         display: none;
     }
 
+    .global-header-next__language {
+        text-align: center;
+        padding: 12px 0;
+        background-color: #eaeaea;
+    }
+    .global-header-next__language-prefix {
+        font-size: 13px;
+        margin-bottom: 6px;
+    }
+
     @media only screen and (max-width: 800px) {
         .global-header-next__primary {
             padding: 10px 20px;
@@ -189,6 +199,7 @@
             }
         }
 
+        .global-header-next__language,
         .global-header-next__actions {
             display: none;
         }

--- a/views/components/icons.njk
+++ b/views/components/icons.njk
@@ -105,14 +105,9 @@
     </svg>
 {% endmacro %}
 
-{% macro iconTick() %}
-    <svg viewbox="0 0 100 96"
-        width="20"
-        height="20"
-        xmlns="http://www.w3.org/2000/svg"
-    >
-        <title>tick by mikicon from the Noun Project</title>
+{% macro iconTick(variant = 'small') %}
+    {% call icon('tick', 'tick by mikicon from the Noun Project', viewbox="0 0 100 96", variant = variant) %}
         <path
             d="M50 6.6C26 6.6 6.6 26 6.6 50S26 93.4 50 93.4 93.4 74 93.4 50 74 6.6 50 6.6zM71 41L45.3 66.6c-.8.8-1.8 1.2-2.8 1.2s-2.1-.4-2.8-1.2L27 54c-1.6-1.6-1.6-4.1 0-5.7 1.6-1.6 4.1-1.6 5.7 0l9.8 9.8 22.8-22.8c1.6-1.6 4.1-1.6 5.7 0 1.5 1.6 1.5 4.2 0 5.7z"></path>
-    </svg>
+    {% endcall %}
 {% endmacro %}

--- a/views/components/language-switcher/examples.njk
+++ b/views/components/language-switcher/examples.njk
@@ -1,0 +1,6 @@
+{% from "components/styleguide.njk" import sgExample %}
+{% from "./macro.njk" import languageSwitcher with context %}
+
+{% call sgExample() %}
+    {{ languageSwitcher(currentLocale = locale) }}
+{% endcall %}

--- a/views/components/language-switcher/macro.njk
+++ b/views/components/language-switcher/macro.njk
@@ -1,0 +1,14 @@
+{% macro languageSwitcher(currentLocale = 'en') %}
+    {% for item in [{ "id": "en", "label": "English" }, { "id": "cy", "label": "Cymraeg" }] %}
+        {% if item.id === currentLocale %}
+            <span class="language-control is-current">
+                ✔ {{ item.label }}
+            </span>
+        {% else %}
+            <a href="{{ getCurrentUrl(item.id) }}"
+                class="language-control">
+                {{ item.label }}
+            </a>
+        {% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/views/components/language-switcher/macro.njk
+++ b/views/components/language-switcher/macro.njk
@@ -1,8 +1,10 @@
+{% from "components/icons.njk" import iconTick %}
+
 {% macro languageSwitcher(currentLocale = 'en') %}
     {% for item in [{ "id": "en", "label": "English" }, { "id": "cy", "label": "Cymraeg" }] %}
         {% if item.id === currentLocale %}
             <span class="language-control is-current">
-                ✔ {{ item.label }}
+                {{ iconTick() }} {{ item.label }}
             </span>
         {% else %}
             <a href="{{ getCurrentUrl(item.id) }}"

--- a/views/includes/footer.njk
+++ b/views/includes/footer.njk
@@ -1,3 +1,5 @@
+{% from "components/language-switcher/macro.njk" import languageSwitcher with context %}
+
 {# Did you find what you were looking for? #}
 {% if not suppressSurvey %}
     <div id="js-survey">
@@ -14,26 +16,28 @@
     </div>
 {% endif %}
 
-<footer role="contentinfo" class="footer">
-    <div class="footer__inner u-inner">
-        <ul class="grid grid--top grid--wide-only">
-            <li class="grid__item u-desktop-only">
-                <p class="t6 u-uppercase">{{ __("global.brand.title") | safe }}</p>
+<footer class="global-footer" role="contentinfo" >
+    <div class="global-footer__inner">
+        <div class="global-footer__quicklinks">
+            <h2 class="global-footer__section-title">{{ __("global.footerLinks.title") | safe }}</h2>
+            <ul class="global-footer__quicklinks-list">
+                {% for link in __("global.footerLinks.links") %}
+                    <li><a href="{{ link.href }}">{{ link.label }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+        <div class="global-footer__meta">
+            <div class="global-footer__address">
+                <p class="global-footer__section-title">{{ __("global.brand.title") | safe }}</p>
                 <address>1 Plough Place, {{ __("global.contact.city") | safe }} EC4A 1DE</address>
                 <p><a href="mailto:{{ __("global.contact.email") | safe }}">{{ __("global.contact.email") | safe }}</a></p>
                 <p>{{ __("global.contact.phone") | safe }}</p>
-            </li>
-            <li class="grid__item">
-                <h2 class="t6 u-uppercase u-desktop-only">{{ __("global.footerLinks.title") | safe }}</h2>
-                <ul class="footer-links">
-                    {% for link in __("global.footerLinks.links") %}
-                        <li><a href="{{ link.href }}">{{ link.label }}</a></li>
-                    {% endfor %}
-                </ul>
-            </li>
-        </ul>
-        {% if globalFootnote %}
-            <small class="footer__footnote u-desktop-only">{{ globalFootnote }}</small>
-        {% endif %}
+            </div>
+
+            <div class="global-footer__language">
+                <h2 class="global-footer__section-title">Language</h2>
+                {{ languageSwitcher(locale) }}
+            </div>
+        </div>
     </div>
 </footer>

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -1,8 +1,13 @@
 {% from "components/icons.njk" import iconHamburger, iconSearch %}
 {% from "components/nav.njk" import navSearchForm, navLangLink with context %}
+{% from "components/language-switcher/macro.njk" import languageSwitcher with context %}
 
 {% macro _navigation() %}
     {% set navigation = [{
+        "label": "Home",
+        "url": "/",
+        "mobileOnly": true
+    }, {
         "label": "Funding",
         "url": "/funding",
         "children": [{
@@ -25,11 +30,15 @@
         "label": "Talk to us",
         "url": "/contact",
         "children": []
+    }, {
+        "label": "About us",
+        "url": "/about",
+        "mobileOnly": true
     }] %}
 
     <ul>
         {% for item in navigation %}
-            <li>
+            <li {% if item.mobileOnly %}class="u-mobile-only"{% endif %}>
                 <a href="{{ item.url }}">{{ item.label }}</a>
                 {% if item.children %}
                     <ul>
@@ -83,6 +92,14 @@
                     <li>{{ navLangLink() }}</li>
                     <li>Advice Line: 0345 4 10 20 30</li>
                 </ul>
+                <div class="global-header-next__language">
+                    <div class="global-header-next__language-prefix">
+                        Mae'r dudalen hon hefyd ar gael yn Cymraeg
+                    </div>
+                    <div class="global-header-next__language-controls">
+                        {{ languageSwitcher(locale) }}
+                    </div>
+                </div>
             </div>
 
             <div class="global-header-next__search">


### PR DESCRIPTION
This PR adds the new language switcher component and refactors the footer to include it. This is arguably part of the new navigation work, but we're good to launch this bit ahead of time. Includes some analytics events to check how this gets used.


<img width="1120" alt="screen shot 2018-08-02 at 10 42 26" src="https://user-images.githubusercontent.com/123386/43576323-fb361c96-9640-11e8-9fe3-1ea28c3dd9ae.png">

As part of these design changes the contact details now show on small screens (they were previously hidden)

<img width="431" alt="screen shot 2018-08-02 at 10 43 01" src="https://user-images.githubusercontent.com/123386/43576269-dd069e26-9640-11e8-9c5e-dbbf0e3b3b76.png">
