### PR TITLE
Add hover state and inbetween breakpoint to new nav

### DIFF
--- a/assets/js/modules/global.js
+++ b/assets/js/modules/global.js
@@ -9,46 +9,9 @@ function initNavToggle() {
     });
 }
 
-function initGlobalHeaderNext() {
-    const stateClassNames = {
-        nav: 'has-toggled-navigation',
-        search: 'has-toggled-search'
-    };
-
-    const $html = $('html');
-    const $el = $('.js-global-header');
-    if ($el.length === 0) {
-        return;
-    }
-
-    const $toggleNav = $el.find('.js-toggle-nav');
-    const $toggleSearch = $el.find('.js-toggle-search');
-
-    $('body').on('click', function(e) {
-        const outsideClick = $(e.target).closest($el).length === 0;
-        if (outsideClick && ($html.hasClass(stateClassNames.search) || $html.hasClass(stateClassNames.nav))) {
-            $html.removeClass(stateClassNames.search);
-            $html.removeClass(stateClassNames.nav);
-        }
-    });
-
-    $toggleNav.on('click', function(e) {
-        e.preventDefault();
-        $html.removeClass(stateClassNames.search);
-        $html.toggleClass(stateClassNames.nav);
-    });
-
-    $toggleSearch.on('click', function(e) {
-        e.preventDefault();
-        $html.removeClass(stateClassNames.nav);
-        $html.toggleClass(stateClassNames.search);
-        $el.find('input[type=search]').focus();
-    });
-}
 
 function init() {
     initNavToggle();
-    initGlobalHeaderNext();
     fitvids('.video-container');
 }
 

--- a/assets/sass/components/global-header-next.scss
+++ b/assets/sass/components/global-header-next.scss
@@ -2,6 +2,9 @@
    Global Header
    ========================================================================= */
 
+$breakpointSmall: 540px;
+$breakpointLarge: 840px;
+
 .global-header-next {
     background: white;
     position: relative;
@@ -35,7 +38,7 @@
         margin-bottom: 6px;
     }
 
