### PR TITLE
Past grant quick fix

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -989,9 +989,11 @@
               "version",
               "enable-feature",
               "disable-feature",
+              "redirectUrl",
+              "s",
               "token"
             ],
-            "Quantity": 5
+            "Quantity": 7
           },
           "QueryString": true,
           "Cookies": {

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -989,9 +989,11 @@
               "version",
               "enable-feature",
               "disable-feature",
+              "redirectUrl",
+              "s",
               "token"
             ],
-            "Quantity": 5
+            "Quantity": 7
           },
           "QueryString": true,
           "Cookies": {

--- a/config/default.json
+++ b/config/default.json
@@ -37,7 +37,8 @@
     "enableHotjar": false,
     "useRemoteAssets": true,
     "enableTimingMetrics": false,
-    "enableMailSendMetrics": false
+    "enableMailSendMetrics": false,
+    "enableNewPastGrantsSearch": false
   },
   "imgix": {
     "mediaDomain": "biglotteryfund-assets.imgix.net"

--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,6 @@
 {
   "features": {
-    "useRemoteAssets": false
+    "useRemoteAssets": false,
+    "enableNewPastGrantsSearch": true
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -2,6 +2,7 @@
   "hotjarId": 1036292,
   "features": {
     "enableHotjar": true,
-    "enableMailSendMetrics": true
+    "enableMailSendMetrics": true,
+    "enableNewPastGrantsSearch": true
   }
 }

--- a/controllers/past-grants/views/grant-results.njk
+++ b/controllers/past-grants/views/grant-results.njk
@@ -5,8 +5,9 @@
 {% macro grantResultItem(grant, options) %}
     <div class="u-margin-bottom-s{% if options.wrapperClass %} {{ options.wrapperClass }}{% endif %}" data-score="{{ grant._textScore }}">
         {% set subtitle %}
+            {% set mainRecipient = grant.recipientOrganization[0] %}
             £{{ grant.amountAwarded | numberWithCommas}} to
-            <strong>{{ grant.recipientOrganization[0].name | striptags }}</strong>
+            <strong><a href="{{ localify("/funding/search-past-grants-alpha/recipient/" + mainRecipient.id) }}">{{ mainRecipient.name | striptags }}</a></strong>
             on {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
         {% endset %}
         {% call promoCard({

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -49,6 +49,7 @@ module.exports = {
          */
         res.locals.enablePrompt = config.get('features.enablePrompt');
         res.locals.enableSurvey = config.get('features.enableSurvey');
+        res.locals.enableNewPastGrantsSearch = config.get('features.enableNewPastGrantsSearch');
 
         /**
          * Metadata (e.g. global title, description)

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -22,11 +22,11 @@
             </div>
             {% if image.caption %}
                 <span class="hero__caption u-desktop-only">
-                    {% if image.grantId %}
+                    {% if image.grantId and enableNewPastGrantsSearch %}
                         <a href="{{ localify("/funding/search-past-grants-alpha/grant/" + image.grantId) }}" class="u-link-unstyled">
                     {% endif %}
                     <span class="u-caption">{{ image.caption }}</span>
-                    {% if image.grantId %}</a>{% endif %}
+                    {% if image.grantId and enableNewPastGrantsSearch %}</a>{% endif %}
                 </span>
             {% endif %}
         </div>


### PR DESCRIPTION
Just realised that the last PR will generate links to grant detail pages from all over the site which we probably don't want yet.

Also adds a quick link for the recipient page.