### PR TITLE
Remove tabs from logo downloads page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -485,8 +485,7 @@ funding:
           ddeddfwriaeth berthnasol arall a ddaw i rym, megis y Rheoliad Diogelu Data
           Cyffredinol (UE) 2016/679.</p>"
     logos:
-      locationPrompt: 'I sicrhau eich bod yn cael y logo cywir, dywedwch wrthym ble
-        mae''ch prosiect wedi''i leoli:'
+      downloadsTitle: Logos uniaith
       locations:
         monolingual: Lloegr, Yr Alban neu Ogledd Iwerddon
         bilingual: Cymru
@@ -503,9 +502,6 @@ funding:
           pink: pinc
           white: gwyn
         download: Lawrlwytho'r
-      logoDownloads:
-        monolingual: Logos uniaith Saesneg
-        bilingual: Logos dwyieithog Cymraeg/Saesneg
       howToUseLogo:
         title: Sut i ddefnyddio ein logo
         sections:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -485,6 +485,8 @@ funding:
           ddeddfwriaeth berthnasol arall a ddaw i rym, megis y Rheoliad Diogelu Data
           Cyffredinol (UE) 2016/679.</p>"
     logos:
+      locationPrompt: 'I sicrhau eich bod yn cael y logo cywir, dywedwch wrthym ble
+        mae''ch prosiect wedi''i leoli:'
       downloadsTitle: Logos uniaith
       locations:
         monolingual: Lloegr, Yr Alban neu Ogledd Iwerddon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,6 +580,8 @@ funding:
           any other relevant legislation that comes into force, such as the General
           Data Protection Regulation (EU) 2016/679.</p>"
     logos:
+      locationPrompt: 'To make sure you get the correct logo please tell us where
+          your project is based:'
       downloadsTitle: Logo downloads
       locations:
         monolingual: England, Scotland or Northern Ireland

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -580,8 +580,7 @@ funding:
           any other relevant legislation that comes into force, such as the General
           Data Protection Regulation (EU) 2016/679.</p>"
     logos:
-      locationPrompt: 'To make sure you get the correct logo please tell us where
-        your project is based:'
+      downloadsTitle: Logo downloads
       locations:
         monolingual: England, Scotland or Northern Ireland
         bilingual: Wales
@@ -598,11 +597,8 @@ funding:
           pink: pink
           white: white
         download: Download
-      logoDownloads:
-        monolingual: English logo downloads
-        bilingual: Bilingual English/Welsh logo downloads
       howToUseLogo:
-        title: "\LHow to use our logo\L"
+        title: How to use our logo
         sections:
           freeKit:
             title: Free branded kit

--- a/views/common/informationPage.njk
+++ b/views/common/informationPage.njk
@@ -28,7 +28,7 @@
             {{ content.introduction | safe }}
         </div>
 
-        {{ segmentLinks(content.segments) }}
+        {{ segmentLinks(customSegmentLinks | default(content.segments)) }}
     {% endmacro %}
 
     <main{% if heroImage %} class="nudge-up"{% endif %}>

--- a/views/components/content-box/macro.njk
+++ b/views/components/content-box/macro.njk
@@ -1,5 +1,6 @@
-{% macro contentBox(accent = 'pink') %}
-    <section class="content-box u-inner-wide-only accent--{{ accent }} a--border-top">
+{% macro contentBox(accent = 'pink', id = false) %}
+    <section class="content-box u-inner-wide-only accent--{{ accent }} a--border-top"
+        {% if id %}id="{{ id }}"{% endif %}>
         <div class="s-prose u-constrained-content-wide">
             {{ caller() }}
         </div>

--- a/views/pages/funding/logos.njk
+++ b/views/pages/funding/logos.njk
@@ -90,9 +90,21 @@
     {{ super() }}
 
     <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top" id="segment-1">
+        <p><strong>{{ copy.locationPrompt }}</strong></p>
+        <div class="o-button-group-flex">
+                <a href="#region1" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
+                    {{ copy.locations.monolingual }}
+                </a>
+                <a href="#region2" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
+                    {{ copy.locations.bilingual }}
+                </a>
+            </div>
+    </div>
+
+    <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top" id="segment-1">
         <h2 class="t--underline">{{ copy.downloadsTitle }} </h2>
 
