### PR TITLE
Unit test services & models

### DIFF
--- a/services/__tests__/feedback.test.js
+++ b/services/__tests__/feedback.test.js
@@ -1,0 +1,30 @@
+/* eslint-env jest */
+'use strict';
+
+describe('createResponse', () => {
+    let feedback;
+
+    beforeEach(async () => {
+        process.env.DB_CONNECTION_URI = 'sqlite://:memory';
+        const models = require('../../models');
+        await models.sequelize.sync();
+        await models.Feedback.destroy({ where: {} });
+        feedback = require('../feedback');
+    });
+
+    it('should create a feedback response', async () => {
+        const item = await feedback.storeFeedback({ description: 'description', message: 'Test message' });
+        expect(item.id).toBe(1);
+        expect(item.dataValues.message).toBe('Test message');
+    });
+
+    it('should get all responses', async () => {
+        await feedback.storeFeedback({ description: 'description 1', message: 'Test message 1' });
+        await feedback.storeFeedback({ description: 'description 1', message: 'Test message 2' });
+        await feedback.storeFeedback({ description: 'description 2', message: 'Test message 3' });
+
+        const all = await feedback.findAll();
+        expect(all['description 1'].length).toBe(2);
+        expect(all['description 2'].length).toBe(1);
+    });
+});

--- a/services/__tests__/surveys.test.js
+++ b/services/__tests__/surveys.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+'use strict';
+
+describe('createResponse', () => {
+    let surveys;
+
+    beforeEach(async () => {
+        process.env.DB_CONNECTION_URI = 'sqlite://:memory';
+        const models = require('../../models');
+        await models.sequelize.sync();
+        await models.SurveyAnswer.destroy({ where: {} });
+        surveys = require('../surveys');
+    });
+
+    it('should create a survey response', async () => {
+        const yes = await surveys.createResponse({ choice: 'yes', path: '/' });
+        expect(yes.id).toBe(1);
+        const no = await surveys.createResponse({ choice: 'no', path: '/about', message: 'Test message' });
+        expect(no.id).toBe(2);
+    });
+
+    it('should get all responses', async () => {
+        await surveys.createResponse({ choice: 'yes', path: '/' });
+        await surveys.createResponse({ choice: 'yes', path: '/funding' });
+        await surveys.createResponse({ choice: 'no', path: '/about', message: 'Test message' });
+
+        const responses = await surveys.getAllResponses();
+
+        expect(responses.totals.totalResponses).toBe(3);
+        expect(responses.totals.percentageYes).toBe(67);
+        expect(responses.totals.percentageNo).toBe(33);
+        expect(Object.keys(responses.groupedPaths).length).toBe(3);
+    });
+
+    it('should get responses for a given path', async () => {
+        await surveys.createResponse({ choice: 'yes', path: '/' });
+        await surveys.createResponse({ choice: 'yes', path: '/funding' });
+        await surveys.createResponse({ choice: 'yes', path: '/funding' });
+        await surveys.createResponse({ choice: 'no', path: '/about', message: 'Test message' });
+
+        const responses = await surveys.getAllResponses({ path: '/funding' });
+
+        expect(responses.totals.totalResponses).toBe(2);
+        expect(responses.totals.percentageYes).toBe(100);
+        expect(responses.totals.percentageNo).toBe(0);
+        expect(Object.keys(responses.groupedPaths).length).toBe(1);
+    });
+});

--- a/services/surveys.js
+++ b/services/surveys.js
@@ -40,7 +40,7 @@ function summariseVotes(responses) {
     return voteData;
 }
 
-async function getAllResponses({ path = null }) {
+async function getAllResponses({ path = null } = {}) {
     try {
         const query = { order: [['updatedAt', 'DESC']] };
         if (path) {


### PR DESCRIPTION
Was looking for a way to unit test sequelize models. Realised focussing on testing the services that use them directly is the best direction as it handles coverage for both.

These test make use of the in-memory sqlite database in order to work so there's a little boilerplate on each one to se this up.

Starting with the feedback and survey services as they are easiest but if this feels OK we can add tests for the (more valuable) order and user services.