### PR TITLE
Avoid implying applications are open on full eligibility page

### DIFF
--- a/controllers/digital-fund/views/full-eligibility.njk
+++ b/controllers/digital-fund/views/full-eligibility.njk
@@ -40,7 +40,11 @@
 
                 <p><a href="{{ localify('/funding/programmes/digital-fund/strand-1') }}"
                     class="btn btn--medium accent--{{ pageAccent }} a--btn u-margin-bottom">
-                    {{ copy.strand1.startApplying }}
+                    {% if featurePreviewDigitalFund %}
+                        {{ copy.strand1.startApplying }}
+                    {% else %}
+                        {{ copy.aboutStrandLabel }}
+                    {% endif %}
                 </a></p>
 
                 <p>{{ copy.strand2.introduction | safe }}</p>
@@ -48,7 +52,11 @@
 
                 <p><a href="{{ localify('/funding/programmes/digital-fund/strand-2') }}"
                     class="btn btn--medium accent--{{ pageAccent }} a--btn u-margin-bottom">
-                    {{ copy.strand2.startApplying }}
+                    {% if featurePreviewDigitalFund %}
+                        {{ copy.strand2.startApplying }}
+                    {% else %}
+                        {{ copy.aboutStrandLabel }}
+                    {% endif %}
                 </a></p>
 
                 {{ copy.successFactors.equalities | safe }}


### PR DESCRIPTION
Uses more neutral wording on the full eligibility page to avoid implying applications are open.

<img width="929" alt="screen shot 2018-10-09 at 14 21 50" src="https://user-images.githubusercontent.com/123386/46672244-ceeadc80-cbce-11e8-8778-843c35771f02.png">
<img width="841" alt="screen shot 2018-10-09 at 14 21 35" src="https://user-images.githubusercontent.com/123386/46672245-cf837300-cbce-11e8-8b8b-410d75027546.png">