-        <h3>{{ copy.locations.monolingual }}</h3>
+        <h3 id="region1">{{ copy.locations.monolingual }}</h3>
 
         <ul class="flex-grid u-margin-bottom-l">
             <li class="flex-grid__item">
@@ -109,7 +121,7 @@
             </li>
         </ul>
 
-        <h3>{{ copy.locations.bilingual }}</h3>
+        <h3 id="region2">{{ copy.locations.bilingual }}</h3>
 
         <ul class="flex-grid u-margin-bottom-l">
             <li class="flex-grid__item">

--- a/views/pages/funding/logos.njk
+++ b/views/pages/funding/logos.njk
@@ -1,41 +1,10 @@
 {% from "components/hero.njk" import hero %}
-{% from "components/tabs.njk" import tabs, paneSet with context %}
+{% from "components/content-box/macro.njk" import contentBox %}
+{% from "components/content-tabs/macro.njk" import contentTabs %}
 {% from "components/icons.njk" import iconClose %}
 
 {% extends "common/informationPage.njk" %}
-
-{% macro howToUseLogo(bilingual = false) %}
-    <div class="s-prose u-padded">
-        {% if locale == 'cy' or bilingual %}
-            {% set logoExamplePath = 'logos/examples-cy.png' %}
-        {% else %}
-            {% set logoExamplePath = 'logos/examples.png' %}
-        {% endif %}
-
-        <h3>{{ copy.howToUseLogo.sections.freeKit.title | safe }}</h3>
-        <p>{{ copy.howToUseLogo.sections.freeKit.body | safe}}</p>
-
-        <h3>{{ copy.howToUseLogo.sections.brandGuidance.title | safe }}</h3>
-        <p>{{ copy.howToUseLogo.sections.brandGuidance.body | safe }}</p>
-
-        <h3>{{ copy.howToUseLogo.sections.format.title | safe }}</h3>
-        <p>{{ copy.howToUseLogo.sections.format.body | safe }}</p>
-
-        <h3>{{ copy.howToUseLogo.sections.options.title | safe }}</h3>
-        <p>{{ copy.howToUseLogo.sections.options.body | safe }}</p>
-
-        <figure>
-            <img src="{{ logoExamplePath | getImagePath }}" alt="Examples of our logo" />
-        </figure>
-    </div>
-{% endmacro %}
-
-{% macro logoTabBar(logoTitle, localeId) %}
-    <ul class="js-tabs tabs unstyled" data-no-initial-selection="true">
-        <li><a class="js-tab-item" href="#logos-{{ localeId }}">{{ logoTitle }}</a></li>
-        <li><a class="js-tab-item" href="#howto-{{ localeId }}">{{ copy.howToUseLogo.title }}</a></li>
-    </ul>
-{% endmacro %}
+{% set pageAccent = content.themeColour %}
 
 {% macro makeLogoTitle(logoName, logoSize) %}
     {{ copy.downloads.download }}
@@ -111,9 +80,21 @@
     </div>
 {% endmacro %}
 
-{% set logosMonolingual %}
-    <div class="u-padded">
-        <ul class="flex-grid">
+{% set customSegmentLinks = [{
+    "title": copy.downloadsTitle
+}, {
+    "title": copy.howToUseLogo.title
+}] %}
+
+{% block contentPrimary %}
+    {{ super() }}
+
+    <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top" id="segment-1">
+        <h2 class="t--underline">{{ copy.downloadsTitle }} </h2>
+
+        <h3>{{ copy.locations.monolingual }}</h3>
+
+        <ul class="flex-grid u-margin-bottom-l">
             <li class="flex-grid__item">
                 {{ logoBlock(1, 'blue', 'blue', 'en', accent = 'turquoise') }}
             </li>
@@ -127,33 +108,10 @@
                 {{ logoBlock(4, 'blue-white', 'white', onlyEps = true, isReversed = true) }}
             </li>
         </ul>
-    </div>
-{% endset %}
 
