### PR TITLE
Make the behaviour of clearing filters and queries more consistent

### DIFF
--- a/assets/js/vue-apps/components/__tests__/facet-group.test.js
+++ b/assets/js/vue-apps/components/__tests__/facet-group.test.js
@@ -11,7 +11,10 @@ describe('FacetGroup', () => {
             propsData: {
                 id: 'test',
                 legend: 'Testing',
-                toggleLabel: 'Toggle'
+                toggleLabel: 'Toggle',
+                trackUi: function() {
+                    // noop
+                }
             },
             slots: {
                 default: '<div>dummy content</div>'

--- a/assets/js/vue-apps/components/grants-filter-summary.vue
+++ b/assets/js/vue-apps/components/grants-filter-summary.vue
@@ -17,7 +17,7 @@ export default {
                 <IconClose id="prompt-close" description="Dismiss prompt" />
             </li>
             <li v-if="filterSummary.length > 0">
-                <button type="button" class="btn-link" @click="$emit('clear-filters')">
+                <button type="button" class="btn-link" @click="$emit('clear-all')">
                     {{ clearLabel }}
                 </button>
             </li>

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -101,6 +101,15 @@ function init() {
                 this.trackFilter(payload.name, payload.label);
             },
 
+            // Resets filters *and* query search
+            clearAll() {
+                this.filters = {};
+                this.filterSummary = [];
+                this.activeQuery = null;
+                this.filterResults();
+                this.trackUi('Clear all filters and queries');
+            },
+
             clearFilters(name) {
                 this.status = { state: states.Loading };
                 if (name) {
@@ -111,7 +120,8 @@ function init() {
                     this.sort.activeSort = null;
                     this.filters = {};
                     this.filters.q = this.activeQuery; // reset query
-                    this.filterSummary = [];
+                    // remove everything except the query from the summary
+                    this.filterSummary = this.filterSummary.filter(i => i.name === 'q');
                     this.trackUi('Clear all filters');
                 }
                 this.filterResults();
@@ -119,8 +129,11 @@ function init() {
 
             updateQuery() {
                 const filterName = 'q';
-                this.filters.q = this.activeQuery;
-                this.handleActiveFilter({ label: this.activeQuery, name: filterName });
+                // Prevent a blank string from appearing in the filter summary
+                this.filters.q = this.activeQuery || undefined;
+                if (this.filters.q) {
+                    this.handleActiveFilter({ label: this.activeQuery, name: filterName });
+                }
                 this.filterResults();
                 this.trackFilter(filterName, this.activeQuery);
             },

--- a/controllers/past-grants/views/search.njk
+++ b/controllers/past-grants/views/search.njk
@@ -114,7 +114,7 @@
                             <grants-filter-summary
                                 :filter-summary="filterSummary"
                                 :clear-label="copy.filters.clearSelection"
-                                @clear-filters="clearFilters" />
+                                @clear-all="clearAll" />
                         </div>
                         <div class="grants-search__sort">
                             <grants-sort


### PR DESCRIPTION
This fixes a few weird things:

Entering a query then clearing the filters would clear the query from the summary even though it was still being applied:
![wtf](https://user-images.githubusercontent.com/394376/47718892-8492d380-dc41-11e8-82f2-ff259ff3f986.gif)

Clearing the summary did the same thing – wiped out the summary but left the query filter in place.
![wtf2](https://user-images.githubusercontent.com/394376/47718893-8492d380-dc41-11e8-9397-049e19933e6b.gif)

This change makes it work like so:

![fixed](https://user-images.githubusercontent.com/394376/47719011-c3288e00-dc41-11e8-8feb-6c14323531a8.gif)
