### PR TITLE
Final past grants tweaks

### DIFF
--- a/assets/js/vue-apps/components/grants-no-results.vue
+++ b/assets/js/vue-apps/components/grants-no-results.vue
@@ -45,7 +45,7 @@ export default {
                 {{ copy.filters.clear }}
             </button>
             <span v-if="canGoBack">
-                or
+                {{ copy.or }}
                 <button type="button"
                         class="btn btn--medium"
                         @click="goBack">

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -50,6 +50,8 @@ function init() {
 
             return {
                 status: { state: states.NotAsked },
+                resultsWereFiltered: false,
+                resultsHtml: null,
                 activeQuery: initialQueryParams.q || null,
                 facets: facets,
                 sort: get(initialData, 'sort', {}),
@@ -214,6 +216,11 @@ function init() {
             updateResults(urlPath, queryString = null) {
                 this.status = { state: states.Loading };
 
+                // Hide server-rendered results
+                if (!this.resultsWereFiltered) {
+                    this.resultsWereFiltered = true;
+                }
+
                 if (window.history.pushState) {
                     window.history.pushState({ urlPath: urlPath }, '', urlPath);
                 }
@@ -224,9 +231,7 @@ function init() {
                     timeout: 20000
                 })
                     .then(response => {
-                        // @TODO vue-ize this
-                        $('#js-grant-results').html(response.resultsHtml);
-
+                        this.resultsHtml = response.resultsHtml;
                         this.totalResults = response.meta.totalResults;
                         this.totalAwarded = response.meta.totalAwarded;
                         this.facets = response.facets;

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -433,6 +433,7 @@ funding:
       resultsCount: o brosiectau gwerth
       totalCount: cyfanswm o
       goBackAStep: Ewch gam yn ôl
+      or: neu
       backToSearch: Yn ôl i’ch canlyniadau chwilio
       sort:
         orderedBy: Wedi'u trefnu fesul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -533,6 +533,7 @@ funding:
       resultsCount: projects found
       totalCount: totalling
       goBackAStep: Go back a step
+      or: or
       backToSearch: Back to your search results
       sort:
         orderedBy: Ordered by

--- a/controllers/grants/views/grant-results.njk
+++ b/controllers/grants/views/grant-results.njk
@@ -24,12 +24,12 @@
                 {% if grant.beneficiaryLocation and not options.hideLocation %}
                     <dt>{{ copy.grantDetail.fields.location }}</dt>
                     <dd>
-                        {{ buildLocationList(grant.beneficiaryLocation) }}
+                        {{ buildLocationList(grant.beneficiaryLocation, showLinks = false) }}
                     </dd>
                 {% endif %}
                 <dt>{{ copy.grantDetail.fields.programme }}</dt>
                 {% for programme in grant.grantProgramme %}
-                    <dd><a href="{{ pgLink('programme', programme.title) }}">{{ programme.title }}</a></dd>
+                    <dd>{{ programme.title }}</dd>
                 {% endfor %}
             </dl>
             {% if grant.isActive %}

--- a/controllers/grants/views/helpers.njk
+++ b/controllers/grants/views/helpers.njk
@@ -5,16 +5,20 @@
     {{ localify('/funding/grants?' + key + '=' + value) }}
 {% endmacro %}
 
-{% macro buildLocationList(locations) -%}
+{% macro buildLocationList(locations, showLinks = true) -%}
     {% for location in locations -%}
         {%- if location.geoCodeType === 'CMLAD' -%}
-            <a href="{{ pgLink('localAuthority', location.geoCode) }}">
+            {% if showLinks %}
+                <a href="{{ pgLink('localAuthority', location.geoCode) }}">
+            {% endif %}
                 {{ location.name -}}
-            </a>
+            {% if showLinks %}</a>{% endif %}
         {%- elseif location.geoCodeType === 'WPC' -%}
-            <a href="{{ pgLink('westminsterConstituency', location.geoCode) }}">
+            {% if showLinks %}
+                <a href="{{ pgLink('westminsterConstituency', location.geoCode) }}">
+            {% endif %}
                 {{ location.name -}}
-            </a>
+            {% if showLinks %}</a>{% endif %}
         {% else %}
             {{ location.name -}}
         {% endif %}

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -69,6 +69,7 @@
                             type="search"
                             id="search-query"
                             name="q"
+                            autocomplete="off"
                             v-model="activeQuery"
                         />
                         <input

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -151,8 +151,14 @@
                                 />
                             </div>
 
-                            <div id="js-grant-results"
-                                 v-show="['NotAsked', 'Success'].indexOf(status.state) !== -1">
+                            {# Placeholder for Vue-rendered HTML  #}
+                            <div v-show="['NotAsked', 'Success'].indexOf(status.state) !== -1"
+                                 v-if="resultsWereFiltered"
+                                 v-html="resultsHtml">
+                            </div>
+
+                            {# Placeholder for server-rendered HTML (later hidden) #}
+                            <div v-if="!resultsWereFiltered">
                                 {{ grantResultList(grants) }}
                             </div>
                         </div>


### PR DESCRIPTION
"Final" lol.

A few minor things:

- Prevents the risk of server-rendered HTML being shown to users post-filter due to race conditions mixing jQuery DOM manipulation with Vue.

- Follow @LynseyJReynolds's advice and remove some of the noisier/more confusing links from the grant results list (eg. location/programme)

- Some minor UI fixes (autocomplete, translation)