### PR TITLE
Add debugging logs to content-api requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "start": "node ./bin/www",
-    "startDev": "export DEBUG=biglotteryfund:*,express-session,connect:session-sequelize; nodemon --inspect ./bin/www",
+    "startDev": "export DEBUG=biglotteryfund:*; nodemon --inspect ./bin/www",
     "test": "npm audit && eslint . && jest --env=node --maxWorkers=4",
     "test-cypress": "wait-on http://localhost:8090 && cypress run",
     "pretest-ci": "npm run build",

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -2,32 +2,15 @@
 const { find, filter, get, getOr, map, sortBy, take } = require('lodash/fp');
 const { isArray } = require('lodash');
 const request = require('request-promise-native');
+const debug = require('debug')('biglotteryfund:content-api');
 
 const mapAttrs = response => map('attributes')(response.data);
 
 const { sanitiseUrlPath } = require('../modules/urls');
 let { CONTENT_API_URL } = require('../modules/secrets');
 
-if (!CONTENT_API_URL) {
-    console.log('Error: CONTENT_API_URL endpoint must be defined');
-    process.exit(1);
-}
-
-/**
- * Setter method exposed to aid with tests
- */
-function setApiUrl(customApiUrl) {
-    CONTENT_API_URL = customApiUrl;
-}
-
-/**
- * Getter method exposed to aid with tests
- */
-function getApiUrl() {
-    return CONTENT_API_URL;
-}
-
 function fetch(urlPath, options) {
+    debug(`Fetching ${urlPath}`);
     const defaults = {
         url: `${CONTENT_API_URL}${urlPath}`,
         json: true
@@ -242,8 +225,6 @@ function getRoutes() {
 }
 
 module.exports = {
-    setApiUrl,
-    getApiUrl,
     mapAttrs,
     mergeWelshBy,
     // API methods


### PR DESCRIPTION
Makes it so we get some nice debugging logs for each content api request that is made on a page.

![image](https://user-images.githubusercontent.com/123386/45229248-402c2c80-b2bd-11e8-8486-29d559bf3cd8.png)

Also removes a couple of methods that aren't being used.