### PR TITLE
Fix homepage hero for API downtime

### DIFF
--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -21,11 +21,13 @@ async function injectHomepageContent(req, res, next) {
 
 router.get('/', injectHomepageContent, (req, res) => {
     const fallbackSuperheroImage = {
-        small: '/assets/images/hero/superhero-fallback-small.jpg',
-        medium: '/assets/images/hero/superhero-fallback-medium.jpg',
-        large: '/assets/images/hero/superhero-fallback-large.jpg',
-        default: '/assets/images/hero/superhero-fallback-medium.jpg',
-        caption: 'Stepping Stones Programme, Grant £405,270'
+        default: {
+            small: '/assets/images/hero/superhero-fallback-small.jpg',
+            medium: '/assets/images/hero/superhero-fallback-medium.jpg',
+            large: '/assets/images/hero/superhero-fallback-large.jpg',
+            default: '/assets/images/hero/superhero-fallback-medium.jpg',
+            caption: 'Stepping Stones Programme, Grant £405,270'
+        }
     };
 
     res.render(path.resolve(__dirname, './views/home'), {


### PR DESCRIPTION
The superhero code expected a `default` hero object whereas we were passing it a default image URL *within* that hero. This fixes it so if the API is down, the default hero appears.