### PR TITLE
Fix session timeouts?

### DIFF
--- a/controllers/helpers/create-form-router.js
+++ b/controllers/helpers/create-form-router.js
@@ -76,7 +76,10 @@ function createFormRouter({ router, formModel }) {
         // for users submitting a step, increase their session expiry
         // so they can save progress beyond a browser session
         function extendSessionDuration(req, res, next) {
-            req.session.cookie.maxAge = moment()
+            // belt and braces: https://stackoverflow.com/a/46631171
+            const maxAge = EXTENDED_SESSION_DURATION_IN_DAYS * 24 * 3600 * 1000;
+            req.session.cookie.maxAge = maxAge;
+            req.session.cookie.expires = moment()
                 .add(EXTENDED_SESSION_DURATION_IN_DAYS, 'days')
                 .toDate();
             req.flash('progressSaved', {

--- a/middleware/session.js
+++ b/middleware/session.js
@@ -30,7 +30,8 @@ module.exports = function(app) {
             sameSite: true,
             secure: !appData.isDev
         },
-        store: store
+        store: store,
+        rolling: true
     };
 
     return [cookieParser(SESSION_SECRET), session(sessionConfig)];


### PR DESCRIPTION
We've been having reports that some users are experiencing data loss when completing the BC form. I've managed to reproduce this just once – it seems random/sporadic, but a newly-started session can be wiped clean. This change fixes what was possibly an error in the original change (eg. setting `maxAge` to a `Date` object (which should be an integer), instead of the `expires` setting (which should be a date).

It also sets `rolling: true`, partly due to [this issue](https://stackoverflow.com/questions/14464873/expressjs-session-expiring-despite-activity) which sounds similar to what we're seeing. This change means that anyone who has a session set will have its `maxAge` reset each time the user visits a page, which might solve this issue. Given I'm struggling to repro it, this is a bit of a stab in the dark, but won't effect users without sessions so shouldn't break caching (though will increase database writes for `session`ed users).