### PR TITLE
Fixup formErrors display for assistance form

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -81,6 +81,7 @@ global:
     documents: dogfennau
     download: lawrlwytho'r
     edit: Golygu
+    errorTitle: Cafwyd problem gyda'ch cyflwyniad
     imageCredit: Cydnabyddiaeth i’r llun
     latestNews: Newyddion diweddaraf
     next: nesaf
@@ -903,7 +904,7 @@ apply:
       <p>Dychwelwch at y cam adolygu a rhowch gynnig arall arni. Os byddwch yn gweld gwall o hyd, ffoniwch <a href="tel:03001230735">0300 123 0735</a> (Dydd Llun i ddydd Gwener, 9am tan 5pm)</p>
   digitalFundDefaults: &digitalFundDefaults
     title: Dywedwch wrthym beth yw eich syniad
-    errorTitle: There was a problem with your submission
+    errorTitle: Cafwyd problem gyda'ch cyflwyniad
     fields:
       name:
         label: Eich enw

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ global:
     documents: documents
     download: download
     edit: Edit
+    errorTitle: There was a problem with your submission
     imageCredit: Image credit
     latestNews: Latest news
     next: next

--- a/controllers/digital-fund/views/assistance.njk
+++ b/controllers/digital-fund/views/assistance.njk
@@ -15,10 +15,12 @@
         <div class="nudge-up">
             <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
                 {{ breadcrumbTrail(breadcrumbs) }}
-                <div class="s-prose u-constrained-wide">
-                    <p><strong>{{ copy.assistance.intro }}</strong></p>
+                <div class="u-constrained-wide">
 
-                    {{ copy.assistance.body | safe }}
+                    <div class="s-prose">
+                        <p><strong>{{ copy.assistance.intro }}</strong></p>
+                        {{ copy.assistance.body | safe }}
+                    </div>
 
                     {% if status === 'SUBMISSION_SUCCESS' %}
                         <div class="submission-message u-tone-background-pale-grey u-padded">
@@ -37,28 +39,30 @@
                             </div>
                         {% endif %}
 
-                        <form class="u-tone-background-pale-grey u-padded" method="post" action="">
+                        <form method="post" action="">
                             {{ formErrors(errors) }}
 
-                            <label for="email" class="ff-label">
-                                {{ copy.assistance.submission.emailAddress }}
-                            </label>
+                            <div class="u-tone-background-pale-grey u-padded">
+                                <label for="form-field-email" class="ff-label">
+                                    {{ copy.assistance.submission.emailAddress }}
+                                </label>
 
-                            <p class="ff-help">
-                                {{ copy.assistance.submission.explanation }}
-                            </p>
+                                <p class="ff-help">
+                                    {{ copy.assistance.submission.explanation }}
+                                </p>
 
-                            <div class="form-field-addon u-constrained">
-                                <input class="form-field-addon__input"
-                                    id="email"
-                                    type="email"
-                                    name="email"
-                                    placeholder="your.email@example.com"
-                                />
-                                <input class="form-field-addon__action"
-                                    type="submit"
-                                    value="{{ copy.assistance.submission.proceedLabel }}"
-                                />
+                                <div class="form-field-addon u-constrained">
+                                    <input class="form-field-addon__input"
+                                        id="form-field-email"
+                                        type="email"
+                                        name="email"
+                                        placeholder="your.email@example.com"
+                                    />
+                                    <input class="form-field-addon__action"
+                                        type="submit"
+                                        value="{{ copy.assistance.submission.proceedLabel }}"
+                                    />
+                                </div>
                             </div>
                         </form>
                     {% endif %}

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -1,9 +1,9 @@
 {% macro formErrors(errors, title) %}
     {% if errors | length > 0 %}
         <div class="form-errors">
-            {% if title %}
-                <h3 class="form-errors__title">{{ title }}</h3>
-            {% endif %}
+            <h3 class="form-errors__title">
+                {% if title -%}{{ title }}{%- else -%}{{ __('global.misc.errorTitle') }}{%- endif %}
+            </h3>
             {% if errors.length > 0 %}
                 <ol class="form-errors__list">
                     {% for error in errors %}


### PR DESCRIPTION
Whilst testing this https://github.com/biglotteryfund/blf-alpha/pull/1391 I spotted that fallback validation errors for the assistance form were displaying weirdly. I'm not sure how many people would actually see this as your browser has to not support HTML validation to even show this, but still it should look right.

Rejigs the template so that "There was a problem with your submission" is used as a default title to avoid future instances of this. Tidies up the markup order to fix the indentation to.

Before:
<img width="938" alt="screen shot 2018-10-23 at 15 48 01" src="https://user-images.githubusercontent.com/123386/47369413-83aaf080-d6db-11e8-818f-e4f7720d2fef.png">


After:
<img width="1020" alt="screen shot 2018-10-23 at 15 48 10" src="https://user-images.githubusercontent.com/123386/47369412-83aaf080-d6db-11e8-968a-4e3f17712356.png">
