### PR TITLE
Prep for VPC move

### DIFF
--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -5,7 +5,7 @@ const assert = require('assert');
 const AWS = require('aws-sdk');
 const { chunk, flatten, partition, unionBy } = require('lodash');
 
-AWS.config.update({ region: 'eu-west-1' });
+AWS.config.update({ region: 'eu-west-2' });
 
 const ssm = new AWS.SSM();
 
@@ -21,7 +21,7 @@ const argv = require('yargs').option('environment', {
  * Get Secrets
  * `describeParameters` returns up to **50** items but `getParameters`
  * will only return **10** items at a time so to get everything we
- * need we'll must chunk up our list of parameters and fetch them
+ * need we must chunk up our list of parameters and fetch them
  * in batches of 10 parameters at a time.
  */
 function getParametersInChunks(parameterNames) {

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 set -e
 
-APP_ENV_PLACEHOLDER="APP_ENV"
+# Configure the patterns for the CodeDeploy deployment group names
+TEST_FLEET="Test_Fleet";
+TEST_IN_PLACE="Test_In_Place";
+LIVE_FLEET="Live_Fleet";
+LIVE_IN_PLACE="Live_In_Place";
+
+# Check if the deployment group name contains one of the above strings
 APP_ENV="development"
-if [ "$APPLICATION_NAME" == "BLF_Test" ]
+if [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_FLEET ]] ||
+   [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_IN_PLACE ]];
 then
     APP_ENV="test"
-elif [ "$APPLICATION_NAME" == "BLF_Live" ]
+elif [[ $DEPLOYMENT_GROUP_NAME =~ $LIVE_FLEET ]] ||
+     [[ $DEPLOYMENT_GROUP_NAME =~ $LIVE_IN_PLACE ]];
 then
     APP_ENV="production"
 fi
 
-# store deployment ID in a JSON file
+# Store deployment ID in a JSON file
 deploy_file=/var/www/biglotteryfund/config/deploy.json
 touch $deploy_file
 if [ -f "$deploy_file" ]
@@ -20,14 +28,15 @@ then
     sed -i "s|$DEPLOY_PLACEHOLDER|$DEPLOYMENT_ID|g" $deploy_file
 fi
 
-# run environment var script to add them to the current shell
+# Run environment var script to add them to the current shell
 /var/www/biglotteryfund/bin/get-secrets --environment=$APP_ENV
 
-# specify NODE_ENV based on deploy group ID
+# Update NODE_ENV based on deploy group ID
+APP_ENV_PLACEHOLDER="APP_ENV"
 nginx_config=/var/www/biglotteryfund/deploy/server.conf
 sed -i "s|$APP_ENV_PLACEHOLDER|$APP_ENV|g" $nginx_config
 
-# configure nginx
+# Configure nginx
 rm -f /etc/nginx/sites-enabled/default
 cp $nginx_config /etc/nginx/sites-enabled
 service nginx restart

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -49,7 +49,7 @@ const APPLICATIONS_SERVICE_ENDPOINT =
     process.env.APPLICATIONS_SERVICE_ENDPOINT || getSecret('applications-service.endpoint', true);
 
 /**
- * Additional: Without these the app will start but some funcitonality will be unavailable
+ * Additional: Without these the app will start but some functionality will be unavailable
  */
 const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
 const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');


### PR DESCRIPTION
Updates deploys to fetch their secrets from `eu-west-2` (which has the same content as `eu-west-1`), meaning when we cut over to a new set of servers we don't need to do anything.

Also updates the bootstrap script to allow for pattern matches on the CodeDeploy group names so that the new VPC groups (with slightly different names) will still count as TEST/PROD deploys.