### PR TITLE
Show UK-wide programmes in the funding finder again

### DIFF
--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -16,9 +16,15 @@
             {{ breadcrumbTrail(breadcrumbs) }}
             <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
 
-            {% if programmes | length > 0 %}
+            {% if isGroupedByRegion and programmes %}
+                {% for region, regionProgrammes in programmes %}
+                    <h3>{{ region }}</h3>
+                    {{ programmeList(regionProgrammes, accent = pageAccent) }}
+                {% endfor %}
+            {% elseif programmes.length > 0 %}
                 {{ programmeList(programmes, accent = pageAccent) }}
             {% else %}
+                {# @TODO i18n #}
                 <p>No results</p>
             {% endif %}
         </section>


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1397

Adds region groups (eg. a specific country, then UK-wide) to all funding programme lists where a country is specified, eg:

![image](https://user-images.githubusercontent.com/394376/47728051-7d75c080-dc55-11e8-818a-7e28cd2037ee.png)

... then:

![image](https://user-images.githubusercontent.com/394376/47728063-85356500-dc55-11e8-983f-f8c0c832163f.png)

One mild quirk of this is that the Welsh version of the above page still says "Scotland" for the heading, not "Yr Alban" – this is because the Scottish programmes don't have Welsh translations so we're using the English, whose title is obviously in English too. Don't think this is the end of the world.