### PR TITLE
Rework logic for over10k group

### DIFF
--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -16,8 +16,8 @@
             {{ breadcrumbTrail(breadcrumbs) }}
             <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
 
-            {% if isGroupedByRegion and programmes %}
-                {% for region, regionProgrammes in programmes %}
+            {% if groupedProgrammes %}
+                {% for region, regionProgrammes in groupedProgrammes %}
                     <h3>{{ region }}</h3>
                     {{ programmeList(regionProgrammes, accent = pageAccent) }}
                 {% endfor %}

--- a/views/static-pages/over10k.njk
+++ b/views/static-pages/over10k.njk
@@ -43,7 +43,7 @@
                 }, {
                     "id": "ukWide",
                     "label": copy.locations.ukWide,
-                    "url": localify('/funding/programmes/awards-from-the-uk-portfolio')
+                    "url": localify('/funding/programmes?min=10000&&location=ukWide')
                 }] %}
 
                 <div class="o-button-group-flex">


### PR DESCRIPTION
Noticed that the "My project will help people right across the UK" link goes to the UK-portfolio when really it should go to `/funding/programmes?location=ukWide` now that there is more than the UK-portfolio which is available UK-wide.

In doing so I noticed a bug with the recent location grouping code which doubles things up when viewing `ukWide`

<img width="367" alt="screen shot 2018-11-02 at 09 26 24" src="https://user-images.githubusercontent.com/123386/47907724-b0050080-de83-11e8-91ee-6c74a6c49d15.png">

Flattened the logic so that we filter by location + ukWide upfront and then only group if we're not UK wide.