### PR TITLE
More copy amends

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,7 +729,7 @@ funding:
 
         <p>We <strong>can’t</strong> fund:</p>
         <ul>
-          <li>proposals from organisations that are run primarily for private gain or to generate profits for private distribution</li>
+          <li>proposals from organisations that are run primarily for private gain or to generate profits for private distribution, or any activities that generate profits for private gain</li>
           <li>religious activity (although we can fund religious organisations if their project benefits the wider community and doesn’t include religious content)</li>
           <li>activities that replace government funding (for example, we can only fund school activities that are additional to the curriculum)</li>
           <li>activities that benefit individuals, rather than the wider community</li>
@@ -800,10 +800,9 @@ funding:
               <li>organisations based outside the UK</li>
               <li>anyone who is applying on behalf of another organisation</li>
               <li>organisations without at least two unconnected<em>*</em> people on the board or committee.</li>
-              <li>Companies that are aimed at generating profits primarily for private distribution. This may change for a future application period for this programme.</li>
+              <li>companies that are aimed at generating profits primarily for private distribution. This may change for a future application period for this programme.</li>
           </ul>
           <p><em>(* not a relation by blood, marriage, in a long-term relationship or people living together at the same address)</em></p>
-          <p>We will consider funding unincorporated groups, but normally expect the groups to use our funding to incorporate and, where appropriate, register as a charity.</p>
       strand1:
         title: Additional eligibility criteria that apply only to Strand 1
         criteria:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -656,7 +656,8 @@ funding:
   digitalFund:
     title: Digital fund
     intro: The Digital Fund is a new UK wide £15 million funding programme to support the charity and voluntary sector. It is about helping the charity and voluntary sector to use digital tools and approaches to support people and communities to thrive.
-    closedMessage: Applications open on 22nd October 2018.
+    openingDates: Applications initially open on 22nd October 2018 and close on 3rd December 2018. There will be further opportunities to apply in 2019.
+    closedMessage: Applications initially open on 22nd October 2018
     aboutStrandLabel: Find out more about this strand
     strand1:
       title: We want to use digital to change our business

--- a/controllers/digital-fund/views/landing.njk
+++ b/controllers/digital-fund/views/landing.njk
@@ -19,9 +19,7 @@
                 {{ breadcrumbTrail(breadcrumbs, isTinted = true) }}
                 <div class="s-prose u-constrained-content-wide">
                     <p>{{ copy.intro }}</p>
-                    {% if not featurePreviewDigitalFund %}
-                        <p><strong>{{ copy.closedMessage }}</strong></p>
-                    {% endif %}
+                    <p><strong>{{ copy.openingDates }}</strong></p>
                 </div>
             </section>
 

--- a/controllers/digital-fund/views/strand-1.njk
+++ b/controllers/digital-fund/views/strand-1.njk
@@ -24,11 +24,9 @@
                     <p>{{ copy.strand1.introduction | safe }}</p>
                 </div>
 
-                {% if not featurePreviewDigitalFund %}
-                    <div class="message">
-                        {{ copy.closedMessage }}
-                    </div>
-                {% endif %}
+                <div class="message">
+                    {{ copy.openingDates }}
+                </div>
 
                 {{ segmentLinks([
                     { "title": copy.process.title },

--- a/controllers/digital-fund/views/strand-2.njk
+++ b/controllers/digital-fund/views/strand-2.njk
@@ -23,11 +23,9 @@
                     <p>{{ copy.strand2.introduction | safe }}</p>
                 </div>
 
-                {% if not featurePreviewDigitalFund %}
-                    <div class="message">
-                        {{ copy.closedMessage }}
-                    </div>
-                {% endif %}
+                <div class="message">
+                    {{ copy.openingDates }}
+                </div>
 
                 {{ segmentLinks([
                     { "title": copy.process.title },

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -174,7 +174,7 @@ async function injectFundingProgramme(req, res, next) {
         res.locals.previewStatus = getPreviewStatus(entry);
         next();
     } catch (error) {
-        next(error);
+        next();
     }
 }
 


### PR DESCRIPTION
Differentiate opening dates message from closed message. There is a longer version we can always show. Reduces the number of conditionals we need.

Copy amends from legal.