-{# england, scotland and NI #}
-{% set contentMonolingual %}
-    {{ tabs(
-        id = 'logo-monolingual',
-        content = [
-            {
-                title: copy.logoDownloads.monolingual,
-                content: logosMonolingual,
-                active: true
-            },
-            {
-                title: copy.howToUseLogo.title,
-                content: howToUseLogo(bilingual = false)
-            }
-        ]
-    )}}
-{% endset %}
+        <h3>{{ copy.locations.bilingual }}</h3>
 
-
-{# Wales #}
-
-{% set logosBilingual %}
-    <div class="u-padded">
-        <ul class="flex-grid">
+        <ul class="flex-grid u-margin-bottom-l">
             <li class="flex-grid__item">
                 {{ logoBlock(5, 'blue', 'blue', logoLocale = 'bilingual', accent = 'turquoise') }}
             </li>
@@ -168,55 +126,25 @@
             </li>
         </ul>
     </div>
-{% endset %}
 
-{% set contentBilingual %}
-    {{ tabs(
-        id = 'logo-bilingual',
-        content = [
-            {
-                title: copy.logoDownloads.bilingual,
-                content: logosBilingual,
-                active: true
-            },
-            {
-                title: copy.howToUseLogo.title,
-                content: howToUseLogo(bilingual = true)
-            }
-        ]
-    )}}
-{% endset %}
+    {% call contentBox(pageAccent, id = "segment-2") %}
+        <h2>{{ copy.howToUseLogo.title }}</h2>
 
-{% block contentPrimary %}
-    {% set pageAccent = content.themeColour %}
-    {{ super() }}
-    <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top accent-content--{{ pageAccent }}">
-        <div class="s-prose">
-            <h2>{{ copy.locationPrompt }}</h2>
-        </div>
+        <h3>{{ copy.howToUseLogo.sections.freeKit.title | safe }}</h3>
+        <p>{{ copy.howToUseLogo.sections.freeKit.body | safe}}</p>
 
-        <div class="js-tabset" data-paneset="paneset-regions">
-            <div class="o-button-group-flex">
-                <a href="#region1" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
-                    {{ copy.locations.monolingual }}
-                </a>
-                <a href="#region2" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
-                    {{ copy.locations.bilingual }}
-                </a>
-            </div>
-        </div>
+        <h3>{{ copy.howToUseLogo.sections.brandGuidance.title | safe }}</h3>
+        <p>{{ copy.howToUseLogo.sections.brandGuidance.body | safe }}</p>
 
-        {{ paneSet(
-            id = "paneset-regions",
-            panes = [{
-                paneId: 'region1',
-                content: contentMonolingual,
-                accordion: false
-            }, {
-                paneId: 'region2',
-                content: contentBilingual,
-                accordion: false
-            }]
-        ) }}
-    </div>
+        <h3>{{ copy.howToUseLogo.sections.format.title | safe }}</h3>
+        <p>{{ copy.howToUseLogo.sections.format.body | safe }}</p>
+
+        <h3>{{ copy.howToUseLogo.sections.options.title | safe }}</h3>
+        <p>{{ copy.howToUseLogo.sections.options.body | safe }}</p>
+
+        <figure>
+            <img src="{{ "logos/examples.png" | getImagePath }}" alt="Examples of our logo" style="display: inline-block" />
+            <img src="{{ "logos/examples-cy.png" | getImagePath }}" alt="Examples of our logo" style="display: inline-block" />
+        </figure>
+    {% endcall %}
 {% endblock %}


### PR DESCRIPTION
Paired with @LynseyJReynolds on updating the logos page to avoid nested tabs. In fact it  now uses no tabs at all and instead shows all the content upfront. We're also merging the two versions of the "how to use our logo" into one as the only difference was the sample image which can be handled by showing both next to each other.

This plus the end result of https://github.com/biglotteryfund/blf-alpha/pull/1211 will allow us to completely remove the old tab macro.

![localhost_3000_funding_funding-guidance_managing-your-funding_grant-acknowledgement-and-logos](https://user-images.githubusercontent.com/123386/44265328-fdc38280-a21d-11e8-9386-6e903136d325.png)
