### PR TITLE
Remove hero image from search past grants

### DIFF
--- a/controllers/grants/search.js
+++ b/controllers/grants/search.js
@@ -10,7 +10,7 @@ const nunjucks = require('nunjucks');
 const Raven = require('raven');
 
 const { PAST_GRANTS_API_URI } = require('../../modules/secrets');
-const { injectHeroImage, injectCopy } = require('../../middleware/inject-content');
+const { injectCopy } = require('../../middleware/inject-content');
 const contentApi = require('../../services/content-api');
 const grantDataDates = config.get('grantData.dateRange');
 
@@ -102,99 +102,94 @@ function buildReturnLink(queryParams, urlBase = './') {
     return returnLink;
 }
 
-router.get(
-    '/',
-    injectHeroImage('active-plus-communities'),
-    injectCopy('funding.pastGrants.search'),
-    async (req, res, next) => {
-        let data;
-        const facetParams = buildAllowedParams(req.query);
-        const paginationLabels = req.i18n.__('global.misc.pagination');
-        let queryWithPage = addPaginationParameters(facetParams, req.query.page);
+router.get('/', injectCopy('funding.pastGrants.search'), async (req, res, next) => {
+    let data;
+    const facetParams = buildAllowedParams(req.query);
+    const paginationLabels = req.i18n.__('global.misc.pagination');
+    let queryWithPage = addPaginationParameters(facetParams, req.query.page);
 
-        // Add a parameter so we know the user came from search
-        // (so we can link them back to their results)
-        const searchQueryString = querystring.stringify(
-            Object.assign({}, queryWithPage, {
-                from: 'search'
-            })
-        );
+    // Add a parameter so we know the user came from search
+    // (so we can link them back to their results)
+    const searchQueryString = querystring.stringify(
+        Object.assign({}, queryWithPage, {
+            from: 'search'
+        })
+    );
 
-        queryWithPage.locale = res.locals.locale;
+    queryWithPage.locale = res.locals.locale;
 
-        try {
-            data = await queryGrantsApi(queryWithPage);
-        } catch (errorResponse) {
-            return res.format({
-                html: () => {
-                    next(errorResponse.error);
-                },
-                'application/json': () => {
-                    res.status(errorResponse.error.error.status || 400).json({
-                        error: errorResponse.error.error
-                    });
-                }
-            });
-        }
-
-        res.format({
-            // Initial / server-only search
-            html: async () => {
-                // Grab some case studies
-                const caseStudiesResponse = await contentApi.getCaseStudies({
-                    locale: req.i18n.getLocale()
-                });
-
-                // Shuffle the valid case studies and grab the first few
-                const caseStudies = sampleSize(caseStudiesResponse.filter(c => c.grantId), 3);
-
-                res.render(path.resolve(__dirname, './views/search'), {
-                    title: res.locals.copy.title,
-                    queryParams: isEmpty(facetParams) ? false : facetParams,
-                    grants: data.results,
-                    facets: data.facets,
-                    meta: data.meta,
-                    grantDataDates: grantDataDates,
-                    caseStudies: caseStudies,
-                    grantNavLink: grantNavLink,
-                    searchQueryString: searchQueryString,
-                    pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels)
-                });
+    try {
+        data = await queryGrantsApi(queryWithPage);
+    } catch (errorResponse) {
+        return res.format({
+            html: () => {
+                next(errorResponse.error);
             },
-
-            // AJAX search for client-side app
             'application/json': () => {
-                const isRelatedSearch = req.query.related === 'true';
-
-                // Repopulate existing app globals so Nunjucks can read them
-                // outside of Express's view engine context
-                const context = Object.assign({}, res.locals, req.app.locals, {
-                    grants: data.results,
-                    searchQueryString: searchQueryString,
-                    pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels),
-                    options: {
-                        wrapperClass: isRelatedSearch ? 'flex-grid__item' : false,
-                        hidePagination: isRelatedSearch
-                    }
-                });
-                const template = path.resolve(__dirname, './views/ajax-results.njk');
-
-                nunjucks.render(template, context, (renderErr, html) => {
-                    if (renderErr) {
-                        Raven.captureException(renderErr);
-                        res.status(400).json({ error: 'ERR-TEMPLATE-ERROR' });
-                    } else {
-                        res.json({
-                            meta: data.meta,
-                            facets: data.facets,
-                            resultsHtml: html
-                        });
-                    }
+                res.status(errorResponse.error.error.status || 400).json({
+                    error: errorResponse.error.error
                 });
             }
         });
     }
-);
+
+    res.format({
+        // Initial / server-only search
+        html: async () => {
+            // Grab some case studies
+            const caseStudiesResponse = await contentApi.getCaseStudies({
+                locale: req.i18n.getLocale()
+            });
+
+            // Shuffle the valid case studies and grab the first few
+            const caseStudies = sampleSize(caseStudiesResponse.filter(c => c.grantId), 3);
+
+            res.render(path.resolve(__dirname, './views/search'), {
+                title: res.locals.copy.title,
+                queryParams: isEmpty(facetParams) ? false : facetParams,
+                grants: data.results,
+                facets: data.facets,
+                meta: data.meta,
+                grantDataDates: grantDataDates,
+                caseStudies: caseStudies,
+                grantNavLink: grantNavLink,
+                searchQueryString: searchQueryString,
+                pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels)
+            });
+        },
+
+        // AJAX search for client-side app
+        'application/json': () => {
+            const isRelatedSearch = req.query.related === 'true';
+
+            // Repopulate existing app globals so Nunjucks can read them
+            // outside of Express's view engine context
+            const context = Object.assign({}, res.locals, req.app.locals, {
+                grants: data.results,
+                searchQueryString: searchQueryString,
+                pagination: buildPagination(data.meta.pagination, queryWithPage, paginationLabels),
+                options: {
+                    wrapperClass: isRelatedSearch ? 'flex-grid__item' : false,
+                    hidePagination: isRelatedSearch
+                }
+            });
+            const template = path.resolve(__dirname, './views/ajax-results.njk');
+
+            nunjucks.render(template, context, (renderErr, html) => {
+                if (renderErr) {
+                    Raven.captureException(renderErr);
+                    res.status(400).json({ error: 'ERR-TEMPLATE-ERROR' });
+                } else {
+                    res.json({
+                        meta: data.meta,
+                        facets: data.facets,
+                        resultsHtml: html
+                    });
+                }
+            });
+        }
+    });
+});
 
 router.get('/recipients/:id', injectCopy('funding.pastGrants.search'), async (req, res, next) => {
     try {

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -7,6 +7,8 @@
 {% from "components/promo-card/macro.njk" import promoCard %}
 {% from "./grant-results.njk" import grantResultList with context %}
 
+{% set bodyClass = 'has-static-header' %}
+
 {% block extraHead %}
     <script>
         window._PAST_GRANTS_SEARCH = {
@@ -22,280 +24,273 @@
 
 {% block content %}
     <main role="main">
-        {{ hero(
-            titleText = title,
-            image = heroImage,
-            accent = pageAccent
-        ) }}
+        <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-        <div class="nudge-up">
-            <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                {{ breadcrumbTrail(breadcrumbs) }}
+            <h1 class="t2 t--underline">{{ title }}</h1>
 
-                <p>
-                    <strong>{{ copy.beta | upper }}:</strong>
-                    {{ __('funding.pastGrants.search.intro', grantNavLink) | safe }}
-                </p>
+            <p>
+                <strong>{{ copy.beta | upper }}:</strong>
+                {{ __('funding.pastGrants.search.intro', grantNavLink) | safe }}
+            </p>
 
 
-                <div id="feedback">
-                    {{ inlineFeedback(
-                        description = "past_grants_new",
-                        promptLabel = copy.survey.prompt,
-                        fieldLabel = copy.survey.label
-                    )  }}
-                </div>
-
-                {% if grantDataDates %}
-                    <p class="u-margin-top">
-                        {{ __("funding.pastGrants.search.dateRange", formatDate(grantDataDates.start, DATE_FORMATS.short), formatDate(grantDataDates.end, DATE_FORMATS.short)) | safe }}
-                    </p>
-                {% endif %}
+            <div id="feedback">
+                {{ inlineFeedback(
+                    description = "past_grants_new",
+                    promptLabel = copy.survey.prompt,
+                    fieldLabel = copy.survey.label
+                )  }}
             </div>
 
-            <form class="u-inner" id="js-past-grants" method="get" action="" v-on:submit.prevent>
+            {% if grantDataDates %}
+                <p class="u-margin-top">
+                    {{ __("funding.pastGrants.search.dateRange", formatDate(grantDataDates.start, DATE_FORMATS.short), formatDate(grantDataDates.end, DATE_FORMATS.short)) | safe }}
+                </p>
+            {% endif %}
+        </div>
 
-                <div class="grants-searchbar js-only">
-                    <label class="ff-label ff-label--append"
-                           for="search-query"
-                           data-append="{{ copy.beta }}">
+        <form class="u-inner" id="js-past-grants" method="get" action="" v-on:submit.prevent>
+
+            <div class="grants-searchbar js-only">
+                <label class="ff-label ff-label--append"
+                        for="search-query"
+                        data-append="{{ copy.beta }}">
+                    {{ copy.title }}
+                </label>
+                <div class="form-field-addon u-margin-bottom-s">
+                    <input
+                        class="form-field-addon__input "
+                        disabled="disabled"
+                        type="search"
+                        id="search-query"
+                        name="q"
+                        v-model="activeQuery"
+                    />
+                    <input
+                        class="form-field-addon__action"
+                        type="submit"
+                        value="{{ copy.submit }}"
+                        @click="updateQuery"
+                    />
+                </div>
+                <p class="ff-help u-no-margin">
+                    {{ copy.helpText }}
+                </p>
+            </div>
+
+            <noscript>
+                <div class="grants-searchbar">
+                    <label class="ff-label" for="search-query-fallback">
                         {{ copy.title }}
                     </label>
                     <div class="form-field-addon u-margin-bottom-s">
                         <input
-                            class="form-field-addon__input "
-                            disabled="disabled"
+                            class="form-field-addon__input"
                             type="search"
-                            id="search-query"
+                            id="search-query-fallback"
                             name="q"
-                            v-model="activeQuery"
+                            value="{{ queryParams.q }}"
                         />
                         <input
                             class="form-field-addon__action"
                             type="submit"
                             value="{{ copy.submit }}"
-                            @click="updateQuery"
                         />
                     </div>
                     <p class="ff-help u-no-margin">
                         {{ copy.helpText }}
                     </p>
                 </div>
+            </noscript>
 
-                <noscript>
-                    <div class="grants-searchbar">
-                        <label class="ff-label" for="search-query-fallback">
-                            {{ copy.title }}
-                        </label>
-                        <div class="form-field-addon u-margin-bottom-s">
-                            <input
-                                class="form-field-addon__input"
-                                type="search"
-                                id="search-query-fallback"
-                                name="q"
-                                value="{{ queryParams.q }}"
-                            />
-                            <input
-                                class="form-field-addon__action"
-                                type="submit"
-                                value="{{ copy.submit }}"
-                            />
-                        </div>
-                        <p class="ff-help u-no-margin">
-                            {{ copy.helpText }}
-                        </p>
+            <div class="grants-search{% if meta.totalResults === 0 %} js-only{% endif %}" v-if="totalResults > 0">
+                <div class="grants-search__meta">
+                    <h2 class="grants-search__total accent--{{ pageAccent }} t--underline">
+                        <grants-total-summary
+                            :total-results="totalResults"
+                            :total-awarded="totalAwarded"
+                            :copy="copy"
+                        />
+                        {{ meta.totalResults | numberWithCommas }} {{ copy.resultsCount }}
+                    </h2>
+
+                </div>
+                <div class="grants-search__meta">
+                    <div>
+                        <grants-filter-summary
+                            :filter-summary="filterSummary"
+                            :clear-label="copy.filters.clearSelection"
+                            @clear-all="clearAll"
+                            @clear-filters="clearFilters" />
                     </div>
-                </noscript>
-
-                <div class="grants-search{% if meta.totalResults === 0 %} js-only{% endif %}" v-if="totalResults > 0">
-                    <div class="grants-search__meta">
-                        <h2 class="grants-search__total accent--{{ pageAccent }} t--underline">
-                            <grants-total-summary
-                                :total-results="totalResults"
-                                :total-awarded="totalAwarded"
-                                :copy="copy"
-                            />
-                            {{ meta.totalResults | numberWithCommas }} {{ copy.resultsCount }}
-                        </h2>
-
+                    <div class="grants-search__sort">
+                        <grants-sort
+                            :sort="sort"
+                            label="{{ copy.sort.orderedBy }}"
+                            @change-sort="handleChangeSort"
+                        />
                     </div>
-                    <div class="grants-search__meta">
-                        <div>
-                            <grants-filter-summary
-                                :filter-summary="filterSummary"
-                                :clear-label="copy.filters.clearSelection"
-                                @clear-all="clearAll"
-                                @clear-filters="clearFilters" />
-                        </div>
-                        <div class="grants-search__sort">
-                            <grants-sort
-                                :sort="sort"
-                                label="{{ copy.sort.orderedBy }}"
-                                @change-sort="handleChangeSort"
-                            />
-                        </div>
-                    </div>
+                </div>
 
-                    <div class="grants-search__content">
+                <div class="grants-search__content">
 
-                        <div class="grants-search__results">
-                            <div class="grants-search__status">
-                                <grants-loading-status
-                                    :status="status"
-                                    :copy="copy"
-                                />
-                            </div>
-
-                            <div id="js-grant-results" v-show="['NotAsked', 'Success'].indexOf(status.state) !== -1">
-                                {{ grantResultList(grants) }}
-                            </div>
-                        </div>
-
-                        <div class="grants-search__filters">
-                            {# Javascript component version of filters #}
-                            <grants-filters
-                                :facets="facets"
-                                :filters="filters"
+                    <div class="grants-search__results">
+                        <div class="grants-search__status">
+                            <grants-loading-status
                                 :status="status"
                                 :copy="copy"
-                                @clear-filters="clearFilters"
-                                :track-ui="trackUi"
-                                :handle-active-filter="handleActiveFilter"
                             />
+                        </div>
 
-                            {# Noscript fallback filters #}
-                            <fieldset class="search-filters">
-                                <div class="search-filters__header">
-                                    <legend class="search-filters__title">{{ copy.filters.title }}</legend>
-                                </div>
-                                {# Filter: Amount awarded #}
-                                {% if facets.amountAwarded %}
-                                    {% set options = (facets.amountAwarded.unshift({
-                                        'label': copy.filters.options.amountAwarded.any,
-                                        'value': ''
-                                    }), facets.amountAwarded) %}
-                                    <div class="facet-group">
-                                        {{ inputChoice({
-                                            type: 'radio',
-                                            name: 'amount',
-                                            label: copy.filters.options.amountAwarded.label,
-                                            value: queryParams.amount,
-                                            options: options,
-                                            silentlyOptional: true
-                                        }) }}
-                                    </div>
-                                {% endif %}
-
-                                {# Filter: Country #}
-                                {% if facets.countries %}
-                                    {% set options = (facets.countries.unshift({
-                                        'label': copy.filters.options.country.any,
-                                        'value': ''
-                                    }), facets.countries) %}
-                                    <div class="facet-group">
-                                        {{ inputChoice({
-                                            type: 'radio',
-                                            name: 'country',
-                                            label: copy.filters.options.country.label,
-                                            value: queryParams.country,
-                                            options: options,
-                                            silentlyOptional: true
-                                        }) }}
-                                    </div>
-                                {% endif %}
-
-                                {# Filter: Grant programme #}
-                                {% if facets.grantProgramme %}
-                                    {% set options = (facets.grantProgramme.unshift({
-                                        'label': copy.filters.options.programme.any,
-                                        'value': ''
-                                    }), facets.grantProgramme) %}
-                                    <div class="facet-group">
-                                        {{ inputSelect({
-                                            type: 'select',
-                                            name: 'programme',
-                                            label: copy.filters.options.programme.label,
-                                            value: queryParams.programme,
-                                            options: options,
-                                            silentlyOptional: true
-                                        }) }}
-                                    </div>
-                                {% endif %}
-
-                                {# Filter: Local Authority #}
-                                {% if facets.localAuthorities %}
-                                    {% set options = (facets.localAuthorities.unshift({
-                                        'label': copy.filters.options.localAuthority.any,
-                                        'value': ''
-                                    }), facets.localAuthorities) %}
-                                    <div class="facet-group">
-                                        {{ inputSelect({
-                                            type: 'select',
-                                            name: 'localAuthority',
-                                            label: copy.filters.options.localAuthority.label,
-                                            value: queryParams.localAuthority,
-                                            options: options,
-                                            silentlyOptional: true
-                                        }) }}
-                                    </div>
-                                {% endif %}
-
-                                {# Filter: Constituency #}
-                                {% if facets.westminsterConstituencies %}
-                                    {% set options = (facets.westminsterConstituencies.unshift({
-                                        'label': copy.filters.options.westminsterConstituency.any,
-                                        'value': ''
-                                    }), facets.westminsterConstituencies) %}
-                                    <div class="facet-group">
-                                        {{ inputSelect({
-                                            type: 'select',
-                                            name: 'westminsterConstituency',
-                                            label: copy.filters.options.westminsterConstituency.label,
-                                            value: queryParams.westminsterConstituency,
-                                            options: options,
-                                            silentlyOptional: true
-                                        }) }}
-                                    </div>
-                                {% endif %}
-
-                                <noscript>
-                                    <div class="search-filters__actions">
-                                        <input type="submit"
-                                               value="{{ copy.filters.submit }}"
-                                               class="btn btn--medium">
-                                    </div>
-                                </noscript>
-                            </fieldset>
+                        <div id="js-grant-results" v-show="['NotAsked', 'Success'].indexOf(status.state) !== -1">
+                            {{ grantResultList(grants) }}
                         </div>
                     </div>
-                </div>{# End grants-search #}
 
-                <grants-no-results
-                    :total-results="totalResults"
-                    :copy="copy"
-                    @clear-all="clearAll"
-                />
+                    <div class="grants-search__filters">
+                        {# Javascript component version of filters #}
+                        <grants-filters
+                            :facets="facets"
+                            :filters="filters"
+                            :status="status"
+                            :copy="copy"
+                            @clear-filters="clearFilters"
+                            :track-ui="trackUi"
+                            :handle-active-filter="handleActiveFilter"
+                        />
 
-                {% if meta.totalResults === 0 %}
-                    <div class="grants-no-results s-prose u-margin-bottom" v-if="totalResults === 0">
-                        <h3>{{ copy.errors.noResults.title }}</h3>
-                        <ul>
-                            {% for s in copy.errors.noResults.suggestions %}
-                                <li>{{ s | safe }}</li>
-                            {% endfor %}
-                        </ul>
-                        <p>{{ copy.errors.noResults.otherOptions | safe }}</p>
-                        <p>
-                            <a class="btn btn--medium"
-                              href="{{ localify('/funding/grants') }}">
-                                {{ copy.filters.clear }}
-                            </a>
-                        </p>
+                        {# Noscript fallback filters #}
+                        <fieldset class="search-filters">
+                            <div class="search-filters__header">
+                                <legend class="search-filters__title">{{ copy.filters.title }}</legend>
+                            </div>
+                            {# Filter: Amount awarded #}
+                            {% if facets.amountAwarded %}
+                                {% set options = (facets.amountAwarded.unshift({
+                                    'label': copy.filters.options.amountAwarded.any,
+                                    'value': ''
+                                }), facets.amountAwarded) %}
+                                <div class="facet-group">
+                                    {{ inputChoice({
+                                        type: 'radio',
+                                        name: 'amount',
+                                        label: copy.filters.options.amountAwarded.label,
+                                        value: queryParams.amount,
+                                        options: options,
+                                        silentlyOptional: true
+                                    }) }}
+                                </div>
+                            {% endif %}
+
+                            {# Filter: Country #}
+                            {% if facets.countries %}
+                                {% set options = (facets.countries.unshift({
+                                    'label': copy.filters.options.country.any,
+                                    'value': ''
+                                }), facets.countries) %}
+                                <div class="facet-group">
+                                    {{ inputChoice({
+                                        type: 'radio',
+                                        name: 'country',
+                                        label: copy.filters.options.country.label,
+                                        value: queryParams.country,
+                                        options: options,
+                                        silentlyOptional: true
+                                    }) }}
+                                </div>
+                            {% endif %}
+
+                            {# Filter: Grant programme #}
+                            {% if facets.grantProgramme %}
+                                {% set options = (facets.grantProgramme.unshift({
+                                    'label': copy.filters.options.programme.any,
+                                    'value': ''
+                                }), facets.grantProgramme) %}
+                                <div class="facet-group">
+                                    {{ inputSelect({
+                                        type: 'select',
+                                        name: 'programme',
+                                        label: copy.filters.options.programme.label,
+                                        value: queryParams.programme,
+                                        options: options,
+                                        silentlyOptional: true
+                                    }) }}
+                                </div>
+                            {% endif %}
+
+                            {# Filter: Local Authority #}
+                            {% if facets.localAuthorities %}
+                                {% set options = (facets.localAuthorities.unshift({
+                                    'label': copy.filters.options.localAuthority.any,
+                                    'value': ''
+                                }), facets.localAuthorities) %}
+                                <div class="facet-group">
+                                    {{ inputSelect({
+                                        type: 'select',
+                                        name: 'localAuthority',
+                                        label: copy.filters.options.localAuthority.label,
+                                        value: queryParams.localAuthority,
+                                        options: options,
+                                        silentlyOptional: true
+                                    }) }}
+                                </div>
+                            {% endif %}
+
+                            {# Filter: Constituency #}
+                            {% if facets.westminsterConstituencies %}
+                                {% set options = (facets.westminsterConstituencies.unshift({
+                                    'label': copy.filters.options.westminsterConstituency.any,
+                                    'value': ''
+                                }), facets.westminsterConstituencies) %}
+                                <div class="facet-group">
+                                    {{ inputSelect({
+                                        type: 'select',
+                                        name: 'westminsterConstituency',
+                                        label: copy.filters.options.westminsterConstituency.label,
+                                        value: queryParams.westminsterConstituency,
+                                        options: options,
+                                        silentlyOptional: true
+                                    }) }}
+                                </div>
+                            {% endif %}
+
+                            <noscript>
+                                <div class="search-filters__actions">
+                                    <input type="submit"
+                                            value="{{ copy.filters.submit }}"
+                                            class="btn btn--medium">
+                                </div>
+                            </noscript>
+                        </fieldset>
                     </div>
-                {% endif %}
-            </form>
-        </div>
+                </div>
+            </div>{# End grants-search #}
 
+            <grants-no-results
+                :total-results="totalResults"
+                :copy="copy"
+                @clear-all="clearAll"
+            />
+
+            {% if meta.totalResults === 0 %}
+                <div class="grants-no-results s-prose u-margin-bottom" v-if="totalResults === 0">
+                    <h3>{{ copy.errors.noResults.title }}</h3>
+                    <ul>
+                        {% for s in copy.errors.noResults.suggestions %}
+                            <li>{{ s | safe }}</li>
+                        {% endfor %}
+                    </ul>
+                    <p>{{ copy.errors.noResults.otherOptions | safe }}</p>
+                    <p>
+                        <a class="btn btn--medium"
+                            href="{{ localify('/funding/grants') }}">
+                            {{ copy.filters.clear }}
+                        </a>
+                    </p>
+                </div>
+            {% endif %}
+        </form>
         {% if caseStudies and caseStudies.length > 0 %}
             <section id="section-case-studies" class="u-padded">
                 <div class="u-inner">


### PR DESCRIPTION
Suggesting this change for a couple of reasons:

- Currently the list of grants can't be seen at all an a good subset of screen sizes, need to scroll down first
- Secondly, I'm not sure if having the hero image here implies that a specific organisation/grant can be used to represent everything we've ever funded.

One for discussion

Best viewed with [?w=1](https://github.com/biglotteryfund/blf-alpha/pull/1421/files?w=1)