### PR TITLE
Add legacy young start redirect

### DIFF
--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -82,6 +82,7 @@ const aliases = {
     '/global-content/programmes/wales/people-and-places-large-grants': '/funding/programmes/people-and-places-large-grants',
     '/global-content/programmes/wales/people-and-places-medium-grants': '/funding/programmes/people-and-places-medium-grants',
     '/global-content/programmes/wales/people-and-places': '/funding/programmes?min=10000&location=wales',
+    '/global-content/programmes/scotland/young-start': '/funding/programmes/young-start',
     '/guidancetrackingprogress': '/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress',
     '/headstart': '/global-content/programmes/england/fulfilling-lives-headstart',
     '/help-and-support': '/about',


### PR DESCRIPTION
Ready for launching the young start page this afternoon. There are more redirects but the rest can be added using the CMS as vanity URLs.