### PR TITLE
Add prototype research landing page

### DIFF
--- a/assets/sass/components/_links.scss
+++ b/assets/sass/components/_links.scss
@@ -53,7 +53,6 @@
 }
 .inline-links__prefix,
 .inline-links__list {
-    font-size: 18px;
     display: inline-block;
 }
 .inline-links__prefix {

--- a/controllers/research/index.js
+++ b/controllers/research/index.js
@@ -5,6 +5,7 @@ const path = require('path');
 const { heroImages } = require('../../modules/images');
 const { isBilingual } = require('../../modules/pageLogic');
 const { injectBreadcrumbs, injectResearch, injectResearchEntry } = require('../../middleware/inject-content');
+const appData = require('../../modules/appData');
 
 module.exports = ({ router }) => {
     router.get('/', injectResearch, (req, res) => {
@@ -31,6 +32,71 @@ module.exports = ({ router }) => {
             links
         });
     });
+
+    if (appData.isNotProduction) {
+        router.get('/landing-new', injectResearch, (req, res) => {
+            const { researchEntries } = res.locals;
+
+            /**
+             * Mock out additional research entries based on CMS data,
+             * allows us to test the page before these pages are published.
+             * Delete these mocks once these pages are live.
+             */
+            const researchEntriesWithMocks = concat(researchEntries, [
+                {
+                    linkUrl: '/research/youth-employment?draft=47',
+                    title: 'Youth employment',
+                    trailText:
+                        'Learnings related to the design and implementation of services for young people who are considered furthest away from the labour market.',
+                    thumbnail:
+                        'https://biglotteryfund-assets.imgix.net/media/heroes/samba-ya-bamba-young-start-2-medium.jpg?auto=compress%2Cformat&crop=entropy&fit=crop&h=360&w=640&s=f484306a78326afcecf2603f166c3b59',
+                    documents: [
+                        {
+                            title: 'Full report',
+                            url:
+                                'https://media.biglotteryfund.org.uk/media/documents/youth-serious-violence-full-report.pdf?mtime=20180816092318',
+                            filetype: 'pdf',
+                            filesize: '824.72 KB',
+                            contents: [
+                                'Full briefing',
+                                'Introduction',
+                                'Talent Match achievements ',
+                                'Lessons for policy and programme design',
+                                'Sources'
+                            ]
+                        }
+                    ]
+                },
+                {
+                    linkUrl: '/research/place-based-working?draft=48',
+                    title: 'Place-based working and funding',
+                    trailText: 'Summary of learning about working and funding in place-based ways',
+                    thumbnail:
+                        'https://biglotteryfund-assets.imgix.net/media/heroes/city-gateway-reaching-communities-medium.jpg?auto=compress%2Cformat&crop=entropy&fit=crop&h=360&w=640&s=651de41cfc0ff05fcdc7e40189cca2ba',
+                    documents: [
+                        {
+                            title: 'Full report',
+                            url:
+                                'https://media.biglotteryfund.org.uk/media/documents/youth-serious-violence-full-report.pdf?mtime=20180816092318',
+                            filetype: 'pdf',
+                            filesize: '824.72 KB',
+                            contents: [
+                                'Introduction',
+                                'Key learning',
+                                'An emerging evidence base?',
+                                'Questions for funders',
+                                'Appendices and bibliography'
+                            ]
+                        }
+                    ]
+                }
+            ]);
+
+            res.render(path.resolve(__dirname, './views/research-landing-new'), {
+                researchEntries: researchEntriesWithMocks
+            });
+        });
+    }
 
     router.get('/:slug', injectResearchEntry, injectBreadcrumbs, (req, res, next) => {
         const { researchEntry } = res.locals;

--- a/controllers/research/views/research-landing-new.njk
+++ b/controllers/research/views/research-landing-new.njk
@@ -1,0 +1,38 @@
+{% extends "layouts/main.njk" %}
+{% from "components/hero.njk" import hero %}
+{% from "components/content-box/macro.njk" import contentBox %}
+{% from "components/research-card/macro.njk" import researchCard with context %}
+
+{% block content %}
+    <main role="main">
+        {{ hero(
+            titleText = title,
+            image = heroImage,
+            accent = pageAccent
+        ) }}
+
+        <div class="nudge-up">
+            {% call contentBox(pageAccent) %}
+                <p>At the Big Lottery Fund we're committed to openness and transparency. To support this, we publish our grant data as well as datasets and related information used in our research.</p>
+
+                <p>Animi nulla dignissimos eum provident repellendus delectus consequatur ratione nihil explicabo, dolorum rem eligendi culpa amet saepe sint exercitationem cupiditate doloremque debitis hic ipsa ad? In quaerat voluptatibus maiores assumenda? Find out more about our <a href="{{ localify('/research/open-data') }}">Open Data policy</a></p>
+            {% endcall %}
+
+            {% if researchEntries.length > 0 %}
+                <section class="u-inner-wide-only u-margin-bottom">
+                    <ul class="flex-grid flex-grid--3up">
+                        {% for research in researchEntries %}
+                            <li class="flex-grid__item">
+                                {{ researchCard(research) }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
+            {% endif %}
+
+            <section class="u-align-center u-margin-bottom-l">
+                <a class="btn btn--medium" href="{{ localify('/research') }}">View more research and insights</a>
+            </section>
+        </div>
+    </main>
+{% endblock %}

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -201,6 +201,12 @@ sections.research.addRoutes({
         path: '/',
         lang: 'toplevel.research',
         heroSlug: 'grassroots-project'
+    }),
+    rootNew: customRoute({
+        path: '/landing-new',
+        lang: 'toplevel.research',
+        heroSlug: 'grassroots-project',
+        live: false
     })
 });
 

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -194,7 +194,8 @@ async function injectStrategicProgrammes(req, res, next) {
 async function injectResearch(req, res, next) {
     try {
         res.locals.researchEntries = await contentApi.getResearch({
-            locale: req.i18n.getLocale()
+            locale: req.i18n.getLocale(),
+            searchQuery: req.query.q
         });
         next();
     } catch (error) {
@@ -204,14 +205,18 @@ async function injectResearch(req, res, next) {
 
 async function injectResearchEntry(req, res, next) {
     try {
-        const entry = await contentApi.getResearch({
-            slug: last(req.path.split('/')),
-            locale: req.i18n.getLocale(),
-            previewMode: res.locals.PREVIEW_MODE || false
-        });
+        // Assumes a parameter of :slug in the request
+        const { slug } = req.params;
+        if (slug) {
+            const entry = await contentApi.getResearch({
+                slug: slug,
+                locale: req.i18n.getLocale(),
+                previewMode: res.locals.PREVIEW_MODE || false
+            });
 
-        res.locals.title = entry.title;
-        res.locals.researchEntry = entry;
+            res.locals.researchEntry = entry;
+            setCommonLocals(res, entry);
+        }
         next();
     } catch (error) {
         next();

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -154,13 +154,16 @@ function getFundingProgramme({ locale, slug, previewMode }) {
     });
 }
 
-function getResearch({ locale, slug, previewMode }) {
+function getResearch({ locale, slug, searchQuery = false, previewMode }) {
     if (slug) {
         return fetch(`/v1/${locale}/research/${slug}`, {
             qs: addPreviewParams(previewMode)
         }).then(response => get('data.attributes')(response));
     } else {
-        return fetchAllLocales(reqLocale => `/v1/${reqLocale}/research`).then(responses => {
+        return fetchAllLocales(reqLocale => {
+            const url = `/v1/${reqLocale}/research`;
+            return searchQuery ? `${url}?q=${searchQuery}` : url;
+        }).then(responses => {
             const [enResults, cyResults] = responses.map(mapAttrs);
             return mergeWelshBy('urlPath')(locale, enResults, cyResults);
         });

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -1,0 +1,22 @@
+{% from "components/promo-card/macro.njk" import promoCard %}
+
+{% macro researchCard(research) %}
+    {% call promoCard({
+        "title": research.title,
+        "subtitle": formatDate(research.dateCreated.date, DATE_FORMATS.month),
+        "trailText": research.trailText,
+        "image": { "url": research.thumbnail, "alt": research.title },
+        "link": { "url": research.linkUrl, "label": __('global.misc.readMore') }
+    }) %}
+        {% if research.documents %}
+            <div class="inline-links">
+                <span class="inline-links__prefix"><strong>{{ __('global.misc.documents') | title }}:</strong></span>
+                <ol class="inline-links__list">
+                    {% for document in research.documents -%}
+                        <li><a href="{{ document.url }}">{{ document.title }} ({{ document.filetype | upper }} {{ document.filesize }})</a></li>
+                    {%- endfor %}
+                </ol>
+            </div>
+        {% endif %}
+    {%- endcall %}
+{% endmacro %}


### PR DESCRIPTION
Builds on from https://github.com/biglotteryfund/blf-alpha/pull/1222 and adds a prototype research landing page. Also adds some basic search functionality. Not exposed in the UI, but you can filter the page with a `?q` parameter.

![image](https://user-images.githubusercontent.com/123386/44474637-0dcad000-a62b-11e8-9fd2-528d38b40143.png)
