### PR TITLE
Remove name from rc sendTo address

### DIFF
--- a/controllers/apply/digital-funding-demo/processor.js
+++ b/controllers/apply/digital-funding-demo/processor.js
@@ -9,7 +9,7 @@ module.exports = function processor({ form, data, stepsWithValues }) {
     /**
      * Construct a primary address (i.e. customer email)
      */
-    const primaryAddress = `${data['first-name']} ${data['last-name']} <${data['email']}>`;
+    const primaryAddress = data['email'];
     const organisationName = `${data['organisation-name']}`;
 
     return mail.generateAndSend([

--- a/controllers/apply/reaching-communities/processor.js
+++ b/controllers/apply/reaching-communities/processor.js
@@ -17,7 +17,7 @@ module.exports = function processor({ form, data, stepsWithValues }) {
     /**
      * Construct a primary address (i.e. customer email)
      */
-    const primaryAddress = `${data['first-name']} ${data['last-name']} <${data['email']}>`;
+    const primaryAddress = data['email'];
     let organisationName = `${data['organisation-name']}`;
     if (data['additional-organisations']) {
         organisationName += ` (plus ${data['additional-organisations']})`;


### PR DESCRIPTION
With the changes in https://github.com/biglotteryfund/blf-alpha/pull/1245 the mail service now determines the best send from address based on the recipient. The limitation is that it requires a plain email address to do that for now. The apply forms were constructing a full address string so would always send from the main domain preventing internal emails from reaching their destination.

For now, the simplest fix is to use a plain email address.