### PR TITLE
Fix disabled merch item

### DIFF
--- a/controllers/materials/views/materials.njk
+++ b/controllers/materials/views/materials.njk
@@ -103,9 +103,12 @@
 {% macro listProducts(languageToShow) %}
     <ul class="flex-grid flex-grid--3up">
         {% for material in materials %}
-            <li class="flex-grid__item">
-                {{ materialCard(material, languageToShow, loop.index) }}
-            </li>
+            {% set productCount = material.products | filter("language", languageToShow) | length %}
+            {% if productCount > 0 %}
+                <li class="flex-grid__item">
+                    {{ materialCard(material, languageToShow, loop.index) }}
+                </li>
+            {% endif %}
         {% endfor %}
     </ul>
 {% endmacro %}

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -12,7 +12,13 @@ router.use(
     noCache,
     noindex,
     buildSecurityMiddleware({
-        defaultSrc: ["'self'", 'maxcdn.bootstrapcdn.com', 'ajax.googleapis.com', 'cdnjs.cloudflare.com']
+        defaultSrc: [
+            "'self'",
+            'maxcdn.bootstrapcdn.com',
+            'ajax.googleapis.com',
+            'cdnjs.cloudflare.com',
+            'cdn.jsdelivr.net'
+        ]
     })
 );
 

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -4,6 +4,29 @@
 
 {% block extraHead %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
+    <script>
+        $(function() {
+            $('.js-datepicker-trigger')
+                .daterangepicker({
+                    minDate: new Date("{{ oldestOrderDate }}"),
+                    maxDate: new Date(),
+                })
+                .on('apply.daterangepicker', function(event, picker) {
+                    const s = picker.startDate.format('YYYY-MM-DD');
+                    const e = picker.endDate.format('YYYY-MM-DD');
+                    window.location = `?start=${s}&end=${e}`;
+                });
+        });
+    </script>
+    <style>
+        .datepicker {
+            font-size: 14px;
+            vertical-align: middle;
+        }
+    </style>
 {% endblock %}
 
 {% macro statBlock(number, caption) %}
@@ -16,147 +39,165 @@
 {% block content %}
     <h1 class="display-4 mb-4">
         All material orders
-        <small class="text-muted">in the last five months</small>
+        <small class="text-muted">
+            <br />
+            {% if dateRange %}
+                {{ formatDate(dateRange.start, DATE_FORMATS.short) }} &mdash;
+                {{ formatDate(dateRange.end, DATE_FORMATS.short) }}
+            {% else %}
+                in the last five months
+            {% endif %}
+            <a class="js-datepicker-trigger datepicker" href="javascript://">Change dates?</a>
+            {% if dateRange %}
+                <a class="datepicker" href="?">or Reset dates?</a>
+            {% endif %}
+        </small>
     </h1>
 
-    <div class="container mb-4">
-        <div class="row">
-            {{ statBlock(data.averageProductsPerOrder, 'average products <br />per order') }}
-            {{ statBlock(data.orders.length, 'total orders<br />from website') }}
-            {{ statBlock(data.averageItemQuantityPerOrder, 'average quantity of <br />items per order') }}
-            {{ statBlock(data.averageOrdersPerDay, 'average orders <br />per day') }}
-        </div>
-    </div>
+    {% if data.orders.length > 0 %}
 
-    <h2 class="mb-4">Most popular items <small class="text-muted">top 10 items</small></h2>
-    <table class="table table-striped mb-5">
-        <thead>
+        <div class="container mb-4">
+            <div class="row">
+                {{ statBlock(data.averageProductsPerOrder, 'average products <br />per order') }}
+                {{ statBlock(data.orders.length, 'total orders<br />from website') }}
+                {{ statBlock(data.averageItemQuantityPerOrder, 'average quantity of <br />items per order') }}
+                {{ statBlock(data.averageOrdersPerDay, 'average orders <br />per day') }}
+            </div>
+        </div>
+
+        <h2 class="mb-4">Most popular items <small class="text-muted">top 10 items</small></h2>
+        <table class="table table-striped mb-5">
+            <thead>
+                <tr>
+                    <th scope="col">Item code</th>
+                    <th scope="col">Item Name</th>
+                    <th scope="col">Number ordered</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in data.mostPopularItems %}
+                    <tr>
+                        <th scope="row">{{ item.code }}</th>
+                        <td>{{ getItemName(item.code) }}</td>
+                        <td>{{ item.count }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+
+        <h2 class="mb-4">Popular postcode areas <small class="text-muted">grouped by area</small></h2>
+        <div class="container mb-5">
+            <div class="row">
+                {% for n in range(0, 3) %}
+                    {{ statBlock(data.ordersByPostcodes[n].code, data.ordersByPostcodes[n].count+ ' orders') }}
+                {% endfor %}
+            </div>
+        </div>
+
+        <h2 class="mb-4">Order reasons <small class="text-muted">including "other" options</small></h2>
+        <table class="table table-striped mb-5">
+            <thead>
             <tr>
-                <th scope="col">Item code</th>
-                <th scope="col">Item Name</th>
-                <th scope="col">Number ordered</th>
+                <th scope="col">Reason</th>
+                <th scope="col">Count</th>
             </tr>
-        </thead>
-        <tbody>
-            {% for item in data.mostPopularItems %}
+            </thead>
+            <tbody>
+            {% for item in data.orderReasons %}
                 <tr>
                     <th scope="row">{{ item.code }}</th>
-                    <td>{{ getItemName(item.code) }}</td>
                     <td>{{ item.count }}</td>
                 </tr>
             {% endfor %}
-        </tbody>
-    </table>
+            </tbody>
+        </table>
 
-    <h2 class="mb-4">Popular postcode areas <small class="text-muted">grouped by area</small></h2>
-    <div class="container mb-5">
-        <div class="row">
-            {% for n in range(0, 3) %}
-                {{ statBlock(data.ordersByPostcodes[n].code, data.ordersByPostcodes[n].count+ ' orders') }}
-            {% endfor %}
+        <h2 class="mb-4">Orders by date</h2>
+        <div style="height: 450px" class="border mb-4">
+            <canvas id="js-chart" width="400" height="400"></canvas>
         </div>
-    </div>
 
-    <h2 class="mb-4">Order reasons <small class="text-muted">including "other" options</small></h2>
-    <table class="table table-striped mb-5">
-        <thead>
-        <tr>
-            <th scope="col">Reason</th>
-            <th scope="col">Count</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for item in data.orderReasons %}
+        <h2 class="mb-4">Grant amounts <small class="text-muted">including "other" options</small></h2>
+        <table class="table table-striped mb-5">
+            <thead>
             <tr>
