### PR TITLE
Add clean up task to survey responses

### DIFF
--- a/services/surveys.js
+++ b/services/surveys.js
@@ -82,7 +82,20 @@ async function getAllResponses({ path = null }) {
 }
 
 function createResponse(response) {
+    cleanupOldData();
     return SurveyAnswer.create(response);
+}
+
+function cleanupOldData() {
+    return SurveyAnswer.destroy({
+        where: {
+            createdAt: {
+                [Op.lte]: moment()
+                    .subtract(3, 'months')
+                    .toDate()
+            }
+        }
+    });
 }
 
 module.exports = {


### PR DESCRIPTION
Noticed we were missing an expiry step for survey responses. Adds the same 3 month limit as we have on feedback responses.