### PR TITLE
Improve logging for newsletter service

### DIFF
--- a/services/newsletter-service.js
+++ b/services/newsletter-service.js
@@ -12,34 +12,44 @@ const { DOTMAILER_API } = require('../modules/secrets');
  * @param {object} options
  * @param {string} options.addressBookId
  * @param {object} options.subscriptionData
+ * @see https://developer.dotmailer.com/docs
+ * @see https://developer.dotmailer.com/docs/error-response-types
  */
 function subscribe({ addressBookId, subscriptionData }) {
     const ENDPOINT = `${config.get('ebulletinApiEndpoint')}/address-books/${addressBookId}/contacts`;
-    return request({
-        uri: ENDPOINT,
-        method: 'POST',
-        auth: {
-            user: DOTMAILER_API.user,
-            pass: DOTMAILER_API.password,
-            sendImmediately: true
-        },
-        json: true,
-        body: subscriptionData,
-        resolveWithFullResponse: true
-    }).then(response => {
-        if (response.statusCode === 200) {
-            debug(`Subscribed to address book: ${addressBookId}`);
-            metrics.count({
-                name: addressBookId,
-                namespace: 'SITE/NEWSLETTER',
-                dimension: 'SUBSCRIBED',
-                value: 'SUBSCRIBED_COUNT'
+
+    return new Promise((resolve, reject) => {
+        request({
+            uri: ENDPOINT,
+            method: 'POST',
+            auth: {
+                user: DOTMAILER_API.user,
+                pass: DOTMAILER_API.password,
+                sendImmediately: true
+            },
+            json: true,
+            body: subscriptionData,
+            resolveWithFullResponse: true
+        })
+            .then(response => {
+                if (response.statusCode === 200) {
+                    debug(`Subscribed to address book: ${addressBookId}`);
+                    metrics.count({
+                        name: addressBookId,
+                        namespace: 'SITE/NEWSLETTER',
+                        dimension: 'SUBSCRIBED',
+                        value: 'SUBSCRIBED_COUNT'
+                    });
+                    resolve(response);
+                } else {
+                    raven.captureMessage(response.message);
+                    reject(new Error(response.message));
+                }
+            })
+            .catch(error => {
+                raven.captureMessage(error.message);
+                reject(new Error(error.message));
             });
-            return response;
-        } else {
-            raven.captureMessage(response.message);
-            throw new Error(response.message);
-        }
     });
 }
 


### PR DESCRIPTION
Adds Raven logging to `catch` block as well as `then`. Make sure we log all failed signups.