### PR TITLE
Fixup bug when fetching research entries

### DIFF
--- a/services/content-api.js
+++ b/services/content-api.js
@@ -143,13 +143,9 @@ function getResearch({ locale, slug = null, searchQuery = null, previewMode = nu
             qs: addPreviewParams(previewMode)
         }).then(response => get('data.attributes')(response));
     } else {
-        return fetchAllLocales(reqLocale => {
-            const url = `/v1/${reqLocale}/research`;
-            return searchQuery ? `${url}?q=${searchQuery}` : url;
-        }).then(responses => {
-            const [enResults, cyResults] = responses.map(mapAttrs);
-            return mergeWelshBy('urlPath')(locale, enResults, cyResults);
-        });
+        const baseUrl = `/v1/${locale}/research`;
+        const url = searchQuery ? `${baseUrl}?q=${searchQuery}` : baseUrl;
+        return fetch(url).then(mapAttrs);
     }
 }
 


### PR DESCRIPTION
Fixes this double research link:

![image](https://user-images.githubusercontent.com/123386/47167811-40c1d500-d2f7-11e8-877c-906a9cce13fd.png)

Caused by `mergeWelshBy` using a non-existing property. Not 100% why that would cause things to double up, but as it happens we don't want he merging behaviour here and instead just want to return the appropriate entries for the locale so can swap this out with a more straightforward API call to fix the issue.