### PR TITLE
Past grants AJAX support

### DIFF
--- a/controllers/past-grants/index.js
+++ b/controllers/past-grants/index.js
@@ -54,16 +54,7 @@ function buildPagination(paginationMeta, currentQuery = {}) {
  * @type {object}
  */
 function buildAllowedParams(queryParams) {
-    const allowedParams = [
-        'q',
-        'amount',
-        'postcode',
-        'programme',
-        'year',
-        'orgType',
-        'sort',
-        'country'
-    ];
+    const allowedParams = ['q', 'amount', 'postcode', 'programme', 'year', 'orgType', 'sort', 'country'];
     return pick(queryParams, allowedParams);
 }
 

--- a/controllers/past-grants/views/ajax-results.njk
+++ b/controllers/past-grants/views/ajax-results.njk
@@ -1,0 +1,2 @@
+{% from "./grant-results.njk" import grantResultList with context %}
+{{ grantResultList(grants) }}

--- a/controllers/past-grants/views/grant-results.njk
+++ b/controllers/past-grants/views/grant-results.njk
@@ -1,0 +1,51 @@
+{% from "components/promo-card/macro.njk" import promoCard %}
+
+{% macro grantResultItem(grant) %}
+    <div class="u-margin-bottom">
+        {% set subtitle %}
+            £{{ grant.amountAwarded | numberWithCommas}} to
+            <strong>{{ grant.recipientOrganization[0].name }}</strong>
+            on {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
+            {% if grant.plannedDates.endDate | isBeforeNow %}
+                <strong>(Active project)</strong>
+            {% endif %}
+        {% endset %}
+        {% call promoCard({
+            "kicker": "Active programme",
+            "title": grant.title,
+            "subtitle": subtitle | safe,
+            "trailText": grant.description,
+            "link": {
+                "url": "/funding/search-past-grants-alpha/" + grant.id,
+                "label": "View full details"
+            }
+        }) %}
+            <dl class="o-definition-list o-definition-list--compact">
+                {% if grant.beneficiaryLocation %}
+                    <dt>Location</dt>
+                    <dd>
+                        {% set comma = joiner() %}
+                        {% for location in grant.beneficiaryLocation -%}
+                            {{ comma() }} {{ location.name }}
+                        {%- endfor %}
+                    </dd>
+                {% endif %}
+                <dt>Grant programme</dt>
+                {% for programme in grant.grantProgramme %}
+                    <dd><a href="?programme={{ programme.title }}">{{ programme.title }}</a></dd>
+                {% endfor %}
+            </dl>
+        {% endcall %}
+    </div>
+{% endmacro %}
+
+{% macro grantResultList(grants) %}
+    {% if grants.length > 0 %}
+        {% for grant in grants %}
+            {{ grantResultItem(grant) }}
+        {% endfor %}
+    {% else %}
+        {# @TODO add suggested search results etc #}
+        <p>No results</p>
+    {% endif %}
+{% endmacro %}

--- a/controllers/past-grants/views/index.njk
+++ b/controllers/past-grants/views/index.njk
@@ -1,7 +1,7 @@
 {% from "components/split-nav/macro.njk" import splitNav with context %}
 {% from "components/form-fields.njk" import formField with context %}
-{% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "./grant-results.njk" import grantResultList with context %}
 
 {% extends "layouts/main.njk" %}
 {% set bodyClass = 'has-static-header' %}
@@ -32,49 +32,7 @@
 
                 <div class="grants-search__content">
                     <div class="grants-search__results">
-                        {% if grants.length > 0 %}
-                            {% for grant in grants %}
-                                <div class="u-margin-bottom">
-                                    {% set subtitle %}
-                                        £{{ grant.amountAwarded | numberWithCommas}} to
-                                        <strong>{{ grant.recipientOrganization[0].name }}</strong>
-                                        on {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
-                                        {% if grant.plannedDates.endDate | isBeforeNow %}
-                                            <strong>(Active project)</strong>
-                                        {% endif %}
-                                    {% endset %}
-                                    {% call promoCard({
-                                        "kicker": "Active programme",
-                                        "title": grant.title,
-                                        "subtitle": subtitle | safe,
-                                        "trailText": grant.description,
-                                        "link": {
-                                            "url": "/funding/search-past-grants-alpha/" + grant.id,
-                                            "label": "View full details"
-                                        }
-                                    }) %}
-                                        <dl class="o-definition-list o-definition-list--compact">
-                                            {% if grant.beneficiaryLocation %}
-                                                <dt>Location</dt>
-                                                <dd>
-                                                {% set comma = joiner() %}
-                                                {% for location in grant.beneficiaryLocation -%}
-                                                    {{ comma() }} {{ location.name }}
-                                                {%- endfor %}
-                                                </dd>
-                                            {% endif %}
-                                            <dt>Grant programme</dt>
-                                            {% for programme in grant.grantProgramme %}
-                                                <dd><a href="?programme={{ programme.title }}">{{ programme.title }}</a></dd>
-                                            {% endfor %}
-                                        </dl>
-                                    {% endcall %}
-                                </div>
-                            {% endfor %}
-                        {% else %}
-                            <p>No results</p>
-                        {% endif %}
-
+                        {{ grantResultList(grants) }}
                         {{ splitNav(pagination.prevLink, pagination.nextLink) }}
                     </div>
 


### PR DESCRIPTION
This adds support for `POST` requests to the past grants search endpoint.

These requests will use the same query object as the `GET` requests, but will instead return an object like this:

```
{
    status: 'success',
    meta: ...,
    facets: ...,
    resultsHtml: ...
}
```

(the `resultsHtml` is the output of rendering the results list to a template – we can then replace the in-page HTML with this, and use the facets/metadata to re-render the UI using VueJS).