### PR TITLE
Check postcodes against the same pattern on client/server

### DIFF
--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -29,6 +29,13 @@ const LENGTH_HINTS = {
     }
 };
 
+// Allows us to share postcode validation on server and client-side
+// via https://github.com/chriso/validator.js/blob/master/lib/isPostalCode.js#L54
+// we have to double-escape the regex patterns here to output it as a native RegExp
+// but also as a string for the HTML pattern attribute
+const POSTCODE_PATTERN = "(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)";
+const POSTCODE_REGEX = new RegExp(POSTCODE_PATTERN, 'i');
+
 const currentWork = [
     {
         legend: 'Your current work',
@@ -342,14 +349,15 @@ const organisationDetails = [
                 label: 'Postcode',
                 size: 10,
                 isRequired: true,
+                customRegex: POSTCODE_PATTERN,
                 validator(field) {
                     return check(field.name)
                         .trim()
                         .not()
                         .isEmpty()
                         .withMessage('Postcode must be provided')
-                        .isPostalCode('GB')
-                        .withMessage('Invalid postcode');
+                        .custom(value => POSTCODE_REGEX.test(value))
+                        .withMessage('Please provide a valid UK postcode');
                 }
             }
         ]

--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -35,6 +35,7 @@ const LENGTH_HINTS = {
 // but also as a string for the HTML pattern attribute
 const POSTCODE_PATTERN = '(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)';
 const POSTCODE_REGEX = new RegExp(POSTCODE_PATTERN, 'i');
+const isValidPostcode = input => POSTCODE_REGEX.test(input);
 
 const currentWork = [
     {
@@ -356,7 +357,7 @@ const organisationDetails = [
                         .not()
                         .isEmpty()
                         .withMessage('Postcode must be provided')
-                        .custom(value => POSTCODE_REGEX.test(value))
+                        .custom(value => isValidPostcode(value))
                         .withMessage('Please provide a valid UK postcode');
                 }
             }
@@ -442,5 +443,6 @@ module.exports = {
     projectEvaluation,
     projectLocation,
     socialConnections,
-    yourIdea
+    yourIdea,
+    isValidPostcode
 };

--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -33,7 +33,7 @@ const LENGTH_HINTS = {
 // via https://github.com/chriso/validator.js/blob/master/lib/isPostalCode.js#L54
 // we have to double-escape the regex patterns here to output it as a native RegExp
 // but also as a string for the HTML pattern attribute
-const POSTCODE_PATTERN = "(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)";
+const POSTCODE_PATTERN = '(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)';
 const POSTCODE_REGEX = new RegExp(POSTCODE_PATTERN, 'i');
 
 const currentWork = [

--- a/controllers/apply/building-connections/fields.test.js
+++ b/controllers/apply/building-connections/fields.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+'use strict';
+
+const { isValidPostcode } = require('./fields');
+
+describe('Postcode validation', () => {
+    it('should correctly validate postcodes', () => {
+        expect(isValidPostcode('EC4A 1DE')).toBe(true);
+    });
+    it('should reject invalid postcodes', () => {
+        expect(isValidPostcode('NOT A POSTCODE')).toBe(false);
+    });
+});

--- a/views/components/forms-new.njk
+++ b/views/components/forms-new.njk
@@ -73,6 +73,7 @@
         value="{% if field.value %}{{ field.value }}{% endif %}"
         {% if field.min %}min="{{ field.min }}"{% endif %}
         {% if field.max %}max="{{ field.max }}"{% endif %}
+        {% if field.customRegex %}pattern="{{ field.customRegex }}"{% endif %}
         {% if field.isRequired %}required aria-required="true"{% endif %}
     />
     {% if field.isCurrency %}


### PR DESCRIPTION
@LynseyJReynolds suggested this (in #1130) and it was easy enough to add.

Turns out the check we were using before (`isPostalCode()`) is defined [here](https://github.com/chriso/validator.js/blob/master/lib/isPostalCode.js#L54) so I took that regex directly and used it as a constant so we can pass it to the templates to validate inline, too. 

Was a bit fiddly passing it around as the HTML field needs it as a raw string whereas the validator needs it as a `RegExp` but this wasn't too painful either.

Minor tweak but means we can keep all of the BC form's validation on the client-side now.

![postcode](https://user-images.githubusercontent.com/394376/43591669-ba8eead0-966b-11e8-802a-6024bd32fedb.gif)
