### PR TITLE
Re-order updates controller

### DIFF
--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -1,81 +1,66 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const { concat, isArray, pick, get, head } = require('lodash');
+const { concat, compact, isArray, pick, get, head } = require('lodash');
+
+const { buildPagination } = require('../../modules/pagination');
+const { injectBreadcrumbs, injectCopy } = require('../../middleware/inject-content');
+const appData = require('../../modules/appData');
+const contentApi = require('../../services/content-api');
 
 const router = express.Router();
 
-const { injectBreadcrumbs, injectCopy } = require('../../middleware/inject-content');
-const { getUpdates } = require('../../services/content-api');
-const appData = require('../../modules/appData');
-const { buildPagination } = require('../../modules/pagination');
-
-function renderListing({
-    res,
-    title,
-    entries = [],
-    entriesMeta = null,
-    breadcrumbs = [],
-    isNewsLandingPage = false,
-    copy
-}) {
-    const pagination = buildPagination(entriesMeta.pagination);
-    const template = isNewsLandingPage ? 'landing' : 'listing';
-    res.render(path.resolve(__dirname, `./views/${template}`), {
-        title,
-        entries,
-        entriesMeta,
-        pagination,
-        breadcrumbs,
-        isNewsLandingPage,
-        copy
-    });
-}
-
-function translateEntryTypeName(entry, copy) {
-    const typeTranslation = get(copy.types, entry.updateType.slug);
-    if (typeTranslation) {
-        entry.updateType.name = typeTranslation;
-    }
-    return entry;
+function translateEntryFor(copy) {
+    return function(entry) {
+        const typeTranslation = get(copy.types, entry.updateType.slug);
+        if (typeTranslation) {
+            entry.updateType.name = typeTranslation;
+        }
+        return entry;
+    };
 }
 
 if (appData.isNotProduction) {
     router.get('/:type?/:date?/:slug?', injectBreadcrumbs, injectCopy('toplevel.news'), async (req, res, next) => {
-        let urlPath = req.params.type ? `/${req.params.type}` : '';
-        const isSinglePost = req.params.date && req.params.slug;
-
-        if (isSinglePost) {
-            // eg. fetch a specific entry
-            urlPath += `/${req.params.date}/${req.params.slug}`;
-        }
-
-        // Listings (but not single posts) can be filtered by the following valid query parameters:
-        let query = !isSinglePost ? pick(req.query, ['page', 'tag', 'author', 'category']) : {};
-
         try {
-            const response = await getUpdates({
+            const urlParts = compact([req.params.type, req.params.date, req.params.slug]);
+
+            const response = await contentApi.getUpdates({
                 locale: req.i18n.getLocale(),
-                urlPath: urlPath,
-                query: query
+                urlPath: `/${urlParts.join('/')}`,
+                // Listings (but not single posts) can be filtered by the following valid query parameters:
+                query: urlParts.length === 3 ? {} : pick(req.query, ['page', 'tag', 'author', 'category'])
             });
 
-            if (response.result) {
-                // Do we have a listing page?
-                if (isArray(response.result)) {
-                    // Map and translate the entry type names into plurals
-                    response.result = response.result.map(entry => translateEntryTypeName(entry, res.locals.copy));
+            if (!response.result) {
+                next();
+            }
 
-                    // Is this a specific listing page (eg. blog, press releases) or everything?
+            const entryWithTranslation = translateEntryFor(res.locals.copy);
+
+            if (isArray(response.result)) {
+                // Map and translate the entry type names into plurals
+                const entries = response.result.map(entryWithTranslation);
+
+                const entriesMeta = response.meta;
+                const pagination = buildPagination(entriesMeta.pagination);
+
+                if (urlParts.length === 0) {
+                    /**
+                     * Render landing page
+                     */
+                    const pageTitle = 'All news'; // @TODO: i18n
+                    res.render(path.resolve(__dirname, `./views/landing`), {
+                        title: pageTitle,
+                        entries: entries,
+                        entriesMeta: entriesMeta,
+                        pagination: pagination,
+                        breadcrumbs: concat(res.locals.breadcrumbs, {
+                            label: pageTitle
+                        })
+                    });
+                } else {
                     const filterType = get(response, 'meta.pageType');
-                    const isNewsLandingPage = !req.params.type && filterType === 'single';
-
-                    // @TODO i18n
-                    let defaultPageTitle = 'All news';
-                    if (!isNewsLandingPage) {
-                        const firstItem = head(response.result);
-                        defaultPageTitle = get(firstItem.updateType.name, 'plural', firstItem.updateType.name);
-                    }
 
                     const filterLabel = {
                         author: get(response, 'meta.activeAuthor'),
@@ -84,53 +69,59 @@ if (appData.isNotProduction) {
                     }[filterType];
 
                     // @TODO i18n
-                    const pageTitle = filterLabel
-                        ? {
-                              author: `Author: ${filterLabel.title}`,
-                              tag: `Tag: ${filterLabel.title}`,
-                              category: `Category: ${filterLabel.title}`
-                          }[filterType]
-                        : defaultPageTitle;
+                    const titleMap = {
+                        author: function() {
+                            return `Author: ${filterLabel.title}`;
+                        },
+                        tag: function() {
+                            return `Tag: ${filterLabel.title}`;
+                        },
+                        category: function() {
+                            return `Category: ${filterLabel.title}`;
+                        },
+                        default: function() {
+                            const firstItem = head(entries);
+                            return get(firstItem.updateType.name, 'plural', firstItem.updateType.name);
+                        }
+                    };
 
-                    const breadcrumbs = concat(res.locals.breadcrumbs, {
-                        label: filterLabel ? filterLabel.title : pageTitle
-                    });
+                    const pageTitle = (titleMap[filterType] || titleMap['default'])();
 
-                    return renderListing({
-                        res,
+                    /**
+                     * Render listing page
+                     */
+                    res.render(path.resolve(__dirname, `./views/listing`), {
                         title: pageTitle,
-                        entries: response.result,
-                        entriesMeta: response.meta,
-                        breadcrumbs: breadcrumbs,
-                        isNewsLandingPage: isNewsLandingPage,
-                        copy: res.locals.copy
+                        entries: entries,
+                        entriesMeta: entriesMeta,
+                        pagination: pagination,
+                        breadcrumbs: concat(res.locals.breadcrumbs, {
+                            label: filterLabel ? filterLabel.title : pageTitle
+                        })
                     });
-                } else {
-                    // Single entry page
-                    if (req.baseUrl + req.path !== response.result.linkUrl) {
-                        // Prevent URL tampering with dates, since we don't validate them on the API end
-                        res.redirect(response.result.linkUrl);
-                    } else {
-                        const entry = translateEntryTypeName(response.result, res.locals.copy);
-                        return res.render(path.resolve(__dirname, './views/post'), {
-                            title: entry.title,
-                            entry: entry,
-                            copy: res.locals.copy,
-                            breadcrumbs: concat(
-                                res.locals.breadcrumbs,
-                                {
-                                    label: get(entry.updateType.name, 'singular', entry.updateType.name),
-                                    url: res.locals.localify(`${req.baseUrl}/${req.params.type}`)
-                                },
-                                {
-                                    label: entry.title
-                                }
-                            )
-                        });
-                    }
                 }
             } else {
-                next();
+                // Prevent URL tampering with dates, since we don't validate them on the API end
+                if (req.baseUrl + req.path !== response.result.linkUrl) {
+                    res.redirect(response.result.linkUrl);
+                } else {
+                    const entry = entryWithTranslation(response.result);
+                    const title = entry.title;
+
+                    const breadcrumbs = concat(
+                        res.locals.breadcrumbs,
+                        {
+                            label: get(entry.updateType.name, 'plural', entry.updateType.name),
+                            url: res.locals.localify(`${req.baseUrl}/${req.params.type}`)
+                        },
+                        { label: title }
+                    );
+
+                    /**
+                     * Render single entry page
+                     */
+                    return res.render(path.resolve(__dirname, './views/post'), { title, entry, breadcrumbs });
+                }
             }
         } catch (e) {
             next(e);

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -43,9 +43,10 @@ if (appData.isNotProduction) {
                 const entries = response.result.map(entryWithTranslation);
 
                 const entriesMeta = response.meta;
+                const filterType = get(entriesMeta, 'pageType');
                 const pagination = buildPagination(entriesMeta.pagination);
 
-                if (urlParts.length === 0) {
+                if (filterType === 'single' && !req.params.type) {
                     /**
                      * Render landing page
                      */
@@ -60,8 +61,6 @@ if (appData.isNotProduction) {
                         })
                     });
                 } else {
-                    const filterType = get(response, 'meta.pageType');
-
                     const filterLabel = {
                         author: get(response, 'meta.activeAuthor'),
                         tag: get(response, 'meta.activeTag'),

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -980,6 +980,74 @@ Object {
           },
           "QueryString": true,
           "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "page",
+              "tag",
+              "author",
+              "category",
+            ],
+            "Quantity": 8,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/news/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
             "Items": Array [],
             "Quantity": 0,
           },
@@ -1425,6 +1493,74 @@ Object {
           },
           "QueryString": true,
           "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "page",
+              "tag",
+              "author",
+              "category",
+            ],
+            "Quantity": 8,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/news/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "blf-alpha-session",
+              ],
+              "Quantity": 3,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
             "Items": Array [],
             "Quantity": 0,
           },
@@ -1446,7 +1582,7 @@ Object {
         "ViewerProtocolPolicy": "redirect-to-https",
       },
     ],
-    "Quantity": 24,
+    "Quantity": 26,
   },
   "DefaultCacheBehavior": Object {
     "AllowedMethods": Object {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -13,10 +13,11 @@ const CLOUDFRONT_PATHS = [
     { path: '*~/link.aspx', isPostable: true, allowAllQueryStrings: true },
     { path: '/api/*', isPostable: true, allowAllQueryStrings: true },
     { path: '/funding/funding-finder', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
-    { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
     { path: '/funding/grants', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
     { path: '/funding/grants/*', allowAllQueryStrings: true, isBilingual: true },
     { path: '/funding/grants/recipients/*', allowAllQueryStrings: true, isBilingual: true },
+    { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
+    { path: '/news/*', queryStrings: ['page', 'tag', 'author', 'category'], isBilingual: true },
     { path: '/search', allowAllQueryStrings: true, isBilingual: true },
     { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }
 ];


### PR DESCRIPTION
Apologies if this looks a little like I'm 🚂 steam-rollering all this. 

After looking at the code a little more I realised some of the conditionals previously handled more than one path and there were a few dead end variables that were being passed around even if that template didn't need it. What this PR does is move around the existing logic to _hopefully_ separate out the logic needed for each type of template more.

💭welcome as to if this is clearer or not.