### PR TITLE
IE bugfix

### DIFF
--- a/assets/js/bootstraps/raven.js
+++ b/assets/js/bootstraps/raven.js
@@ -2,6 +2,7 @@ import Raven from 'raven-js';
 
 function init() {
     Raven.config('https://53aa5923a25c43cd9a645d9207ae5b6c@sentry.io/226416', {
+        environment: window.AppConfig.environment,
         autoBreadcrumbs: {
             xhr: false,
             // https://github.com/getsentry/raven-js/issues/879

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -184,15 +184,16 @@ function init(STORAGE_KEY) {
             },
 
             storeSearchPath(filters) {
-                if (Object.keys(filters).length === 0) {
-                    return canStore && window.localStorage.removeItem(STORAGE_KEY);
+                if (filters.length > 0) {
+                    setWithExpiry({
+                        type: 'localStorage',
+                        key: STORAGE_KEY,
+                        data: filters,
+                        expiryInMinutes: 60
+                    });
+                } else {
+                    canStore && window.localStorage.removeItem(STORAGE_KEY);
                 }
-                return setWithExpiry({
-                    type: 'localStorage',
-                    key: STORAGE_KEY,
-                    data: filters,
-                    expiryInMinutes: 60
-                });
             },
 
             filterResults() {


### PR DESCRIPTION
`storeSearchPath` gets called with a string via `this.storeSearchPath(newQueryString)` but we were calling `Object.keys` on it it instead. Chrome "allows" this and turns `q=example` into `[0, 1, 2, …]` for whatever the length of the string is so the check passes. IE, quite rightly, throws an error.

I was wondering why this wasn't turning up in Sentry as we should be alerted to this. Turns out it was but our client-side config doesn't include an environment and we default to and alert on `production` errors only. So adding in the environment here too to make sure we see these events in future.