### PR TITLE
Research landing prep

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -411,6 +411,11 @@ toplevel:
       - label: Answering big questions
         caption: Impacts and lessons learned from our evaluation and research (PDF 1.8MB)
         href: https://www.biglotteryfund.org.uk/-/media/Files/Research%20Documents/er_res_answering_big_questions.pdf
+  researchNew:
+    title: Research
+    intro: >
+      <p>At the Big Lottery Fund we're committed to openness and transparency. To support this, we publish our grant data as well as datasets and related information used in our research.</p>
+    moreLinkText: View more research and insights
   data:
     title: "Key data about the Big Lottery Fund: financial year 2017/18"
     keyStats: Key statistics

--- a/controllers/research/index.js
+++ b/controllers/research/index.js
@@ -43,7 +43,7 @@ if (appData.isNotProduction) {
     router.get(
         '/landing-new',
         injectHeroImage('hapani'),
-        injectCopy('toplevel.research'),
+        injectCopy('toplevel.researchNew'),
         injectResearch,
         (req, res) => {
             res.render(path.resolve(__dirname, './views/research-landing-new'));

--- a/controllers/research/index.js
+++ b/controllers/research/index.js
@@ -42,70 +42,11 @@ router.get('/', injectHeroImage('hapani'), injectCopy('toplevel.research'), inje
 if (appData.isNotProduction) {
     router.get(
         '/landing-new',
-        injectHeroImage('grassroots-project'),
+        injectHeroImage('hapani'),
         injectCopy('toplevel.research'),
         injectResearch,
         (req, res) => {
-            const { researchEntries } = res.locals;
-
-            /**
-             * Mock out additional research entries based on CMS data,
-             * allows us to test the page before these pages are published.
-             * Delete these mocks once these pages are live.
-             */
-            const researchEntriesWithMocks = concat(researchEntries, [
-                {
-                    linkUrl: '/research/youth-employment?draft=47',
-                    title: 'Youth employment',
-                    trailText:
-                        'Learnings related to the design and implementation of services for young people who are considered furthest away from the labour market.',
-                    thumbnail:
-                        'https://biglotteryfund-assets.imgix.net/media/heroes/samba-ya-bamba-young-start-2-medium.jpg?auto=compress%2Cformat&crop=entropy&fit=crop&h=360&w=640&s=f484306a78326afcecf2603f166c3b59',
-                    documents: [
-                        {
-                            title: 'Full report',
-                            url:
-                                'https://media.biglotteryfund.org.uk/media/documents/youth-serious-violence-full-report.pdf?mtime=20180816092318',
-                            filetype: 'pdf',
-                            filesize: '824.72 KB',
-                            contents: [
-                                'Full briefing',
-                                'Introduction',
-                                'Talent Match achievements ',
-                                'Lessons for policy and programme design',
-                                'Sources'
-                            ]
-                        }
-                    ]
-                },
-                {
-                    linkUrl: '/research/place-based-working?draft=48',
-                    title: 'Place-based working and funding',
-                    trailText: 'Summary of learning about working and funding in place-based ways',
-                    thumbnail:
-                        'https://biglotteryfund-assets.imgix.net/media/heroes/city-gateway-reaching-communities-medium.jpg?auto=compress%2Cformat&crop=entropy&fit=crop&h=360&w=640&s=651de41cfc0ff05fcdc7e40189cca2ba',
-                    documents: [
-                        {
-                            title: 'Full report',
-                            url:
-                                'https://media.biglotteryfund.org.uk/media/documents/youth-serious-violence-full-report.pdf?mtime=20180816092318',
-                            filetype: 'pdf',
-                            filesize: '824.72 KB',
-                            contents: [
-                                'Introduction',
-                                'Key learning',
-                                'An emerging evidence base?',
-                                'Questions for funders',
-                                'Appendices and bibliography'
-                            ]
-                        }
-                    ]
-                }
-            ]);
-
-            res.render(path.resolve(__dirname, './views/research-landing-new'), {
-                researchEntries: researchEntriesWithMocks
-            });
+            res.render(path.resolve(__dirname, './views/research-landing-new'));
         }
     );
 }

--- a/controllers/research/views/research-detail.njk
+++ b/controllers/research/views/research-detail.njk
@@ -37,7 +37,7 @@
                         <div class="content-meta">
                             <dl class="o-definition-list o-definition-list--compact">
                                 <dt>{{ __('research.detail.datePublished') }}</dt>
-                                <dd>{{ formatDate(entry.dateCreated.date, DATE_FORMATS.month) }}</dd>
+                                <dd>{{ formatDate(entry.postDate.date, DATE_FORMATS.month) }}</dd>
                                 {% if entry.researchPartners %}
                                     <dt>{{ __('research.detail.researchPartners') }}</dt>
                                     <dd>{{ entry.researchPartners }}</dd>

--- a/controllers/research/views/research-landing-new.njk
+++ b/controllers/research/views/research-landing-new.njk
@@ -13,25 +13,21 @@
 
         <div class="nudge-up">
             {% call contentBox(pageAccent) %}
-                <p>At the Big Lottery Fund we're committed to openness and transparency. To support this, we publish our grant data as well as datasets and related information used in our research.</p>
-
-                <p>Animi nulla dignissimos eum provident repellendus delectus consequatur ratione nihil explicabo, dolorum rem eligendi culpa amet saepe sint exercitationem cupiditate doloremque debitis hic ipsa ad? In quaerat voluptatibus maiores assumenda? Find out more about our <a href="{{ localify('/research/open-data') }}">Open Data policy</a></p>
+                {{ copy.intro | safe }}
             {% endcall %}
 
-            {% if researchEntries.length > 0 %}
-                <section class="u-inner-wide-only u-margin-bottom">
-                    <ul class="flex-grid flex-grid--3up">
-                        {% for research in researchEntries %}
-                            <li class="flex-grid__item">
-                                {{ researchCard(research) }}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </section>
-            {% endif %}
+            <section class="u-inner-wide-only u-margin-bottom">
+                <ul class="flex-grid flex-grid--3up">
+                    {% for research in researchEntries %}
+                        <li class="flex-grid__item">
+                            {{ researchCard(research) }}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </section>
 
             <section class="u-align-center u-margin-bottom-l">
-                <a class="btn btn--medium" href="{{ localify('/research') }}">View more research and insights</a>
+                <a class="btn btn--medium" href="{{ localify('/research') }}">{{ copy.moreLinkText }}</a>
             </section>
         </div>
     </main>

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -3,7 +3,7 @@
 {% macro researchCard(research) %}
     {% call promoCard({
         "title": research.title,
-        "subtitle": formatDate(research.dateCreated.date, DATE_FORMATS.month),
+        "subtitle": formatDate(research.postDate.date, DATE_FORMATS.month),
         "trailText": research.trailText,
         "image": { "url": research.thumbnail, "alt": research.title },
         "link": { "url": research.linkUrl, "label": __('global.misc.readMore') }


### PR DESCRIPTION
Makes some adjustments to the new research landing page in preparation for launching it once we have one more research page.

Fixes a current bug too where we are using the created date rather than the publish date for research pages. The date below should read October.

![image](https://user-images.githubusercontent.com/123386/47295241-19c11700-d607-11e8-9997-6d97dca78084.png)
