### PR TITLE
Fix spacing on programme stats

### DIFF
--- a/assets/sass/scaffolding/lists.scss
+++ b/assets/sass/scaffolding/lists.scss
@@ -17,11 +17,6 @@
     overflow: auto;
     margin-bottom: 0.5em;
 
-    dt,
-    dd {
-        margin-bottom: 0.25em;
-    }
-
     dt {
         display: block;
         float: left;


### PR DESCRIPTION
Fixes a wrapping issue with programme stats. Most notable on small screens but was happening wherever text wraps.

<img width="1030" alt="screen shot 2018-08-14 at 12 08 07" src="https://user-images.githubusercontent.com/123386/44088374-cbbf8abe-9fba-11e8-82ee-94c6e16d9462.png">
<img width="1035" alt="screen shot 2018-08-14 at 12 08 03" src="https://user-images.githubusercontent.com/123386/44088375-cbd64420-9fba-11e8-8ee8-a9073d99f892.png">
