### PR TITLE
More SPG tweaks

### DIFF
--- a/assets/js/vue-apps/grant-filters.js
+++ b/assets/js/vue-apps/grant-filters.js
@@ -39,11 +39,8 @@ function init() {
             // Watch for changes to filters then make AJAX call
             filters: {
                 handler: function() {
-                    if (this.filters.q) {
-                        this.ignoreSort = true;
-                    } else {
-                        this.ignoreSort = false;
-                    }
+                    this.ignoreSort = !!this.filters.q;
+                    this.isCalculating = true;
                     this.filterResults();
                 },
                 deep: true
@@ -66,6 +63,7 @@ function init() {
                     direction: direction
                 };
                 this.filters.sort = `${sortKey}|${direction}`;
+                this.isCalculating = true;
                 this.filterResults();
             },
 
@@ -124,7 +122,6 @@ function init() {
 
             // Send the data to the AJAX endpoint and output the results to the page
             filterResults: debounce(function() {
-                this.isCalculating = true;
                 this.searchError = false;
 
                 setTimeout(() => {

--- a/assets/js/vue-apps/grant-filters.js
+++ b/assets/js/vue-apps/grant-filters.js
@@ -1,6 +1,8 @@
 import $ from 'jquery';
 import Vue from 'vue';
 import debounce from 'lodash/debounce';
+import cloneDeep from 'lodash/cloneDeep';
+import omit from 'lodash/omit';
 
 function init() {
     const mountEl = document.getElementById('js-grant-filters');
@@ -91,11 +93,9 @@ function init() {
 
             // Convert filters into URL-friendly state
             filtersToString: function() {
-                let filterClone = Object.assign({}, this.filters);
-                if (this.ignoreSort && filterClone.sort) {
-                    delete filterClone.sort;
-                }
-                return Object.keys(filterClone)
+                const filterClone = cloneDeep(this.filters);
+                const cleanFilters = this.ignoreSort && filterClone.sort ? omit(filterClone, 'sort') : filterClone;
+                return Object.keys(cleanFilters)
                     .filter(key => !!filterClone[key])
                     .map(key => {
                         return `${encodeURIComponent(key)}=${encodeURIComponent(filterClone[key])}`;

--- a/assets/js/vue-apps/grant-filters.js
+++ b/assets/js/vue-apps/grant-filters.js
@@ -32,6 +32,7 @@ function init() {
                 filters: Object.assign({}, defaultFilters, queryParams),
                 isCalculating: false,
                 totalResults: PGS.totalResults || 0,
+                totalAwarded: PGS.totalAwarded || 0,
                 searchError: false
             };
         },
@@ -137,6 +138,7 @@ function init() {
                             // @TODO vue-ize this
                             $('#js-grant-results').html(response.resultsHtml);
                             this.totalResults = response.meta.totalResults;
+                            this.totalAwarded = response.meta.totalAwarded;
                             this.facets = response.facets;
                             this.updateUrl();
                             this.isCalculating = false;

--- a/assets/js/vue-apps/grant-filters.js
+++ b/assets/js/vue-apps/grant-filters.js
@@ -96,6 +96,7 @@ function init() {
                     delete filterClone.sort;
                 }
                 return Object.keys(filterClone)
+                    .filter(key => !!filterClone[key])
                     .map(key => {
                         return `${encodeURIComponent(key)}=${encodeURIComponent(filterClone[key])}`;
                     })

--- a/assets/sass/components/_past-grants.scss
+++ b/assets/sass/components/_past-grants.scss
@@ -60,9 +60,12 @@
         }
 
         &.is-ascending::before,
-        &.is-ascending::after {
+        &.is-descending::before {
             position: relative;
             top: 2px; // Optically align
+            margin-right: 4px;
+            display: inline-block;
+            text-decoration: none;
         }
 
         &.is-ascending::before {

--- a/controllers/past-grants/index.js
+++ b/controllers/past-grants/index.js
@@ -119,7 +119,7 @@ router.get('/', async (req, res, next) => {
         // Initial / server-only search
         html: () => {
             res.render(path.resolve(__dirname, './views/index'), {
-                title: 'Past grants search',
+                title: 'Search Past Grants',
                 queryParams: isEmpty(facetParams) ? false : facetParams,
                 grants: data.results,
                 facets: data.facets,

--- a/controllers/past-grants/views/grant-results.njk
+++ b/controllers/past-grants/views/grant-results.njk
@@ -2,7 +2,7 @@
 {% from "components/split-nav/macro.njk" import splitNav with context %}
 
 {% macro grantResultItem(grant) %}
-    <div class="u-margin-bottom">
+    <div class="u-margin-bottom" data-score="{{ grant._textScore }}">
         {% set subtitle %}
             £{{ grant.amountAwarded | numberWithCommas}} to
             <strong>{{ grant.recipientOrganization[0].name }}</strong>

--- a/controllers/past-grants/views/index.njk
+++ b/controllers/past-grants/views/index.njk
@@ -86,41 +86,29 @@
                                 {% if meta.currentSort.type === 'awardDate' and meta.currentSort.direction === 'desc' %}
                                     <a class="sort-controls__item is-active is-descending"
                                         href="?{{ queryParams | addQueryParam([['sort', 'awardDate|asc']]) }}"
-                                        aria-label="Sort by newest first">
-                                        Award date
-                                    </a>
+                                        aria-label="Sort by newest first">Award date</a>
                                 {% elseif meta.currentSort.type === 'awardDate' and meta.currentSort.direction === 'asc'  %}
                                     <a class="sort-controls__item is-active is-ascending"
                                         href="?{{ queryParams | addQueryParam([['sort', 'awardDate|desc']]) }}"
-                                        aria-label="Sort by oldest first">
-                                        Award date
-                                    </a>
+                                        aria-label="Sort by oldest first">Award date</a>
                                 {% else %}
                                     <a class="sort-controls__item"
                                         href="?{{ queryParams | addQueryParam([['sort', 'awardDate|desc']]) }}"
-                                        aria-label="Sort by oldest first">
-                                        Award date
-                                    </a>
+                                        aria-label="Sort by oldest first">Award date</a>
                                 {% endif %}
 
                                 {% if meta.currentSort.type === 'amountAwarded' and meta.currentSort.direction === 'desc' %}
                                     <a class="sort-controls__item is-active is-descending"
                                         href="?{{ queryParams | addQueryParam([['sort', 'amountAwarded|asc']]) }}"
-                                        aria-label="Sort by highest amount awarded first">
-                                        Amount awarded
-                                    </a>
+                                        aria-label="Sort by highest amount awarded first">Amount awarded</a>
                                 {% elseif meta.currentSort.type === 'amountAwarded' and meta.currentSort.direction === 'asc'  %}
                                     <a class="sort-controls__item is-active is-ascending"
                                         href="?{{ queryParams | addQueryParam([['sort', 'amountAwarded|desc']]) }}"
-                                        aria-label="Sort by lowest amount awarded first">
-                                        Amount awarded
-                                    </a>
+                                        aria-label="Sort by lowest amount awarded first">Amount awarded</a>
                                 {% else %}
                                     <a class="sort-controls__item"
                                         href="?{{ queryParams | addQueryParam([['sort', 'amountAwarded|desc']]) }}"
-                                        aria-label="Sort by highest amount awarded first">
-                                        Amount awarded
-                                    </a>
+                                        aria-label="Sort by highest amount awarded first">Amount awarded</a>
                                 {% endif %}
 
                                 {% if meta.currentSort %}
@@ -136,9 +124,7 @@
                                    v-bind:class="sortLinkClasses('awardDate')"
                                    v-bind:href="'?' + filtersToString()"
                                    v-on:click.prevent="sortData('awardDate', sort.direction)"
-                                   v-cloak>
-                                    Award date
-                                </a>
+                                   v-cloak>Award date</a>
 
                                 <a class="sort-controls__item"
                                    v-bind:title="getSortTitle('Sort by highest amount awarded first', 'Sort by lowest amount awarded first')"
@@ -146,9 +132,7 @@
                                    v-bind:class="sortLinkClasses('amountAwarded')"
                                    v-bind:href="'?' + filtersToString()"
                                    v-on:click.prevent="sortData('amountAwarded', sort.direction)"
-                                   v-cloak>
-                                    Amount awarded
-                                </a>
+                                   v-cloak>Amount awarded</a>
                             </span>
 
                             {# @TODO should there be a way to remove sorts and return to default? #}

--- a/controllers/past-grants/views/index.njk
+++ b/controllers/past-grants/views/index.njk
@@ -24,6 +24,7 @@
             facets: {{ facets | dump | safe }},
             queryParams: {{ queryParams | dump | safe }},
             totalResults: {{ meta.totalResults }},
+            totalAwarded: {{ meta.totalAwarded}},
             sort: {{ meta.currentSort | dump | safe }}
         };
     </script>
@@ -74,6 +75,10 @@
                             <noscript>{{ meta.totalResults | numberWithCommas }}</noscript>
                         </strong>
                         results
+                        <span v-cloak v-show="totalAwarded">totalling <strong>£<% totalAwarded.toLocaleString() %></strong></span>
+                        {% if meta.totalAwarded %}
+                            <noscript>totalling <strong>£{{ meta.totalAwarded | numberWithCommas }}</strong></noscript>
+                        {% endif %}
                     </span>
 
                     <div class="grants-search__sort">


### PR DESCRIPTION
This pairs with https://github.com/biglotteryfund/grants-service/pull/20.

I noticed that when you apply a sort to your results, it effectively means any future text search will be sorted by whichever sort parameter you applied (eg. not the `textScore`). This change means whenever the text query search is modified, it resets/ignores the previous sort value (eg. so the API knows to order by score).

Also in here: a pairing change to show the total awarded (adds a slightly delay onto the results but not really noticeable, and worth it IMO):

![image](https://user-images.githubusercontent.com/394376/46604071-e81b5c80-caec-11e8-9638-6a246d8c9a1f.png)

There was also a change from last week which sets the `isCalculating` toggle as soon as input is made which means the UI doesn't flicker so much:

### Before:
![before](https://user-images.githubusercontent.com/394376/46604158-2ca6f800-caed-11e8-9fa3-7a14ace2faf1.gif)

### After:
![after](https://user-images.githubusercontent.com/394376/46604157-2ca6f800-caed-11e8-8a7d-d9ab1950bb3c.gif)

Minor downside is it may look like the search has started as soon as you press a key (whereas in fact the search is still debounced and doesn't start until 500ms after typing):

![search](https://user-images.githubusercontent.com/394376/46604223-6ed03980-caed-11e8-9900-122d96d906e9.gif)

Finally we don't bother outputting default (eg. empty) filters for URLs / AJAX calls, eg:

### Before:

`?amount=&year=&programme=&country=&localAuthority=&constituency=&q=cats`

### After:

`?q=cats`