### PR TITLE
Update research pages to fetch content from the CMS

### DIFF
--- a/assets/sass/components/_research.scss
+++ b/assets/sass/components/_research.scss
@@ -3,15 +3,15 @@
    ========================================================================= */
 
 /* =========================================================================
-   Research Section
-   ========================================================================= */
+    Research Intro
+    ========================================================================= */
 
-.research-section {
+.research-intro {
     @include mq('medium-major') {
         display: flex;
     }
 
-    .research-section__primary {
+    .research-intro__primary {
         font-size: 18px;
         max-width: $constrained;
         margin-bottom: $spacingUnit;
@@ -22,17 +22,47 @@
         }
     }
 
-    .research-section__secondary {
+    .research-intro__secondary {
         @include mq('medium-major') {
             flex: 0 0 32%;
         }
     }
 
-    .research-section__prefix {
+    .research-intro__prefix {
         font-size: 16px;
         font-style: italic;
         color: palette('charcoal-note');
         margin-bottom: 0;
+    }
+}
+
+/* =========================================================================
+   Research Sections
+   ========================================================================= */
+
+.research-sections {
+    .research-sections__content {
+        font-size: 18px;
+        max-width: $constrained;
+        margin-bottom: $spacingUnit;
+
+        @include mq('medium-major') {
+            float: left;
+            width: 68%;
+            padding-right: $spacingUnit;
+            clear: left;
+        }
+    }
+
+    .research-sections__callout {
+        @include mq('medium-major') {
+            float: right;
+            width: 32%;
+        }
+    }
+
+    .research-sections__meta {
+        clear: both;
     }
 }
 

--- a/bin/www
+++ b/bin/www
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const app = require('../server');
-const debug = require('debug')('blf-alpha:server');
+const debug = require('debug')('biglotteryfund:server');
 const http = require('http');
 const models = require('../models');
 

--- a/config/default.json
+++ b/config/default.json
@@ -20,6 +20,7 @@
   },
   "siteDomain": "www.biglotteryfund.org.uk",
   "dateFormats": {
+    "month": "MMMM YYYY",
     "short": "D MMMM, YYYY",
     "full": "dddd D MMMM YYYY",
     "fullTimestamp": "dddd D MMM YYYY (hh:mm a)"

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -271,6 +271,7 @@ toplevel:
   research:
     title: Ymchwil
     intro: Cael gwybod mwy am beth rydym yn ei ddysgu o’r prosiectau a ariannwn.
+    newReport: Adroddiad newydd
     sectionLinks:
     - label: Cymunedau a lleoedd
       href: "/welsh/research/communities-and-places"
@@ -551,150 +552,10 @@ funding:
     over10k: Grantiau dros £10,000
     breadcrumbAll: Pob Rhaglenni
 research:
-  youthviolence:
-    title: 'Trais difrifol ymysg pobl ifainc'
-    intro:
-      <p><strong>Dysgu o'r sector gwirfoddol a chymunedol ynghylch beth sy'n gweithio wrth atal trais difrifol ymysg pobl ifainc</strong></p><p>Yma, rydym yn amlygu enghreifftiau o arfer addawol ac sydd wedi profi ei werth o elusennau ar draws y wlad ac yn rhannu ein profiadau fel ariannwr ynglŷn â'r egwyddorion sydd wedi gweithio i ni wrth gynllunio, dylunio a gweithredu rhaglenni ariannu yn y maes hwn.</p>
-    sectionsPrefix: Gwersi ar gyfer dylunio polisi a rhaglenni
-    sections:
-    - title: Atal
-      contentParts:
-      - title: Cydweithio i atal niwed yn ystod plentyndod
-        points:
-        - Symudwch y diwylliant a gwariant tuag at gefnogaeth a gwasanaethau sy'n ffocysu ar atal.
-        - Mabwysiadwch ddull Iechyd Cyhoeddus o atal trais, gan gynnwys cydweithio i leihau ffactorau risg a hyrwyddo ffactorau diogelu
-        - Sicrhewch waith partneriaeth effeithiol fel bod cefnogaeth a gwasanaethau'n llai biwrocratig ac yn fwy cydlynol.
-        callout:
-          isQuote: false
-          content:
-            Mae pobl sy'n cael profiadau niweidiol yn ystod plentyndod wyth waith yn fwy tebygol o gael dedfryd carchar
-      - title: Gwella deilliannau ar gyfer yr holl blant
-        points:
-        - Cefnogwch blant i ddatblygu sgiliau cymdeithasol ac emosiynol fel y gallant ddatblygu perthnasoedd cadarnhaol ac ymdopi â sefyllfaoedd anodd.
-        - Buddsoddwch mewn gwasanaethau cyffredinol, fel gwasanaethau blynyddoedd cynnar, addysg a phobl ifainc sy'n fwy cefnogol ac ymatebol.
-        - Darparwch wasanaethau cynnar, wedi'u targedu ar gyfer ysgolion a grwpiau sy'n wynebu risgiau penodol.
-        - Darparwch y sgiliau a dealltwriaeth y mae eu hangen ar rieni a chymunedau i atal a rheoli ffactorau risg.
-      - title: Edrych dros yr hir dymor
-        points:
-        - Cydnabyddwch lefelau anhrefn, trawma a dadfreinio ym mywydau llawer o bobl ifainc.
-        - Darparwch yr amser a lle y mae eu hangen ar elusennau a staff rheng flaen i gefnogi eu buddiolwyr.
-        - Byddwch yn ‘amyneddgar’ gyda rhaglenni a phrosiectau newydd; gan roi amser a lle iddynt addasu a newid wrth iddynt ddysgu yn sgil darparu.
-      - title: Adnabod a chefnogi plant a phobl ifainc sy'n wynebu risg yn brydlon
-        points:
-        - Mae angen i waith ar y cyd rhwng asiantaethau statudol a grwpiau gwirfoddol a chymunedol (SGCh) ymestyn o gywain data i'w rannu a'i ddefnyddio i adnabod pobl ifainc sy'n wynebu risg mor gynnar â phosib.
-        - Hyfforddwch weithwyr proffesiynol a'r gymuned ehangach i adnabod a deall ffactorau risg ac ymddygiadau sy'n peri risg trwy ddulliau wedi'u llywio gan drawma.
-        - Cymerwch i ystyriaeth fod pobl ifainc sy'n wynebu risg yn arbennig o dda wrth adnabod pobl ifainc eraill sy'n wynebu risg
-        - Sicrhewch fod cefnogaeth ychwanegol ar gael ar gyfer pobl ifainc sy'n profi newidiadau (e.e. o'r ysgol gynradd i'r ysgol uwchradd, mynd i mewn i ofal, symud rhwng carchar pobl ifainc a charchar i oedolion, etc.).
-        callout:
-          isQuote: true
-          content:
-            …mae risgiau yn ystod babandod yn cynyddu'r cyfle o ymddygiad gwrthgymdeithasol yn ystod plentyndod, sydd yn ei dro'n cynyddu'r tebygolrwydd o droseddu yn ystod glasoed…
-          citation: Prif Swyddog Meddygol, 2012
-    - title: Ymyrraeth Gynnar
-      contentParts:
-      - title: Rhoi'r cymwyseddau a hyder i bobl ifainc reoli gwrthdaro ac ymdopi â phwysau gan gymheiriaid
-        points:
-        - Rhowch gyfle i bobl ifainc ymarfer technegau i osgoi a datrys gwrthdaro, rheoli dicter, cyfathrebu'n fwy effeithiol a dangos uniaethu.
-        - Helpwch bobl ifainc i ddeall achosion a chanlyniadau gwrthdaro, gan gynnwys newid y ffordd y mae pobl ifainc yn meddwl am drais ac atgyfnerthu rhesymau dros beidio â bod yn dreisgar.
-        - Pan fo'n bosib, cydweithiwch â grwpiau cyfeillgarwch a phobl ifainc sy'n ymwneud â throseddu fel grŵp (neu weithgarwch gangiau) yn hytrach nag unigolion yn unig.
-        - Grymuswch bobl ifainc i wneud y dewisiadau iawn ar sail gwybodaeth a chefnogaeth yn hytrach na 'dull brawychu'.
-        - Sicrhewch fod gwasanaethau'n cymryd amgylchiadau, anghenion a dymuniadau penodol dynion a menywod ifainc sy'n ymwneud - yn uniongyrchol neu'n anuniongyrchol - â ffyrdd o fyw treisgar i ystyriaeth.
-        - Ymdriniwch â'r defnydd o gyfryngau cymdeithasol i gyfareddu, dangos a symbylu trais.
-      - title: Mae adeiladu perthnasoedd cefnogol a ffyddlon yn sail i waith y mwyafrif o elusennau
-        points:
-        - Mae gan lawer o bobl ifainc yn y grŵp targed hwn ddiffyg ffydd mewn asiantaethau statudol ac felly mae grwpiau gwirfoddol y mae gan y gymuned ffydd ynddynt a mynediad atynt mewn sefyllfa ddelfrydol i ddarparu mentora a chreu cysylltiadau a ffydd.
-        - Ni ddylid rhuthro adeiladu perthnasoedd a dylid dechrau gyda diddordebau, dymuniadau a chryfderau pobl ifainc.
-        callout:
-          isQuote: false
-          content: Gall mentora fod yn effeithiol wrth leihau trais ond ceir tystiolaeth gymysg ynghylch effaith mentora ar arestiadau ac aildroseddu
-      - title: Estyn cefnogaeth i leoedd a gofodau y mae pobl ifainc yn teimlo'n gyfforddus ynddynt
-        points:
-        - Mae angen i gefnogaeth ymestyn o ysgolion a gwasanaethau statudol i'r gymuned - ac adeiladu ar yr hyn sydd eisoes yn gweithio'n dda'n lleol.
-        - Mae lleoliad hyblyg yn arbennig o bwysig yng nghyd-destun gangiau côd post, gan y gall fod yn beryglus i rai pobl ifainc adael eu cymdogaethau. Mae llawer o bobl ifainc sy'n ymwneud ag ymddygiad gwrthgymdeithasol mewn ystadau y tu allan i ganol dinasoedd a threfi sydd wedi'u heffeithio gan dlodi'n gadael eu hystâd yn anaml, neu ddim o gwbl, i gyrchu cyfleoedd.
-      - title: Ymgorffori, neu gysylltu â, chefnogaeth iechyd meddwl arbenigol
-        points:
-        - Mae'n bwysig taclo stigma a'i wneud yn haws i bobl ifainc gamu i fyny i siarad am iechyd meddwl. Yn ei dro, dylai gwasanaethau iechyd meddwl beidio â stigmateiddio a bod yn berthnasol.
-        - Nid yw atebion cyflym i broblemau iechyd meddwl yn gweithio.
-        - Dylid hyfforddi gweithwyr proffesiynol a gwirfoddolwyr i fod yn sensitif i broblemau iechyd meddwl posib.
-        - Gallai fod angen dull teulu cyfan, yn enwedig os yw'r teulu cyfan wedi profi trallod arwyddocaol ac mae problemau teuluol ehangach fel cefndir i berson ifainc sy'n ymwneud â thrais.
-        - Dylid darparu gwasanaethau iechyd meddwl mewn amrywiaeth o leoliadau gwahanol.
-        callout:
-          isQuote: false
-          content: Amcangyfrifir bod gan un o bob tri o bobl ifainc sy'n troseddu angen iechyd meddwl  heb ei ddiwallu ar adeg y drosedd
-      - title: Mae chwaraeon a'r celfyddydau'n hyrwyddo gwerthoedd cadarnhaol ac yn ddull da o fachu cyfranogiad
-        points:
-        - Gallant ddarparu'r amgylchedd a dylanwadau iawn i hyrwyddo gwerthoedd cadarnhaol, gan gynnwys ymgymryd â chyfrifoldeb a dysgu sut i ddatrys gwrthdaro mewn ffordd gadarnhaol
-        - Mae angen i brosiectau chwaraeon a chelfyddydau fod yn hir dymor eu natur ac wedi'u cynnwys, lle bo'n bosib, o fewn rhaglen addysg a chefnogaeth ddatblygiadol ehangach.
-        - Mae rôl a sgiliau'r hyfforddwyr yn hollbwysig felly mae angen i staff prosiectau celfyddydau a chwaraeon gael eu hyfforddi a'u cefnogi.
-        - Mae angen i brosiectau chwaraeon a chelfyddydau gael eu targedu'n dda o ran eu lleoliad ac ennyn diddordeb pobl ifainc.
-        callout:
-          isQuote: false
-          content: Gall apêl chwaraeon a'r celfyddydau weithredu fel ‘bach’ ennyn diddordeb a chreu ymdeimlad o gyffro, “yn debyg i'r teimladau a brofir fel rhan o gang.”
-      - title: Mae amseru'n bwysig o ran ennyn diddordeb a chefnogaeth
-        points:
-        - Mae ennyn diddordeb llwyddiannus yn gysylltiedig nid yn unig â lle ond hefyd ag amseru'r ymyrraeth. Mae angen rhoi cefnogaeth ar yr amser iawn ym mywyd y person ifanc.
-      - title: Gallwn ddysgu o arbenigedd a phrofiad pobl ifainc
-        points:
-        - Mae pobl ifainc sydd wedi ymwneud â gangiau a throseddu'n helpu symbylu gwaith llawer o elusennau sy'n llwyddo i ddargyfeirio pobl ifainc i ffwrdd o ffyrdd o fyw treisgar.
-        - Mae cyd-gynhyrchu go iawn yn cymryd amser i'w sefydlu a'i redeg.
-        - Dylid cynnwys pobl ifainc ar lefel y maent yn teimlo sy'n briodol iddynt ar y pryd.
-        - Croesewch bobl ifainc, anogwch nhw i herio dulliau gweithio sydd eisoes yn bodoli; parchwch eu cyfraniadau. Sicrhewch fod cyfranogiad yn wirfoddol a bod angen iddynt fedru newid eu meddwl.
-        - Os bydd pobl ifainc yn cymryd rhan mewn cyfarfodydd bwrdd neu bartneriaeth, gwnewch yn siŵr fod yr wybodaeth wedi'i darparu mewn iaith glir, heb jargon ac mewn fformat sy'n addas i'r oedran y gellir ei ddeall yn hawdd
-        - Gwnewch yn siŵr fod y bobl ifainc yn deall sut y gallant elwa o gymryd rhan.
-        - Gwnewch yn siŵr eich bod yn dathlu eu gwaith ac yn sicrhau bod staff, mudiadau partner a phobl ifainc yn gwybod beth sydd wedi newid o ganlyniad i'w cyfraniadau.
-        - Meddyliwch am sut i gywain barn pobl o gefndiroedd gwahanol a gyda phrofiadau gwahanol.
-    - title: Dulliau partneriaeth
-      contentParts:
-      - title: Mae cynnwys y SGCh yn fwy na dymunol - mae'n hanfodol
-        points:
-        - Gall grwpiau gwirfoddol a chymunedol ychwanegu gwerth sylweddol at waith gwasanaethau statudol ym maes trais ymysg pobl ifainc. Mae hyn oherwydd y gallant gynrychioli a chefnogi pobl ifainc sydd wedi'u cuddio neu'n ddatgysylltiedig rhag gwasanaethau eraill.
-        - Dylai partneriaethau ddod â mudiadau llai, gan gynnwys grwpiau llawr gwlad, ynghyd i gynhyrchu syniadau sydd wedi'u hymwreiddio ym mhrofiad cymunedau, gydag ymgyrhaeddiad a maint mudiadau mwy.
-        - Deallwch yr heriau a wynebir gan fudiadau llawr gwlad bach sy'n canolbwyntio ar ddarpariaeth rheng flaen - mae eu gallu i gymryd rhan ar lefel strategol yn gyfyngedig a dylid ei gefnogi.
-        - Gwerthfawrogwch arbenigedd partneriaid – mae gan lawer o grwpiau arbenigedd arloesol a blynyddoedd/degawdau o brofiad, gan gynnwys profiad byw o'r heriau a wynebir gan y rhai y maent yn eu cefnogi.
-        callout:
-          isQuote: false
-          content: Gallai grwpiau llai ei chael hi'n anodd cydweithio mewn hinsawdd o gystadlu dros gyfleoedd ariannu tymor byr sy'n seiliedig ar brosiectau
-      - title: Mae arweinwyr hael a gweledigaeth a rennir yn rhai o 'gynhwysion allweddol' partneriaethau llwyddiannus
-        points:
-        - Mae parodrwydd i rannu cyfrifoldeb a dylanwad i gyflawni budd cyffredin yn bwysig, ynghyd â chymhelliant i adeiladu cynghreiriau cryfion gydag unigolion, grwpiau a chymunedau a all gyflawni amcanion a rennir gyda'i gilydd.
-        - Dylai partneriaid gael eu cymell gan set o nodau a gwerthoedd a rennir. Mae'r rhain yn dechrau gyda'r ecosystem ehangach, yn hytrach na blaenoriaethau unigol pob partner.
-        - Peidiwch ag ystyried dim ond yr hyn y gall partneriaid gwahanol ddod ag ef at y bwrdd, ystyriwch ganlyniadau hepgor nhw hefyd.
-        - Dewch o hyd i ddulliau cydweithio ag arweinwyr ffydd a chyflogwyr, gan gynnwys cwmnïau mawr a'u cadwynau cyflenwi yn ogystal â busnesau bach a chanolig. Gallant ddarparu cyfleoedd lleoliad gwaith a chyflogaeth, sy'n arbennig o bwysig ar gyfer y rhai sydd â dibynyddion.
-        - Pennwch derfynau ar gyfer atebolrwydd, rhannu gwybodaeth a thargedau. Mae cyfathrebu rheolaidd ac ymrwymiad gweladwy gan staff uwch yn bwysig.
-      - title: Adeiladu dull system gyfan
-        points:
-        - Crëwch ymgyrch i gydnabod trais difrifol ymysg pobl ifainc fel mater iechyd cyhoeddus y mae angen ymateb cymuned gyfan a dull sy'n peidio â barnu i ymdrin ag ef.
-        - Ymddiriedwch mewn perthnasoedd, arbenigedd a phrofiad grwpiau SGCh i gefnogi pobl ifainc sy'n ymwneud â thrais difrifol.
-        - Mae newid systemau'n golygu canolbwyntio ar achosion craidd materion cymdeithasol a gweithio i greu systemau sy'n gweithredu'n gynnar i atal problemau.
-        callout:
-          isQuote: false
-          content: Wrth i un person ifanc symud i ffwrdd o droseddu cyfundrefnol mae'n bosib y bydd eraill, fel teulu a ffrindiau, yn dilyn
-    metadata:
-    - label: Dyddiad cyhoeddi
-      content: Gorffennaf 2018
-    - label: Manylion cyswllt
-      content: <a href="mailto:knowledge@biglotteryfund.org.uk">knowledge@biglotteryfund.org.uk</a>
-    documents:
-      title: Dogfennau
-      trailText: Mae'r adroddiad llawn yn cynnwys mwy o'r hyn a ddysgwyd ac argymhellion gweithredu manylach.
-      documents:
-      - title: Adroddiad llawn
-        filetype: PDF
-        filesize: 900KB
-        url: https://media.biglotteryfund.org.uk/media/documents/BLF_KL18-12_SeriousViolence.pdf
-        contents:
-        - Crynodeb Gweithredol
-        - Cyflwyniad
-        - Atal - beth sy'n gweithio?
-        - Ymyrraeth gynnar - beth sy'n gweithio?
-        - Dulliau partneriaeth – beth sy'n gweithio?
-        - Ffynonellau
-    relatedProgrammes:
-      title: Rhaglenni cysylltiedig
-      items:
-        - title: A Better Start
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/fulfilling-lives-a-better-start
-        - title: HeadStart
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/fulfilling-lives-headstart
-        - title: Talent Match
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/talent-match
+  detail:
+    documents: Dogfennau
+    relatedProgrammes: Rhaglenni cysylltiedig
+    datePublished: Dyddiad cyhoeddi
+    # @TODO: Translate me!
+    researchPartners: Research partners
+    contact: Manylion cyswllt

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,9 +363,8 @@ toplevel:
   research:
     title: Research
     intro: Find out more about what we’re learning from the projects we fund.
+    newReport: New report
     sectionLinks:
-    - label: "New report: youth serious violence"
-      href: "/research/youth-serious-violence"
     - label: Communities and places
       href: "/research/communities-and-places"
     - label: Older people
@@ -646,150 +645,9 @@ funding:
     over10k: Awards over £10,000
     breadcrumbAll: All Programmes
 research:
-  youthviolence:
-    title: 'Youth serious violence'
-    intro:
-      '<p><strong>Learnings from the voluntary and community sector on what works in preventing serious youth violence</strong></p><p>We highlight examples of both proven and promising practices from charities across the country and share our experiences as a funder about the principles that have worked for us in planning, designing and implementing funding programmes in this field.</p>'
-    sectionsPrefix: Lessons for policy and programme design
-    sections:
-    - title: Prevention
-      contentParts:
-      - title: Working together to prevent childhood adversity
-        points:
-        - Shift culture and spending towards prevention-focused support and services.
-        - Take a Public Health approach to violence prevention, including working together to reduce risk factors and promote protective factors.
-        - Ensure effective partnership-working so that support and services are less bureaucratic and more joined-up.
-        callout:
-          isQuote: false
-          content:
-            People who experience four or more adverse childhood experiences are eight times more likely to end up in prison
-      - title: Improving outcomes for all children
-        points:
-        - Support children to develop social and emotional skills so they can develop positive relationships and cope with difficult situations.
-        - Invest in universal services, such as more supportive, responsive and integrated early years, education and youth services.
-        - Provide early, targeted services for schools and groups at particular risk.
-        - Give parents and communities the skills and understanding they need to prevent and manage risk factors.
-      - title: Take a long-term view
-        points:
-        - Recognise the level of chaos, trauma and disenfranchisement in many young people’s lives.
-        - Give charities and front-line staff the time and space they need to support their beneficiaries.
-        - Be ‘patient’ with new programmes and projects; giving them the time and space to adapt and change as they learn from delivery.
-      - title: Identify and supporting at-risk children and young people in a timely manner
-        points:
-        - Joint working between statutory agencies and voluntary and community (VCS) groups needs to extend from collecting data, to sharing and making use of it to identify and support at-risk youth at the earliest opportunity.
-        - Train professionals and the wider community to recognise and understand risk factors and behaviours through trauma-informed approaches.
-        - Take into consideration that young people at risk are particularly good at identifying other young people at risk
-        - Ensure additional support is available for young people going through transitions (e.g. from primary to secondary school, going in to care, moving between youth and adult prison, etc.).
-        callout:
-          isQuote: true
-          content:
-            …risks during infancy increase the chances of anti-social behaviour during childhood, which in turn amplifies the likelihood of convictions during adolescence…
-          citation: Chief Medical Officer, 2012
-    - title: Early Intervention
-      contentParts:
-      - title: Give young people the competences and confidence to manage conflict and cope with peer pressure
-        points:
-        - Give young people an opportunity to practice techniques to avoid and resolve conflicts, manage anger, communicate more effectively, and show empathy.
-        - Help young people to understand the causes and consequences of conflict, including changing the way young people think about violence and reinforcing reasons for being non-violent.
-        - Where possible, work with friendship groups and young people involved in group offending (or gang activity) rather than just individuals.
-        - Empower young people to make the right choices on the basis of knowledge and support rather than ‘scare tactics’.
-        - Ensure that services take into consideration the specific circumstances, needs and wishes of young men and women who are - directly or indirectly - involved in violent lifestyles.
-        - Address the use of social media platforms to glamorise, display and incite violence.
-      - title: Building trusting, supportive relationships underpins the work of most charities
-        points:
-        - Many young people in this target group have a deep mistrust of statutory agencies and therefore voluntary groups which have access to and the trust of the community are in an ideal position to provide mentoring and build bridges and trust.
-        - Relationship-building shouldn’t be rushed and it should start with young people’s interests, wishes and strengths.
-        callout:
-          isQuote: false
-          content: Mentoring may be effective in violence reduction but the evidence is mixed on the impact of mentoring on arrests and reconvictions
-      - title: Extend support to places and spaces where young people feel comfortable
-        points:
-        - Support needs to extend from schools and statutory services into the community – and build on what is already working well locally.
-        - A flexible location is particularly important in the context of postcode gangs, as it may be dangerous for some young people to leave their neighbourhoods. Many young people involved in antisocial behaviour in out-of-centre estates affected by poverty rarely, or never, leave their estate to access opportunities.
-      - title: Incorporate, or link with, specialist mental health support
-        points:
-        - It is important to tackle stigma and make it easier for young people to come forward to talk about mental health. In turn, mental health services should be non-stigmatizing and relevant.
-        - Quick fixes for mental health problems don’t work.
-        - Professionals and volunteers should be trained to be sensitive to potential mental health issues.
-        - A whole family approach may be needed, especially if the whole family has been through significant adversity and there are wider family issues behind a young person’s involvement in violence.
-        - Mental health services should be provided in a variety of different settings.
-        callout:
-          isQuote: false
-          content: It has been estimated that up to one in three young people who offend have an unmet mental health need at the time of the offence
-      - title: Sport and the arts promote positive values and are a great hook for engagement
-        points:
-        - They can provide the right environment and influences to promote positive values, including taking on responsibility and learning how to resolve conflicts constructively
-        - Sport and art projects need to be long-term in nature and when possible included within a wider developmental programme of education and support.
-        - The role and skills of the coaches and trainers are critical therefore staff in arts and sports projects need to be trained and supported.
-        - Sport and art projects need to be well targeted in terms of both their location and the engagement of young people.
-        callout:
-          isQuote: false
-          content: The appeal of sport and the arts can act as a ‘hook’ for engagement and generate a sense of excitement, “similar to feelings experienced as part of a gang.”
-      - title: Timing matters for engagement and support
-        points:
-        - Successful engagement isn’t just linked to a place but also to the timing of the intervention. Support needs to be given at the right time in the young person’s life.
-      - title: We can learn from young people's expertise and experience
-        points:
-        - Young people who have been involved in gangs and crime help to drive the work of many charities that are successfully diverting young people away from violent lifestyles.
-        - Genuine co-production takes time and resource to set up and run.
-        - Involve young people at a level that they feel is appropriate to them at the time.
-        - Make young people feel welcome, encourage them to challenge existing ways of working; respect their contributions. Ensure participation is voluntary and they need to be able to change their mind.
-        - If young people take part in board or partnership meetings, ensure the meetings are run and written information is provided in jargon-free, Plain English and in an age-friendly format that is easily understandable
-        - Make sure the young people understand how they can benefit from getting involved.
-        - Make sure you celebrate their work and ensure staff, partner organisations and young people know what has changed as a result of their contributions.
-        - Think how to gather the views of people from different backgrounds and with different experiences.
-    - title: Partnership based approaches
-      contentParts:
-      - title: Involving the VCS isn’t just desirable but essential
-        points:
-        - Voluntary and community groups can add significant value to the work of statutory services in the field of youth violence. This is because they are able to represent and support young people who are ‘hidden’ or disengaged from other services.
-        - Partnerships should bring together smaller organisations, including grassroots groups, to produce ideas that are rooted in the experience of communities, with the reach and size of larger organisations.
-        - Understand the challenges faced by small grassroots organisations which focus on frontline delivery – their capacity to get involved at a strategic level is limited and should be supported.
-        - Value the expertise of partners – many groups have cutting-edge expertise and years/decades of experience, including lived experience of the challenges faced by those who they are supporting.
-        callout:
-          isQuote: false
-          content: Smaller groups may find it difficult to collaborate in a climate of competition for short-term, project-based funding opportunities
-      - title: Generous leaders and shared vision are some of the ‘key ingredients’ of successful partnerships
-        points:
-        - A willingness to share responsibility and influence to achieve the common good is important, coupled with a drive to build strong alliances with individuals, groups and communities who can achieve shared objectives together.
-        - Partners should be driven by a shared set of goals and values. These should start with the wider ecosystem, rather than each partner's individual priorities.
-        - Don't only consider what different partners can bring to the table, but also consider the consequences of leaving them out.
-        - Find ways to work with faith leaders and employers, including big companies and their supply chains as well as SMEs. They can provide placements and employment opportunities, which is particularly important for those who have dependents.
-        - Set boundaries on accountability, information sharing and targets. Regular communication and visible senior commitment are important.
-      - title: Build a whole system approach
-        points:
-        - Create a movement to recognise serious youth violence as a public health issue that requires a whole community response and a non-judgemental approach.
-        - Trust the relationships, expertise and experience of VCS groups in supporting young people involved in serious violence.
-        - Systems change involves focusing on the root causes of social issues and working to create systems that act early to prevent problems.
-        callout:
-          isQuote: false
-          content: As one young person moves away from organised crime, others such as friends and siblings may follow
-    metadata:
-      - label: Date published
-        content: July 2018
-      - label: Contact
-        content: <a href="mailto:knowledge@biglotteryfund.org.uk">knowledge@biglotteryfund.org.uk</a>
-    documents:
-      title: Documents
-      trailText: The full report contains more learnings and more detailed recommendations for implementation.
-      documents:
-        - title: Full report
-          filetype: PDF
-          filesize: 900KB
-          url: https://media.biglotteryfund.org.uk/media/documents/youth-serious-violence-full-report.pdf
-          contents:
-            - Executive Summary
-            - Introduction
-            - Prevention – what works?
-            - Early intervention – what works?
-            - Partnership-based approaches – what works?
-            - Sources
-    relatedProgrammes:
-      title: Related programmes
-      items:
-        - title: A Better Start
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/fulfilling-lives-a-better-start
-        - title: HeadStart
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/fulfilling-lives-headstart
-        - title: Talent Match
-          url: https://www.biglotteryfund.org.uk/global-content/programmes/england/talent-match
+  detail:
+    documents: Documents
+    relatedProgrammes: Related programmes
+    datePublished: Date published
+    researchPartners: Research partners
+    contact: Contact

--- a/controllers/research/index.js
+++ b/controllers/research/index.js
@@ -1,0 +1,50 @@
+'use strict';
+const { concat, get } = require('lodash');
+const path = require('path');
+
+const { heroImages } = require('../../modules/images');
+const { isBilingual } = require('../../modules/pageLogic');
+const { injectBreadcrumbs, injectResearch, injectResearchEntry } = require('../../middleware/inject-content');
+
+module.exports = ({ router }) => {
+    router.get('/', injectResearch, (req, res) => {
+        const { copy } = res.locals;
+        const researchEntries = get(res.locals, 'researchEntries', []);
+
+        /**
+         * Prepend new reports from the CMS to the list of section links
+         */
+        let links = copy.sectionLinks;
+        if (researchEntries.length > 0) {
+            links = concat(
+                researchEntries.map(entry => {
+                    return {
+                        label: `${copy.newReport}: ${entry.title}`,
+                        href: entry.linkUrl
+                    };
+                }),
+                links
+            );
+        }
+
+        res.render(path.resolve(__dirname, './views/research-landing'), {
+            links
+        });
+    });
+
+    router.get('/:slug', injectResearchEntry, injectBreadcrumbs, (req, res, next) => {
+        const { researchEntry } = res.locals;
+
+        if (researchEntry) {
+            res.render(path.resolve(__dirname, './views/research-detail'), {
+                entry: researchEntry,
+                heroImage: researchEntry.hero || heroImages.fallbackHeroImage,
+                isBilingual: isBilingual(researchEntry.availableLanguages)
+            });
+        } else {
+            next();
+        }
+    });
+
+    return router;
+};

--- a/controllers/research/views/research-detail.njk
+++ b/controllers/research/views/research-detail.njk
@@ -6,8 +6,6 @@
 {% from "components/print-button/macro.njk" import printButton %}
 {% from "components/segment-links/macro.njk" import segmentLinks %}
 
-{% set pageAccent = 'pink' %}
-
 {% block content %}
     <main role="main">
         {{ hero(
@@ -21,10 +19,10 @@
             <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
                 {{ breadcrumbTrail(breadcrumbs) }}
 
-                <div class="research-section">
-                    <div class="research-section__primary">
+                <div class="research-intro">
+                    <div class="research-intro__primary">
                         <div class="s-prose">
-                            {{ copy.intro | safe }}
+                            {{ entry.introduction | safe }}
                         </div>
 
                         <div class="u-margin-bottom">
@@ -32,93 +30,97 @@
                         </div>
 
                         {{ segmentLinks(
-                            prefix = copy.sectionsPrefix,
-                            segments = copy.sections
+                            prefix = entry.sectionsPrefix,
+                            segments = entry.sections
                         ) }}
 
-                        {% if copy.metadata %}
-                            <div class="content-meta">
-                                <dl class="o-definition-list o-definition-list--compact">
-                                    {% for item in copy.metadata %}
-                                        <dt>{{ item.label }}</dt>
-                                        <dd>{{ item.content | safe }}</dd>
-                                    {% endfor %}
-                                </dl>
-                            </div>
-                        {% endif %}
+                        <div class="content-meta">
+                            <dl class="o-definition-list o-definition-list--compact">
+                                <dt>{{ __('research.detail.datePublished') }}</dt>
+                                <dd>{{ formatDate(entry.dateCreated.date, DATE_FORMATS.month) }}</dd>
+                                {% if entry.researchPartners %}
+                                    <dt>{{ __('research.detail.researchPartners') }}</dt>
+                                    <dd>{{ entry.researchPartners }}</dd>
+                                {% endif %}
+                                {% if entry.contactEmail %}
+                                    <dt>{{ __('research.detail.contact') }}</dt>
+                                    <dd>{{ entry.contactEmail | mailto | safe }}</dd>
+                                {% endif %}
+                            </dl>
+                        </div>
                     </div>
-                    <div class="research-section__secondary">
-                        {{ documentsCard(
-                            title = copy.documents.title,
-                            documents = copy.documents.documents,
-                            accent = pageAccent
-                        ) }}
+                    <div class="research-intro__secondary">
+                        {% if entry.documents %}
+                            {{ documentsCard(
+                                title = __('research.detail.documents'),
+                                documents = entry.documents,
+                                accent = pageAccent
+                            ) }}
+                        {% endif %}
 
-                        <aside class="card">
-                            <header class="card__header">
-                                <h3 class="card__title">{{ copy.relatedProgrammes.title }}</h3>
-                                <div class="card__body">
-                                    {% for relatedProgramme in copy.relatedProgrammes.items %}
-                                        <a href="{{ relatedProgramme.url }}" class="related-programme">
-                                            {% if relatedProgramme.thumbnail %}
-                                                <span class="related-programme__media">
-                                                    <img src="{{ relatedProgramme.thumbnail }}"
-                                                        alt="{{ relatedProgramme.title }}" />
-                                                </span>
-                                            {% endif %}
-                                            <span class="related-programme__label">{{ relatedProgramme.title }}</span>
-                                        </a>
-                                    {% endfor %}
-                                </div>
-                            </header>
-                        </aside>
+                        {% if entry.relatedFundingProgrammes.length > 0 %}
+                            <aside class="card">
+                                <header class="card__header">
+                                    <h3 class="card__title">{{ __('research.detail.relatedProgrammes') }}</h3>
+                                    <div class="card__body">
+                                        {% for programme in entry.relatedFundingProgrammes %}
+                                            <a href="{{ programme.linkUrl }}" class="related-programme">
+                                                {% if programme.thumbnail %}
+                                                    <span class="related-programme__media">
+                                                        <img src="{{ programme.thumbnail }}"
+                                                            alt="{{ programme.title }}" />
+                                                    </span>
+                                                {% endif %}
+                                                <span class="related-programme__label">{{ programme.title }}</span>
+                                            </a>
+                                        {% endfor %}
+                                    </div>
+                                </header>
+                            </aside>
+                        {% endif %}
                     </div>
                 </div>
             </section>
 
             {# Content #}
-            {% for section in copy.sections %}
+            {% for section in entry.sections %}
                 <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}" id="segment-{{ loop.index }}">
-                    <p class="u-prefix">{{ copy.sectionsPrefix }}</p>
+                    {% if section.prefix %}<p class="u-prefix">{{ section.prefix }}</p>{% endif %}
                     <h2 class="t--underline">{{ section.title }}</h2>
 
-                    {% for part in section.contentParts %}
-                        <div class="research-section accent-content--{{ pageAccent }}">
-                            <div class="research-section__primary s-prose">
-                                <p><strong>{{ part.title }}</strong></p>
-                                <ul>
-                                    {% for point in part.points %}
-                                        <li>{{ point }}</li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                            {% if part.callout %}
-                                <div class="research-section__secondary">
+                    <div class="research-sections">
+                        {% for part in section.parts %}
+                            {% if part.type === 'contentArea' %}
+                                <div class="research-sections__content s-prose">
+                                    <p><strong>{{ part.title }}</strong></p>
+                                    {{ part.content | safe }}
+                                </div>
+                            {% elseif part.type === 'callout' %}
+                                <div class="research-sections__callout">
                                     {{ callout(
-                                        content = part.callout.content,
-                                        citation = part.callout.citation,
-                                        isQuote = part.callout.isQuote
+                                        content = part.content,
+                                        citation = part.credit,
+                                        isQuote = part.isQuote
                                     ) }}
                                 </div>
                             {% endif %}
-                        </div>
-                    {% endfor %}
-
-
-                    <div class="content-meta u-constrained">
-                        <p><strong>{{ copy.documents.trailText }}</strong></p>
-                        {% for document in copy.documents.documents %}
-                            <p><a class="btn btn--medium btn--outline" href="{{ document.url }}">
-                                {{ document.title }}
-                                {% if document.filetype or document.filesize %}
-                                    <small>({{ document.filetype }} {{ document.filesize }})</small>
-                                {% endif %}
-                            </a></p>
-
                         {% endfor %}
-                        <p><a href="#content">↑ {{ __('global.misc.backToTop') }}</a>
-                    </div>
 
+                        <div class="research-sections__meta content-meta">
+                            {% if entry.documentsPrefix %}
+                                <p><strong>{{ entry.documentsPrefix }}</strong></p>
+                            {% endif %}
+                            {% for document in entry.documents %}
+                                <p><a class="btn btn--medium btn--outline" href="{{ document.url }}">
+                                    {{ document.title }}
+                                    {% if document.filetype or document.filesize %}
+                                        <small>({{ document.filetype | upper }} {{ document.filesize }})</small>
+                                    {% endif %}
+                                </a></p>
+                            {% endfor %}
+                            <p><a href="#content">↑ {{ __('global.misc.backToTop') }}</a>
+                        </div>
+                    </div>
                 </section>
             {% endfor %}
         </div>

--- a/controllers/research/views/research-landing.njk
+++ b/controllers/research/views/research-landing.njk
@@ -24,7 +24,7 @@
             {# Section Links #}
             <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
                 <p>{{ copy.intro }}</p>
-                {{ sectionLinks(copy.sectionLinks) }}
+                {{ sectionLinks(links) }}
             </section>
 
             {# Downloads #}

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -30,7 +30,8 @@ const sections = {
     }),
     research: createSection({
         path: '/research',
-        langTitlePath: 'global.nav.research'
+        langTitlePath: 'global.nav.research',
+        controllerPath: path.resolve(__dirname, './research')
     }),
     about: createSection({
         path: '/about',
@@ -196,18 +197,10 @@ sections.funding.addRoutes({
  * Research Routes
  */
 sections.research.addRoutes({
-    root: staticContentRoute({
+    root: customRoute({
         path: '/',
-        sMaxAge: '30m',
-        template: 'pages/toplevel/research',
         lang: 'toplevel.research',
         heroSlug: 'grassroots-project'
-    }),
-    youthViolence: staticContentRoute({
-        path: '/youth-serious-violence',
-        template: 'controllers/research/views/research-detail',
-        lang: 'research.youthviolence',
-        heroSlug: 'paws-for-progress'
     })
 });
 

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -191,6 +191,33 @@ async function injectStrategicProgrammes(req, res, next) {
     }
 }
 
+async function injectResearch(req, res, next) {
+    try {
+        res.locals.researchEntries = await contentApi.getResearch({
+            locale: req.i18n.getLocale()
+        });
+        next();
+    } catch (error) {
+        next();
+    }
+}
+
+async function injectResearchEntry(req, res, next) {
+    try {
+        const entry = await contentApi.getResearch({
+            slug: last(req.path.split('/')),
+            locale: req.i18n.getLocale(),
+            previewMode: res.locals.PREVIEW_MODE || false
+        });
+
+        res.locals.title = entry.title;
+        res.locals.researchEntry = entry;
+        next();
+    } catch (error) {
+        next();
+    }
+}
+
 async function injectBlogPosts(req, res, next) {
     try {
         res.locals.blogPosts = await contentApi.getBlogPosts({
@@ -263,6 +290,8 @@ module.exports = {
     injectFundingProgrammes,
     injectStrategicProgramme,
     injectStrategicProgrammes,
+    injectResearch,
+    injectResearchEntry,
     injectHeroImage,
     injectListingContent,
     injectMerchandise,

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -154,6 +154,19 @@ function getFundingProgramme({ locale, slug, previewMode }) {
     });
 }
 
+function getResearch({ locale, slug, previewMode }) {
+    if (slug) {
+        return fetch(`/v1/${locale}/research/${slug}`, {
+            qs: addPreviewParams(previewMode)
+        }).then(response => get('data.attributes')(response));
+    } else {
+        return fetchAllLocales(reqLocale => `/v1/${reqLocale}/research`).then(responses => {
+            const [enResults, cyResults] = responses.map(mapAttrs);
+            return mergeWelshBy('urlPath')(locale, enResults, cyResults);
+        });
+    }
+}
+
 function getStrategicProgrammes({ locale, slug, previewMode }) {
     if (slug) {
         return fetch(`/v1/${locale}/strategic-programmes/${slug}`, {
@@ -238,6 +251,7 @@ module.exports = {
     getFlexibleContent,
     getFundingProgramme,
     getFundingProgrammes,
+    getResearch,
     getStrategicProgrammes,
     getHeroImage,
     getHomepage,

--- a/views/components/documents-card/macro.njk
+++ b/views/components/documents-card/macro.njk
@@ -9,7 +9,7 @@
                     <a class="document-summary__link u-document-link" href="{{ document.url }}">
                         {{ document.title }}
                         {% if document.filetype or document.filesize %}
-                            <small>({{ document.filetype }} {{ document.filesize }})</small>
+                            <small>({{ document.filetype | upper }} {{ document.filesize }})</small>
                         {% endif %}
                     </a>
                     {% if document.contents %}

--- a/views/components/segment-links/macro.njk
+++ b/views/components/segment-links/macro.njk
@@ -1,7 +1,7 @@
 {% macro segmentLinks(segments, prefix = null) %}
     {% if segments.length > 1 %}
         <div class="segment-links">
-            {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}:</p>{% endif %}
+            {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}</p>{% endif %}
             <ul>
                 {% for segment in segments %}
                     <li><a href="#segment-{{ loop.index }}">{{ segment.title }}</a></li>


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/87

Updates research pages to fetch content from the CMS. Also includes an update to the research landing page to dynamically prepend "new report" entires from the CMS.

<img width="1064" alt="screen shot 2018-08-21 at 10 59 59" src="https://user-images.githubusercontent.com/123386/44397439-40e06700-a538-11e8-8c09-27cfa95bed01.png">

There's a couple of missing translations which I'll get done at the same time as translating the new research page.

~**Note**: This can't go live until CMS changes have been deployed and the youth violence report has been migrated over.~ Now done