### PR TITLE
Fix query summary

### DIFF
--- a/assets/js/vue-apps/components/grants-no-results.vue
+++ b/assets/js/vue-apps/components/grants-no-results.vue
@@ -24,7 +24,7 @@ export default {
         <p>
             <button type="button"
                     class="btn btn--medium"
-                    @click="$emit('clear-filters')">
+                    @click="$emit('clear-all')">
                 {{ copy.filters.clear }}
             </button>
             <span v-if="canGoBack">

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -158,7 +158,6 @@ function init() {
                     this.filterSummary = this.filterSummary.filter(i => i.name === 'q');
                     this.trackUi('Clear all filters');
                 }
-                this.filterResults();
             },
 
             updateQuery() {

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -122,9 +122,13 @@ function init() {
             },
 
             handleActiveFilter(payload) {
-                const match = find(this.filterSummary, item => item.name === payload.name);
+                let match = find(this.filterSummary, item => item.name === payload.name);
                 if (!match) {
+                    // Add the new summary item
                     this.filterSummary = [].concat(this.filterSummary, [payload]);
+                } else {
+                    // Update the existing one
+                    this.filterSummary.find(i => i.name === payload.name).label = payload.label;
                 }
                 this.trackFilter(payload.name, payload.label);
             },
@@ -161,6 +165,9 @@ function init() {
                 this.filters.q = this.activeQuery || undefined;
                 if (this.filters.q) {
                     this.handleActiveFilter({ label: this.activeQuery, name: filterName });
+                } else {
+                    // Delete the query summary item
+                    this.filterSummary = this.filterSummary.filter(i => i.name !== 'q');
                 }
                 this.filterResults();
                 this.trackFilter(filterName, this.activeQuery);

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -48,39 +48,13 @@ function init() {
             const initialQueryParams = get(initialData, 'queryParams', {}) || {};
             const facets = get(initialData, 'facets', {});
 
-            // Reconstruct the summary by grabbing labels from facets
-            // (eg. for the subset of filters which have different labels
-            // to their URL-provided values
-            const initialFilterSummary = map(initialQueryParams, (value, key) => {
-                let label;
-                switch (key) {
-                    case 'amount':
-                        label = get(facets, 'amountAwarded[0].label');
-                        break;
-                    case 'awardDate':
-                        label = get(facets, 'awardDate[0].label');
-                        break;
-                    case 'localAuthority':
-                        label = get(facets, 'localAuthorities[0].label');
-                        break;
-                    case 'westminsterConstituency':
-                        label = get(facets, 'westminsterConstituencies[0].label');
-                        break;
-                }
-
-                return {
-                    name: key,
-                    label: label || value
-                };
-            });
-
             return {
                 status: { state: states.NotAsked },
                 activeQuery: initialQueryParams.q || null,
                 facets: facets,
                 sort: get(initialData, 'sort', {}),
                 filters: initialQueryParams,
-                filterSummary: initialFilterSummary,
+                filterSummary: this.buildFilterSummary(initialQueryParams),
                 totalResults: initialData.totalResults || 0,
                 totalAwarded: initialData.totalAwarded || 0,
                 copy: initialData.lang
@@ -108,11 +82,39 @@ function init() {
                 if (!this.filters.q) {
                     this.activeQuery = null;
                 }
-                this.filterSummary = [];
+                this.filterSummary = this.buildFilterSummary(this.filters);
                 this.trackUi('Navigation', 'Back');
             };
         },
         methods: {
+            buildFilterSummary(queryParams) {
+                // Reconstruct the summary by grabbing labels from facets
+                // (eg. for the subset of filters which have different labels
+                // to their URL-provided values
+                return map(queryParams, (value, key) => {
+                    let label;
+                    switch (key) {
+                        case 'amount':
+                            label = get(this.facets, 'amountAwarded[0].label');
+                            break;
+                        case 'awardDate':
+                            label = get(this.facets, 'awardDate[0].label');
+                            break;
+                        case 'localAuthority':
+                            label = get(this.facets, 'localAuthorities[0].label');
+                            break;
+                        case 'westminsterConstituency':
+                            label = get(this.facets, 'westminsterConstituencies[0].label');
+                            break;
+                    }
+
+                    return {
+                        name: key,
+                        label: label || value
+                    };
+                });
+            },
+
             trackFilter(filterName, filterValue = null) {
                 trackEvent('Past Grants Filter', filterName, filterValue);
             },

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -273,7 +273,7 @@
                 <grants-no-results
                     :total-results="totalResults"
                     :copy="copy"
-                    @clear-filters="clearFilters"
+                    @clear-all="clearAll"
                 />
 
                 {% if meta.totalResults === 0 %}


### PR DESCRIPTION
Fixes a few minor past grant issues:

- Query summaries weren't updating: 
![broken](https://user-images.githubusercontent.com/394376/47847073-0f024100-ddc2-11e8-8c93-4c8d1ddc1f2a.gif)

- We were sending two AJAX requests when clearing filters, so this removes the dupe:
![image](https://user-images.githubusercontent.com/394376/47847110-25a89800-ddc2-11e8-8760-075c6afe4890.png)

- If you ran a typed search and got no results, clicking "clear filters" did nothing. Now we clear the query, too (checked with @LynseyJReynolds).