### PR TITLE
Post-auth cleanup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-public/
-views/
-coverage/

--- a/config/default.json
+++ b/config/default.json
@@ -37,7 +37,6 @@
     "useHotjar": true,
     "useRemoteAssets": true,
     "enableTimingMetrics": false,
-    "azureAuthEnabled": true,
     "enableMailSendMetrics": false
   },
   "imgix": {

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -4,7 +4,6 @@ const jwt = require('jsonwebtoken');
 const Raven = require('raven');
 const path = require('path');
 
-const { noCache } = require('../../middleware/cached');
 const { requireUserAuth } = require('../../middleware/authed');
 const { JWT_SIGNING_TOKEN } = require('../../modules/secrets');
 const userService = require('../../services/user');
@@ -42,7 +41,7 @@ function activate(token, user) {
     });
 }
 
-router.route('/').get(noCache, requireUserAuth, async (req, res) => {
+router.route('/').get(requireUserAuth, async (req, res) => {
     const token = req.query.token;
 
     if (token) {

--- a/controllers/user/dashboard.js
+++ b/controllers/user/dashboard.js
@@ -3,10 +3,7 @@ const path = require('path');
 const express = require('express');
 const router = express.Router();
 
-const { noCache } = require('../../middleware/cached');
-const { requireAuthed } = require('../../middleware/authed');
-
-router.get('/', noCache, requireAuthed, (req, res) => {
+router.get('/', (req, res) => {
     res.render(path.resolve(__dirname, './views/dashboard'), {
         user: req.user,
         errors: res.locals.errors || [],

--- a/controllers/user/forgotten-password.js
+++ b/controllers/user/forgotten-password.js
@@ -7,7 +7,6 @@ const Raven = require('raven');
 
 const { getAbsoluteUrl } = require('../../modules/urls');
 const { JWT_SIGNING_TOKEN } = require('../../modules/secrets');
-const { noCache } = require('../../middleware/cached');
 const { purifyUserInput } = require('../../modules/validators');
 const { requireUnauthed } = require('../../middleware/authed');
 const { sendEmail } = require('../../services/mail');
@@ -75,7 +74,7 @@ async function handleRequestReset(req, res) {
 router
     .route('/')
     .all(requireUnauthed)
-    .get(noCache, renderRequestReset)
+    .get(renderRequestReset)
     .post(validators.emailAddress, handleRequestReset);
 
 module.exports = router;

--- a/controllers/user/logout.js
+++ b/controllers/user/logout.js
@@ -3,12 +3,10 @@ const express = require('express');
 
 const router = express.Router();
 
-const { noCache } = require('../../middleware/cached');
-
-router.get('/', noCache, (req, res) => {
+router.get('/', (req, res) => {
     req.logout();
     req.session.save(() => {
-        res.redirect(`/user/login`);
+        res.redirect('/user/login');
     });
 });
 

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -1,10 +1,10 @@
 'use strict';
-const path = require('path');
 const express = require('express');
-const { validationResult } = require('express-validator/check');
-const { matchedData } = require('express-validator/filter');
-const Raven = require('raven');
 const passport = require('passport');
+const path = require('path');
+const Raven = require('raven');
+const { matchedData } = require('express-validator/filter');
+const { validationResult } = require('express-validator/check');
 
 const { csrfProtection } = require('../../middleware/cached');
 const { requireUnauthed } = require('../../middleware/authed');

--- a/controllers/user/reset-password.js
+++ b/controllers/user/reset-password.js
@@ -5,7 +5,6 @@ const { validationResult } = require('express-validator/check');
 const express = require('express');
 
 const { JWT_SIGNING_TOKEN } = require('../../modules/secrets');
-const { noCache } = require('../../middleware/cached');
 const { requireUnauthed } = require('../../middleware/authed');
 const userService = require('../../services/user');
 
@@ -54,7 +53,7 @@ function renderFormExpired(req, res) {
 router
     .route('/')
     .all(requireUnauthed)
-    .get(noCache, async (req, res) => {
+    .get(async (req, res) => {
         let token = req.query.token ? req.query.token : res.locals.token;
         if (!token) {
             return res.redirect('/user/login');

--- a/controllers/user/staff.js
+++ b/controllers/user/staff.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const passport = require('passport');
 const path = require('path');
+
 const router = express.Router();
 
 router.get('/interstitial', (req, res) => {

--- a/controllers/user/staff.js
+++ b/controllers/user/staff.js
@@ -19,43 +19,36 @@ router.get('/login', function(req, res, next) {
     // We pass customState to allow redirecting to the original URL once authed
     // because the session bug (below) causes req.session to be uninitialised when we need it
     passport.authenticate('azuread-openidconnect', {
-        response: res,
         failureRedirect: '/user/staff/error',
-        customState: req.session.redirectUrl
+        customState: req.query.redirectUrl
     })(req, res, next);
 });
 
 // User will be returned here
 router.post('/auth/openid/return', function(req, res, next) {
-    passport.authenticate(
-        'azuread-openidconnect',
-        {
-            response: res,
-            failureRedirect: '/user/staff/error'
-        },
-        function(authError, user) {
-            if (authError) {
-                return next(authError);
-            }
-            if (!user) {
-                return res.redirect('/user/login');
-            }
-
-            req.login(user, loginErr => {
-                if (loginErr) {
-                    return next(loginErr);
-                }
-
-                // HACKY WORKAROUND:
-                // There's a long-running Passport/session bug where redirects
-                // fire before session is created:
-                // https://github.com/jaredhanson/passport/pull/680
-                // So we have a temporary holding page which allows the request to resolve
-                // @TODO see if a fix is possible for this
-                return res.redirect(`/user/staff/interstitial?redirectUrl=${req.body.state}`);
-            });
+    passport.authenticate('azuread-openidconnect', { failureRedirect: '/user/staff/error' }, function(authError, user) {
+        if (authError) {
+            return next(authError);
         }
-    )(req, res, next);
+
+        if (!user) {
+            return res.redirect('/user/login');
+        }
+
+        req.login(user, loginErr => {
+            if (loginErr) {
+                return next(loginErr);
+            }
+
+            // HACKY WORKAROUND:
+            // There's a long-running Passport/session bug where redirects
+            // fire before session is created:
+            // https://github.com/jaredhanson/passport/pull/680
+            // So we have a temporary holding page which allows the request to resolve
+            // @TODO see if a fix is possible for this
+            return res.redirect(`/user/staff/interstitial?redirectUrl=${req.body.state}`);
+        });
+    })(req, res, next);
 });
 
 router.get('/error', (req, res) => {

--- a/controllers/user/views/dashboard.njk
+++ b/controllers/user/views/dashboard.njk
@@ -22,13 +22,13 @@
 
             {% if user %}
                 {% if user.userType === 'user' %}
-                    <p class="navbar-text">Logged in as <strong>{{ user.userData.username }}</strong>
+                    <p>Logged in as <strong>{{ user.userData.username }}</strong>
                 {% elseif user.userType === 'staff' %}
-                    <p class="navbar-text">Logged in as <strong>{{ user.userData.fullName }}</strong>
+                    <p>Staff: logged in as <strong>{{ user.userData.fullName }}</strong>
                 {% endif %}
                 <p><a class="btn btn--small" href="/user/logout">Log out?</a></p>
             {% else %}
-                <p class="navbar-text"><a href="/user/login">Log in</a></p>
+                <p><a class="btn btn--small" href="/user/login">Log in</a></p>
             {% endif %}
         </div>
     </main>

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -157,7 +157,7 @@ describe('user', () => {
     it('should block access to staff-only tools', () => {
         cy.checkRedirect({
             from: '/tools/survey-results',
-            to: '/user/staff/login',
+            to: '/user/staff/login?redirectUrl=/tools/survey-results',
             status: 302
         });
     });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -161,7 +161,6 @@ describe('user', () => {
             status: 302
         });
     });
-
 });
 
 const loremLong = `Lorem, ipsum dolor sit amet consectetur adipisicing elit. Praesentium quidem nihil, similique voluptatibus tempore quasi, cumque laborum officia voluptatem laboriosam tempora.

--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -40,10 +40,7 @@ const requireStaffAuth = (req, res, next) => {
     if (req.isAuthenticated() && get(req, 'user.userType', false) === 'staff') {
         return next();
     } else {
-        req.session.redirectUrl = req.originalUrl;
-        req.session.save(() => {
-            res.redirect('/user/staff/login');
-        });
+        res.redirect(`/user/staff/login?redirectUrl=${req.originalUrl}`);
     }
 };
 

--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -37,16 +37,14 @@ const requireUserAuth = (req, res, next) => {
 
 // Middleware for staff users only
 const requireStaffAuth = (req, res, next) => {
-    if (!config.get('features.azureAuthEnabled')) {
-        res.redirect('/user/login');
-    }
     if (req.isAuthenticated() && get(req, 'user.userType', false) === 'staff') {
         return next();
+    } else {
+        req.session.redirectUrl = req.originalUrl;
+        req.session.save(() => {
+            res.redirect('/user/staff/login');
+        });
     }
-    req.session.redirectUrl = req.originalUrl;
-    req.session.save(() => {
-        res.redirect('/user/staff/login');
-    });
 };
 
 module.exports = {

--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -1,51 +1,43 @@
 'use strict';
 const { get } = require('lodash');
-const config = require('config');
 
-const checkAuthStatus = (req, res, next) => {
-    if (req.isAuthenticated || req.user) {
-        return next();
-    } else {
-        // we use req.originalUrl not req.path to preserve querystring
-        req.session.redirectUrl = req.originalUrl;
-        req.session.save(() => {
-            res.redirect('/user/login');
-        });
-    }
-};
-
-// middleware for pages only authenticated users should see
-// eg. dashboard
-const requireAuthed = (req, res, next) => checkAuthStatus(req, res, next);
-// middleware for pages only non-authed users should see
-// eg. register/login
-const requireUnauthed = (req, res, next) => {
+/**
+ * Require unauthed
+ * Only allow non-authenticated users
+ */
+function requireUnauthed(req, res, next) {
     if (!req.user) {
         return next();
     } else {
         res.redirect('/user');
     }
-};
+}
 
-// Middleware for pages only authenticated users should see
-const requireUserAuth = (req, res, next) => {
+/**
+ * Required user auth
+ * Middleware to require that the visitor is logged in as a public user
+ */
+function requireUserAuth(req, res, next) {
     if (req.isAuthenticated() && get(req, 'user.userType', false) === 'user') {
         return next();
+    } else {
+        res.redirect('/user/login');
     }
-    res.redirect('/user/login');
-};
+}
 
-// Middleware for staff users only
-const requireStaffAuth = (req, res, next) => {
+/**
+ * Required staff auth
+ * Middleware to require that the visitor is logged in as a staff user
+ */
+function requireStaffAuth(req, res, next) {
     if (req.isAuthenticated() && get(req, 'user.userType', false) === 'staff') {
         return next();
     } else {
         res.redirect(`/user/staff/login?redirectUrl=${req.originalUrl}`);
     }
-};
+}
 
 module.exports = {
-    requireAuthed,
     requireUnauthed,
     requireUserAuth,
     requireStaffAuth

--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -1,6 +1,5 @@
 'use strict';
 const passport = require('passport');
-const config = require('config');
 const LocalStrategy = require('passport-local').Strategy;
 const OIDCStrategy = require('passport-azure-ad').OIDCStrategy;
 
@@ -31,9 +30,11 @@ module.exports = function() {
         })
     );
 
-    // Only initialise this auth strategy if secrets exist (eg. not on CI)
-    if (config.get('features.azureAuthEnabled') && AZURE_AUTH.MS_CLIENT_ID) {
-        // Configure staff user sign-in (eg. internal authentication)
+    /**
+     * Configure staff user sign-in (eg. internal authentication)
+     * Only initialise this auth strategy if secrets exist (eg. not on CI)
+     */
+    if (AZURE_AUTH.MS_CLIENT_ID) {
         passport.use(
             new OIDCStrategy(
                 {

--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -34,24 +34,15 @@ module.exports = function() {
     // Only initialise this auth strategy if secrets exist (eg. not on CI)
     if (config.get('features.azureAuthEnabled') && AZURE_AUTH.MS_CLIENT_ID) {
         // Configure staff user sign-in (eg. internal authentication)
-        const authEndpoint =
-            'https://login.microsoftonline.com/biglotteryfund.onmicrosoft.com/.well-known/openid-configuration';
-
-        // Separate out the combined cookie encryption keys
-        const cookieKeys = AZURE_AUTH.MS_COOKIES.map(keyPair => {
-            const [key, iv] = keyPair.split(';');
-            return { key, iv };
-        });
-
         passport.use(
             new OIDCStrategy(
                 {
-                    identityMetadata: authEndpoint,
+                    identityMetadata:
+                        'https://login.microsoftonline.com/biglotteryfund.onmicrosoft.com/.well-known/openid-configuration',
                     clientID: AZURE_AUTH.MS_CLIENT_ID,
                     allowHttpForRedirectUrl: appData.isDev,
                     redirectUrl: AZURE_AUTH.MS_REDIRECT_URL,
                     clientSecret: AZURE_AUTH.MS_CLIENT_SECRET,
-                    cookieEncryptionKeys: cookieKeys,
                     responseType: 'code id_token',
                     responseMode: 'form_post',
                     validateIssuer: true,

--- a/models/index.js
+++ b/models/index.js
@@ -5,9 +5,7 @@ const debug = require('debug')('biglotteryfund:models');
 
 const { DB_CONNECTION_URI } = require('../modules/secrets');
 
-const useSqlite = process.env.NODE_ENV !== 'production' && startsWith(DB_CONNECTION_URI, 'sqlite://');
-const dialect = useSqlite ? 'sqlite' : 'mysql';
-
+const dialect = startsWith(DB_CONNECTION_URI, 'sqlite://') ? 'sqlite' : 'mysql';
 debug(`Using ${dialect} database`);
 
 const sequelize = new Sequelize(DB_CONNECTION_URI, {

--- a/modules/__tests__/parameter-store.test.js
+++ b/modules/__tests__/parameter-store.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 'use strict';
 
-const { getSecretFromRawParameters } = require('../secrets');
+const { getSecretFromRawParameters } = require('../parameter-store');
 
 describe('Get secrets', () => {
     const mockParameters = [

--- a/modules/parameter-store.js
+++ b/modules/parameter-store.js
@@ -1,0 +1,40 @@
+'use strict';
+const fs = require('fs');
+const { flow, get, keyBy, mapValues } = require('lodash/fp');
+
+function getRawParameters() {
+    let rawParameters;
+    try {
+        rawParameters = JSON.parse(fs.readFileSync('/etc/blf/parameters.json', 'utf8'));
+    } catch (e) {} // eslint-disable-line no-empty
+    return rawParameters;
+}
+
+function parseSecrets(rawParameters) {
+    const mapKeyedValues = flow(
+        keyBy('Name'),
+        mapValues('Value')
+    );
+    return mapKeyedValues(rawParameters);
+}
+
+function getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing = false) {
+    const secrets = parseSecrets(rawParameters);
+    const secret = get(name)(secrets);
+
+    if (shouldThrowIfMissing === true && typeof secret === 'undefined') {
+        throw new Error(`Secret missing: ${name}`);
+    } else {
+        return secret;
+    }
+}
+
+function getSecret(name, shouldThrowIfMissing = false) {
+    const rawParameters = getRawParameters();
+    return getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing);
+}
+
+module.exports = {
+    getSecretFromRawParameters,
+    getSecret
+};

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -65,11 +65,6 @@ const MS_CLIENT_ID = process.env.MS_CLIENT_ID || getSecret('ms.auth.clientId');
 const MS_CLIENT_SECRET = process.env.MS_CLIENT_SECRET || getSecret('ms.auth.clientSecret');
 const MS_REDIRECT_URL = process.env.MS_REDIRECT_URL || getSecret('ms.auth.redirectUrl');
 
-// We store these strings in one parameter for the sake of sanity
-// in the format <string:32>;<string:12>
-const MS_COOKIE_1 = process.env.MS_COOKIE_1 || getSecret('ms.cookie.1');
-const MS_COOKIE_2 = process.env.MS_COOKIE_2 || getSecret('ms.cookie.2');
-
 module.exports = {
     getRawParameters,
     getSecretFromRawParameters,
@@ -88,7 +83,6 @@ module.exports = {
     AZURE_AUTH: {
         MS_CLIENT_ID,
         MS_REDIRECT_URL,
-        MS_CLIENT_SECRET,
-        MS_COOKIES: [MS_COOKIE_1, MS_COOKIE_2]
+        MS_CLIENT_SECRET
     }
 };

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -1,52 +1,91 @@
 'use strict';
+const appData = require('./appData');
 const { getSecret } = require('./parameter-store');
 
-/* =========================================================================
-   Secret Constants
-   ========================================================================= */
-
 /**
- * Required: Without these the app won't start
+ * Primary session secret
+ * We allow overriding through an environment variable for CI
  */
-const APPLICATIONS_SERVICE_ENDPOINT =
-    process.env.APPLICATIONS_SERVICE_ENDPOINT || getSecret('applications-service.endpoint', true);
-const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url', true);
-const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || getSecret('db.connection-uri', true);
-const JWT_SIGNING_TOKEN = process.env.JWT_SIGNING_TOKEN || getSecret('user.jwt.secret', true);
 const SESSION_SECRET = process.env.SESSION_SECRET || getSecret('session.secret', true);
 
 /**
- * Additional: Without these the app will start but some functionality will be unavailable
+ * Database connection uri
+ * In development we default to an in-memory sqlite database as the
+ * databases defined in parameter store can't be accessed outside of a VPC.
+ * We allow overriding through an environment variable for CI and to allow
+ * using a local MySQL database locally as an option.
  */
-const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecret('dotmailer.api.password') };
-const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
+const defaultConnectionUri = appData.isDev ? 'sqlite://:memory' : getSecret('db.connection-uri', true);
+const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || defaultConnectionUri;
+
+/**
+ * Content API url
+ * We allow overriding through an environment variable for CI and to allow
+ * switching to a local instance of the CMS in development
+ */
+const CONTENT_API_URL = process.env.CONTENT_API_URL || getSecret('content-api.url', true);
+
+/**
+ * Preview domain
+ * Define what domain to use for CMS content previewing
+ */
 const PREVIEW_DOMAIN = process.env.PREVIEW_DOMAIN || getSecret('preview.domain');
-const SENTRY_DSN = process.env.SENTRY_DSN || getSecret('sentry.dsn');
-const DIGITAL_FUNDING_EMAIL = process.env.DIGITAL_FUNDING_EMAIL || getSecret('emails.digitalfund.demo');
-const PAST_GRANTS_API_URI = process.env.PAST_GRANTS_API_URI || getSecret('pastgrants.api.uri');
+
+/**
+ * Past grants API
+ * We allow overriding through an environment variable for CI and to allow
+ * switching to a local instance of the API in development
+ */
+const PAST_GRANTS_API_URI = process.env.PAST_GRANTS_API_URI || getSecret('pastgrants.api.uri', true);
+
+/**
+ * JWT signing token, used for user authentication
+ * We allow overriding through an environment variable for CI
+ */
+const JWT_SIGNING_TOKEN = process.env.JWT_SIGNING_TOKEN || getSecret('user.jwt.secret', true);
+
+/**
+ * Sentry DSN for error reporting
+ */
+const SENTRY_DSN = getSecret('sentry.dsn');
 
 /**
  * Azure authentication secrets (optional, used for tools sign-in)
  */
-const MS_CLIENT_ID = process.env.MS_CLIENT_ID || getSecret('ms.auth.clientId');
-const MS_CLIENT_SECRET = process.env.MS_CLIENT_SECRET || getSecret('ms.auth.clientSecret');
-const MS_REDIRECT_URL = process.env.MS_REDIRECT_URL || getSecret('ms.auth.redirectUrl');
+const AZURE_AUTH = {
+    MS_CLIENT_ID: getSecret('ms.auth.clientId'),
+    MS_CLIENT_SECRET: getSecret('ms.auth.clientSecret'),
+    MS_REDIRECT_URL: process.env.MS_REDIRECT_URL || getSecret('ms.auth.redirectUrl')
+};
+
+/**
+ * Dotmailer API credentials
+ * Used to sign up to email lists
+ */
+const DOTMAILER_API = { user: getSecret('dotmailer.api.user'), password: getSecret('dotmailer.api.password') };
+
+/**
+ * Material supplier email
+ * Used for sending order emails when placing and order for free materials
+ */
+const MATERIAL_SUPPLIER = process.env.MATERIAL_SUPPLIER || getSecret('emails.materials.supplier');
+
+/**
+ * Digital funding email
+ * Email address used to send expressions of interest from digital funding applicaiton forms
+ */
+const DIGITAL_FUNDING_EMAIL = process.env.DIGITAL_FUNDING_EMAIL || getSecret('emails.digitalfund.demo');
 
 module.exports = {
-    APPLICATIONS_SERVICE_ENDPOINT,
+    AZURE_AUTH,
     CONTENT_API_URL,
     DB_CONNECTION_URI,
+    DIGITAL_FUNDING_EMAIL,
     DOTMAILER_API,
     JWT_SIGNING_TOKEN,
     MATERIAL_SUPPLIER,
+    PAST_GRANTS_API_URI,
     PREVIEW_DOMAIN,
     SENTRY_DSN,
-    SESSION_SECRET,
-    DIGITAL_FUNDING_EMAIL,
-    PAST_GRANTS_API_URI,
-    AZURE_AUTH: {
-        MS_CLIENT_ID,
-        MS_REDIRECT_URL,
-        MS_CLIENT_SECRET
-    }
+    SESSION_SECRET
 };

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -1,38 +1,5 @@
 'use strict';
-const fs = require('fs');
-const { flow, get, keyBy, mapValues } = require('lodash/fp');
-
-function getRawParameters() {
-    let rawParameters;
-    try {
-        rawParameters = JSON.parse(fs.readFileSync('/etc/blf/parameters.json', 'utf8'));
-    } catch (e) {} // eslint-disable-line no-empty
-    return rawParameters;
-}
-
-function parseSecrets(rawParameters) {
-    const mapKeyedValues = flow(
-        keyBy('Name'),
-        mapValues('Value')
-    );
-    return mapKeyedValues(rawParameters);
-}
-
-function getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing = false) {
-    const secrets = parseSecrets(rawParameters);
-    const secret = get(name)(secrets);
-
-    if (shouldThrowIfMissing === true && typeof secret === 'undefined') {
-        throw new Error(`Secret missing: ${name}`);
-    } else {
-        return secret;
-    }
-}
-
-function getSecret(name, shouldThrowIfMissing = false) {
-    const rawParameters = getRawParameters();
-    return getSecretFromRawParameters(rawParameters, name, shouldThrowIfMissing);
-}
+const { getSecret } = require('./parameter-store');
 
 /* =========================================================================
    Secret Constants
@@ -66,9 +33,6 @@ const MS_CLIENT_SECRET = process.env.MS_CLIENT_SECRET || getSecret('ms.auth.clie
 const MS_REDIRECT_URL = process.env.MS_REDIRECT_URL || getSecret('ms.auth.redirectUrl');
 
 module.exports = {
-    getRawParameters,
-    getSecretFromRawParameters,
-    getSecret,
     APPLICATIONS_SERVICE_ENDPOINT,
     CONTENT_API_URL,
     DB_CONNECTION_URI,

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -15,8 +15,9 @@ const SESSION_SECRET = process.env.SESSION_SECRET || getSecret('session.secret',
  * We allow overriding through an environment variable for CI and to allow
  * using a local MySQL database locally as an option.
  */
-const defaultConnectionUri = appData.isDev ? 'sqlite://:memory' : getSecret('db.connection-uri', true);
-const DB_CONNECTION_URI = process.env.DB_CONNECTION_URI || defaultConnectionUri;
+const DB_CONNECTION_URI = appData.isDev
+    ? process.env.DB_CONNECTION_URI || 'sqlite://:memory'
+    : process.env.DB_CONNECTION_URI || getSecret('db.connection-uri', true);
 
 /**
  * Content API url

--- a/package.json
+++ b/package.json
@@ -51,33 +51,6 @@
   "prettier": {
     "singleQuote": true
   },
-  "babel": {
-    "plugins": [
-      "syntax-dynamic-import"
-    ],
-    "presets": [
-      [
-        "env",
-        {
-          "modules": false,
-          "targets": {
-            "browsers": [
-              ">0.25% in GB",
-              "ie >= 10",
-              "not op_mini all"
-            ]
-          }
-        }
-      ]
-    ],
-    "env": {
-      "test": {
-        "plugins": [
-          "transform-es2015-modules-commonjs"
-        ]
-      }
-    }
-  },
   "browserslist": [
     ">0.25% in GB",
     "ie >= 10",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
     "ie >= 10",
     "not op_mini all"
   ],
+  "eslintIgnore": [
+    "public/",
+    "views/",
+    "coverage/"
+  ],
   "nodemonConfig": {
     "verbose": true,
     "ignore": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,13 @@
 'use strict';
 const path = require('path');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
+const assert = require('assert');
+
 const isProduction = process.env.NODE_ENV === 'production';
-const pkgConfig = require('./package.json').config;
+const pkg = require('./package.json');
+const pkgConfig = pkg.config;
+
+assert(pkg.browserslist.length > 0);
 
 const babelOptions = {
     plugins: ['syntax-dynamic-import'],
@@ -13,7 +18,7 @@ const babelOptions = {
             {
                 modules: false,
                 targets: {
-                    browsers: ['>0.25% in GB', 'ie >= 10', 'not op_mini all']
+                    browsers: pkg.browserslist
                 }
             }
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,26 @@ const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const isProduction = process.env.NODE_ENV === 'production';
 const pkgConfig = require('./package.json').config;
 
+const babelOptions = {
+    plugins: ['syntax-dynamic-import'],
+    presets: [
+        [
+            'env',
+            {
+                modules: false,
+                targets: {
+                    browsers: ['>0.25% in GB', 'ie >= 10', 'not op_mini all']
+                }
+            }
+        ]
+    ],
+    env: {
+        test: {
+            plugins: ['transform-es2015-modules-commonjs']
+        }
+    }
+};
+
 const commonConfig = {
     mode: isProduction ? 'production' : 'development',
     performance: {
@@ -15,7 +35,8 @@ const commonConfig = {
             {
                 test: /\.js$/,
                 exclude: /node_modules/,
-                loader: 'babel-loader'
+                loader: 'babel-loader',
+                options: babelOptions
             },
             {
                 test: /\.vue$/,


### PR DESCRIPTION
Bit of cleanup off the back of the auth changes. Main change are:

- Removes cookie encryption keys as we are using the session so the are not needed
- Uses query instead of session for passing the redirect url around
- Cleans up the secrets config, adds comments for everything
- Fixes an issue with fresh clones/setup process where we can no longer connect to the database in dev (due to VPC). Uses sqlite in dev by default now