### PR TITLE
Fix IE issues and other past grants fun

### DIFF
--- a/assets/js/vue-apps/components/facet-select.vue
+++ b/assets/js/vue-apps/components/facet-select.vue
@@ -38,7 +38,7 @@ export default {
                 :id="id"
                 :name="name"
                 :value="value"
-                @input="handleInput">
+                @change="handleInput">
                 <option value="" v-if="labelAny">{{ labelAny }}</option>
                 <template v-if="isOptgroup">
                     <optgroup v-for="(group, groupLabel) in options" :label="groupLabel" :key="groupLabel">

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -160,7 +160,7 @@ function init() {
                 }
             },
 
-            updateQuery() {
+            updateQuery(shouldFilterResults = true) {
                 const filterName = 'q';
                 // Prevent a blank string from appearing in the filter summary
                 this.filters.q = this.activeQuery || undefined;
@@ -170,11 +170,17 @@ function init() {
                     // Delete the query summary item
                     this.filterSummary = this.filterSummary.filter(i => i.name !== 'q');
                 }
-                this.filterResults();
-                this.trackFilter(filterName, this.activeQuery);
+                if (shouldFilterResults) {
+                    this.filterResults();
+                    this.trackFilter(filterName, this.activeQuery);
+                }
             },
 
             filterResults() {
+                // Grab the query value and update the filter object
+                // in case someone typed a search but didn't submit it
+                this.updateQuery(false);
+
                 const combinedFilters = cloneDeep(this.filters);
 
                 if (this.sort.activeSort && this.sort.activeSort !== this.sort.defaultSort) {

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -54,7 +54,7 @@ function init() {
                 facets: facets,
                 sort: get(initialData, 'sort', {}),
                 filters: initialQueryParams,
-                filterSummary: this.buildFilterSummary(initialQueryParams),
+                filterSummary: [],
                 totalResults: initialData.totalResults || 0,
                 totalAwarded: initialData.totalAwarded || 0,
                 copy: initialData.lang
@@ -73,6 +73,9 @@ function init() {
             $(this.$el)
                 .find('[disabled]')
                 .removeAttr('disabled');
+
+            // Generate summary once we've parsed the facets
+            this.filterSummary = this.buildFilterSummary(this.filters);
 
             window.onpopstate = event => {
                 const historyUrlPath = get(event, 'state.urlPath', window.location.pathname);

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -577,6 +577,124 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/grants/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/grants/recipients/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [
               "draft",
               "version",
@@ -1179,6 +1297,124 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/grants/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/grants/recipients/*"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [
               "draft",
               "version",
@@ -1275,6 +1511,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 20
+    "Quantity": 24
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -577,6 +577,124 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/grants/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/grants/recipients/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [
               "draft",
               "version",
@@ -1179,6 +1297,124 @@
             "Quantity": 2
           },
           "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/grants/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session"
+              ],
+              "Quantity": 3
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/grants/recipients/*"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
             "Items": [
               "draft",
               "version",
@@ -1275,6 +1511,6 @@
         "PathPattern": "/welsh/search"
       }
     ],
-    "Quantity": 20
+    "Quantity": 24
   }
 }

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -519,6 +519,124 @@ Object {
           },
           "QueryString": true,
           "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/grants/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/grants/recipients/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
             "Items": Array [
               "draft",
               "version",
@@ -1121,6 +1239,124 @@ Object {
           },
           "QueryString": true,
           "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/grants/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/grants/recipients/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
             "Items": Array [
               "draft",
               "version",
@@ -1210,7 +1446,7 @@ Object {
         "ViewerProtocolPolicy": "redirect-to-https",
       },
     ],
-    "Quantity": 20,
+    "Quantity": 24,
   },
   "DefaultCacheBehavior": Object {
     "AllowedMethods": Object {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -15,6 +15,8 @@ const CLOUDFRONT_PATHS = [
     { path: '/funding/funding-finder', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
     { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
     { path: '/funding/grants', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
+    { path: '/funding/grants/*', allowAllQueryStrings: true, isBilingual: true },
+    { path: '/funding/grants/recipients/*', allowAllQueryStrings: true, isBilingual: true },
     { path: '/search', allowAllQueryStrings: true, isBilingual: true },
     { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }
 ];


### PR DESCRIPTION
Prevents the select box issue with IE from failing to update when changing, and also fixes some Cloudfront caching issues and filter summaries not properly generating  (eg. visit `/funding/grants?awardDate=2017-01-01%7C2017-12-31&localAuthority=E08000025` and watch it fail to populate properly as the `facets` object hasn't loaded yet).