### PR TITLE
Translate past grants search

### DIFF
--- a/assets/js/vue-apps/components/grants-no-results.vue
+++ b/assets/js/vue-apps/components/grants-no-results.vue
@@ -29,11 +29,10 @@ export default {
             </button>
             <span v-if="canGoBack">
                 or
-                <!-- @TODO i18n -->
                 <button type="button"
                         class="btn btn--medium"
                         @click="goBack">
-                    Go back a step
+                    {{ copy.goBackAStep }}
                 </button>
             </span>
         </p>

--- a/config/default.json
+++ b/config/default.json
@@ -53,8 +53,8 @@
   "ebulletinApiEndpoint": "https://apiconnector.com/v2",
   "grantData": {
     "dateRange": {
-      "start": "1 April 2004",
-      "end": "12 September 2018"
+      "start": "2004-04-01",
+      "end": "2018-09-12"
     }
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -88,6 +88,8 @@ global:
     no: Nac ydw
     optional: Dewisol
     or: neu
+    to: i
+    on: ar
     printThisPage: Argraffu'r dudalen hon
     projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
     readMore: Darllen mwy
@@ -99,6 +101,9 @@ global:
     topics: pynciau
     viewAllNews: Gweld pob erthygl newyddion
     yes: Ydw
+    pagination:
+      prev: Tudalen flaenorol
+      next: Tudalen nesaf
   programmes:
     programmeLabels:
       area: Ardal
@@ -404,9 +409,6 @@ funding:
   pastGrants:
     title: Chwilio Pob Prosiect a Ariannwyd
     intro: Rydym yn deall bod chwilio trwy grantiau blaenorol y Gronfa Loteri Fawr yn bwysig i lawer o bobl. Rydym wrthi’n gwella’r gwasanaeth a gynigiwn ar hyn o bryd.
-    survey:
-      prompt: Helpwch ni i wneud chwilio am grantiau blaenorol yn well trwy ateb un cwestiwn
-      label: Dywedwch pam y daethoch i'r dudalen hon heddiw
     optionsIntro: Yn y cyfamser, mae dau ddull i chi chwilio trwy ein grantiau blaenorol.
     grantnav:
       title: 1. Defnyddio’r wefan GrantNav
@@ -416,95 +418,105 @@ funding:
       title: 2. Defnyddio ein cronfa ddata grantiau bresennol
       linkText: Chwilio grantiau blaenorol
     search:
-      title: Search awarded grants
+      title: Chwilio grantiau a ddyfarnwyd
+      survey:
+        prompt: Helpwch ni i wneud chwilio am grantiau blaenorol yn well trwy ateb un cwestiwn
+        label: Dywedwch pam y daethoch i'r dudalen hon heddiw
       beta: Beta
-      intro: Thank you for choosing to use our new “search awarded grants” service. We are working to improve the service we currently offer, your feedback will help us do that.
-      helpText: e.g. a keyword such as “loneliness”, a location, an organisation, or an area of work
-      submit: Search
-      pleaseWait: Searching, please wait...
-      resultsCount: projects found
-      totalCount: totalling
+      intro: >
+        Diolch am ddewis defnyddio ein gwasanaeth "chwilio grantiau a ddyfarnwyd" newydd. Rydym yn gweithio i wella'r gwasanaeth a gynigiwn i chi, bydd eich adborth yn ein helpu gwneud hynny. Gallwch roi cynnig ar ein gwasanaeth newydd mewn Beta nawr, <a href="%s">pori ein data gyda GrantNav</a> neu ddefnyddio ein hen <a href="/welsh/funding/search-past-grants">cronfa ddata grantiau blaenorol</a>.
+      helpText: e.e. allweddair fel "unigrwydd", lleoliad, mudiad neu faes gwaith
+      dateRange: >
+        Ar hyn o bryd mae ein data grantiau'n cwmpasu <strong>%s - %s</strong>. Rydym yn diweddaru'r data hwn bob mis.
+      submit: Chwilio
+      pleaseWait: Wrthi'n chwilio, arhoswch...
+      resultsCount: o brosiectau gwerth
+      totalCount: cyfanswm o
+      goBackAStep: Ewch gam yn ôl
+      backToSearch: Yn ôl i’ch canlyniadau chwilio
       sort:
-        orderedBy: Ordered by
+        orderedBy: Wedi'u trefnu fesul
       filters:
-        title: Filter by
-        submit: Filter
-        clear: Clear all filters
-        reset: Reset filters
-        clearSelection: Clear selection
-        toggle: Toggle
-        organisationLegend: Organisation
+        title: Hidlwch fesul
+        submit: Hidlo
+        clear: Clirio pob hidlydd
+        reset: Ail-osod hidlyddion
+        clearSelection: Clirio detholiad
+        toggle: Switsio
+        organisationLegend: Mudiad
         grantLegend: Grant
-        locationLegend: Location
+        locationLegend: Lleoliad
         options:
           truncate:
-            seeMore: See more options
-            seeFewer: See fewer options
+            seeMore: Gweld mwy o opsiynau
+            seeFewer: Gweld llai o opsiynau
           amountAwarded:
-            label: Grant amount
-            any: Any amount
+            label: Swm y grant
+            any: Unrhyw swm
+          awardDate:
+            label: Dyddiad dyfarnu
           country:
-            label: Country
-            any: All countries
-            labelClosed: See advanced location options
-            labelOpen: Hide advanced location options
+            label: Gwlad
+            any: Pob gwlad
+            labelClosed: Gweler opsiynau lleoliad manwl
+            labelOpen: Cuddio opsiynau lleoliad manwl
           programme:
-            label: Funding programme
-            any: All programmes
+            label: Rhaglen ariannu
+            any: Pob rhaglen
           localAuthority:
-            label: Local authority
-            any: All local authorities
+            label: Awdurdod lleol
+            any: Pob awdurdod lleol
           westminsterConstituency:
-            label: Westminster constituency
-            any: All constituencies
+            label: Etholaeth San Steffan
+            any: Pob etholaeth
           organisationType:
-            label: Organisation type
-            any: All organisation types
-          organisation: Organisation
+            label: Math o fudiad
+            any: Pob math o fudiad
+          organisation: Mudiad
       errors:
         noResults:
-          heading: We're sorry, we couldn't find any results matching your criteria
+          heading: Mae'n flin gennym, ni allem ddod o hyd i unrhyw ganlyniadau sy'n cyfateb i'ch meini prawf
           suggestions:
-          - Try a different query or clear your filters
-          - Try searching something less specific — sometimes using a more general search term may help
-          - Double check the spelling of any keywords you are searching for
-          - 'Our database might not have the details for grants awarded under 1 month ago. Please check our <a href="/news-and-events">news section</a> if you are looking for a recently awarded grant'
+            - Rhowch gynnig ar chwiliad gwahanol neu cliriwch eich hidlyddion
+            -	Ceisiwch chwilio am rywbeth llai penodol - weithiau gallai defnyddio term chwilio mwy cyffredinol helpu
+            -	Gwiriwch sillafu unrhyw allweddeiriau rydych yn eu chwilio'n ofalus
+            -	'Efallai nad fydd gan ein cronfa ddata fanylion grantiau a ddyfarnwyd o fewn y mis diwethaf. Gwiriwch ein <a href="/welsh/news-and-events">hadran newyddion</a> os ydych yn chwilio am grant a ddyfarnwyd yn ddiweddar'
           otherOptions: >
-            If you're looking for something specific and would like some help <a href="/contact">please contact us</a>.
-        postcode: The postcode you entered was invalid – please try another one.
-        generic: There was an error with your search.
-      featuredGrants: Featured grants
-      viewGrantDetails: View full grant details
+            Os ydych yn chwilio am rywbeth penodol ac fe hoffech gael cymorth <a href="/welsh/contact">cysylltwch â ni</a>.
+        postcode: Roedd y côd post a nodoch yn annilys - rhowch gynnig ar un arall.
+        generic: Cafwyd gwall gyda'ch chwiliad - rhowch gynnig ar un arall.
+      featuredGrants: Grantiau a amlygir
+      viewGrantDetails: Gweld manylion llawn y grant
       feedback:
-        title: Is something missing?
+        title: Oes rhywbeth ar goll?
         body: >
-          Please <a href="#feedback">send us feedback</a> to help us improve this service
+          <a href="#feedback">Gyrrwch adborth</a> atom i'n helpu gwella'r gwasanaeth hwn
       grantDetail:
-        projectOverview: Project overview
-        viewAllForRecipient: View all grants awarded to this recipient
-        fundedBy: Funded by
-        readMoreAbout: Read more about
-        photoCaption: Photo
-        moreLikeThis: More like this
+        projectOverview: Trosolwg o'r prosiect
+        viewAllForRecipient: Gweld pob grant a ddyfarnwyd i'r derbynnydd hwn
+        fundedBy: Ariannwyd gan
+        readMoreAbout: Darllen mwy am
+        photoCaption: Llun
+        moreLikeThis: Mwy fel hyn
         fields:
-          location: Location
-          multipleLocations: Multiple locations
-          duration: Duration
-          programme: Grant Programme
-          status: Status
-          recipientOrg: Recipient organisation
-          orgName: Organisation name
-          type: Type
-          charityNumber: Charity number
-          companyNumber: Company number
+          location: Lleoliad
+          multipleLocations: Lleoliadau lluosog
+          duration: Hyd
+          programme: Rhaglen grant
+          status: Statws
+          recipientOrg: Mudiad derbyn
+          orgName: Enw'r mudiad
+          type: Math
+          charityNumber: Rhif elusen
+          companyNumber: Rhif cwmni
         statuses:
-          active: Active
-          inactive: inActive
-          activeProject: Active Project
+          active: Gweithredol
+          inactive: Anweithredol
+          activeProject: Prosiect Gweithredol
       recipientDetail:
-        awardingProgrammes: Awarding programmes
-        searchGoogle: Search for %s with Google
-        numFundedTotal: '%s project(s) funded by Big Lottery Fund (£%s awarded in total)'
+        awardingProgrammes: Rhaglenni dyfarnu
+        searchGoogle: Chwilio am %s gyda Google
+        numFundedTotal: "ariannwyd %s o brosiectau gan y Gronfa Loteri Fawr (cyfanswm o £%s wedi'i ddyfarnu)"
   guidance:
     order-free-materials:
       title: Sut i gael deunyddiau â'n brand arnynt am ddim

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,8 @@ global:
     no: No
     optional: Optional
     or: or
+    to: to
+    on: on
     printThisPage: Print this page
     projectExamples: Examples of projects that have been funded
     readMore: Read more
@@ -100,6 +102,9 @@ global:
     topics: topics
     viewAllNews: View all news articles
     yes: Yes
+    pagination:
+      prev: Previous page
+      next: Next page
   programmes:
     programmeLabels:
       area: Area
@@ -504,9 +509,6 @@ funding:
       <p>Explore our database to find out what we've funded since 2004.</p>
       <p>We understand that searching through the Big Lottery Fund's past grants is important for many people. We are currently working to improve the service we currently offer.</p>
       <p>You can try our new service in Beta now, <a href="%s">explore our data with GrantNav</a> or use our <a href="/funding/search-past-grants">old past grants database</a>.</p>
-    survey:
-      prompt: Please help us make the past grants search better by answering this one question
-      label: Tell us why you came to this page today
     optionsIntro: In the the meantime, there are two ways you can explore our past grants.
     grantnav:
       title: 1. Use the GrantNav site
@@ -516,14 +518,22 @@ funding:
       title: 2. Use our current grants database
       linkText: Search past grants
     search:
-      title: Search awarded grants
+      title: Search all grants
+      survey:
+        prompt: Please help us make the past grants search better by answering this one question
+        label: Tell us why you came to this page today
       beta: Beta
-      intro: Thank you for choosing to use our new “search awarded grants” service. We are working to improve the service we currently offer, your feedback will help us do that.
+      intro: >
+        Thank you for choosing to use our new “search awarded grants” service. We are working to improve the service we currently offer, your feedback will help us do that. You can try our new service in Beta now, <a href="%s">explore our data with GrantNav</a> or use our <a href="/funding/search-past-grants">old past grants database</a>.
       helpText: e.g. a keyword such as “loneliness”, a location, an organisation, or an area of work
+      dateRange: >
+        Our grants data currently runs from <strong>%s - %s</strong>. We update this data on a monthly basis.
       submit: Search
       pleaseWait: Searching, please wait...
       resultsCount: projects found
       totalCount: totalling
+      goBackAStep: Go back a step
+      backToSearch: Back to your search results
       sort:
         orderedBy: Ordered by
       filters:
@@ -574,7 +584,7 @@ funding:
           otherOptions: >
             If you're looking for something specific and would like some help <a href="/contact">please contact us</a>.
         postcode: The postcode you entered was invalid – please try another one.
-        generic: There was an error with your search.
+        generic: There was an error with your search – please try another one.
       featuredGrants: Featured grants
       viewGrantDetails: View full grant details
       feedback:

--- a/controllers/grants/search.js
+++ b/controllers/grants/search.js
@@ -27,19 +27,19 @@ function makePageLink(currentQuery, page) {
     return '?' + querystring.stringify(withPage);
 }
 
-function buildPagination(paginationMeta, currentQuery = {}) {
+function buildPagination(paginationMeta, currentQuery = {}, labels) {
     if (paginationMeta && paginationMeta.totalPages > 1) {
         const currentPage = paginationMeta.currentPage;
         const totalPages = paginationMeta.totalPages;
 
         const prevLink = {
             url: makePageLink(currentQuery, currentPage - 1),
-            label: 'Previous page'
+            label: labels.prev
         };
 
         const nextLink = {
             url: makePageLink(currentQuery, currentPage + 1),
-            label: 'Next page'
+            label: labels.next
         };
 
         return {
@@ -109,6 +109,7 @@ router.get(
     async (req, res, next) => {
         let data;
         const facetParams = buildAllowedParams(req.query);
+        const paginationLabels = req.i18n.__('global.misc.pagination');
         let queryWithPage = addPaginationParameters(facetParams, req.query.page);
 
         // Add a parameter so we know the user came from search
@@ -157,7 +158,7 @@ router.get(
                     caseStudies: caseStudies,
                     grantNavLink: grantNavLink,
                     searchQueryString: searchQueryString,
-                    pagination: buildPagination(data.meta.pagination, queryWithPage)
+                    pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels)
                 });
             },
 
@@ -170,7 +171,7 @@ router.get(
                 const context = Object.assign({}, res.locals, req.app.locals, {
                     grants: data.results,
                     searchQueryString: searchQueryString,
-                    pagination: buildPagination(data.meta.pagination, queryWithPage),
+                    pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels),
                     options: {
                         wrapperClass: isRelatedSearch ? 'flex-grid__item' : false,
                         hidePagination: isRelatedSearch
@@ -206,6 +207,8 @@ router.get('/recipients/:id', injectCopy('funding.pastGrants.search'), async (re
             qs: qs
         });
 
+        const paginationLabels = req.i18n.__('global.misc.pagination');
+
         if (data && data.meta.totalResults > 0) {
             const firstResult = head(data.results);
             const organisation = head(firstResult.recipientOrganization);
@@ -219,7 +222,7 @@ router.get('/recipients/:id', injectCopy('funding.pastGrants.search'), async (re
                 totalResults: data.meta.totalResults.toLocaleString(),
                 breadcrumbs: concat(res.locals.breadcrumbs, { label: organisation.name }),
                 returnLink: buildReturnLink(req.query, '../'),
-                pagination: buildPagination(data.meta.pagination, qs)
+                pagination: buildPagination(data.meta.pagination, qs, paginationLabels)
             });
         } else {
             next();

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -32,7 +32,7 @@
                             <p>{{ grant.description }}</p>
                         {% endif %}
 
-                        {{ buildReturnLink(returnLink) }}
+                        {{ buildReturnLink(returnLink, copy.backToSearch) }}
                     </div>
                 </div>
 

--- a/controllers/grants/views/grant-results.njk
+++ b/controllers/grants/views/grant-results.njk
@@ -6,9 +6,9 @@
     <div class="u-margin-bottom-s{% if options.wrapperClass %} {{ options.wrapperClass }}{% endif %}" data-score="{{ grant._textScore }}">
         {% set subtitle %}
             {% set mainRecipient = grant.recipientOrganization[0] %}
-            £{{ grant.amountAwarded | numberWithCommas}} to
+            £{{ grant.amountAwarded | numberWithCommas}} {{ __('global.misc.to') }}
             <strong><a href="{{ localify("/funding/grants/recipients/" + mainRecipient.id + '?' + searchQueryString) }}">{{ mainRecipient.name | striptags }}</a></strong>
-            on {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
+            {{ __('global.misc.on') }} {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
         {% endset %}
         {% set description = false if options.hideDescription or grant.description === grant.title else grant.description %}
         {% call promoCard({

--- a/controllers/grants/views/helpers.njk
+++ b/controllers/grants/views/helpers.njk
@@ -29,7 +29,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro buildReturnLink(returnLink) %}
+{% macro buildReturnLink(returnLink, label) %}
     {% if returnLink %}
         <p class="u-no-margin">
             <a class="btn btn--small btn--outline accent--pink"
@@ -37,7 +37,7 @@
                 <span class="btn__icon btn__icon-left">
                     {{ iconArrowLeft('small') }}
                 </span>
-                Back to your search results
+                {{ label }}
             </a>
         </p>
     {% endif %}

--- a/controllers/grants/views/index.njk
+++ b/controllers/grants/views/index.njk
@@ -21,8 +21,8 @@
                     <p>{{ copy.intro }}</p>
                     {{ inlineFeedback(
                         description = "Past Grants",
-                        promptLabel = copy.survey.prompt,
-                        fieldLabel = copy.survey.label
+                        promptLabel = copy.search.survey.prompt,
+                        fieldLabel = copy.search.survey.label
                     )  }}
                     <hr />
                     <p>{{ copy.optionsIntro }}</p>

--- a/controllers/grants/views/recipient-detail.njk
+++ b/controllers/grants/views/recipient-detail.njk
@@ -57,7 +57,7 @@
                             </strong>
                         </p>
 
-                        {{ buildReturnLink(returnLink) }}
+                        {{ buildReturnLink(returnLink, copy.backToSearch) }}
 
                     </div>
                 </div>

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -34,24 +34,21 @@
 
                 <p>
                     <strong>{{ copy.beta | upper }}:</strong>
-                    {{ copy.intro }}
-                    {# @TODO i18n #}
-                    You can try this new service in beta, <a href="{{ grantNavLink }}">explore our data with GrantNav</a> or use our <a href="{{ localify('/funding/search-past-grants') }}">old past grants database</a>.
+                    {{ __('funding.pastGrants.search.intro', grantNavLink) | safe }}
                 </p>
 
 
                 <div id="feedback">
-                    {# @TODO i18n #}
                     {{ inlineFeedback(
-                        description = "past_grants_beta",
-                        promptLabel = "Can you spare a minute to give us some feedback?",
-                        fieldLabel = "Tell us why you came to this page today"
+                        description = "past_grants_new",
+                        promptLabel = copy.survey.prompt,
+                        fieldLabel = copy.survey.label
                     )  }}
                 </div>
 
                 {% if grantDataDates %}
                     <p class="u-margin-top">
-                        Our grants data currently runs from <strong>{{ grantDataDates.start }} &mdash; {{ grantDataDates.end }}</strong>. We update this data on a monthly basis.
+                        {{ __("funding.pastGrants.search.dateRange", formatDate(grantDataDates.start, DATE_FORMATS.short), formatDate(grantDataDates.end, DATE_FORMATS.short)) | safe }}
                     </p>
                 {% endif %}
             </div>


### PR DESCRIPTION
Adds a whole load of Welsh translations. Hopefully this is all of it – the rest are over in biglotteryfund/grants-service#36.

Possibly some of this is redundant (eg. things we changed after requesting translations) but it's fiddly to say until we switch over to the new search.

Once this (and the corresponding API one) are live on the TEST env I'll send it to Dave for some final sanity checks, given it's quite hard for us to tell if it's right.