### PR TITLE
Remove unneeded variables from templates

### DIFF
--- a/controllers/apply/reaching-communities/startpage.njk
+++ b/controllers/apply/reaching-communities/startpage.njk
@@ -1,10 +1,8 @@
 {% from "components/buttons.njk" import startButton %}
 {% from "components/feedback.njk" import inlineFeedback with context %}
 
-
 {% extends "layouts/main.njk" %}
 {% set bodyClass = 'has-static-header' %}
-{% set pageAccent = 'pink' %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/errors/views/downtime.njk
+++ b/controllers/errors/views/downtime.njk
@@ -2,22 +2,15 @@
 
 {% extends "layouts/main.njk" %}
 
-{% block title %}{{ title }} | {% endblock %}
-
 {% set heroImage = heroImages.fallbackHeroImage %}
 {% set socialImage = heroImage %}
 
 {% block content %}
-
-    {% set pageAccent = 'pink' %}
-
-    {{
-        hero(
-            titleText = title,
-            image = heroImage,
-            accent = pageAccent
-        )
-    }}
+    {{ hero(
+        titleText = title,
+        image = heroImage,
+        accent = pageAccent
+    ) }}
 
     <main class="nudge-up">
         <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">

--- a/controllers/errors/views/error.njk
+++ b/controllers/errors/views/error.njk
@@ -1,10 +1,8 @@
 {% from "components/hero.njk" import hero %}
 
 {% extends "layouts/main.njk" %}
-
 {% set heroImage = heroImages.fallbackHeroImage %}
 {% set socialImage = heroImage %}
-{% set pageAccent = 'pink' %}
 
 {% block content %}
     <main role="main">

--- a/controllers/programmes/views/programme.njk
+++ b/controllers/programmes/views/programme.njk
@@ -6,7 +6,6 @@
 
 {% extends "layouts/main.njk" %}
 
-{% set pageAccent = 'pink' %}
 {% if entry.summary.area.value === 'wales' %}
     {% set bodyClass = "has-welsh-logo" %}
 {% endif %}

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -3,7 +3,6 @@
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% extends "layouts/main.njk" %}
-{% set pageAccent = 'pink' %}
 
 {% block content %}
     <main role="main">

--- a/controllers/research/views/research-landing.njk
+++ b/controllers/research/views/research-landing.njk
@@ -4,21 +4,13 @@
 
 {% extends "layouts/main.njk" %}
 
-{% block title %}{{ title }} | {% endblock %}
-
-{% set socialImage = heroImage %}
-
 {% block content %}
-    {% set pageAccent = 'pink' %}
-
     <main role="main">
-        {{
-            hero(
-                titleText = title,
-                image = heroImage,
-                accent = pageAccent
-            )
-        }}
+        {{ hero(
+            titleText = title,
+            image = heroImage,
+            accent = pageAccent
+        ) }}
 
         <div class="nudge-up">
             {# Section Links #}

--- a/controllers/strategic-investments/views/strategic-programme.njk
+++ b/controllers/strategic-investments/views/strategic-programme.njk
@@ -7,8 +7,6 @@
 
 {% extends "layouts/main.njk" %}
 
-{% set pageAccent = 'pink' %}
-
 {% macro renderContentBlocks(contentBlocks) %}
     {% for part in contentBlocks  %}
         <div class="content-slice">

--- a/views/layouts/profiles.njk
+++ b/views/layouts/profiles.njk
@@ -4,7 +4,6 @@
 {% extends "layouts/main.njk" %}
 
 {% block content %}
-    {% set pageAccent = 'pink' %}
     {{ hero(
         titleText = title,
         image = heroImage,

--- a/views/pages/about/ebulletin.njk
+++ b/views/pages/about/ebulletin.njk
@@ -4,7 +4,6 @@
 {% extends "layouts/main.njk" %}
 
 {% block content %}
-    {% set pageAccent = 'pink' %}
     {{ hero(
         titleText = title,
         image = heroImage,

--- a/views/pages/funding/index.njk
+++ b/views/pages/funding/index.njk
@@ -4,13 +4,7 @@
 
 {% extends "layouts/main.njk" %}
 
-{% block title %}{{ title }} | {% endblock %}
-
-{% set socialImage = heroImage %}
-
 {% block content %}
-    {% set pageAccent = 'pink' %}
-
     <main role="main">
         {{
             hero(

--- a/views/pages/funding/past-grants.njk
+++ b/views/pages/funding/past-grants.njk
@@ -5,8 +5,6 @@
 {% extends "layouts/main.njk" %}
 
 {% block content %}
-    {% set pageAccent = 'pink' %}
-
     <main role="main">
         {{ hero(
             titleText = copy.title,

--- a/views/pages/toplevel/region.njk
+++ b/views/pages/toplevel/region.njk
@@ -23,8 +23,6 @@
 {% endmacro %}
 
 {% block content %}
-    {% set pageAccent = 'pink' %}
-
    {% set availableFundingContent %}
         <div class="s-prose u-constrained-content-wide">
             <p>{{ copy.sections.availableFunding.introduction | safe }}</p>


### PR DESCRIPTION
This PR removes a few things from templates:

- Loads of `{% set pageAccent = 'pink' %}`. Pink is set as the default.

- All instances of `{% block title %}{{ title }} | {% endblock %}`. This is the default content of the block so we only need to set this if the format differs.

- All instances of `{% set socialImage = heroImage %}`. This is done for you when using `injectHeroImage`
