### PR TITLE
Add an email address for the internal Digital Fund demo form

### DIFF
--- a/controllers/apply/digital-funding-demo/processor.js
+++ b/controllers/apply/digital-funding-demo/processor.js
@@ -1,5 +1,7 @@
 'use strict';
 const mail = require('../../../modules/mail');
+const appData = require('../../../modules/appData');
+const { DIGITAL_FUND_DEMO_EMAIL } = require('../../../modules/secrets');
 
 module.exports = function processor(form, formData) {
     const flatData = form.getStepValuesFlattened(formData);
@@ -9,6 +11,7 @@ module.exports = function processor(form, formData) {
      * Construct a primary address (i.e. customer email)
      */
     const primaryAddress = `${flatData['first-name']} ${flatData['last-name']} <${flatData['email']}>`;
+    const organisationName = `${flatData['organisation-name']}`;
 
     return mail.generateAndSend([
         {
@@ -19,6 +22,18 @@ module.exports = function processor(form, formData) {
             templateName: 'emails/applicationSummary',
             templateData: {
                 summary: summary,
+                form: form,
+                data: flatData
+            }
+        },
+        {
+            name: 'digital_funding_demo_internal',
+            sendTo: (appData.isDev) ? primaryAddress : DIGITAL_FUND_DEMO_EMAIL,
+            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
+            subject: `New Digital Fund idea submission from website: ${organisationName}`,
+            templateName: 'emails/applicationSummaryInternal',
+            templateData: {
+                summary: form.orderStepsForInternalUse(summary),
                 form: form,
                 data: flatData
             }

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -55,6 +55,7 @@ const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecr
 const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
 const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');
 const SENTRY_DSN = process.env.SENTRY_DSN || getSecret('sentry.dsn');
+const DIGITAL_FUND_DEMO_EMAIL = process.env.DIGITAL_FUND_DEMO_EMAIL || getSecret('emails.digitalfund.demo');
 
 module.exports = {
     getRawParameters,
@@ -68,5 +69,6 @@ module.exports = {
     MATERIAL_SUPPLIER,
     PREVIEW_DOMAIN,
     SENTRY_DSN,
-    SESSION_SECRET
+    SESSION_SECRET,
+    DIGITAL_FUND_DEMO_EMAIL
 };


### PR DESCRIPTION
By request from Stuart. I've added the secret already (an email address which he said shouldn't be public), otherwise this just re-uses the RC form logic.