### PR TITLE
Close building connections fund

### DIFF
--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -4,7 +4,6 @@ const express = require('express');
 const appData = require('../../modules/appData');
 const { createFormRouter } = require('../helpers/create-form-router');
 const reachingCommunitiesForm = require('./reaching-communities/form-model');
-const buildingConnectionsForm = require('./building-connections/form-model');
 const digitalFundingDemoForm = require('./digital-funding-demo/form-model');
 
 function initFormRouter(formModel) {
@@ -24,7 +23,16 @@ module.exports = ({ router }) => {
     });
 
     router.use('/your-idea', initFormRouter(reachingCommunitiesForm));
-    router.use('/building-connections', initFormRouter(buildingConnectionsForm));
+
+    router.get('/building-connections', (req, res) => {
+        res.render('pages/apply/building-connections/startpage-closed', {
+            title: 'Building Connections Fund'
+        });
+    });
+
+    router.all('/building-connections/*', (req, res) => {
+        res.redirect(`${req.baseUrl}/building-connections`);
+    });
 
     if (appData.isNotProduction) {
         router.use('/digital-funding-demo', initFormRouter(digitalFundingDemoForm));

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -181,9 +181,6 @@ describe('common', function() {
     });
 });
 
-const lorem =
-    'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium quidem nihil, similique voluptatibus tempore quasi, cumque laborum officia voluptatem laboriosam tempora.';
-
 const loremLong = `Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium quidem nihil, similique voluptatibus tempore quasi, cumque laborum officia voluptatem laboriosam tempora.
 
 - Repudiandae doloremque necessitatibus
@@ -379,96 +376,6 @@ describe('e2e', function() {
             .find('form')
             .submit();
         cy.get('@feedbackForm').should('contain', 'Thank you for sharing');
-    });
-
-    it('should submit a building connections application form', () => {
-        const submitSelector = '.js-application-form input[type="submit"]';
-        cy.visit('/apply/building-connections');
-
-        // Start page
-        cy.get('.start-button .btn')
-            .first()
-            .click();
-
-        // Step 1
-        cy.get('#field-current-work')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get(submitSelector).click();
-
-        // Step 2
-        cy.get('#field-project-name')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get('#field-project-idea')
-            .invoke('val', loremLong)
-            .trigger('change');
-
-        cy.get('#field-project-impact')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get(submitSelector).click();
-
-        // Step 3
-        cy.get('#field-project-activities-a')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get(submitSelector).click();
-
-        // Step 4
-        cy.get('#field-social-connections')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get(submitSelector).click();
-
-        // Step 5
-        cy.get('#field-project-evaluation')
-            .invoke('val', lorem)
-            .trigger('change');
-
-        cy.get(submitSelector).click();
-
-        // Step 6
-        cy.get('#field-location-1').check();
-        cy.get('#field-location-3').check();
-        cy.get('#field-project-location').type('Example', { delay: 0 });
-        cy.get(submitSelector).click();
-
-        // Step 7
-        cy.get('#field-project-budget-total').type('100000', { delay: 0 });
-        cy.get('#field-project-budget-a-amount').type('50000', { delay: 0 });
-        cy.get('#field-project-budget-a-description')
-            .invoke('val', lorem)
-            .trigger('change');
-        cy.get(submitSelector).click();
-
-        // Step 8
-        cy.get('#field-organisation-name').type('Test organisation', { delay: 0 });
-        cy.get('#field-organisation-charity-number').type('123456789', { delay: 0 });
-        cy.get('#field-address-building-street').type('1 Plough Place', { delay: 0 });
-        cy.get('#field-address-town-city').type('London', { delay: 0 });
-        cy.get('#field-address-county').type('Greater London', { delay: 0 });
-        cy.get('#field-address-postcode').type('EC4A 1DE', { delay: 0 });
-        cy.get(submitSelector).click();
-
-        // Step 9
-        cy.get('#field-first-name').type('Anne', { delay: 0 });
-        cy.get('#field-last-name').type('Example', { delay: 0 });
-        cy.get('#field-email').type(`example-${new Date().getTime()}@example.com`, { delay: 0 });
-        cy.get('#field-phone-number').type('0123456789', { delay: 0 });
-        cy.get(submitSelector).click();
-
-        // Review
-        cy.get(submitSelector).click();
-
-        // Success
-        cy.url().should('include', '/apply/building-connections/success');
-        cy.get('.form-message').should('contain', 'Thank you');
     });
 
     it('should submit materials order', () => {

--- a/views/pages/apply/building-connections/startpage-closed.njk
+++ b/views/pages/apply/building-connections/startpage-closed.njk
@@ -1,0 +1,24 @@
+{% from "components/buttons.njk" import startButton %}
+{% from "components/print-button/macro.njk" import printButton %}
+
+{% extends "layouts/main.njk" %}
+{% set bodyClass = 'has-static-header' %}
+
+{% block content %}
+    <main role="main" id="content">
+        <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+            <h1>{{ title }}</h1>
+
+            <div class="s-prose accent-content--{{ pageAccent }} u-constrained-wide">
+                <div class="message">
+                    The Building Connections Fund closed for applications on <strong>Friday 24 August at 12 noon</strong>. Please go to the <a href="/funding/programmes">funding section of our website</a> to see our open funding programmes.
+                </div>
+            </div>
+
+            <ul class="o-image-list u-margin-top-l">
+                <li><img src="{{ 'logos/partners/blf.png' | getImagePath }}" alt="Big Lottery Fund logo" width="157" /></li>
+                <li><img src="{{ 'logos/partners/hm-gov.png' | getImagePath }}" alt="HM Government logo" width="375" /></li>
+            </ul>
+        </div>
+    </main>
+{% endblock %}


### PR DESCRIPTION
This change disables the application form for building connections fund. Rather than completely removing the routes I've updated the start page to explain that the programme is now closed (this is the same copy that will be used on the programme page) and added a handler to redirect any in-progress submissions back to the start page. This is to avoid showing an error message if someone tries to submit the form after this change goes out.

![image](https://user-images.githubusercontent.com/123386/44517618-13262a00-a6c0-11e8-949f-e516808aa6fd.png)
