### PR TITLE
Remove use of flash messages for material order form

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -427,6 +427,9 @@ funding:
       languageOptions:
         monolingual: yn Saesneg
         bilingual: yn Gymraeg a Saesneg
+      validationError:
+        title: Mae'n flin gennym, cafwyd gwall wrth gofnodi'ch data.
+        link: Rhowch gynnig arall arni.
       orderSubmitted:
         success:
           title: Diolch am eich archeb.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -517,6 +517,9 @@ funding:
       languageOptions:
         monolingual: in English
         bilingual: in Welsh & English
+      validationError:
+        title: We’re sorry, there was an error recording your response.
+        link: Please try again.
       orderSubmitted:
         success:
           title: Thank you for your order.

--- a/views/components/forms.njk
+++ b/views/components/forms.njk
@@ -1,6 +1,6 @@
 {% macro textInput(fieldName, fieldLabel, inputType = 'text', required = false, extraClasses = false, helpText = false, charLimit = false, showErrorsBelowFields = false) %}
 
-    {% set error = getFormErrorForField(getFlash(request, 'formErrors'), fieldName) %}
+    {% set error = getFormErrorForField(formErrors, fieldName) %}
     {# this is whitespace sensitive so don't add newlines! #}
     {% set placeholderText %}{{ fieldLabel }}{% if required %} *{% endif %}{% endset %}
     {% if not showErrorsBelowFields %}
@@ -14,13 +14,13 @@
         <textarea class="{% if error %} is-error{% endif %}{% if extraClasses %} {{ extraClasses }}{% endif %}{% if charLimit %} js-has-char-limit{% endif %}"{% if error %} aria-invalid{% endif %}
                   name="{{ fieldName }}"
                   placeholder="{{ placeholderText }}"
-                  id="ff-{{ fieldName }}"{% if required %} required aria-required="true"{% endif %}{% if charLimit %} data-char-limit="{{ charLimit }}"{% endif %}>{{ getFlash(request, 'formValues', fieldName) }}</textarea>
+                  id="ff-{{ fieldName }}"{% if required %} required aria-required="true"{% endif %}{% if charLimit %} data-char-limit="{{ charLimit }}"{% endif %}>{{ formValues[fieldName] }}</textarea>
     {% else %}
         <input class="{% if error %} is-error{% endif %}{% if extraClasses %} {{ extraClasses }}{% endif %}{% if charLimit %} js-has-char-limit{% endif %}"{% if error %} aria-invalid{% endif %}
                type="{{ inputType }}"
                name="{{ fieldName }}"
                id="ff-{{ fieldName }}"{% if required %} required aria-required="true"{% endif %}
-               value="{{ getFlash(request, 'formValues', fieldName) }}"
+               value="{{ formValues[fieldName] }}"
                placeholder="{{ placeholderText }}"{% if charLimit %} data-char-limit="{{ charLimit }}"{% endif %}>
     {% endif %}
     {% if showErrorsBelowFields %}
@@ -34,7 +34,7 @@
 {% endmacro %}
 
 {% macro checkboxes(fieldName, options) %}
-    {% set error = getFormErrorForField(getFlash(request, 'formErrors'), fieldName) %}
+    {% set error = getFormErrorForField(formErrors, fieldName) %}
     {% if error %}<p class="error t6">{{ error.msg }}</p>{% endif %}
 
     {% for o in options %}
@@ -52,7 +52,7 @@
 
 {% macro radioButton(fieldName, label, value, required = false, suppressErrors = false, translateOptionLabels = false, hasOther = false) %}
     {% set uniqueId = 'ff-radio-' + fieldName + '-' + value %}
-    {% set error = getFormErrorForField(getFlash(request, 'formErrors'), fieldName) %}
+    {% set error = getFormErrorForField(formErrors, fieldName) %}
     {% if not suppressErrors and error %}
         <p class="error">{{ error.msg }}</p>
     {% endif %}
@@ -70,7 +70,7 @@
 {% macro radios(fieldName, label = false, options, allowOther = false, translateOptionLabels = false, required = false) %}
     {% set otherId = 'js-other-' + fieldName %}
     {% if allowOther %}<div class="js-has-radios" data-other-id="{{ otherId }}">{% endif %}
-    {% set error = getFormErrorForField(getFlash(request, 'formErrors'), fieldName) %}
+    {% set error = getFormErrorForField(formErrors, fieldName) %}
 
     <fieldset class="form-fieldset">
         <legend class="form-fieldset__legend">{{ label }}{% if required %} *{% endif %}</legend>

--- a/views/pages/funding/order-free-materials.njk
+++ b/views/pages/funding/order-free-materials.njk
@@ -125,7 +125,20 @@
             <h3 class="t2 accent--{{ pageAccent }} a--text">{{ copy.orderSubmitted.failure.subtitle }}</h3>
         </div>
     {% else %}
+
+        {# Warn about validation errors and link to anchor #}
+        {% if orderStatus == formHelpers.FORM_STATES.VALIDATION_ERROR %}
+            <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+                <h2 class="t2 accent--pink a--text">{{ copy.validationError.title }}</h2>
+                <h3 class="t2 accent--{{ pageAccent }} a--text">
+                    <a href="#{{ formAnchorName }}">{{ copy.validationError.link }}</a>
+                </h3>
+            </div>
+        {% endif %}
+
+        {# CMS content #}
         {{ super() }}
+
         <div id="js-vue" class="no-vue" data-orders="{{ orders | dump }}">
             <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
                 <h2>{{ copy.locationPrompt }}</h2>
@@ -163,7 +176,7 @@
 
                 </div>
 
-                <div class="u-inner accent--{{ pageAccent }} a--border-top p" id="your-details">
+                <div class="u-inner accent--{{ pageAccent }} a--border-top p" id="{{ formAnchorName }}">
                     <div class="u-padded">
                         <h3 class="t2">{{ copy.enterDeliveryAddress }}</h3>
 


### PR DESCRIPTION
Removes the `flash` middleware in favour of just rendering out the error. This was actually quite straightforward and the form already submits to the correct `?lang=` endpoint without needing any extra code (eg. so the Vue component re-inits with the correct products). Only trick was maintaining the form anchor, but I added a top-of-page validation message with an anchor link to the form:

![image](https://user-images.githubusercontent.com/394376/44037363-1060f838-9f0c-11e8-9c79-b89ed3a13788.png)