-                <th scope="row">{{ item.code }}</th>
-                <td>{{ item.count }}</td>
+                <th scope="col">Grant size</th>
+                <th scope="col">Count</th>
             </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-
-    <h2 class="mb-4">Orders by date</h2>
-    <div style="height: 450px" class="border mb-4">
-        <canvas id="js-chart" width="400" height="400"></canvas>
-    </div>
-
-    <h2 class="mb-4">Grant amounts <small class="text-muted">including "other" options</small></h2>
-    <table class="table table-striped mb-5">
-        <thead>
-        <tr>
-            <th scope="col">Grant size</th>
-            <th scope="col">Count</th>
-        </tr>
-        </thead>
-        <tbody>
-        {% for item in data.grantAmounts %}
-            <tr>
-                <th scope="row">{{ item.code }}</th>
-                <td>{{ item.count }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+            {% for item in data.grantAmounts %}
+                <tr>
+                    <th scope="row">{{ item.code }}</th>
+                    <td>{{ item.count }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
 
 
 
-    <script>
-        var ctx = document.getElementById('js-chart');
+        <script>
+            var ctx = document.getElementById('js-chart');
 
-        var config = {
-            type: 'line',
-            data: {
-                datasets: [
-                    {
-                        label: 'Number of orders',
-                        backgroundColor: '#2a7f53',
-                        borderColor: '#41c27f',
-                        fill: false,
-                        data: {{ data.ordersByDay | dump | safe }},
-                    }
-                ]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                title: {
-                    display: false,
-                    text: "Orders over time"
+            var config = {
+                type: 'line',
+                data: {
+                    datasets: [
+                        {
+                            label: 'Number of orders',
+                            backgroundColor: '#2a7f53',
+                            borderColor: '#41c27f',
+                            fill: false,
+                            data: {{ data.ordersByDay | dump | safe }},
+                        }
+                    ]
                 },
-                scales: {
-                    xAxes: [{
-                        type: "time",
-                        display: true,
-                        scaleLabel: {
-                            display: false,
-                            labelString: 'Date'
-                        },
-                        ticks: {
-                            major: {
-                                fontStyle: "bold",
-                                fontColor: "#FF0000"
-                            }
-                        },
-                        time: {
-                            round: 'day',
-                            unit: 'day'
-                        }
-                    }],
-                    yAxes: [{
-                        display: true,
-                        scaleLabel: {
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    title: {
+                        display: false,
+                        text: "Orders over time"
+                    },
+                    scales: {
+                        xAxes: [{
+                            type: "time",
                             display: true,
-                            labelString: 'Number of orders'
-                        },
-                        ticks: {
-                            beginAtZero: true,
-                            stepSize: 1
-                        }
-                    }]
+                            scaleLabel: {
+                                display: false,
+                                labelString: 'Date'
+                            },
+                            ticks: {
+                                major: {
+                                    fontStyle: "bold",
+                                    fontColor: "#FF0000"
+                                }
+                            },
+                            time: {
+                                round: 'day',
+                                unit: 'day'
+                            }
+                        }],
+                        yAxes: [{
+                            display: true,
+                            scaleLabel: {
+                                display: true,
+                                labelString: 'Number of orders'
+                            },
+                            ticks: {
+                                beginAtZero: true,
+                                stepSize: 1
+                            }
+                        }]
+                    }
                 }
-            }
-        };
+            };
 
-        var myChart = new Chart(ctx, config);
-    </script>
+            var myChart = new Chart(ctx, config);
+        </script>
+
+    {% else %}
+        <div class="alert alert-warning" role="alert">No orders found for this date range.</div>
+    {% endif %}
 {% endblock %}

--- a/services/orders.js
+++ b/services/orders.js
@@ -5,9 +5,20 @@ const { Order, OrderItem } = require('../models');
 const { take, countBy, meanBy, sortBy, flatMap, map, reverse } = require('lodash');
 const { filter } = require('lodash/fp');
 
-function getAllOrders() {
+function getAllOrders(dateRange = {}) {
+    let whereClause = {};
+
+    if (dateRange.start && dateRange.end) {
+        whereClause = {
+            createdAt: {
+                [Op.between]: [dateRange.start, dateRange.end]
+            }
+        };
+    }
+
     return Order.findAll({
         order: [['updatedAt', 'DESC']],
+        where: whereClause,
         include: [
             {
                 model: OrderItem,
@@ -84,6 +95,12 @@ function getAllOrders() {
     });
 }
 
+function getOldestOrder() {
+    return Order.findOne({
+        order: [['createdAt', 'ASC']]
+    });
+}
+
 function storeOrder({ grantAmount, orderReason, postcodeArea, items }) {
     cleanupOldOrders();
     return Order.create(
@@ -119,5 +136,6 @@ function cleanupOldOrders() {
 
 module.exports = {
     storeOrder,
-    getAllOrders
+    getAllOrders,
+    getOldestOrder
 };


### PR DESCRIPTION
Had a weird thing where if we disabled a single product within a merch item (eg. a bilingual banner), the frontend still tried to render it, resulting in a broken image:

![image](https://user-images.githubusercontent.com/394376/48272889-95a8c500-e437-11e8-9f73-b827e13b0af4.png)

This fix prevents these items from rendering, so we can disable things on a per-product basis (rather than removing the entire merch item).