### PR TITLE
Simplify routes

### DIFF
--- a/controllers/__tests__/__snapshots__/alises.test.js.snap
+++ b/controllers/__tests__/__snapshots__/alises.test.js.snap
@@ -1,0 +1,3646 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`alises should export mappedAliases 1`] = `
+Array [
+  Object {
+    "from": "/A4A",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/A4A",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/A4A",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/A4A",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/A4A",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/A4A",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/A4A",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/A4A",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/A4A",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/A4A",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/a4a",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/a4a",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/a4a",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/a4a",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/a4a",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/a4a",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/a4a",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/a4a",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/a4a",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/a4a",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/about-big",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/about-big",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/england/about-big",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/england/about-big",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/scotland/about-big",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/northernireland/about-big",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/wales/about-big",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/wales/about-big",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/about-big/contact-us",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/about-big/contact-us",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/england/about-big/contact-us",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/england/about-big/contact-us",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/scotland/about-big/contact-us",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/contact-us",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/northernireland/about-big/contact-us",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/contact-us",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/wales/about-big/contact-us",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/contact-us",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/about-big/customer-service/bogus-lottery-emails",
+    "to": "/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/bogus-lottery-emails",
+    "to": "/welsh/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/bogus-lottery-emails",
+    "to": "/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/bogus-lottery-emails",
+    "to": "/welsh/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/bogus-lottery-emails",
+    "to": "/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/bogus-lottery-emails",
+    "to": "/welsh/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/bogus-lottery-emails",
+    "to": "/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/bogus-lottery-emails",
+    "to": "/welsh/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/bogus-lottery-emails",
+    "to": "/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/bogus-lottery-emails",
+    "to": "/welsh/about/customer-service/bogus-lottery-emails",
+  },
+  Object {
+    "from": "/about-big/customer-service/cookies",
+    "to": "/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/cookies",
+    "to": "/welsh/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/cookies",
+    "to": "/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/cookies",
+    "to": "/welsh/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/cookies",
+    "to": "/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/cookies",
+    "to": "/welsh/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/cookies",
+    "to": "/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/cookies",
+    "to": "/welsh/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/cookies",
+    "to": "/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/cookies",
+    "to": "/welsh/about/customer-service/cookies",
+  },
+  Object {
+    "from": "/about-big/customer-service/customer-feedback",
+    "to": "/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/customer-feedback",
+    "to": "/welsh/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/customer-feedback",
+    "to": "/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/customer-feedback",
+    "to": "/welsh/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/customer-feedback",
+    "to": "/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/customer-feedback",
+    "to": "/welsh/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/customer-feedback",
+    "to": "/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/customer-feedback",
+    "to": "/welsh/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/customer-feedback",
+    "to": "/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/customer-feedback",
+    "to": "/welsh/about/customer-service/customer-feedback",
+  },
+  Object {
+    "from": "/about-big/customer-service/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/about-big/customer-service/fraud",
+    "to": "/contact#segment-6",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/fraud",
+    "to": "/welsh/contact#segment-6",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/fraud",
+    "to": "/contact#segment-6",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/fraud",
+    "to": "/welsh/contact#segment-6",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/fraud",
+    "to": "/contact#segment-6",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/fraud",
+    "to": "/welsh/contact#segment-6",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/fraud",
+    "to": "/contact#segment-6",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/fraud",
+    "to": "/welsh/contact#segment-6",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/fraud",
+    "to": "/contact#segment-6",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/fraud",
+    "to": "/welsh/contact#segment-6",
+  },
+  Object {
+    "from": "/about-big/customer-service/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/about-big/customer-service/making-a-complaint",
+    "to": "/contact#segment-5",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/making-a-complaint",
+    "to": "/welsh/contact#segment-5",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/making-a-complaint",
+    "to": "/contact#segment-5",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/making-a-complaint",
+    "to": "/welsh/contact#segment-5",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/making-a-complaint",
+    "to": "/contact#segment-5",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/making-a-complaint",
+    "to": "/welsh/contact#segment-5",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/making-a-complaint",
+    "to": "/contact#segment-5",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/making-a-complaint",
+    "to": "/welsh/contact#segment-5",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/making-a-complaint",
+    "to": "/contact#segment-5",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/making-a-complaint",
+    "to": "/welsh/contact#segment-5",
+  },
+  Object {
+    "from": "/about-big/customer-service/privacy-policy",
+    "to": "/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/privacy-policy",
+    "to": "/welsh/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/privacy-policy",
+    "to": "/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/privacy-policy",
+    "to": "/welsh/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/privacy-policy",
+    "to": "/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/privacy-policy",
+    "to": "/welsh/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/privacy-policy",
+    "to": "/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/privacy-policy",
+    "to": "/welsh/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/privacy-policy",
+    "to": "/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/privacy-policy",
+    "to": "/welsh/about/customer-service/privacy-policy",
+  },
+  Object {
+    "from": "/about-big/customer-service/terms-of-use",
+    "to": "/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/terms-of-use",
+    "to": "/welsh/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/terms-of-use",
+    "to": "/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/terms-of-use",
+    "to": "/welsh/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/terms-of-use",
+    "to": "/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/terms-of-use",
+    "to": "/welsh/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/terms-of-use",
+    "to": "/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/terms-of-use",
+    "to": "/welsh/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/terms-of-use",
+    "to": "/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/terms-of-use",
+    "to": "/welsh/about/customer-service/terms-of-use",
+  },
+  Object {
+    "from": "/about-big/customer-service/welsh-language-scheme",
+    "to": "/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/welsh/about-big/customer-service/welsh-language-scheme",
+    "to": "/welsh/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/england/about-big/customer-service/welsh-language-scheme",
+    "to": "/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/welsh/england/about-big/customer-service/welsh-language-scheme",
+    "to": "/welsh/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/scotland/about-big/customer-service/welsh-language-scheme",
+    "to": "/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/customer-service/welsh-language-scheme",
+    "to": "/welsh/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/northernireland/about-big/customer-service/welsh-language-scheme",
+    "to": "/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/customer-service/welsh-language-scheme",
+    "to": "/welsh/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/wales/about-big/customer-service/welsh-language-scheme",
+    "to": "/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/customer-service/welsh-language-scheme",
+    "to": "/welsh/about/customer-service/welsh-language-scheme",
+  },
+  Object {
+    "from": "/about-big/ebulletin-subscription",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/about-big/ebulletin-subscription",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/england/about-big/ebulletin-subscription",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/england/about-big/ebulletin-subscription",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/scotland/about-big/ebulletin-subscription",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/ebulletin-subscription",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/northernireland/about-big/ebulletin-subscription",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/ebulletin-subscription",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/wales/about-big/ebulletin-subscription",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/ebulletin-subscription",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/about-big/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/about-big/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/england/about-big/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/england/about-big/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/scotland/about-big/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/northernireland/about-big/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/wales/about-big/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/about-big/jobs",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/about-big/jobs",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/england/about-big/jobs",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/england/about-big/jobs",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/scotland/about-big/jobs",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/jobs",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/northernireland/about-big/jobs",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/jobs",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/wales/about-big/jobs",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/jobs",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/about-big/jobs/benefits",
+    "to": "/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/about-big/jobs/benefits",
+    "to": "/welsh/jobs/benefits",
+  },
+  Object {
+    "from": "/england/about-big/jobs/benefits",
+    "to": "/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/england/about-big/jobs/benefits",
+    "to": "/welsh/jobs/benefits",
+  },
+  Object {
+    "from": "/scotland/about-big/jobs/benefits",
+    "to": "/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/jobs/benefits",
+    "to": "/welsh/jobs/benefits",
+  },
+  Object {
+    "from": "/northernireland/about-big/jobs/benefits",
+    "to": "/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/jobs/benefits",
+    "to": "/welsh/jobs/benefits",
+  },
+  Object {
+    "from": "/wales/about-big/jobs/benefits",
+    "to": "/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/jobs/benefits",
+    "to": "/welsh/jobs/benefits",
+  },
+  Object {
+    "from": "/about-big/jobs/current-vacancies",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/about-big/jobs/current-vacancies",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/england/about-big/jobs/current-vacancies",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/england/about-big/jobs/current-vacancies",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/scotland/about-big/jobs/current-vacancies",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/jobs/current-vacancies",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/northernireland/about-big/jobs/current-vacancies",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/jobs/current-vacancies",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/wales/about-big/jobs/current-vacancies",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/jobs/current-vacancies",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/about-big/jobs/how-to-apply",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/about-big/jobs/how-to-apply",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/england/about-big/jobs/how-to-apply",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/england/about-big/jobs/how-to-apply",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/scotland/about-big/jobs/how-to-apply",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/jobs/how-to-apply",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/northernireland/about-big/jobs/how-to-apply",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/jobs/how-to-apply",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/wales/about-big/jobs/how-to-apply",
+    "to": "/jobs",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/jobs/how-to-apply",
+    "to": "/welsh/jobs",
+  },
+  Object {
+    "from": "/about-big/our-approach/accessibility",
+    "to": "/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/welsh/about-big/our-approach/accessibility",
+    "to": "/welsh/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/england/about-big/our-approach/accessibility",
+    "to": "/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/welsh/england/about-big/our-approach/accessibility",
+    "to": "/welsh/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/scotland/about-big/our-approach/accessibility",
+    "to": "/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/our-approach/accessibility",
+    "to": "/welsh/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/northernireland/about-big/our-approach/accessibility",
+    "to": "/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/our-approach/accessibility",
+    "to": "/welsh/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/wales/about-big/our-approach/accessibility",
+    "to": "/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/our-approach/accessibility",
+    "to": "/welsh/about/customer-service/accessibility",
+  },
+  Object {
+    "from": "/about-big/our-people/senior-management-team",
+    "to": "/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/welsh/about-big/our-people/senior-management-team",
+    "to": "/welsh/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/england/about-big/our-people/senior-management-team",
+    "to": "/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/welsh/england/about-big/our-people/senior-management-team",
+    "to": "/welsh/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/scotland/about-big/our-people/senior-management-team",
+    "to": "/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/our-people/senior-management-team",
+    "to": "/welsh/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/northernireland/about-big/our-people/senior-management-team",
+    "to": "/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/our-people/senior-management-team",
+    "to": "/welsh/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/wales/about-big/our-people/senior-management-team",
+    "to": "/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/our-people/senior-management-team",
+    "to": "/welsh/about/our-people/senior-management-team",
+  },
+  Object {
+    "from": "/about-big/strategic-framework",
+    "to": "/about/strategic-framework",
+  },
+  Object {
+    "from": "/welsh/about-big/strategic-framework",
+    "to": "/welsh/about/strategic-framework",
+  },
+  Object {
+    "from": "/england/about-big/strategic-framework",
+    "to": "/about/strategic-framework",
+  },
+  Object {
+    "from": "/welsh/england/about-big/strategic-framework",
+    "to": "/welsh/about/strategic-framework",
+  },
+  Object {
+    "from": "/scotland/about-big/strategic-framework",
+    "to": "/about/strategic-framework",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/strategic-framework",
+    "to": "/welsh/about/strategic-framework",
+  },
+  Object {
+    "from": "/northernireland/about-big/strategic-framework",
+    "to": "/about/strategic-framework",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/strategic-framework",
+    "to": "/welsh/about/strategic-framework",
+  },
+  Object {
+    "from": "/wales/about-big/strategic-framework",
+    "to": "/about/strategic-framework",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/strategic-framework",
+    "to": "/welsh/about/strategic-framework",
+  },
+  Object {
+    "from": "/about-big/tender-opportunities",
+    "to": "/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/welsh/about-big/tender-opportunities",
+    "to": "/welsh/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/england/about-big/tender-opportunities",
+    "to": "/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/welsh/england/about-big/tender-opportunities",
+    "to": "/welsh/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/scotland/about-big/tender-opportunities",
+    "to": "/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/tender-opportunities",
+    "to": "/welsh/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/northernireland/about-big/tender-opportunities",
+    "to": "/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/tender-opportunities",
+    "to": "/welsh/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/wales/about-big/tender-opportunities",
+    "to": "/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/tender-opportunities",
+    "to": "/welsh/about/customer-service/supplier-zone",
+  },
+  Object {
+    "from": "/awardsforall",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/awardsforall",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/awardsforall",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/awardsforall",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/awardsforall",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/awardsforall",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/awardsforall",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/awardsforall",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/awardsforall",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/awardsforall",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/cymru",
+    "to": "/welsh/wales",
+  },
+  Object {
+    "from": "/welsh/cymru",
+    "to": "/welsh/welsh/wales",
+  },
+  Object {
+    "from": "/england/cymru",
+    "to": "/welsh/wales",
+  },
+  Object {
+    "from": "/welsh/england/cymru",
+    "to": "/welsh/welsh/wales",
+  },
+  Object {
+    "from": "/scotland/cymru",
+    "to": "/welsh/wales",
+  },
+  Object {
+    "from": "/welsh/scotland/cymru",
+    "to": "/welsh/welsh/wales",
+  },
+  Object {
+    "from": "/northernireland/cymru",
+    "to": "/welsh/wales",
+  },
+  Object {
+    "from": "/welsh/northernireland/cymru",
+    "to": "/welsh/welsh/wales",
+  },
+  Object {
+    "from": "/wales/cymru",
+    "to": "/welsh/wales",
+  },
+  Object {
+    "from": "/welsh/wales/cymru",
+    "to": "/welsh/welsh/wales",
+  },
+  Object {
+    "from": "/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/england/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/england/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/scotland/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/scotland/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/northernireland/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/northernireland/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/wales/data-protection",
+    "to": "/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/welsh/wales/data-protection",
+    "to": "/welsh/about/customer-service/data-protection",
+  },
+  Object {
+    "from": "/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/england/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/england/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/scotland/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/scotland/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/northernireland/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/northernireland/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/wales/ebulletin",
+    "to": "/about/ebulletin",
+  },
+  Object {
+    "from": "/welsh/wales/ebulletin",
+    "to": "/welsh/about/ebulletin",
+  },
+  Object {
+    "from": "/en-gb",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/en-gb",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/en-gb",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/en-gb",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/en-gb",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/en-gb",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/en-gb",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/en-gb",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/en-gb",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/en-gb",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/england",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/england",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/england",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/england",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/england",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/england",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/england",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/england",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/englandwebinars",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/englandwebinars",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/england/englandwebinars",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/england/englandwebinars",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/scotland/englandwebinars",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/scotland/englandwebinars",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/northernireland/englandwebinars",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/northernireland/englandwebinars",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/wales/englandwebinars",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/wales/englandwebinars",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/england/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/england/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/scotland/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/scotland/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/northernireland/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/northernireland/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/wales/freedom-of-information",
+    "to": "/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/welsh/wales/freedom-of-information",
+    "to": "/welsh/about/customer-service/freedom-of-information",
+  },
+  Object {
+    "from": "/funded-projects",
+    "to": "/funding/past-grants",
+  },
+  Object {
+    "from": "/welsh/funded-projects",
+    "to": "/welsh/funding/past-grants",
+  },
+  Object {
+    "from": "/england/funded-projects",
+    "to": "/funding/past-grants",
+  },
+  Object {
+    "from": "/welsh/england/funded-projects",
+    "to": "/welsh/funding/past-grants",
+  },
+  Object {
+    "from": "/scotland/funded-projects",
+    "to": "/funding/past-grants",
+  },
+  Object {
+    "from": "/welsh/scotland/funded-projects",
+    "to": "/welsh/funding/past-grants",
+  },
+  Object {
+    "from": "/northernireland/funded-projects",
+    "to": "/funding/past-grants",
+  },
+  Object {
+    "from": "/welsh/northernireland/funded-projects",
+    "to": "/welsh/funding/past-grants",
+  },
+  Object {
+    "from": "/wales/funded-projects",
+    "to": "/funding/past-grants",
+  },
+  Object {
+    "from": "/welsh/wales/funded-projects",
+    "to": "/welsh/funding/past-grants",
+  },
+  Object {
+    "from": "/funding-uk",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/funding-uk",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/england/funding-uk",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/england/funding-uk",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/scotland/funding-uk",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/scotland/funding-uk",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/northernireland/funding-uk",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding-uk",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/wales/funding-uk",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/wales/funding-uk",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/funding/Awards-For-All",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/funding/Awards-For-All",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/funding/Awards-For-All",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/funding/Awards-For-All",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/funding/Awards-For-All",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/Awards-For-All",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/funding/Awards-For-All",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/Awards-For-All",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/funding/Awards-For-All",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/funding/Awards-For-All",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/funding/awards-for-all",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/funding/awards-for-all",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/funding/awards-for-all",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/funding/awards-for-all",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/funding/awards-for-all",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/awards-for-all",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/funding/awards-for-all",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/awards-for-all",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/funding/awards-for-all",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/funding/awards-for-all",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/funding/funding-guidance",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/funding/funding-guidance/applying-for-funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/applying-for-funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/applying-for-funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/applying-for-funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/applying-for-funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/applying-for-funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/applying-for-funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/applying-for-funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/applying-for-funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/applying-for-funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
+    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+  },
+  Object {
+    "from": "/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/welsh/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/welsh/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/welsh/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/welsh/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/applying-for-funding/information-checks",
+    "to": "/welsh/funding/funding-guidance/information-checks",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/help-with-publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/logodownloads",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/ordering-free-materials/bilingual-materials-for-use-in-wales",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/self-evaluation",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/evaluation",
+  },
+  Object {
+    "from": "/funding/scotland-portfolio",
+    "to": "/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/welsh/funding/scotland-portfolio",
+    "to": "/welsh/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/england/funding/scotland-portfolio",
+    "to": "/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/welsh/england/funding/scotland-portfolio",
+    "to": "/welsh/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/scotland/funding/scotland-portfolio",
+    "to": "/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/scotland-portfolio",
+    "to": "/welsh/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/northernireland/funding/scotland-portfolio",
+    "to": "/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/scotland-portfolio",
+    "to": "/welsh/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/wales/funding/scotland-portfolio",
+    "to": "/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/welsh/wales/funding/scotland-portfolio",
+    "to": "/welsh/funding/programmes?location=scotland",
+  },
+  Object {
+    "from": "/global-content/programmes/england/awards-for-all-england",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/awards-for-all-england",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/awards-for-all-england",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/awards-for-all-england",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/awards-for-all-england",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/awards-for-all-england",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/awards-for-all-england",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/awards-for-all-england",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/awards-for-all-england",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/awards-for-all-england",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/global-content/programmes/england/building-better-opportunities",
+    "to": "/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/building-better-opportunities",
+    "to": "/welsh/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/building-better-opportunities",
+    "to": "/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/building-better-opportunities",
+    "to": "/welsh/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/building-better-opportunities",
+    "to": "/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/building-better-opportunities",
+    "to": "/welsh/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/building-better-opportunities",
+    "to": "/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/building-better-opportunities",
+    "to": "/welsh/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/building-better-opportunities",
+    "to": "/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/building-better-opportunities",
+    "to": "/welsh/funding/programmes/building-better-opportunities",
+  },
+  Object {
+    "from": "/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/welsh/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/welsh/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/welsh/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/welsh/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/building-better-opportunities/building-better-opportunities-resources",
+    "to": "/welsh/funding/programmes/building-better-opportunities/building-better-opportunities-resources",
+  },
+  Object {
+    "from": "/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/welsh/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/welsh/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/welsh/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/welsh/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/building-better-opportunities/guide-to-delivering-european-funding",
+    "to": "/welsh/funding/programmes/building-better-opportunities/guide-to-delivering-european-funding",
+  },
+  Object {
+    "from": "/global-content/programmes/england/place-based-social-action",
+    "to": "/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/place-based-social-action",
+    "to": "/welsh/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/place-based-social-action",
+    "to": "/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/place-based-social-action",
+    "to": "/welsh/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/place-based-social-action",
+    "to": "/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/place-based-social-action",
+    "to": "/welsh/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/place-based-social-action",
+    "to": "/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/place-based-social-action",
+    "to": "/welsh/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/place-based-social-action",
+    "to": "/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/place-based-social-action",
+    "to": "/welsh/funding/programmes/place-based-social-action",
+  },
+  Object {
+    "from": "/global-content/programmes/england/reaching-communities-england",
+    "to": "/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/reaching-communities-england",
+    "to": "/welsh/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/reaching-communities-england",
+    "to": "/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/reaching-communities-england",
+    "to": "/welsh/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/reaching-communities-england",
+    "to": "/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/reaching-communities-england",
+    "to": "/welsh/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/reaching-communities-england",
+    "to": "/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/reaching-communities-england",
+    "to": "/welsh/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/reaching-communities-england",
+    "to": "/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/reaching-communities-england",
+    "to": "/welsh/funding/programmes/reaching-communities-england",
+  },
+  Object {
+    "from": "/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/welsh/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/england/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/welsh/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/welsh/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/welsh/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
+    "to": "/welsh/funding/programmes/awards-for-all-northern-ireland",
+  },
+  Object {
+    "from": "/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/welsh/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/england/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/welsh/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/welsh/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/welsh/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/northern-ireland/empowering-young-people",
+    "to": "/welsh/funding/programmes/empowering-young-people",
+  },
+  Object {
+    "from": "/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/welsh/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/england/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/welsh/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/welsh/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/welsh/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/northern-ireland/people-and-communities",
+    "to": "/welsh/funding/programmes/people-and-communities",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/awards-for-all-scotland",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-scotland",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/community-assets",
+    "to": "/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/community-assets",
+    "to": "/welsh/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/community-assets",
+    "to": "/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/community-assets",
+    "to": "/welsh/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/community-assets",
+    "to": "/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/community-assets",
+    "to": "/welsh/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/community-assets",
+    "to": "/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/community-assets",
+    "to": "/welsh/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/community-assets",
+    "to": "/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/community-assets",
+    "to": "/welsh/funding/programmes/community-assets",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/welsh/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/welsh/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/welsh/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/welsh/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/grants-for-community-led-activity",
+    "to": "/welsh/funding/programmes/grants-for-community-led-activity",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/welsh/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/welsh/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/welsh/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/welsh/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/grants-for-improving-lives",
+    "to": "/welsh/funding/programmes/grants-for-improving-lives",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/our-place",
+    "to": "/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/our-place",
+    "to": "/welsh/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/our-place",
+    "to": "/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/our-place",
+    "to": "/welsh/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/our-place",
+    "to": "/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/our-place",
+    "to": "/welsh/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/our-place",
+    "to": "/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/our-place",
+    "to": "/welsh/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/our-place",
+    "to": "/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/our-place",
+    "to": "/welsh/funding/programmes/our-place",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/welsh/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/welsh/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/welsh/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/welsh/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/scottish-land-fund",
+    "to": "/welsh/funding/programmes/scottish-land-fund",
+  },
+  Object {
+    "from": "/global-content/programmes/scotland/young-start",
+    "to": "/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/scotland/young-start",
+    "to": "/welsh/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/england/global-content/programmes/scotland/young-start",
+    "to": "/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/scotland/young-start",
+    "to": "/welsh/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/scotland/young-start",
+    "to": "/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/scotland/young-start",
+    "to": "/welsh/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/scotland/young-start",
+    "to": "/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/scotland/young-start",
+    "to": "/welsh/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/scotland/young-start",
+    "to": "/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/scotland/young-start",
+    "to": "/welsh/funding/programmes/young-start",
+  },
+  Object {
+    "from": "/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/england/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/uk-wide/coastal-communities",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/welsh/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/england/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/welsh/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/welsh/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/welsh/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/uk-wide/forces-in-mind",
+    "to": "/welsh/funding/programmes/forces-in-mind",
+  },
+  Object {
+    "from": "/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/welsh/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/england/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/welsh/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/welsh/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/welsh/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/uk-wide/lottery-funding",
+    "to": "/welsh/funding/programmes/other-lottery-funders",
+  },
+  Object {
+    "from": "/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/welsh/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/england/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/welsh/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/welsh/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/welsh/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/uk-wide/the-peoples-projects",
+    "to": "/welsh/funding/programmes/the-peoples-projects",
+  },
+  Object {
+    "from": "/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/welsh/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/england/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/welsh/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/welsh/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/welsh/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/uk-wide/uk-portfolio",
+    "to": "/welsh/funding/programmes/awards-from-the-uk-portfolio",
+  },
+  Object {
+    "from": "/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/england/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/wales/awards-for-all-wales",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-wales",
+  },
+  Object {
+    "from": "/global-content/programmes/wales/helping-working-families",
+    "to": "/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/wales/helping-working-families",
+    "to": "/welsh/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/england/global-content/programmes/wales/helping-working-families",
+    "to": "/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/wales/helping-working-families",
+    "to": "/welsh/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/wales/helping-working-families",
+    "to": "/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/wales/helping-working-families",
+    "to": "/welsh/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/wales/helping-working-families",
+    "to": "/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/wales/helping-working-families",
+    "to": "/welsh/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/wales/helping-working-families",
+    "to": "/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/wales/helping-working-families",
+    "to": "/welsh/funding/programmes/helping-working-families",
+  },
+  Object {
+    "from": "/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/welsh/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/england/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/welsh/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/welsh/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/welsh/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/wales/people-and-places-large-grants",
+    "to": "/welsh/funding/programmes/people-and-places-large-grants",
+  },
+  Object {
+    "from": "/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/welsh/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/england/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/welsh/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/welsh/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/welsh/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/wales/people-and-places-medium-grants",
+    "to": "/welsh/funding/programmes/people-and-places-medium-grants",
+  },
+  Object {
+    "from": "/global-content/programmes/wales/people-and-places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/wales/people-and-places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/england/global-content/programmes/wales/people-and-places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/wales/people-and-places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/wales/people-and-places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/wales/people-and-places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/wales/people-and-places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/wales/people-and-places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/wales/people-and-places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/wales/people-and-places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/guidancetrackingprogress",
+    "to": "/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/welsh/guidancetrackingprogress",
+    "to": "/welsh/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/england/guidancetrackingprogress",
+    "to": "/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/welsh/england/guidancetrackingprogress",
+    "to": "/welsh/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/scotland/guidancetrackingprogress",
+    "to": "/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/welsh/scotland/guidancetrackingprogress",
+    "to": "/welsh/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/northernireland/guidancetrackingprogress",
+    "to": "/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/welsh/northernireland/guidancetrackingprogress",
+    "to": "/welsh/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/wales/guidancetrackingprogress",
+    "to": "/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/welsh/wales/guidancetrackingprogress",
+    "to": "/welsh/funding/funding-guidance/applying-for-funding/tracking-project-progress/guidance-on-tracking-progress",
+  },
+  Object {
+    "from": "/headstart",
+    "to": "/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/welsh/headstart",
+    "to": "/welsh/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/england/headstart",
+    "to": "/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/welsh/england/headstart",
+    "to": "/welsh/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/scotland/headstart",
+    "to": "/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/welsh/scotland/headstart",
+    "to": "/welsh/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/northernireland/headstart",
+    "to": "/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/welsh/northernireland/headstart",
+    "to": "/welsh/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/wales/headstart",
+    "to": "/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/welsh/wales/headstart",
+    "to": "/welsh/global-content/programmes/england/fulfilling-lives-headstart",
+  },
+  Object {
+    "from": "/help-and-support",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/help-and-support",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/england/help-and-support",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/england/help-and-support",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/scotland/help-and-support",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/scotland/help-and-support",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/northernireland/help-and-support",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/northernireland/help-and-support",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/wales/help-and-support",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/wales/help-and-support",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/home",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/home",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/home",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/home",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/home",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/home",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/home",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/home",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/home",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/home",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/home/funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/home/funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/england/home/funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/england/home/funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/scotland/home/funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/scotland/home/funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/northernireland/home/funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/home/funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/wales/home/funding",
+    "to": "/funding",
+  },
+  Object {
+    "from": "/welsh/wales/home/funding",
+    "to": "/welsh/funding",
+  },
+  Object {
+    "from": "/Home/Funding/Funding*Finder",
+    "to": "/funding/programmes",
+  },
+  Object {
+    "from": "/welsh/Home/Funding/Funding*Finder",
+    "to": "/welsh/funding/programmes",
+  },
+  Object {
+    "from": "/england/Home/Funding/Funding*Finder",
+    "to": "/funding/programmes",
+  },
+  Object {
+    "from": "/welsh/england/Home/Funding/Funding*Finder",
+    "to": "/welsh/funding/programmes",
+  },
+  Object {
+    "from": "/scotland/Home/Funding/Funding*Finder",
+    "to": "/funding/programmes",
+  },
+  Object {
+    "from": "/welsh/scotland/Home/Funding/Funding*Finder",
+    "to": "/welsh/funding/programmes",
+  },
+  Object {
+    "from": "/northernireland/Home/Funding/Funding*Finder",
+    "to": "/funding/programmes",
+  },
+  Object {
+    "from": "/welsh/northernireland/Home/Funding/Funding*Finder",
+    "to": "/welsh/funding/programmes",
+  },
+  Object {
+    "from": "/wales/Home/Funding/Funding*Finder",
+    "to": "/funding/programmes",
+  },
+  Object {
+    "from": "/welsh/wales/Home/Funding/Funding*Finder",
+    "to": "/welsh/funding/programmes",
+  },
+  Object {
+    "from": "/index.html",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/index.html",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/index.html",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/index.html",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/index.html",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/index.html",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/index.html",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/index.html",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/index.html",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/index.html",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/logos",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/logos",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/england/logos",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/england/logos",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/scotland/logos",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/scotland/logos",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/northernireland/logos",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/northernireland/logos",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/wales/logos",
+    "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/welsh/wales/logos",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
+  },
+  Object {
+    "from": "/news-and-events/contact-press-team",
+    "to": "/contact#segment-4",
+  },
+  Object {
+    "from": "/welsh/news-and-events/contact-press-team",
+    "to": "/welsh/contact#segment-4",
+  },
+  Object {
+    "from": "/england/news-and-events/contact-press-team",
+    "to": "/contact#segment-4",
+  },
+  Object {
+    "from": "/welsh/england/news-and-events/contact-press-team",
+    "to": "/welsh/contact#segment-4",
+  },
+  Object {
+    "from": "/scotland/news-and-events/contact-press-team",
+    "to": "/contact#segment-4",
+  },
+  Object {
+    "from": "/welsh/scotland/news-and-events/contact-press-team",
+    "to": "/welsh/contact#segment-4",
+  },
+  Object {
+    "from": "/northernireland/news-and-events/contact-press-team",
+    "to": "/contact#segment-4",
+  },
+  Object {
+    "from": "/welsh/northernireland/news-and-events/contact-press-team",
+    "to": "/welsh/contact#segment-4",
+  },
+  Object {
+    "from": "/wales/news-and-events/contact-press-team",
+    "to": "/contact#segment-4",
+  },
+  Object {
+    "from": "/welsh/wales/news-and-events/contact-press-team",
+    "to": "/welsh/contact#segment-4",
+  },
+  Object {
+    "from": "/northernireland",
+    "to": "/northern-ireland",
+  },
+  Object {
+    "from": "/welsh/northernireland",
+    "to": "/welsh/northern-ireland",
+  },
+  Object {
+    "from": "/england/northernireland",
+    "to": "/northern-ireland",
+  },
+  Object {
+    "from": "/welsh/england/northernireland",
+    "to": "/welsh/northern-ireland",
+  },
+  Object {
+    "from": "/scotland/northernireland",
+    "to": "/northern-ireland",
+  },
+  Object {
+    "from": "/welsh/scotland/northernireland",
+    "to": "/welsh/northern-ireland",
+  },
+  Object {
+    "from": "/northernireland/northernireland",
+    "to": "/northern-ireland",
+  },
+  Object {
+    "from": "/welsh/northernireland/northernireland",
+    "to": "/welsh/northern-ireland",
+  },
+  Object {
+    "from": "/wales/northernireland",
+    "to": "/northern-ireland",
+  },
+  Object {
+    "from": "/welsh/wales/northernireland",
+    "to": "/welsh/northern-ireland",
+  },
+  Object {
+    "from": "/over10k",
+    "to": "/funding/over10k",
+  },
+  Object {
+    "from": "/welsh/over10k",
+    "to": "/welsh/funding/over10k",
+  },
+  Object {
+    "from": "/england/over10k",
+    "to": "/funding/over10k",
+  },
+  Object {
+    "from": "/welsh/england/over10k",
+    "to": "/welsh/funding/over10k",
+  },
+  Object {
+    "from": "/scotland/over10k",
+    "to": "/funding/over10k",
+  },
+  Object {
+    "from": "/welsh/scotland/over10k",
+    "to": "/welsh/funding/over10k",
+  },
+  Object {
+    "from": "/northernireland/over10k",
+    "to": "/funding/over10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/over10k",
+    "to": "/welsh/funding/over10k",
+  },
+  Object {
+    "from": "/wales/over10k",
+    "to": "/funding/over10k",
+  },
+  Object {
+    "from": "/welsh/wales/over10k",
+    "to": "/welsh/funding/over10k",
+  },
+  Object {
+    "from": "/prog_people_places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/prog_people_places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/england/prog_people_places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/england/prog_people_places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/scotland/prog_people_places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/scotland/prog_people_places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/northernireland/prog_people_places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/northernireland/prog_people_places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/wales/prog_people_places",
+    "to": "/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/welsh/wales/prog_people_places",
+    "to": "/welsh/funding/programmes?min=10000&location=wales",
+  },
+  Object {
+    "from": "/publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/england/publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/england/publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/scotland/publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/scotland/publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/northernireland/publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/wales/publicity",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/wales/publicity",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/scotland",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/scotland",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/scotland",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/scotland",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/scotland",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/scotland",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/scotland",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/scotland",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/scotland",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/uk-wide",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/uk-wide",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/england/uk-wide",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/england/uk-wide",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/scotland/uk-wide",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/scotland/uk-wide",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/northernireland/uk-wide",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/northernireland/uk-wide",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/wales/uk-wide",
+    "to": "/",
+  },
+  Object {
+    "from": "/welsh/wales/uk-wide",
+    "to": "/welsh/",
+  },
+  Object {
+    "from": "/under10k",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/under10k",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/england/under10k",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/england/under10k",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/scotland/under10k",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/scotland/under10k",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/northernireland/under10k",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/northernireland/under10k",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/wales/under10k",
+    "to": "/funding/under10k",
+  },
+  Object {
+    "from": "/welsh/wales/under10k",
+    "to": "/welsh/funding/under10k",
+  },
+  Object {
+    "from": "/welcome",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/welcome",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/england/welcome",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/england/welcome",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/scotland/welcome",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/scotland/welcome",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/northernireland/welcome",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/northernireland/welcome",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/wales/welcome",
+    "to": "/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/welsh/wales/welcome",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding",
+  },
+  Object {
+    "from": "/yourgrant",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/yourgrant",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/england/yourgrant",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/england/yourgrant",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/scotland/yourgrant",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/scotland/yourgrant",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/northernireland/yourgrant",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/northernireland/yourgrant",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/wales/yourgrant",
+    "to": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+  Object {
+    "from": "/welsh/wales/yourgrant",
+    "to": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+  },
+]
+`;