-    @media only screen and (max-width: 800px) {
+    @media only screen and (max-width: $breakpointLarge) {
         .global-header-next__primary {
             padding: 10px 20px;
             display: flex;
@@ -124,7 +127,7 @@
         }
     }
 
-    @media only screen and (max-width: 600px) {
+    @media only screen and (max-width: $breakpointSmall) {
         .global-header-next__search {
             position: absolute;
             top: 100%;
@@ -150,7 +153,7 @@
         }
     }
 
-    @media only screen and (min-width: 600px) and (max-width: 800px) {
+    @media only screen and (min-width: $breakpointSmall + 1px) and (max-width: $breakpointLarge) {
         .global-header-next__search {
             position: absolute;
             top: 50%;
@@ -165,7 +168,7 @@
         }
     }
 
-    @media only screen and (min-width: 800px) {
+    @media only screen and (min-width: $breakpointLarge) {
         .global-header-next__inner {
             display: flex;
             align-items: flex-end;
@@ -221,10 +224,11 @@
                         margin-right: -3px;
                         margin-left: 3px;
                     }
+                }
 
-                    &:hover {
-                        color: palette('pink');
-                    }
+                > li:hover > a,
+                > li.is-current > a {
+                    color: palette('pink');
                 }
 
                 > li.has-children:hover {
@@ -270,10 +274,6 @@
             text-transform: uppercase;
             font-size: 13px;
 
-            @include mq('large') {
-                top: $spacingUnit;
-            }
-
             > li {
                 margin-right: $spacingUnit * 2;
                 &:last-child {
@@ -312,7 +312,6 @@
 .global-search-next {
     margin: 0;
     position: relative;
-    outline: 2px solid palette('border');
 
     .global-search-next__input {
         @include poppins();
@@ -320,32 +319,59 @@
         font-weight: normal;
         border: none;
         width: 100%;
-        margin-top: 0;
-        padding: 6px 32px 6px 12px;
+        margin: 0;
+        margin-bottom: $spacingUnit / 2;
     }
 
-    .global-search-next__submit {
-        border: 0;
-        outline: none;
-        position: absolute;
-        top: 0;
-        right: 0;
-        cursor: pointer;
-        height: 100%;
-        background-color: #ededed;
-
-        .icon {
-            width: 21px;
-            height: 21px;
-            fill: palette('charcoal');
-            vertical-align: middle;
-            position: relative;
-            top: -2px;
+    @media only screen and (max-width: $breakpointSmall) {
+        .global-search-next__input {
+            padding: 0.75em 1em;
         }
 
-        @include on-interact {
+        .global-search-next__submit {
+            @include poppins();
+            color: white;
+            background-color: palette('pink');
+            display: block;
+            width: 100%;
+            border: none;
+            border-radius: 50px;
+            padding: 5px 12px;
+        }
+        .global-search-next__icon {
+            display: none;
+        }
+    }
+
+    @media only screen and (min-width: $breakpointSmall) {
+        outline: 2px solid palette('border');
+
+        .global-search-next__input {
+            margin: 0;
+            padding: 6px 32px 6px 12px;
+        }
+
+        .global-search-next__submit {
+            border: 0;
+            outline: none;
+            position: absolute;
+            top: 0;
+            right: 0;
+            cursor: pointer;
+            height: 100%;
+            background-color: #ededed;
+
             .icon {
+                width: 21px;
+                height: 21px;
                 fill: palette('charcoal');
+                vertical-align: middle;
+                position: relative;
+                top: -2px;
+            }
+
+            .global-search-next__label {
+                @include visually-hidden();
             }
         }
     }
@@ -361,14 +387,15 @@
     background-position: left center;
     background-image: url(../../../images/logos/logo.png);
     background-size: auto 100%;
-    margin: 0 5px 0 0;
+    margin: 0;
+    margin-right: $spacingUnit / 2;
 
     height: 80px;
     width: 100px;
 
     @include mq('large') {
-        height: 105px;
-        width: 130px;
+        height: 96px;
+        width: 120px;
     }
 
     /**
@@ -380,11 +407,6 @@
         background-image: url(../../../images/logos/logo-welsh.png);
         width: 110px;
         height: 105px;
-
-        @include mq('large') {
-            width: 140px;
-            height: 133px;
-        }
     }
 
     @media print {

--- a/assets/sass/components/global-header-next.scss
+++ b/assets/sass/components/global-header-next.scss
@@ -44,8 +44,7 @@
             align-items: center;
         }
 
-        .global-header-next__navigation,
-        .global-header-next__search {
+        .global-header-next__navigation {
             position: absolute;
             top: 100%;
             width: 100%;
@@ -58,15 +57,6 @@
             display: none;
 
             html.has-toggled-navigation & {
-                display: block;
-            }
-        }
-
-        .global-header-next__search {
-            padding: $spacingUnit;
-            display: none;
-
-            html.has-toggled-search & {
                 display: block;
             }
         }
@@ -92,19 +82,18 @@
             }
         }
 
-        .global-header-next__toggle-search {
-            html.has-toggled-search & {
-                color: palette('pink');
-            }
-        }
-
         .global-header-next__navigation-primary {
             > ul > li {
                 border-bottom: 1px solid #e6e6e6;
                 &:last-child {
                     border-bottom: none;
                 }
+
+                .icon {
+                    display: none;
+                }
             }
+
             > ul > li > a {
                 text-align: center;
                 text-decoration: none;
@@ -135,6 +124,47 @@
         }
     }
 
+    @media only screen and (max-width: 600px) {
+        .global-header-next__search {
+            position: absolute;
+            top: 100%;
+            width: 100%;
+            background-color: #f4f4f4;
+            box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.15);
+            z-index: 100;
+        }
+
+        .global-header-next__search {
+            padding: $spacingUnit;
+            display: none;
+
+            html.has-toggled-search & {
+                display: block;
+            }
+        }
+
+        .global-header-next__toggle-search {
+            html.has-toggled-search & {
+                color: palette('pink');
+            }
+        }
+    }
+
+    @media only screen and (min-width: 600px) and (max-width: 800px) {
+        .global-header-next__search {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            margin-left: $spacingUnit; // Optically align
+            width: 50%;
+        }
+
+        .global-header-next__toggle-search {
+            display: none;
+        }
+    }
+
     @media only screen and (min-width: 800px) {
         .global-header-next__inner {
             display: flex;
@@ -150,41 +180,99 @@
 
         .global-header-next__secondary {
             flex: 1 1 0%;
-            margin-bottom: $spacingUnit;
             display: flex;
             justify-content: space-between;
             align-items: center;
+            margin-bottom: $spacingUnit / 2;
+
+            @include mq('large') {
+                margin-bottom: $spacingUnit;
+            }
         }
         .global-header-next__navigation {
             flex: 1 1 auto;
         }
         .global-header-next__search {
-            flex: 0 0 auto;
+            flex: 0 0 25%;
         }
 
         .global-header-next__navigation-primary {
-            margin: 0 $spacingUnit;
+            margin: 0;
             max-width: 540px;
 
             > ul {
                 display: flex;
                 justify-content: space-between;
-            }
 
-            > ul > li {
-                padding-right: 0.5em;
+                > li {
+                    flex: 1 1 auto;
+                    position: relative;
+                }
+
+                > li > a {
+                    display: inline-block;
+                    width: 100%;
+                    height: 100%;
+                    padding: 6px 10px;
+
+                    .icon {
+                        display: inline-block;
+                        vertical-align: middle;
+                        margin-right: -3px;
+                        margin-left: 3px;
+                    }
+
+                    &:hover {
+                        color: palette('pink');
+                    }
+                }
+
+                > li.has-children:hover {
+                    > a {
+                        color: white;
+                        background-color: rgba(226, 0, 135, 0.95);
+                    }
+
+                    ul {
+                        display: block;
+                        position: absolute;
+                        z-index: 100;
+                        left: 0;
+                        top: 100%;
+                        color: white;
+                        background-color: rgba(226, 0, 135, 0.95);
+                        box-shadow: 3px 3px 6px 0 rgba(0, 0, 0, 0.1);
+
+                        a {
+                            display: block;
+                            color: inherit;
+                            text-decoration: none;
+                            white-space: nowrap;
+                            font-size: 14px;
+                            padding: 10px 12px;
+
+                            &:hover {
+                                text-decoration: underline;
+                            }
+                        }
+                    }
+                }
             }
         }
 
         .global-header-next__navigation-secondary {
             position: absolute;
             right: 0;
-            top: $spacingUnit;
+            top: $spacingUnit / 2;
             display: flex;
             flex-direction: row;
             color: palette('charcoal-note');
             text-transform: uppercase;
             font-size: 13px;
+
+            @include mq('large') {
+                top: $spacingUnit;
+            }
 
             > li {
                 margin-right: $spacingUnit * 2;
@@ -196,6 +284,10 @@
             > li > a {
                 color: inherit;
                 text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
+                }
             }
         }
 
@@ -213,18 +305,68 @@
     }
 }
 
+/* =========================================================================
+   Global Search Form
+   ========================================================================= */
+
+.global-search-next {
+    margin: 0;
+    position: relative;
+    outline: 2px solid palette('border');
+
+    .global-search-next__input {
+        @include poppins();
+        font-size: 16px;
+        font-weight: normal;
+        border: none;
+        width: 100%;
+        margin-top: 0;
+        padding: 6px 32px 6px 12px;
+    }
+
+    .global-search-next__submit {
+        border: 0;
+        outline: none;
+        position: absolute;
+        top: 0;
+        right: 0;
+        cursor: pointer;
+        height: 100%;
+        background-color: #ededed;
+
+        .icon {
+            width: 21px;
+            height: 21px;
+            fill: palette('charcoal');
+            vertical-align: middle;
+            position: relative;
+            top: -2px;
+        }
+
+        @include on-interact {
+            .icon {
+                fill: palette('charcoal');
+            }
+        }
+    }
+}
+
+/* =========================================================================
+   Brand Logo
+   ========================================================================= */
+
 .brand-logo {
     display: inline-block;
     background-repeat: no-repeat;
     background-position: left center;
     background-image: url(../../../images/logos/logo.png);
     background-size: auto 100%;
-    margin: 0;
+    margin: 0 5px 0 0;
 
     height: 80px;
     width: 100px;
 
-    @include mq('medium') {
+    @include mq('large') {
         height: 105px;
         width: 130px;
     }
@@ -239,7 +381,7 @@
         width: 110px;
         height: 105px;
 
-        @include mq('medium') {
+        @include mq('large') {
             width: 140px;
             height: 133px;
         }

--- a/assets/sass/globals/base.scss
+++ b/assets/sass/globals/base.scss
@@ -81,7 +81,6 @@ p {
 
 a {
     color: palette('blue-text');
-    transition: color 0.1s ease-in-out;
 
     @include on-interact {
         text-decoration: underline;

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -150,3 +150,60 @@
         </div>
     </div>
 </header>
+
+<script>
+/**
+ * Initialise event listeners on header navigation early
+ * (e.g. search and menu toggle)
+ *
+ * We do this early so that users can interact
+ * with the navigation before the main script bundle has loaded
+ * increasing time-to-interactive
+ */
+(function() {
+    const elSelector = '.js-global-header';
+    var stateClassNames = {
+        nav: 'has-toggled-navigation',
+        search: 'has-toggled-search'
+    };
+
+    var body = document.querySelector('body');
+    var html = document.querySelector('html');
+    var el = document.querySelector(elSelector);
+    var searchInput = el.querySelector('input[type=search]');
+
+    if (!el) {
+        return;
+    }
+
+    var toggleNav = el.querySelector('.js-toggle-nav');
+    var toggleSearch = el.querySelector('.js-toggle-search');
+
+    toggleNav.addEventListener('click', function(e) {
+        e.preventDefault();
+        html.classList.remove(stateClassNames.search);
+        html.classList.toggle(stateClassNames.nav);
+    });
+
+    toggleSearch.addEventListener('click', function(e) {
+        e.preventDefault();
+        html.classList.remove(stateClassNames.nav);
+        html.classList.toggle(stateClassNames.search);
+
+        if (searchInput) {
+            searchInput.focus();
+        }
+    });
+
+    body.addEventListener('click', function(e) {
+        var isOutsideClick = e.target.closest(elSelector) === null;
+        if (
+            isOutsideClick &&
+            (html.classList.contains(stateClassNames.search) || html.classList.contains(stateClassNames.nav))
+        ) {
+            html.classList.remove(stateClassNames.search);
+            html.classList.remove(stateClassNames.nav);
+        }
+    });
+}());
+</script>

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -1,5 +1,4 @@
-{% from "components/icons.njk" import iconHamburger, iconSearch %}
-{% from "components/nav.njk" import navSearchForm, navLangLink with context %}
+{% from "components/icons.njk" import iconHamburger, iconSearch, iconArrowDown %}
 {% from "components/language-switcher/macro.njk" import languageSwitcher with context %}
 
 {% macro _navigation() %}
@@ -11,8 +10,17 @@
         "label": "Funding",
         "url": "/funding",
         "children": [{
-            "label": "Thing",
-            "url": "/funding/blah"
+            "label": "Thinking of applying",
+            "url": "/funding/under10k"
+        }, {
+            "label": "Funding programmes",
+            "url": "/funding/programmes"
+        }, {
+            "label": "What we’ve funded",
+            "url": "/funding/past-grants"
+        }, {
+            "label": "Continue your application",
+            "url": "https://apply.biglotteryfund.org.uk/Login.aspx"
         }]
     }, {
         "label": "In your area",
@@ -38,9 +46,12 @@
 
     <ul>
         {% for item in navigation %}
-            <li {% if item.mobileOnly %}class="u-mobile-only"{% endif %}>
-                <a href="{{ item.url }}">{{ item.label }}</a>
-                {% if item.children %}
+            {% set hasChildren = item.children.length > 0 %}
+            <li class="{% if hasChildren %}has-children{% endif %}{% if item.mobileOnly %} u-mobile-only{% endif %}">
+                <a href="{{ item.url }}">
+                    {{ item.label }} {% if hasChildren %}{{ iconArrowDown() }}{% endif %}
+                </a>
+                {% if hasChildren %}
                     <ul>
                         {% for child in item.children %}
                             <li>
@@ -52,6 +63,28 @@
             </li>
         {% endfor %}
     </ul>
+{% endmacro %}
+
+{% macro globalSearch() %}
+    <form class="global-search-next" role="search" action="/search">
+        <input type="hidden" name="lang" value="en-GB">
+        <input type="hidden" name="type" value="All">
+        <input type="hidden" name="order" value="r">
+        <label class="u-visually-hidden" for="global-search-input">
+            {{ __("global.misc.search") }}
+        </label>
+        <input
+            class="global-search-next__input ff-text"
+            id="global-search-input"
+            name="q"
+            type="search"
+            placeholder="{{ __("global.misc.search") }}"
+        >
+        <button class="global-search-next__submit" type="submit">
+            {{ iconSearch() }}
+            <span class="u-visually-hidden">{{ __("global.misc.search") }}</span>
+        </button>
+    </form>
 {% endmacro %}
 
 <header class="global-header-next js-global-header" role="banner">
@@ -89,7 +122,15 @@
                 <ul class="global-header-next__navigation-secondary">
                     <li><a href="{{ localify('/') }}">Home</a></li>
                     <li><a href="{{ localify('/about') }}">About us</a></li>
-                    <li>{{ navLangLink() }}</li>
+                    <li>
+                        {% if isBilingual %}
+                            {% if locale == 'en' %}
+                                <a class="qa-lang-switcher" href="{{ getCurrentUrl('cy') }}">Cymraeg</a>
+                            {% else %}
+                                <a class="qa-lang-switcher" href="{{ getCurrentUrl('en') }}">English</a>
+                            {% endif %}
+                        {% endif %}
+                    </li>
                     <li>Advice Line: 0345 4 10 20 30</li>
                 </ul>
                 <div class="global-header-next__language">
@@ -103,7 +144,7 @@
             </div>
 
             <div class="global-header-next__search">
-                {{ navSearchForm() }}
+                {{ globalSearch() }}
             </div>
         </div>
     </div>

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -28,7 +28,7 @@
         "children": []
     }, {
         "label": "News",
-        "url": "/news",
+        "url": "/blog",
         "children": []
     }, {
         "label": "Research",
@@ -47,7 +47,8 @@
     <ul>
         {% for item in navigation %}
             {% set hasChildren = item.children.length > 0 %}
-            <li class="{% if hasChildren %}has-children{% endif %}{% if item.mobileOnly %} u-mobile-only{% endif %}">
+            {% set pathname = request.baseUrl + request.path | replace(r/\/$/, '') %}
+            <li class="{% if hasChildren %}has-children{% endif %}{% if item.mobileOnly %} u-mobile-only{% endif %}{% if pathname === item.url %} is-current{% endif %}">
                 <a href="{{ item.url }}">
                     {{ item.label }} {% if hasChildren %}{{ iconArrowDown() }}{% endif %}
                 </a>
@@ -81,8 +82,8 @@
             placeholder="{{ __("global.misc.search") }}"
         >
         <button class="global-search-next__submit" type="submit">
-            {{ iconSearch() }}
-            <span class="u-visually-hidden">{{ __("global.misc.search") }}</span>
+            <span class="global-search-next__icon">{{ iconSearch() }}</span>
+            <span class="global-search-next__label">{{ __("global.misc.search") }}</span>
         </button>
     </form>
 {% endmacro %}

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -68,9 +68,6 @@
 
 {% macro globalSearch() %}
     <form class="global-search-next" role="search" action="/search">
-        <input type="hidden" name="lang" value="en-GB">
-        <input type="hidden" name="type" value="All">
-        <input type="hidden" name="order" value="r">
         <label class="u-visually-hidden" for="global-search-input">
             {{ __("global.misc.search") }}
         </label>
@@ -162,6 +159,12 @@
  */
 (function() {
     const elSelector = '.js-global-header';
+    var el = document.querySelector(elSelector);
+
+    if (!el) {
+        return;
+    }
+
     var stateClassNames = {
         nav: 'has-toggled-navigation',
         search: 'has-toggled-search'
@@ -169,12 +172,7 @@
 
     var body = document.querySelector('body');
     var html = document.querySelector('html');
-    var el = document.querySelector(elSelector);
     var searchInput = el.querySelector('input[type=search]');
-
-    if (!el) {
-        return;
-    }
 
     var toggleNav = el.querySelector('.js-toggle-nav');
     var toggleSearch = el.querySelector('.js-toggle-search');

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -3,7 +3,7 @@
 <link rel="stylesheet" type="text/css" href="{{ 'stylesheets/style.css' | getCachebustedPath }}">
 <link href="https://fonts.googleapis.com/css?family=Poppins:300,500,600|Roboto:400,700" rel="stylesheet">
 
-<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=HTMLPictureElement,Promise,Array.prototype.find"></script>
+<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=HTMLPictureElement,Promise,Array.prototype.find,Element.prototype.closest"></script>
 <script id="script-config">
 
 (function() {


### PR DESCRIPTION
This PR adds hover styles for the drop-down nav in the new header and adds "inbetween" breakpoint styles as well as generally refining things.

![hover](https://user-images.githubusercontent.com/123386/43637665-b865194e-970d-11e8-9645-6206c7a10776.gif)

<img width="734" alt="screen shot 2018-08-03 at 11 06 04" src="https://user-images.githubusercontent.com/123386/43637666-b930fb9a-970d-11e8-9e08-69bf0dbdde2e.png">

This brings us to the point where the navigation prototype is largely "done" in that it's inline with design. The css and templates behind this could definitely stand to be cleaned up but that can wait until we've run some tests with this.