### PR TITLE
Fixup tests

### DIFF
--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -243,7 +243,7 @@ describe('e2e', function() {
         cy.checkMetaTitles('Hafan | Cronfa Loteri Fawr');
         cy.get('.qa-global-nav .qa-nav-link a')
             .first()
-            .should('have.text', 'Hafan');
+            .should('contain', 'Hafan');
 
         // ================================================
         // Step: Micro-surveys (Welsh)
@@ -359,7 +359,7 @@ describe('e2e', function() {
         cy.get('@feedbackForm').should('contain', 'Thank you for sharing');
     });
 
-    it.only('should submit a digital fund application form', () => {
+    it('should submit a digital fund application form', () => {
         cy.visit('/apply/digital-fund-strand-1/1/');
 
         cy.get('#field-name').type('Example Name', { delay: 0 });

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -43,8 +43,9 @@ module.exports = {
          * Navigation sections for top-level nav
          */
         const itemsToShow = omitBy(routes.sections, s => s.showInNavigation === false);
-        res.locals.navigationSections = map(itemsToShow, section => {
+        res.locals.navigationSections = map(itemsToShow, (section, id) => {
             return {
+                id: id,
                 path: localify(locale)(section.path),
                 label: req.i18n.__(section.langTitlePath)
             };

--- a/views/components/nav.njk
+++ b/views/components/nav.njk
@@ -2,7 +2,7 @@
 
 {% macro navlinks(itemClass) %}
     {% for section in navigationSections %}
-        <li class="{% if sectionUrl === section.path %}is-selected{% endif %}{% if itemClass %} {{ itemClass }}{% if loop.last %} {{ itemClass }}--last{% endif %}{% endif %} qa-nav-link qa-nav-link--{{ id }}">
+        <li class="{% if sectionUrl === section.path %}is-selected{% endif %}{% if itemClass %} {{ itemClass }}{% if loop.last %} {{ itemClass }}--last{% endif %}{% endif %} qa-nav-link qa-nav-link--{{ section.id }}">
             <a href="{{ section.path }}">
                 {{ section.label }}
             </a>


### PR DESCRIPTION
Spotted a regression in the tests. Had a rogue `.only` which was masking a (thankfully QA-only) issue with the navigation.