### PR TITLE
Remove hub emails from secrets, these are public

### DIFF
--- a/controllers/apply/reaching-communities/constants.js
+++ b/controllers/apply/reaching-communities/constants.js
@@ -1,6 +1,14 @@
 'use strict';
 
-const { HUB_EMAILS } = require('../../../modules/secrets');
+const HUB_EMAILS = {
+    england: 'englandteam@biglotteryfund.org.uk',
+    londonSouthEast: 'londonandsoutheastteam@biglotteryfund.org.uk',
+    midlands: 'midlandsteam@biglotteryfund.org.uk',
+    northEastCumbria: 'neandcumbriateam@biglotteryfund.org.uk',
+    northWest: 'northwestteam@biglotteryfund.org.uk',
+    southWest: 'southwestteam@biglotteryfund.org.uk',
+    yorksHumber: 'yorksandhumberteam@biglotteryfund.org.uk'
+};
 
 const PROJECT_LOCATIONS = [
     {

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -41,29 +41,20 @@ function getSecret(name, shouldThrowIfMissing = false) {
 /**
  * Required: Without these the app won't start
  */
-const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || getSecret('db.connection-uri', true);
-const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url', true);
-const SESSION_SECRET = process.env.SESSION_SECRET || getSecret('session.secret', true);
-const JWT_SIGNING_TOKEN = process.env.JWT_SIGNING_TOKEN || getSecret('user.jwt.secret', true);
 const APPLICATIONS_SERVICE_ENDPOINT =
     process.env.APPLICATIONS_SERVICE_ENDPOINT || getSecret('applications-service.endpoint', true);
+const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url', true);
+const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || getSecret('db.connection-uri', true);
+const JWT_SIGNING_TOKEN = process.env.JWT_SIGNING_TOKEN || getSecret('user.jwt.secret', true);
+const SESSION_SECRET = process.env.SESSION_SECRET || getSecret('session.secret', true);
 
 /**
  * Additional: Without these the app will start but some functionality will be unavailable
  */
+const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecret('dotmailer.api.password') };
 const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
 const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');
 const SENTRY_DSN = process.env.SENTRY_DSN || getSecret('sentry.dsn');
-const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecret('dotmailer.api.password') };
-const HUB_EMAILS = {
-    northWest: getSecret('emails.hubs.northwest'),
-    northEastCumbria: getSecret('emails.hubs.northeastcumbria'),
-    midlands: getSecret('emails.hubs.midlands'),
-    southWest: getSecret('emails.hubs.southwest'),
-    londonSouthEast: getSecret('emails.hubs.londonsoutheast'),
-    yorksHumber: getSecret('emails.hubs.yorkshumber'),
-    england: getSecret('emails.hubs.england')
-};
 
 module.exports = {
     getRawParameters,
@@ -73,7 +64,6 @@ module.exports = {
     CONTENT_API_URL,
     DB_CONNECTION_URI,
     DOTMAILER_API,
-    HUB_EMAILS,
     JWT_SIGNING_TOKEN,
     MATERIAL_SUPPLIER,
     PREVIEW_DOMAIN,


### PR DESCRIPTION
The hub emails are published on the public Reaching Communities page so there's no need for these to live in secrets. 🌎 