### PR TITLE
Disable nunjucks cache as well as view cache

### DIFF
--- a/server.js
+++ b/server.js
@@ -147,7 +147,7 @@ function initViewEngine() {
     const templateEnv = nunjucks.configure(['.', 'views'], {
         autoescape: true,
         express: app,
-        noCache: appData.isDev,
+        noCache: true, // Disable nunjucks memory cache
         // only watch files if we explicitly request
         // (eg. for CI, which tries to watch node_modules)
         watch: process.env.WATCH_TEMPLATES === true
@@ -158,8 +158,8 @@ function initViewEngine() {
     });
 
     app.set('view engine', 'njk').set('engineEnv', templateEnv);
-    // attempt to fix session sharing bug
-    // see https://stackoverflow.com/questions/32307933/passportjs-session-mixed-up
+
+    // Disable express  view cache
     app.disable('view cache');
 }
 


### PR DESCRIPTION
This is slightly speculative but seeing very occasional issues with template changes coming through that might be the mismatch between the view cache being disabled but the nunjucks memory cache being enabled. Disabling both as a belt and braces thing.