### PR TITLE
Share field add-on styles

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -58,6 +58,10 @@
     }
 }
 
+/* =========================================================================
+   Form field container
+   ========================================================================= */
+
 .form-field {
     margin-bottom: 1.5em;
 
@@ -80,6 +84,44 @@
 .no-js .form-field[hidden] {
     display: block;
 }
+
+/* =========================================================================
+   Form field add-on
+   ========================================================================= */
+/* @see https://philipwalton.github.io/solved-by-flexbox/demos/input-add-ons/ */
+
+.form-field-addon {
+    display: flex;
+
+    .form-field-addon__input {
+        flex: 1 1 0%;
+
+        padding: 6px 12px;
+        border: 2px solid palette('blue');
+
+        &:focus {
+            outline: 3px solid lighten(palette('turquoise'), 25%);
+            outline-offset: 0;
+        }
+    }
+
+    .form-field-addon__action {
+        font-size: 18px;
+        font-family: font-stack('display');
+        font-weight: 500;
+        color: white;
+        border: none;
+        -webkit-appearance: none;
+        background-color: palette('blue');
+        padding-left: $spacingUnit / 2;
+        padding-right: $spacingUnit;
+        border-radius: 0 50px 50px 0;
+    }
+}
+
+/* =========================================================================
+   Fields (individual field styles)
+   ========================================================================= */
 
 .ff-label {
     display: block;
@@ -201,9 +243,10 @@
     }
 }
 
-/**
- * Form actions
- */
+
+/* =========================================================================
+   Form Actions
+   ========================================================================= */
 .form-actions {
     max-width: $constrainedWide;
     border-top: 1px solid palette('border');
@@ -446,77 +489,3 @@
     }
 }
 
-/* =========================================================================
-   Search bar
-   ========================================================================= */
-
-.search-bar {
-    padding: $spacingUnit;
-    margin-bottom: $spacingUnit / 2;
-    background: palette('pale-grey');
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .search-bar__label,
-    .search-bar__submit {
-        flex: 0 0 auto;
-    }
-
-    .search-bar__field {
-        flex: 1 1 0%;
-        border: none;
-        font-size: 18px;
-        padding: 0.5em 1em;
-    }
-
-    .search-bar__label {
-        font-family: font-stack('display');
-        font-size: 18px;
-        font-weight: bold;
-        padding-right: $spacingUnit;
-    }
-
-    .search-bar__submit {
-        padding-left: $spacingUnit;
-    }
-}
-
-/* =========================================================================
-   Email Signup
-   ========================================================================= */
-
-.email-signup {
-    background-color: palette('pale-grey');
-    padding: $spacingUnit;
-
-    .email-signup__field {
-        display: flex;
-        max-width: 25em;
-    }
-
-    .email-signup__field-input {
-        flex: 1 1 0%;
-
-        padding: 6px 12px;
-        border: 2px solid palette('blue');
-
-        &:focus {
-            outline: 3px solid lighten(palette('turquoise'), 25%);
-            outline-offset: 0;
-        }
-    }
-
-    .email-signup__field-action {
-        font-size: 18px;
-        font-family: font-stack('display');
-        font-weight: 500;
-        color: white;
-        border: none;
-        -webkit-appearance: none;
-        background-color: palette('blue');
-        padding-left: $spacingUnit / 2;
-        padding-right: $spacingUnit;
-        border-radius: 0 50px 50px 0;
-    }
-}

--- a/assets/sass/utilities/_utilities-accents.scss
+++ b/assets/sass/utilities/_utilities-accents.scss
@@ -10,6 +10,9 @@
 .u-tone-background-tint {
     background-color: palette('tint');
 }
+.u-tone-background-pale-grey {
+    background-color: palette('pale-grey');
+}
 .u-tone-background-dark {
     background-color: palette('charcoal');
 }

--- a/controllers/digital-fund/views/assistance.njk
+++ b/controllers/digital-fund/views/assistance.njk
@@ -23,15 +23,13 @@
                     {{ copy.assistance.body | safe }}
 
                     {% if status === 'SUBMISSION_SUCCESS' %}
-                        <div class="email-signup">
-                            <div class="submission-message">
-                                <div class="submission-message__icon">
-                                    {{ iconTick() }}
-                                </div>
-                                <div class="submission-message__text">
-                                    <p><strong>{{ copy.assistance.submission.success.title }}</strong></p>
-                                    <p>{{ copy.assistance.submission.success.message }}</p>
-                                </div>
+                        <div class="submission-message u-tone-background-pale-grey u-padded">
+                            <div class="submission-message__icon">
+                                {{ iconTick() }}
+                            </div>
+                            <div class="submission-message__text">
+                                <p><strong>{{ copy.assistance.submission.success.title }}</strong></p>
+                                <p>{{ copy.assistance.submission.success.message }}</p>
                             </div>
                         </div>
                     {% else %}
@@ -41,7 +39,7 @@
                             </div>
                         {% endif %}
 
-                        <form class="email-signup" method="post" action="">
+                        <form class="u-tone-background-pale-grey u-padded" method="post" action="">
                             {{ formErrors(errors) }}
 
                             <label for="email" class="ff-label">
@@ -52,13 +50,14 @@
                                 {{ copy.assistance.submission.explanation }}
                             </p>
 
-                            <div class="email-signup__field">
-                                <input class="email-signup__field-input"
+                            <div class="form-field-addon u-constrained">
+                                <input class="form-field-addon__input"
                                     id="email"
                                     type="email"
                                     name="email"
+                                    placeholder="your.email@example.com"
                                 />
-                                <input class="email-signup__field-action"
+                                <input class="form-field-addon__action"
                                     type="submit"
                                     value="{{ copy.assistance.submission.proceedLabel }}"
                                 />

--- a/controllers/past-grants/views/index.njk
+++ b/controllers/past-grants/views/index.njk
@@ -13,16 +13,15 @@
             <form class="grants-search" method="get" action="">
                 <h1>Search past grants</h1>
 
-                <div class="search-bar">
-                    <label class="search-bar__label" for="search-query">
-                        Search
-                    </label>
-                    <input class="search-bar__field" type="search"
-                        id="search-query" name="q"
-                        value="{{ queryParams.q }}"
-                        placeholder="Enter a search term, location, or postcode">
-                    <div class="search-bar__submit">
-                        <input class="btn btn--medium" type="submit" value="Search" />
+
+                <div class="u-tone-background-pale-grey u-padded">
+                    <label class="u-visually-hidden" for="search-query">Search</label>
+                    <div class="form-field-addon">
+                        <input class="form-field-addon__input" type="search"
+                            id="search-query" name="q"
+                            value="{{ queryParams.q }}"
+                            placeholder="Enter a search term, location, or postcode">
+                        <input class="form-field-addon__action" type="submit" value="Search" />
                     </div>
                 </div>
 


### PR DESCRIPTION
Makes this [input add-on](https://philipwalton.github.io/solved-by-flexbox/demos/input-add-ons/) style a shared pattern. Exactly how we style this pattern is still up for-grabs but made sense to consider it the same concept.

<img width="871" alt="screen shot 2018-10-02 at 15 54 03" src="https://user-images.githubusercontent.com/123386/46357017-cdb03180-c65b-11e8-9bbf-a0ffebe682fb.png">

![image](https://user-images.githubusercontent.com/123386/46357033-d3a61280-c65b-11e8-9eeb-89eddf0fe7b8.png)