--- a/controllers/__tests__/alises.test.js
+++ b/controllers/__tests__/alises.test.js
@@ -1,0 +1,9 @@
+/* eslint-env jest */
+'use strict';
+const aliases = require('../aliases');
+
+describe('alises', () => {
+    it('should export mappedAliases', () => {
+        expect(aliases).toMatchSnapshot();
+    });
+});

--- a/controllers/__tests__/route-types.test.js
+++ b/controllers/__tests__/route-types.test.js
@@ -26,8 +26,6 @@ describe('Route types', () => {
         });
 
         expect(section.path).toBe('/example');
-        expect(section.find('exampleSection')).toBe('/example/some/url');
-        expect(() => section.find('doesNotExist')).toThrowError('No route found for doesNotExist');
     });
 
     it('should define a custom route schema', () => {

--- a/controllers/__tests__/route-types.test.js
+++ b/controllers/__tests__/route-types.test.js
@@ -10,7 +10,7 @@ const {
     basicContentRoute,
     flexibleContentRoute,
     legacyRoute
-} = require('./route-types');
+} = require('../route-types');
 
 describe('Route types', () => {
     it('should create a new section', () => {

--- a/controllers/__tests__/route-types.test.js
+++ b/controllers/__tests__/route-types.test.js
@@ -3,7 +3,6 @@
 const config = require('config');
 const {
     CONTENT_TYPES,
-    createSection,
     customRoute,
     sessionRoute,
     staticContentRoute,
@@ -13,21 +12,6 @@ const {
 } = require('../route-types');
 
 describe('Route types', () => {
-    it('should create a new section', () => {
-        const section = createSection({
-            path: '/example',
-            langTitlePath: 'global.nav.about'
-        });
-
-        section.addRoutes({
-            exampleSection: customRoute({
-                path: '/some/url'
-            })
-        });
-
-        expect(section.path).toBe('/example');
-    });
-
     it('should define a custom route schema', () => {
         const route = customRoute({ path: '/some/url', queryStrings: ['foo', 'bar'] });
         expect(route).toEqual({

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -1,29 +1,11 @@
 'use strict';
 const config = require('config');
-const { get } = require('lodash');
 
 const CONTENT_TYPES = {
     STATIC: 'STATIC', // A page with no content from the cms and a static template
     CMS_BASIC: 'CMS_BASIC', // Page using the basic cms content type
     CMS_FLEXIBLE_CONTENT: 'CMS_FLEXIBLE_CONTENT' // Page using the cms flexible content type
 };
-
-/**
- * Create a top-level section
- *
- * path - top-level URL path, e.g. /funding
- * controllerPath - path to controller file
- * langTitlePath - locale property for translated page title
- */
-function createSection({ path, pages = null, controller = null, langTitlePath = null, showInNavigation = true }) {
-    return {
-        path: path,
-        pages: pages,
-        controller: controller,
-        langTitlePath: langTitlePath,
-        showInNavigation: showInNavigation
-    };
-}
 
 /**
  * Default parameters for cloudfront routes
@@ -91,7 +73,6 @@ function legacyRoute(props) {
 
 module.exports = {
     CONTENT_TYPES,
-    createSection,
     customRoute,
     sessionRoute,
     staticContentRoute,

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -40,18 +40,6 @@ function createSection({ path, controllerPath = null, langTitlePath = null, show
         newSection.pages = sectionRoutes;
     };
 
-    /**
-     * Find the canonical path for a given page key
-     */
-    newSection.find = function(pageId) {
-        const pagePath = get(newSection.pages, `${pageId}.path`);
-        if (pagePath) {
-            return `${path}${pagePath}`;
-        } else {
-            throw new Error(`No route found for ${pageId}`);
-        }
-    };
-
     return newSection;
 }
 

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -15,23 +15,14 @@ const CONTENT_TYPES = {
  * controllerPath - path to controller file
  * langTitlePath - locale property for translated page title
  */
-function createSection({ path, controller = null, langTitlePath = null, showInNavigation = true }) {
-    const newSection = {
+function createSection({ path, pages = null, controller = null, langTitlePath = null, showInNavigation = true }) {
+    return {
         path: path,
-        pages: null,
+        pages: pages,
         controller: controller,
         langTitlePath: langTitlePath,
         showInNavigation: showInNavigation
     };
-
-    /**
-     * Setter for route pages
-     */
-    newSection.addRoutes = function(sectionRoutes) {
-        newSection.pages = sectionRoutes;
-    };
-
-    return newSection;
 }
 
 /**

--- a/controllers/route-types.js
+++ b/controllers/route-types.js
@@ -15,23 +15,14 @@ const CONTENT_TYPES = {
  * controllerPath - path to controller file
  * langTitlePath - locale property for translated page title
  */
-function createSection({ path, controllerPath = null, langTitlePath = null, showInNavigation = true }) {
+function createSection({ path, controller = null, langTitlePath = null, showInNavigation = true }) {
     const newSection = {
         path: path,
         pages: null,
-        controller: null,
+        controller: controller,
         langTitlePath: langTitlePath,
         showInNavigation: showInNavigation
     };
-
-    /**
-     * Controller loader function, allows us to auto-init routes
-     */
-    if (controllerPath) {
-        newSection.controller = function(options) {
-            return require(controllerPath)(options);
-        };
-    }
 
     /**
      * Setter for route pages

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -2,7 +2,6 @@
 
 const aliases = require('./aliases');
 const {
-    createSection,
     customRoute,
     sessionRoute,
     staticContentRoute,
@@ -11,8 +10,22 @@ const {
     legacyRoute
 } = require('./route-types');
 
-const sectionToplevel = createSection({
+/**
+ * @typedef {object} Section
+ * @property {string} path
+ * @property {boolean} showInNavigation
+ * @property {object} pages
+ * @property {function} [controller]
+ * @property {string} [langTitlePath]
+ */
+
+/**
+ * Home and top-level routes
+ * @type {Section}
+ */
+const sectionToplevel = {
     path: '',
+    showInNavigation: true,
     langTitlePath: 'global.nav.home',
     controller: function(options) {
         return require('./toplevel')(options);
@@ -59,10 +72,15 @@ const sectionToplevel = createSection({
             allowAllQueryStrings: true
         })
     }
-});
+};
 
-const sectionFunding = createSection({
+/**
+ * Funding section
+ * @type {Section}
+ */
+const sectionFunding = {
     path: '/funding',
+    showInNavigation: true,
     langTitlePath: 'global.nav.funding',
     controller: function(options) {
         return require('./funding')(options);
@@ -152,9 +170,13 @@ const sectionFunding = createSection({
             path: '/funding-finder'
         })
     }
-});
+};
 
-const sectionLocal = createSection({
+/**
+ * Local section
+ * @type {Section}
+ */
+const sectionLocal = {
     path: '/local',
     langTitlePath: 'global.nav.local',
     showInNavigation: false,
@@ -168,10 +190,15 @@ const sectionLocal = createSection({
             live: false
         })
     }
-});
+};
 
-const sectionResearch = createSection({
+/**
+ * Research section
+ * @type {Section}
+ */
+const sectionResearch = {
     path: '/research',
+    showInNavigation: true,
     langTitlePath: 'global.nav.research',
     controller: function(options) {
         return require('./research')(options);
@@ -189,10 +216,15 @@ const sectionResearch = createSection({
             live: false
         })
     }
-});
+};
 
-const sectionAbout = createSection({
+/**
+ * About section
+ * @type {Section}
+ */
+const sectionAbout = {
     path: '/about',
+    showInNavigation: true,
     langTitlePath: 'global.nav.about',
     controller: function(options) {
         return require('./about')(options);
@@ -224,9 +256,13 @@ const sectionAbout = createSection({
             path: '/*'
         })
     }
-});
+};
 
-const sectionBlog = createSection({
+/**
+ * Blog section
+ * @type {Section}
+ */
+const sectionBlog = {
     path: '/blog',
     showInNavigation: false,
     langTitlePath: 'global.nav.blog',
@@ -243,9 +279,13 @@ const sectionBlog = createSection({
             live: false
         })
     }
-});
+};
 
-const sectionApply = createSection({
+/**
+ * Apply section
+ * @type {Section}
+ */
+const sectionApply = {
     path: '/apply',
     showInNavigation: false,
     controller: function(options) {
@@ -260,7 +300,7 @@ const sectionApply = createSection({
             isPostable: true
         })
     }
-});
+};
 
 /**
  * Sections

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const aliases = require('./aliases');
 const {
     createSection,
@@ -16,12 +15,16 @@ const sections = {
     toplevel: createSection({
         path: '',
         langTitlePath: 'global.nav.home',
-        controllerPath: path.resolve(__dirname, './toplevel')
+        controller: function(options) {
+            return require('./toplevel')(options);
+        }
     }),
     funding: createSection({
         path: '/funding',
         langTitlePath: 'global.nav.funding',
-        controllerPath: path.resolve(__dirname, './funding')
+        controller: function(options) {
+            return require('./funding')(options);
+        }
     }),
     local: createSection({
         path: '/local',
@@ -31,23 +34,31 @@ const sections = {
     research: createSection({
         path: '/research',
         langTitlePath: 'global.nav.research',
-        controllerPath: path.resolve(__dirname, './research')
+        controller: function(options) {
+            return require('./research')(options);
+        }
     }),
     about: createSection({
         path: '/about',
         langTitlePath: 'global.nav.about',
-        controllerPath: path.resolve(__dirname, './about')
+        controller: function(options) {
+            return require('./about')(options);
+        }
     }),
     blog: createSection({
         path: '/blog',
+        showInNavigation: false,
         langTitlePath: 'global.nav.blog',
-        controllerPath: path.resolve(__dirname, './blog'),
-        showInNavigation: false
+        controller: function(options) {
+            return require('./blog')(options);
+        }
     }),
     apply: createSection({
         path: '/apply',
-        controllerPath: path.resolve(__dirname, './apply'),
-        showInNavigation: false
+        showInNavigation: false,
+        controller: function(options) {
+            return require('./apply')(options);
+        }
     })
 };
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -23,7 +23,7 @@ const {
  * Home and top-level routes
  * @type {Section}
  */
-const sectionToplevel = {
+const toplevel = {
     path: '',
     showInNavigation: true,
     langTitlePath: 'global.nav.home',
@@ -78,7 +78,7 @@ const sectionToplevel = {
  * Funding section
  * @type {Section}
  */
-const sectionFunding = {
+const funding = {
     path: '/funding',
     showInNavigation: true,
     langTitlePath: 'global.nav.funding',
@@ -176,7 +176,7 @@ const sectionFunding = {
  * Local section
  * @type {Section}
  */
-const sectionLocal = {
+const local = {
     path: '/local',
     langTitlePath: 'global.nav.local',
     showInNavigation: false,
@@ -196,7 +196,7 @@ const sectionLocal = {
  * Research section
  * @type {Section}
  */
-const sectionResearch = {
+const research = {
     path: '/research',
     showInNavigation: true,
     langTitlePath: 'global.nav.research',
@@ -222,7 +222,7 @@ const sectionResearch = {
  * About section
  * @type {Section}
  */
-const sectionAbout = {
+const about = {
     path: '/about',
     showInNavigation: true,
     langTitlePath: 'global.nav.about',
@@ -262,7 +262,7 @@ const sectionAbout = {
  * Blog section
  * @type {Section}
  */
-const sectionBlog = {
+const blog = {
     path: '/blog',
     showInNavigation: false,
     langTitlePath: 'global.nav.blog',
@@ -285,7 +285,7 @@ const sectionBlog = {
  * Apply section
  * @type {Section}
  */
-const sectionApply = {
+const apply = {
     path: '/apply',
     showInNavigation: false,
     controller: function(options) {
@@ -307,13 +307,13 @@ const sectionApply = {
  * The order here defines the order of the navigation
  */
 const sections = {
-    sectionToplevel,
-    sectionFunding,
-    sectionLocal,
-    sectionResearch,
-    sectionAbout,
-    sectionBlog,
-    sectionApply
+    toplevel: toplevel,
+    funding: funding,
+    local: local,
+    research: research,
+    about: about,
+    blog: blog,
+    apply: apply
 };
 
 /**

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -11,280 +11,270 @@ const {
     legacyRoute
 } = require('./route-types');
 
+const sectionToplevel = createSection({
+    path: '',
+    langTitlePath: 'global.nav.home',
+    controller: function(options) {
+        return require('./toplevel')(options);
+    },
+    pages: {
+        home: customRoute({
+            path: '/',
+            template: 'pages/toplevel/home',
+            lang: 'toplevel.home',
+            isPostable: true
+        }),
+        northernIreland: staticContentRoute({
+            path: '/northern-ireland',
+            sMaxAge: '30m',
+            template: 'pages/toplevel/region',
+            lang: 'toplevel.northernIreland',
+            isBilingual: false,
+            heroSlug: 'down-right-brilliant'
+        }),
+        wales: staticContentRoute({
+            path: '/wales',
+            sMaxAge: '30m',
+            template: 'pages/toplevel/region',
+            lang: 'toplevel.wales',
+            heroSlug: 'grassroots-wales'
+        }),
+        contact: basicContentRoute({
+            path: '/contact'
+        }),
+        data: customRoute({
+            path: '/data',
+            template: 'pages/toplevel/data',
+            lang: 'toplevel.data',
+            heroSlug: 'young-shoulders-programme'
+        }),
+        jobs: basicContentRoute({
+            path: '/jobs'
+        }),
+        jobsBenefits: basicContentRoute({
+            path: '/jobs/benefits'
+        }),
+        search: customRoute({
+            path: '/search',
+            allowAllQueryStrings: true
+        })
+    }
+});
+
+const sectionFunding = createSection({
+    path: '/funding',
+    langTitlePath: 'global.nav.funding',
+    controller: function(options) {
+        return require('./funding')(options);
+    },
+    pages: {
+        root: customRoute({
+            path: '/',
+            sMaxAge: '30m',
+            template: 'pages/funding/index',
+            lang: 'toplevel.funding',
+            heroSlug: 'active-plus-communities'
+        }),
+        rootTest: staticContentRoute({
+            path: '/test',
+            template: 'pages/funding/index-test',
+            lang: 'toplevel.funding',
+            heroSlug: 'ragroof-players',
+            live: false
+        }),
+        thinkingOfApplying: staticContentRoute({
+            path: '/thinking-of-applying',
+            template: 'pages/funding/thinking-of-applying',
+            lang: 'funding.thinkingOfApplying',
+            heroSlug: 'building-bridges',
+            live: false
+        }),
+        under10k: customRoute({
+            path: '/under10k',
+            template: 'pages/funding/under10k',
+            lang: 'funding.under10k',
+            heroSlug: 'friends-of-greenwich'
+        }),
+        over10k: customRoute({
+            path: '/over10k',
+            template: 'pages/funding/over10k',
+            lang: 'funding.over10k',
+            heroSlug: 'passion-4-fusion-3'
+        }),
+        pastGrants: staticContentRoute({
+            path: '/past-grants',
+            template: 'pages/funding/past-grants',
+            lang: 'funding.pastGrants',
+            heroSlug: 'active-plus-communities'
+        }),
+        pastGrantsAlpha: customRoute({
+            path: '/search-past-grants-alpha',
+            live: false,
+            template: 'pages/grants/search',
+            isPostable: true,
+            allowAllQueryStrings: true
+        }),
+        programmes: customRoute({
+            path: '/programmes',
+            template: 'pages/funding/programmes',
+            lang: 'funding.programmes',
+            heroSlug: 'the-young-foundation',
+            queryStrings: ['location', 'amount', 'min', 'max']
+        }),
+        programmeDetail: customRoute({
+            path: '/programmes/*',
+            template: 'pages/funding/programme-detail'
+        }),
+        buildingBetterOpportunities: basicContentRoute({
+            path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding'
+        }),
+        buildingBetterOpportunitiesResources: basicContentRoute({
+            path: '/programmes/building-better-opportunities/building-better-opportunities-resources'
+        }),
+        fundingGuidanceLogos: basicContentRoute({
+            path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
+            template: 'pages/funding/logos',
+            lang: 'funding.guidance.logos'
+        }),
+        fundingGuidanceMaterials: sessionRoute({
+            path: '/funding-guidance/managing-your-funding/ordering-free-materials',
+            lang: 'funding.guidance.order-free-materials',
+            isPostable: true
+        }),
+        fundingGuidanceMaterialsActions: sessionRoute({
+            path: '/funding-guidance/managing-your-funding/ordering-free-materials/*',
+            isPostable: true
+        }),
+        fundingGuidance: basicContentRoute({
+            path: '/funding-guidance/*'
+        }),
+        fundingFinderLegacy: legacyRoute({
+            path: '/funding-finder'
+        })
+    }
+});
+
+const sectionLocal = createSection({
+    path: '/local',
+    langTitlePath: 'global.nav.local',
+    showInNavigation: false,
+    pages: {
+        root: staticContentRoute({
+            path: '/',
+            template: 'pages/toplevel/local',
+            isBilingual: false,
+            lang: 'toplevel.local',
+            heroSlug: 'arkwright-meadows',
+            live: false
+        })
+    }
+});
+
+const sectionResearch = createSection({
+    path: '/research',
+    langTitlePath: 'global.nav.research',
+    controller: function(options) {
+        return require('./research')(options);
+    },
+    pages: {
+        root: customRoute({
+            path: '/',
+            lang: 'toplevel.research',
+            heroSlug: 'grassroots-project'
+        }),
+        rootNew: customRoute({
+            path: '/landing-new',
+            lang: 'toplevel.research',
+            heroSlug: 'grassroots-project',
+            live: false
+        })
+    }
+});
+
+const sectionAbout = createSection({
+    path: '/about',
+    langTitlePath: 'global.nav.about',
+    controller: function(options) {
+        return require('./about')(options);
+    },
+    pages: {
+        root: flexibleContentRoute({
+            path: '/'
+        }),
+        seniorManagement: customRoute({
+            path: '/our-people/senior-management-team',
+            template: 'pages/about/senior-management-team',
+            lang: 'about.ourPeople.seniorManagement',
+            heroSlug: 'mental-health-foundation'
+        }),
+        board: customRoute({
+            path: '/our-people/board',
+            template: 'pages/about/board',
+            lang: 'about.ourPeople.board',
+            live: false
+        }),
+        ebulletin: customRoute({
+            path: '/ebulletin',
+            template: 'pages/about/ebulletin',
+            lang: 'toplevel.ebulletin',
+            heroSlug: 'street-dreams',
+            isPostable: true
+        }),
+        content: basicContentRoute({
+            path: '/*'
+        })
+    }
+});
+
+const sectionBlog = createSection({
+    path: '/blog',
+    showInNavigation: false,
+    langTitlePath: 'global.nav.blog',
+    controller: function(options) {
+        return require('./blog')(options);
+    },
+    pages: {
+        root: customRoute({
+            path: '/',
+            live: false
+        }),
+        articles: customRoute({
+            path: '/*',
+            live: false
+        })
+    }
+});
+
+const sectionApply = createSection({
+    path: '/apply',
+    showInNavigation: false,
+    controller: function(options) {
+        return require('./apply')(options);
+    },
+    pages: {
+        root: customRoute({
+            path: '/'
+        }),
+        applicationForms: sessionRoute({
+            path: '/*',
+            isPostable: true
+        })
+    }
+});
+
+/**
+ * Sections
+ * The order here defines the order of the navigation
+ */
 const sections = {
-    toplevel: createSection({
-        path: '',
-        langTitlePath: 'global.nav.home',
-        controller: function(options) {
-            return require('./toplevel')(options);
-        }
-    }),
-    funding: createSection({
-        path: '/funding',
-        langTitlePath: 'global.nav.funding',
-        controller: function(options) {
-            return require('./funding')(options);
-        }
-    }),
-    local: createSection({
-        path: '/local',
-        langTitlePath: 'global.nav.local',
-        showInNavigation: false
-    }),
-    research: createSection({
-        path: '/research',
-        langTitlePath: 'global.nav.research',
-        controller: function(options) {
-            return require('./research')(options);
-        }
-    }),
-    about: createSection({
-        path: '/about',
-        langTitlePath: 'global.nav.about',
-        controller: function(options) {
-            return require('./about')(options);
-        }
-    }),
-    blog: createSection({
-        path: '/blog',
-        showInNavigation: false,
-        langTitlePath: 'global.nav.blog',
-        controller: function(options) {
-            return require('./blog')(options);
-        }
-    }),
-    apply: createSection({
-        path: '/apply',
-        showInNavigation: false,
-        controller: function(options) {
-            return require('./apply')(options);
-        }
-    })
+    sectionToplevel,
+    sectionFunding,
+    sectionLocal,
+    sectionResearch,
+    sectionAbout,
+    sectionBlog,
+    sectionApply
 };
-
-/**
- * Top-level Routes
- */
-sections.toplevel.addRoutes({
-    home: customRoute({
-        path: '/',
-        template: 'pages/toplevel/home',
-        lang: 'toplevel.home',
-        isPostable: true
-    }),
-    northernIreland: staticContentRoute({
-        path: '/northern-ireland',
-        sMaxAge: '30m',
-        template: 'pages/toplevel/region',
-        lang: 'toplevel.northernIreland',
-        isBilingual: false,
-        heroSlug: 'down-right-brilliant'
-    }),
-    wales: staticContentRoute({
-        path: '/wales',
-        sMaxAge: '30m',
-        template: 'pages/toplevel/region',
-        lang: 'toplevel.wales',
-        heroSlug: 'grassroots-wales'
-    }),
-    contact: basicContentRoute({
-        path: '/contact'
-    }),
-    data: customRoute({
-        path: '/data',
-        template: 'pages/toplevel/data',
-        lang: 'toplevel.data',
-        heroSlug: 'young-shoulders-programme'
-    }),
-    jobs: basicContentRoute({
-        path: '/jobs'
-    }),
-    jobsBenefits: basicContentRoute({
-        path: '/jobs/benefits'
-    }),
-    search: customRoute({
-        path: '/search',
-        allowAllQueryStrings: true
-    })
-});
-
-/**
- * Local Routes
- */
-sections.local.addRoutes({
-    root: staticContentRoute({
-        path: '/',
-        template: 'pages/toplevel/local',
-        isBilingual: false,
-        lang: 'toplevel.local',
-        heroSlug: 'arkwright-meadows',
-        live: false
-    })
-});
-
-/**
- * Funding Routes
- */
-sections.funding.addRoutes({
-    root: customRoute({
-        path: '/',
-        sMaxAge: '30m',
-        template: 'pages/funding/index',
-        lang: 'toplevel.funding',
-        heroSlug: 'active-plus-communities'
-    }),
-    rootTest: staticContentRoute({
-        path: '/test',
-        template: 'pages/funding/index-test',
-        lang: 'toplevel.funding',
-        heroSlug: 'ragroof-players',
-        live: false
-    }),
-    thinkingOfApplying: staticContentRoute({
-        path: '/thinking-of-applying',
-        template: 'pages/funding/thinking-of-applying',
-        lang: 'funding.thinkingOfApplying',
-        heroSlug: 'building-bridges',
-        live: false
-    }),
-    under10k: customRoute({
-        path: '/under10k',
-        template: 'pages/funding/under10k',
-        lang: 'funding.under10k',
-        heroSlug: 'friends-of-greenwich'
-    }),
-    over10k: customRoute({
-        path: '/over10k',
-        template: 'pages/funding/over10k',
-        lang: 'funding.over10k',
-        heroSlug: 'passion-4-fusion-3'
-    }),
-    pastGrants: staticContentRoute({
-        path: '/past-grants',
-        template: 'pages/funding/past-grants',
-        lang: 'funding.pastGrants',
-        heroSlug: 'active-plus-communities'
-    }),
-    pastGrantsAlpha: customRoute({
-        path: '/search-past-grants-alpha',
-        live: false,
-        template: 'pages/grants/search',
-        isPostable: true,
-        allowAllQueryStrings: true
-    }),
-    programmes: customRoute({
-        path: '/programmes',
-        template: 'pages/funding/programmes',
-        lang: 'funding.programmes',
-        heroSlug: 'the-young-foundation',
-        queryStrings: ['location', 'amount', 'min', 'max']
-    }),
-    programmeDetail: customRoute({
-        path: '/programmes/*',
-        template: 'pages/funding/programme-detail'
-    }),
-    buildingBetterOpportunities: basicContentRoute({
-        path: '/programmes/building-better-opportunities/guide-to-delivering-european-funding'
-    }),
-    buildingBetterOpportunitiesResources: basicContentRoute({
-        path: '/programmes/building-better-opportunities/building-better-opportunities-resources'
-    }),
-    fundingGuidanceLogos: basicContentRoute({
-        path: '/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
-        template: 'pages/funding/logos',
-        lang: 'funding.guidance.logos'
-    }),
-    fundingGuidanceMaterials: sessionRoute({
-        path: '/funding-guidance/managing-your-funding/ordering-free-materials',
-        lang: 'funding.guidance.order-free-materials',
-        isPostable: true
-    }),
-    fundingGuidanceMaterialsActions: sessionRoute({
-        path: '/funding-guidance/managing-your-funding/ordering-free-materials/*',
-        isPostable: true
-    }),
-    fundingGuidance: basicContentRoute({
-        path: '/funding-guidance/*'
-    }),
-    fundingFinderLegacy: legacyRoute({
-        path: '/funding-finder'
-    })
-});
-
-/**
- * Research Routes
- */
-sections.research.addRoutes({
-    root: customRoute({
-        path: '/',
-        lang: 'toplevel.research',
-        heroSlug: 'grassroots-project'
-    }),
-    rootNew: customRoute({
-        path: '/landing-new',
-        lang: 'toplevel.research',
-        heroSlug: 'grassroots-project',
-        live: false
-    })
-});
-
-/**
- * About Routes
- */
-sections.about.addRoutes({
-    root: flexibleContentRoute({
-        path: '/'
-    }),
-    seniorManagement: customRoute({
-        path: '/our-people/senior-management-team',
-        template: 'pages/about/senior-management-team',
-        lang: 'about.ourPeople.seniorManagement',
-        heroSlug: 'mental-health-foundation'
-    }),
-    board: customRoute({
-        path: '/our-people/board',
-        template: 'pages/about/board',
-        lang: 'about.ourPeople.board',
-        live: false
-    }),
-    ebulletin: customRoute({
-        path: '/ebulletin',
-        template: 'pages/about/ebulletin',
-        lang: 'toplevel.ebulletin',
-        heroSlug: 'street-dreams',
-        isPostable: true
-    }),
-    content: basicContentRoute({
-        path: '/*'
-    })
-});
-
-/**
- * Blog routes
- */
-sections.blog.addRoutes({
-    root: customRoute({
-        path: '/',
-        live: false
-    }),
-    articles: customRoute({
-        path: '/*',
-        live: false
-    })
-});
-
-/**
- * Apply routes
- */
-sections.apply.addRoutes({
-    root: customRoute({
-        path: '/'
-    }),
-    applicationForms: sessionRoute({
-        path: '/*',
-        isPostable: true
-    })
-});
 
 /**
  * Other Routes

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -1,0 +1,1895 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+Object {
+  "CacheBehaviors": Object {
+    "Items": Array [
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "*~/link.aspx",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/-/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/PastGrants.ashx",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/apply/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "url",
+            ],
+            "Quantity": 5,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/contrast/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/css/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/default.css",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/funding-finder",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/funding-guidance/managing-your-funding/ordering-free-materials/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "location",
+              "amount",
+              "min",
+              "max",
+            ],
+            "Quantity": 8,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/programmes",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/search-past-grants",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/search-past-grants-alpha",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/search-past-grants/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/images/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/js/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "all",
+          },
+          "Headers": Object {
+            "Items": Array [
+              "*",
+            ],
+            "Quantity": 1,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/news-and-events",
+        "SmoothStreaming": false,
+        "TargetOriginId": "LEGACY",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "allow-all",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/search",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/tools/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "token",
+            ],
+            "Quantity": 5,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/user/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/apply/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/funding-finder",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/funding-guidance/managing-your-funding/ordering-free-materials/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "location",
+              "amount",
+              "min",
+              "max",
+            ],
+            "Quantity": 8,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/programmes",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "DELETE",
+            "POST",
+            "GET",
+            "OPTIONS",
+            "PUT",
+            "PATCH",
+          ],
+          "Quantity": 7,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/search-past-grants-alpha",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/search",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+    ],
+    "Quantity": 27,
+  },
+  "DefaultCacheBehavior": Object {
+    "AllowedMethods": Object {
+      "CachedMethods": Object {
+        "Items": Array [
+          "HEAD",
+          "GET",
+        ],
+        "Quantity": 2,
+      },
+      "Items": Array [
+        "HEAD",
+        "DELETE",
+        "POST",
+        "GET",
+        "OPTIONS",
+        "PUT",
+        "PATCH",
+      ],
+      "Quantity": 7,
+    },
+    "Compress": true,
+    "DefaultTTL": 86400,
+    "FieldLevelEncryptionId": "",
+    "ForwardedValues": Object {
+      "Cookies": Object {
+        "Forward": "whitelist",
+        "WhitelistedNames": Object {
+          "Items": Array [
+            "contrastMode",
+            "blf-features",
+            "blf-alpha-session",
+          ],
+          "Quantity": 3,
+        },
+      },
+      "Headers": Object {
+        "Items": Array [
+          "Accept",
+          "Host",
+        ],
+        "Quantity": 2,
+      },
+      "QueryString": true,
+      "QueryStringCacheKeys": Object {
+        "Items": Array [
+          "draft",
+          "version",
+          "enable-feature",
+          "disable-feature",
+        ],
+        "Quantity": 4,
+      },
+    },
+    "LambdaFunctionAssociations": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "MaxTTL": 31536000,
+    "MinTTL": 0,
+    "SmoothStreaming": false,
+    "TargetOriginId": "ELB_LIVE",
+    "TrustedSigners": Object {
+      "Enabled": false,
+      "Items": Array [],
+      "Quantity": 0,
+    },
+    "ViewerProtocolPolicy": "redirect-to-https",
+  },
+}
+`;
+
+exports[`#makeBehaviourItem should allow all cookies and querystrings 1`] = `
+Object {
+  "AllowedMethods": Object {
+    "CachedMethods": Object {
+      "Items": Array [
+        "HEAD",
+        "GET",
+      ],
+      "Quantity": 2,
+    },
+    "Items": Array [
+      "HEAD",
+      "DELETE",
+      "POST",
+      "GET",
+      "OPTIONS",
+      "PUT",
+      "PATCH",
+    ],
+    "Quantity": 7,
+  },
+  "Compress": true,
+  "DefaultTTL": 86400,
+  "FieldLevelEncryptionId": "",
+  "ForwardedValues": Object {
+    "Cookies": Object {
+      "Forward": "all",
+    },
+    "Headers": Object {
+      "Items": Array [
+        "*",
+      ],
+      "Quantity": 1,
+    },
+    "QueryString": true,
+    "QueryStringCacheKeys": Object {
+      "Items": Array [],
+      "Quantity": 0,
+    },
+  },
+  "LambdaFunctionAssociations": Object {
+    "Items": Array [],
+    "Quantity": 0,
+  },
+  "MaxTTL": 31536000,
+  "MinTTL": 0,
+  "PathPattern": "/~/*",
+  "SmoothStreaming": false,
+  "TargetOriginId": "BLF_LEGACY_EXAMPLE",
+  "TrustedSigners": Object {
+    "Enabled": false,
+    "Items": Array [],
+    "Quantity": 0,
+  },
+  "ViewerProtocolPolicy": "allow-all",
+}
+`;
+
+exports[`#makeBehaviourItem should return cloudfront behaviour for route 1`] = `
+Object {
+  "AllowedMethods": Object {
+    "CachedMethods": Object {
+      "Items": Array [
+        "HEAD",
+        "GET",
+      ],
+      "Quantity": 2,
+    },
+    "Items": Array [
+      "HEAD",
+      "DELETE",
+      "POST",
+      "GET",
+      "OPTIONS",
+      "PUT",
+      "PATCH",
+    ],
+    "Quantity": 7,
+  },
+  "Compress": true,
+  "DefaultTTL": 86400,
+  "FieldLevelEncryptionId": "",
+  "ForwardedValues": Object {
+    "Cookies": Object {
+      "Forward": "whitelist",
+      "WhitelistedNames": Object {
+        "Items": Array [
+          "example",
+        ],
+        "Quantity": 1,
+      },
+    },
+    "Headers": Object {
+      "Items": Array [
+        "Accept",
+        "Host",
+      ],
+      "Quantity": 2,
+    },
+    "QueryString": true,
+    "QueryStringCacheKeys": Object {
+      "Items": Array [
+        "draft",
+        "version",
+        "enable-feature",
+        "disable-feature",
+        "q",
+      ],
+      "Quantity": 5,
+    },
+  },
+  "LambdaFunctionAssociations": Object {
+    "Items": Array [],
+    "Quantity": 0,
+  },
+  "MaxTTL": 31536000,
+  "MinTTL": 0,
+  "PathPattern": "/",
+  "SmoothStreaming": false,
+  "TargetOriginId": "BLF_EXAMPLE",
+  "TrustedSigners": Object {
+    "Enabled": false,
+    "Items": Array [],
+    "Quantity": 0,
+  },
+  "ViewerProtocolPolicy": "redirect-to-https",
+}
+`;

--- a/modules/__tests__/cloudfront.test.js
+++ b/modules/__tests__/cloudfront.test.js
@@ -1,177 +1,105 @@
 /* eslint-env jest */
 'use strict';
+const config = require('config');
 
-const { defaultsDeep } = require('lodash');
-const { generateUrlList, makeBehaviourItem } = require('../cloudfront');
+const routes = require('../../controllers/routes');
+const cloudfrontDistributions = config.get('aws.cloudfrontDistributions');
 
-describe('Cloudfront Helpers', () => {
-    const testRoutes = {
-        sections: {
-            purple: {
-                path: '/purple',
-                pages: {
-                    monkey: {
-                        path: '/monkey/dishwasher',
-                        live: true,
-                        isPostable: true,
-                        aliases: ['/green/orangutan/fridge'],
-                        queryStrings: ['foo', 'bar']
-                    }
+const { generateUrlList, makeBehaviourItem, generateBehaviours } = require('../cloudfront');
+
+const testRoutes = {
+    sections: {
+        purple: {
+            path: '/purple',
+            pages: {
+                monkey: {
+                    path: '/monkey/dishwasher',
+                    live: true,
+                    isPostable: true,
+                    aliases: ['/green/orangutan/fridge'],
+                    queryStrings: ['foo', 'bar']
                 }
             }
-        },
-        archivedRoutes: [
-            {
-                path: '/some/archived/path/*',
-                live: true
-            }
-        ],
-        otherUrls: [
-            {
-                path: '/unicorns',
-                isPostable: true,
-                live: true
-            },
-            {
-                path: '/draft',
-                live: false
-            }
-        ]
-    };
-
-    describe('#generateUrlList', () => {
-        it('should filter out non-custom routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.length).toBe(2);
-            done();
-        });
-
-        it('should generate the correct section/page path', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).toBe(1);
-            done();
-        });
-
-        it('should generate welsh versions of canonical routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).toBe(1);
-            done();
-        });
-
-        it('should store properties against routes', done => {
-            const urls = generateUrlList(testRoutes);
-            expect(urls.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).toBe(true);
-            done();
-        });
-    });
-
-    describe('#makeBehaviourItem', () => {
-        function withDefaults(behaviourConfig) {
-            return defaultsDeep(behaviourConfig, {
-                MinTTL: 0,
-                MaxTTL: 31536000,
-                DefaultTTL: 86400,
-                FieldLevelEncryptionId: '',
-                SmoothStreaming: false,
-                Compress: true,
-                AllowedMethods: {
-                    Items: ['HEAD', 'GET'],
-                    Quantity: 2,
-                    CachedMethods: {
-                        Items: ['HEAD', 'GET'],
-                        Quantity: 2
-                    }
-                },
-                ForwardedValues: {
-                    QueryStringCacheKeys: {
-                        Items: [],
-                        Quantity: 0
-                    },
-                    QueryString: false
-                },
-                TrustedSigners: {
-                    Enabled: false,
-                    Items: [],
-                    Quantity: 0
-                },
-                LambdaFunctionAssociations: {
-                    Items: [],
-                    Quantity: 0
-                }
-            });
         }
+    },
+    archivedRoutes: [
+        {
+            path: '/some/archived/path/*',
+            live: true
+        }
+    ],
+    otherUrls: [
+        {
+            path: '/unicorns',
+            isPostable: true,
+            live: true
+        },
+        {
+            path: '/draft',
+            live: false
+        }
+    ]
+};
 
-        it('should return cloudfront behaviour for route', () => {
-            const behaviour = makeBehaviourItem({
-                originId: 'BLF_EXAMPLE',
-                pathPattern: '/',
-                isPostable: false,
-                cookiesInUse: ['example']
-            });
-
-            expect(behaviour).toEqual(
-                withDefaults({
-                    TargetOriginId: 'BLF_EXAMPLE',
-                    ViewerProtocolPolicy: 'redirect-to-https',
-                    PathPattern: '/',
-                    ForwardedValues: {
-                        Headers: {
-                            Items: ['Accept', 'Host'],
-                            Quantity: 2
-                        },
-                        Cookies: {
-                            Forward: 'whitelist',
-                            WhitelistedNames: {
-                                Items: ['example'],
-                                Quantity: 1
-                            }
-                        },
-                        QueryString: true,
-                        QueryStringCacheKeys: {
-                            Items: ['draft', 'version', 'enable-feature', 'disable-feature'],
-                            Quantity: 4
-                        }
-                    }
-                })
-            );
-        });
-
-        it('should allow all cookies and querystrings', () => {
-            const behaviour = makeBehaviourItem({
-                originId: 'BLF_LEGACY_EXAMPLE',
-                pathPattern: '/~/*',
-                isPostable: true,
-                allowAllQueryStrings: true,
-                allowAllCookies: true,
-                protocol: 'allow-all',
-                headersToKeep: ['*']
-            });
-
-            expect(behaviour).toEqual(
-                withDefaults({
-                    TargetOriginId: 'BLF_LEGACY_EXAMPLE',
-                    ViewerProtocolPolicy: 'allow-all',
-                    PathPattern: '/~/*',
-                    AllowedMethods: {
-                        Items: ['HEAD', 'DELETE', 'POST', 'GET', 'OPTIONS', 'PUT', 'PATCH'],
-                        Quantity: 7
-                    },
-                    ForwardedValues: {
-                        Headers: {
-                            Items: ['*'],
-                            Quantity: 1
-                        },
-                        Cookies: {
-                            Forward: 'all'
-                        },
-                        QueryStringCacheKeys: {
-                            Items: [],
-                            Quantity: 0
-                        },
-                        QueryString: true
-                    }
-                })
-            );
-        });
+describe('#generateUrlList', () => {
+    it('should filter out non-custom routes', done => {
+        const urls = generateUrlList(testRoutes);
+        expect(urls.length).toBe(2);
+        done();
     });
+
+    it('should generate the correct section/page path', done => {
+        const urls = generateUrlList(testRoutes);
+        expect(urls.filter(r => r.path === '/purple/monkey/dishwasher').length).toBe(1);
+        done();
+    });
+
+    it('should generate welsh versions of canonical routes', done => {
+        const urls = generateUrlList(testRoutes);
+        expect(urls.filter(r => r.path === '/welsh/purple/monkey/dishwasher').length).toBe(1);
+        done();
+    });
+
+    it('should store properties against routes', done => {
+        const urls = generateUrlList(testRoutes);
+        expect(urls.filter(r => r.path === '/purple/monkey/dishwasher')[0].isPostable).toBe(true);
+        done();
+    });
+});
+
+describe('#makeBehaviourItem', () => {
+    it('should return cloudfront behaviour for route', () => {
+        const behaviour = makeBehaviourItem({
+            originId: 'BLF_EXAMPLE',
+            pathPattern: '/',
+            isPostable: true,
+            queryStringWhitelist: ['q'],
+            cookiesInUse: ['example']
+        });
+
+        expect(behaviour).toMatchSnapshot();
+    });
+
+    it('should allow all cookies and querystrings', () => {
+        const behaviour = makeBehaviourItem({
+            originId: 'BLF_LEGACY_EXAMPLE',
+            pathPattern: '/~/*',
+            isPostable: true,
+            allowAllQueryStrings: true,
+            allowAllCookies: true,
+            protocol: 'allow-all',
+            headersToKeep: ['*']
+        });
+
+        expect(behaviour).toMatchSnapshot();
+    });
+});
+
+describe('generateBehaviours', () => {
+    const behaviours = generateBehaviours({
+        routesConfig: routes,
+        origins: cloudfrontDistributions.live.origins
+    });
+
+    expect(behaviours).toMatchSnapshot();
 });


### PR DESCRIPTION
This PR does two main things.

- Uses Jest snapshot tests for generated cloudfront routes and aliases. Notably, the cloudfront snapshot is essentially the same as the committed `live.json` file but with the added benefit of being able to assert against it every time we run tests, so we can be more confident it won't change without us meaning to.

- Removes the need for `createSection` when defining routes. I've keep each stage of this change as a granular commit so you can see the thought process here. Same reason we were able to get rid of `createFormModel`. 