### PR TITLE
Region config cleanup

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 require('dotenv').config();
+const config = require('config');
 
 const has = require('lodash/has');
 
@@ -45,7 +46,7 @@ const CONF = {
 
 // create AWS SDK instance
 const credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
-AWS.config.update({ region: 'eu-west-2' });
+AWS.config.update({ region: config.get('aws.region') });
 AWS.config.credentials = credentials;
 const codedeploy = new AWS.CodeDeploy();
 

--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -3,9 +3,10 @@
 const fs = require('fs');
 const assert = require('assert');
 const AWS = require('aws-sdk');
+const config = require('config');
 const { chunk, flatten, partition, unionBy } = require('lodash');
 
-AWS.config.update({ region: 'eu-west-2' });
+AWS.config.update({ region: config.get('aws.region') });
 
 const ssm = new AWS.SSM();
 

--- a/bin/start-test-server
+++ b/bin/start-test-server
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export DEBUG=blf-alpha:*;
+export DEBUG=biglotteryfund:*;
 export DB_CONNECTION_URI=sqlite://:memory;
 export PORT=8090;
 export DONT_SEND_EMAIL=true;

--- a/config/default.json
+++ b/config/default.json
@@ -33,7 +33,8 @@
     "enablePrompt": true,
     "enableAbTests": true,
     "useHotjar": true,
-    "useRemoteAssets": true
+    "useRemoteAssets": true,
+    "enableTimingMetrics": false
   },
   "imgix": {
     "mediaDomain": "biglotteryfund-assets.imgix.net"

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,6 @@
 {
   "aws": {
-    "region": "eu-west-1",
+    "region": "eu-west-2",
     "cloudfrontDistributions": {
       "test": {
         "distributionId": "E3D5QJTWAG3GDP",

--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,5 @@
 {
   "features": {
-    "enableAbTests": true,
     "useRemoteAssets": false
   }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -1,3 +1,6 @@
 {
-  "googleAnalyticsCode": "UA-637620-2"
+  "googleAnalyticsCode": "UA-637620-2",
+  "features": {
+    "enableTimingMetrics": true
+  }
 }

--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -2,7 +2,7 @@
 const AWS = require('aws-sdk');
 const config = require('config');
 const responseTime = require('response-time');
-const debug = require('debug')('blf-alpha:timings');
+const debug = require('debug')('biglotteryfund:timings');
 
 const CloudWatch = new AWS.CloudWatch({
     apiVersion: '2010-08-01',

--- a/middleware/timings.js
+++ b/middleware/timings.js
@@ -2,39 +2,40 @@
 const AWS = require('aws-sdk');
 const config = require('config');
 const responseTime = require('response-time');
-const appData = require('../modules/appData');
+const debug = require('debug')('blf-alpha:timings');
 
 const CloudWatch = new AWS.CloudWatch({
     apiVersion: '2010-08-01',
     region: config.get('aws.region')
 });
 
+const featureIsEnabled = config.get('features.enableTimingMetrics');
+
 module.exports = responseTime(function(req, res, time) {
-    if (appData.isNotProduction) {
-        return;
-    }
+    if (featureIsEnabled === true) {
+        const method = req.method.toUpperCase();
 
-    const method = req.method.toUpperCase();
+        if (method === 'GET' || method === 'POST') {
+            const isLegacy = res.getHeader('X-BLF-Legacy') === 'true';
+            const metricPrefix = isLegacy ? 'RESPONSE_TIME_LEGACY' : 'RESPONSE_TIME';
 
-    if (method === 'GET' || method === 'POST') {
-        const isLegacy = res.getHeader('X-BLF-Legacy') === 'true';
-        const metricPrefix = isLegacy ? 'RESPONSE_TIME_LEGACY' : 'RESPONSE_TIME';
+            const metric = {
+                MetricName: `${metricPrefix}_${method}`,
+                Dimensions: [
+                    {
+                        Name: 'RESPONSE_TIME',
+                        Value: 'TIME_IN_MS'
+                    }
+                ],
+                Unit: 'Milliseconds',
+                Value: time
+            };
 
-        const metric = {
-            MetricName: `${metricPrefix}_${method}`,
-            Dimensions: [
-                {
-                    Name: 'RESPONSE_TIME',
-                    Value: 'TIME_IN_MS'
-                }
-            ],
-            Unit: 'Milliseconds',
-            Value: time
-        };
-
-        CloudWatch.putMetricData({
-            MetricData: [metric],
-            Namespace: 'SITE/TRAFFIC'
-        }).send();
+            debug('Sending response timings to CloudWatch');
+            CloudWatch.putMetricData({
+                MetricData: [metric],
+                Namespace: 'SITE/TRAFFIC'
+            }).send();
+        }
     }
 });

--- a/models/index.js
+++ b/models/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const { startsWith } = require('lodash');
 const Sequelize = require('sequelize');
-const debug = require('debug')('blf-alpha:models');
+const debug = require('debug')('biglotteryfund:models');
 
 const { DB_CONNECTION_URI } = require('../modules/secrets');
 

--- a/modules/appData.js
+++ b/modules/appData.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const config = require('config');
 const { get } = require('lodash');
-const debug = require('debug')('blf-alpha:appData');
+const debug = require('debug')('biglotteryfund:appData');
 
 /**
  * Extract deploy ID from AWS (where provided)

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -9,19 +9,17 @@ const path = require('path');
 const Raven = require('raven');
 const util = require('util');
 
-const appData = require('./appData');
 const app = require('../server');
-
-const AWS_REGION = config.get('aws.region');
 
 const SES = new AWS.SES({
     apiVersion: '2010-12-01',
-    region: AWS_REGION
+    // @TODO: Migrate SES to eu-west-2?
+    region: 'eu-west-1'
 });
 
 const CloudWatch = new AWS.CloudWatch({
     apiVersion: '2010-08-01',
-    region: AWS_REGION
+    region: config.get('aws.region')
 });
 
 /**

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -1,7 +1,7 @@
 'use strict';
 const AWS = require('aws-sdk');
 const config = require('config');
-const debug = require('debug')('blf-alpha:mailer');
+const debug = require('debug')('biglotteryfund:mailer');
 const htmlToText = require('html-to-text');
 const juice = require('juice');
 const nodemailer = require('nodemailer');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "blf-alpha",
+  "name": "biglotteryfund",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1088,9 +1088,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.285.1",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.285.1.tgz",
-      "integrity": "sha512-lkroCYcnb7UWR/jbaW6wyjAeGROrsBFWyqUukQjICuCV4a0Mapnjsxefl2A/z+0SX3gnBN7owUb/60UjQSHpzA==",
+      "version": "2.295.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.295.0.tgz",
+      "integrity": "sha512-FMXlRnQoeII+l+V7XC6viC6RaJ0O3KDMC7KDtfqgZOOwfElyttNQ39MLKZCpo7Ua6mOn/9mJ+zy7yXaReX1Yyw==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "ext": "js,json,yml"
   },
   "dependencies": {
-    "aws-sdk": "^2.259.1",
+    "aws-sdk": "2.295.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "config": "^1.26.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "blf-alpha",
-  "description": "Big Lottery Fund Alpha",
+  "name": "biglotteryfund",
+  "description": "Big Lottery Fund",
   "version": "1.0.0",
   "private": true,
   "config": {
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "node ./bin/www",
-    "startDev": "export DEBUG=blf-alpha:*,express-session,connect:session-sequelize; nodemon --inspect ./bin/www",
+    "startDev": "export DEBUG=biglotteryfund:*,express-session,connect:session-sequelize; nodemon --inspect ./bin/www",
     "test": "npm audit && eslint . && jest --env=node --maxWorkers=4",
     "test-cypress": "wait-on http://localhost:8090 && cypress run",
     "pretest-ci": "npm run build",


### PR DESCRIPTION
Updates the default region to be `eu-west-2` and removes some hard-coded instances of that config. This updates Cloudwatch to post custom metrics to `eu-west-2`. Confirmed that these are created on send and no further configuration is needed.

<img width="1203" alt="screen shot 2018-08-17 at 10 21 16" src="https://user-images.githubusercontent.com/123386/44259173-baaae480-a208-11e8-808d-9043eb88b68a.png">

 Conversely hard-codes SES to be in `eu-west-1` as that is the remaining service still in `eu-west-1`.

Also made a couple of tweaks:

- Timings metrics are now configured using a feature flag, rather than implied by the app environment
- Renamed all `debug` loggers to use `biglotteryfund` rather than `blf-alpha` and updated the package.json name.

 