### PR TITLE
Add the concept of a "silently optional" field

### DIFF
--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -377,8 +377,7 @@ const organisationDetails = [
                 explanation: `
                     If you're unsure, you can
                     <a href="http://beta.charitycommission.gov.uk" target="_blank" rel="noopener">
-                        look it up on the Charity Commission website</a>. <br>
-                    If you don't have one, you can provide a Companies House number below instead.`
+                        look it up on the Charity Commission website</a>.`
             },
             {
                 type: 'text',
@@ -388,7 +387,7 @@ const organisationDetails = [
                     If you're unsure, you can
                     <a href="https://beta.companieshouse.gov.uk" target="_blank" rel="noopener">
                         look it up on the Companies House website
-                    </a>`
+                    </a>.`
             }
         ]
     }

--- a/controllers/apply/building-connections/fields.js
+++ b/controllers/apply/building-connections/fields.js
@@ -279,6 +279,7 @@ const projectBudget = [
                 min: 0,
                 max: FUND_SIZE.max,
                 isCurrency: true,
+                silentlyOptional: true,
                 size: 20,
                 label: 'How much do you plan to spend for the period until April 2019–March 2020?'
             },
@@ -286,6 +287,7 @@ const projectBudget = [
                 name: 'project-budget-b-description',
                 type: 'textarea',
                 lengthHint: LENGTH_HINTS.FEW_PARAS,
+                silentlyOptional: true,
                 label: 'What do you plan to spend the money on for the period from April 2019–March 2020?'
             },
             {
@@ -294,6 +296,7 @@ const projectBudget = [
                 min: 0,
                 max: FUND_SIZE.max,
                 isCurrency: true,
+                silentlyOptional: true,
                 size: 20,
                 label: 'How much do you plan to spend for the period until April 2020–March 2021?'
             },
@@ -301,6 +304,7 @@ const projectBudget = [
                 name: 'project-budget-c-description',
                 type: 'textarea',
                 lengthHint: LENGTH_HINTS.FEW_PARAS,
+                silentlyOptional: true,
                 label: 'What do you plan to spend the money on for the period April 2020–March 2021?'
             }
         ]

--- a/views/components/forms-new.njk
+++ b/views/components/forms-new.njk
@@ -1,4 +1,4 @@
-{% macro getLabelClasses(field) %}ff-label{% if field.isRequired %} ff-label--required{% else %} ff-label--optional{% endif %}{% endmacro %}
+{% macro getLabelClasses(field) %}ff-label{% if field.isRequired %} ff-label--required{% elseif not field.silentlyOptional %} ff-label--optional{% endif %}{% endmacro %}
 
 {% macro formHeader(title, stepProgress) %}
     <div class="form-header">


### PR DESCRIPTION
There's a bit of concern that some users aren't filling in some of the optional BC form steps because they think they don't need to provide that information, rather than because their project doesn't run for those dates. To try to combat this, we've added the concept of a field which is optional but isn't explicitly called out this way:

## Before
![image](https://user-images.githubusercontent.com/394376/43719426-95bcc0f2-9985-11e8-8b53-bda15dae4b71.png)

## After
![image](https://user-images.githubusercontent.com/394376/43719436-9dc22116-9985-11e8-8320-707e9a096b3a.png)

Hopefully this will reduce the number of applications we're seeing with missing information – and if not, it should have no effect on people whose projects run for short periods as the fields are still optional and not marked as required.