### PR TITLE
Update mail service to determine appropriate send from address

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -48,6 +48,5 @@
   },
   "googleAnalyticsCode": "UA-98908627-1",
   "legacyDomain": "https://wwwlegacy.biglotteryfund.org.uk",
-  "ebulletinApiEndpoint": "https://apiconnector.com/v2",
-  "emailSender": "noreply@biglotteryfund.org.uk"
+  "ebulletinApiEndpoint": "https://apiconnector.com/v2"
 }

--- a/controllers/apply/digital-funding-demo/processor.js
+++ b/controllers/apply/digital-funding-demo/processor.js
@@ -16,7 +16,6 @@ module.exports = function processor({ form, data, stepsWithValues }) {
         {
             name: 'digital_funding_demo_customer',
             sendTo: primaryAddress,
-            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             subject: 'Thank you for getting in touch with the Big Lottery Fund!',
             template: path.resolve(__dirname, './customer-email'),
             templateData: {
@@ -27,7 +26,6 @@ module.exports = function processor({ form, data, stepsWithValues }) {
         {
             name: 'digital_funding_demo_internal',
             sendTo: appData.isDev ? primaryAddress : DIGITAL_FUND_DEMO_EMAIL,
-            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             subject: `New Digital Fund idea submission from website: ${organisationName}`,
             template: path.resolve(__dirname, './internal-email'),
             templateData: {

--- a/controllers/apply/reaching-communities/processor.js
+++ b/controllers/apply/reaching-communities/processor.js
@@ -44,7 +44,6 @@ module.exports = function processor({ form, data, stepsWithValues }) {
         {
             name: 'reaching_communities_customer',
             sendTo: primaryAddress,
-            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             subject: 'Thank you for getting in touch with the Big Lottery Fund!',
             template: path.resolve(__dirname, './customer-email'),
             templateData: {
@@ -55,7 +54,6 @@ module.exports = function processor({ form, data, stepsWithValues }) {
         {
             name: 'reaching_communities_internal',
             sendTo: internalAddress,
-            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             subject: `New idea submission from website: ${organisationName}`,
             template: path.resolve(__dirname, './internal-email'),
             templateData: {

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -117,8 +117,7 @@ const sendResetEmail = (req, res) => {
                         name: 'user_password_reset',
                         subject: 'Reset the password for your Big Lottery Fund website account',
                         text: `Please click the following link to reset your password: ${resetUrl}`,
-                        sendTo: email,
-                        sendFrom: 'Big Lottery Fund <noreply@blf.digital>'
+                        sendTo: email
                     });
 
                     sendEmail.catch(() => {

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -36,7 +36,6 @@ const sendActivationEmail = (user, req, isBrandNewUser) => {
             name: 'user_activate_account',
             subject: 'Activate your Big Lottery Fund website account',
             text: `Please click the following link to activate your account: ${activateUrl}`,
-            sendFrom: 'Big Lottery Fund <noreply@blf.digital>',
             sendTo: email
         };
 

--- a/modules/__tests__/mail.test.js
+++ b/modules/__tests__/mail.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+'use strict';
+const { getSendAddress } = require('../mail-helpers');
+
+describe('mail', () => {
+    const expectedDefault = `noreply@biglotteryfund.org.uk`;
+    const expectedInternal = `noreply@blf.digital`;
+
+    it('it should return default send from address for external send to addresses', () => {
+        expect(getSendAddress('example@example.com')).toBe(expectedDefault);
+        expect(getSendAddress('example@gmail.com')).toBe(expectedDefault);
+    });
+
+    it('should return internal send from address for internal send to addresses', () => {
+        expect(getSendAddress('example@biglotteryfund.org.uk')).toBe(expectedInternal);
+        // Assert against similar looking but incorrect emails to test for false positives
+        expect(getSendAddress('example@biggerlotteryfund.org.uk')).toBe(expectedDefault);
+        expect(getSendAddress('example@biggestlotteryfund.org.uk')).toBe(expectedDefault);
+        expect(getSendAddress('biglotteryfund.org.uk@example.com')).toBe(expectedDefault);
+    });
+});

--- a/modules/mail-helpers.js
+++ b/modules/mail-helpers.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Get send from address
+ *
+ * - If we are sending to a biglotteryfund domain use the blf.digital
+ * - Otherwise, use the default send from address
+ *
+ * @param {String} recipient
+ */
+function getSendAddress(recipient) {
+    if (/@biglotteryfund.org.uk$/.test(recipient)) {
+        return 'noreply@blf.digital';
+    } else {
+        return 'noreply@biglotteryfund.org.uk';
+    }
+}
+
+module.exports = {
+    getSendAddress
+};

--- a/modules/mail.js
+++ b/modules/mail.js
@@ -171,7 +171,6 @@ function generateAndSend(schemas) {
             return send({
                 name: email.data.name,
                 sendTo: email.data.sendTo,
-                sendFrom: email.data.sendFrom,
                 subject: email.data.subject,
                 html: email.html
             });


### PR DESCRIPTION
Adds a new `getSendAddress` which determines the best send from address to use based on the sender. i.e. if we're sending **to** and internal email we need to send from the internal domain, otherwise we can use the default.

The reason it's in a single `mail-helpers.js` file is because loading `mail.js` in tests is slow as it requires `server.js` to render emails and create nodemailer/cloudfront instances so ends up with lots of side effects that are not good for a unit test. Hints that there is some work to do to make the wider code more testable, but this suits for now.

Closes #1239