### PR TITLE
Show all programmes

### DIFF
--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -3,6 +3,8 @@ const path = require('path');
 const { concat, map, groupBy } = require('lodash');
 const express = require('express');
 
+const { buildPagination } = require('../../modules/pagination');
+
 const {
     injectBreadcrumbs,
     injectCopy,
@@ -34,7 +36,8 @@ router.get(
     injectCopy('funding.programmes'),
     injectFundingProgrammes,
     (req, res) => {
-        const allFundingProgrammes = res.locals.fundingProgrammes || [];
+        const allFundingProgrammes = res.locals.fundingProgrammes.result || [];
+        const pagination = buildPagination(res.locals.fundingProgrammes.meta.pagination);
 
         const locationParam = getValidLocation(allFundingProgrammes, req.query.location);
 
@@ -87,6 +90,7 @@ router.get(
 
         res.render(path.resolve(__dirname, './views/programmes-list'), {
             programmes,
+            pagination,
             groupedProgrammes,
             activeBreadcrumbsSummary
         });

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -37,7 +37,7 @@ router.get(
     injectFundingProgrammes,
     (req, res) => {
         const allFundingProgrammes = res.locals.fundingProgrammes.result || [];
-        const pagination = buildPagination(res.locals.fundingProgrammes.meta.pagination);
+        const pagination = buildPagination(res.locals.fundingProgrammes.meta.pagination, req.query);
 
         const locationParam = getValidLocation(allFundingProgrammes, req.query.location);
 
@@ -128,7 +128,7 @@ router.use('/digital-fund', require('../digital-fund'));
  */
 router.get('/:slug', injectFundingProgramme, (req, res, next) => {
     const { fundingProgramme } = res.locals;
-    if (fundingProgramme && fundingProgramme.contentSections.length > 0) {
+    if (fundingProgramme) {
         res.render(path.resolve(__dirname, './views/programme'), {
             entry: fundingProgramme,
             breadcrumbs: concat(res.locals.breadcrumbs, [{ label: res.locals.title }])

--- a/controllers/programmes/views/programme.njk
+++ b/controllers/programmes/views/programme.njk
@@ -47,12 +47,19 @@
                     {%- endfor %}
 
                     {{ contentTabs(tabItems) }}
-                {% else %}
+                {% elseif entry.contentSections.length === 1 %}
                     {% set section = entry.contentSections[0] %}
                     <div class="content-box content-box--borderless">
                         <div class="s-prose u-constrained-content-wide accent-content--{{ pageAccent }}">
                             <h2 class="t2 t--underline accent--{{ pageAccent }} a--text">{{ section.title }}</h2>
                             {{ section.body | safe }}
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="content-box content-box--borderless">
+                        <div class="s-prose u-constrained-content-wide accent-content--{{ pageAccent }}">
+                            <h2 class="t2 t--underline accent--{{ pageAccent }} a--text">Archived programme</h2>
+                            <p>This programme is no longer available. </p>
                         </div>
                     </div>
                 {% endif %}

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -1,6 +1,7 @@
 {% from "components/hero.njk" import hero with context %}
 {% from "components/programmes.njk" import programmeList with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/split-nav/macro.njk" import splitNav %}
 
 {% extends "layouts/main.njk" %}
 
@@ -23,6 +24,18 @@
                 {% endfor %}
             {% elseif programmes.length > 0 %}
                 {{ programmeList(programmes, accent = pageAccent) }}
+
+                {{ splitNav(
+                    prevLink = {
+                        "label": "Previous page",
+                        "url": pagination.prevLink
+                    },
+                    nextLink = {
+                        "label": "Next page",
+                        "url": pagination.nextLink
+                    }
+                ) }}
+
             {% else %}
                 {# @TODO i18n #}
                 <p>No results</p>

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -190,7 +190,10 @@ async function injectFundingProgramme(req, res, next) {
 async function injectFundingProgrammes(req, res, next) {
     try {
         res.locals.fundingProgrammes = await contentApi.getFundingProgrammes({
-            locale: req.i18n.getLocale()
+            locale: req.i18n.getLocale(),
+            showAll: req.query.all,
+            page: req.query.page || 1,
+            pageLimit: req.query.all ? 10 : 100
         });
         next();
     } catch (error) {

--- a/modules/pagination.js
+++ b/modules/pagination.js
@@ -1,15 +1,21 @@
 'use strict';
+const querystring = require('querystring');
 
 /**
  * Build pagination
  * Translate content API pagination into an object for use in views
  */
-function buildPagination(paginationMeta) {
+function buildPagination(paginationMeta, additionalParams = {}) {
     if (paginationMeta && paginationMeta.total_pages > 1) {
         const currentPage = paginationMeta.current_page;
         const totalPages = paginationMeta.total_pages;
-        const prevLink = `?page=${currentPage - 1}`;
-        const nextLink = `?page=${currentPage + 1}`;
+
+        let prevLink =
+            currentPage > 1 ? '?' + querystring.stringify({ ...additionalParams, ...{ page: currentPage - 1 } }) : null;
+        let nextLink =
+            currentPage < totalPages
+                ? '?' + querystring.stringify({ ...additionalParams, ...{ page: currentPage + 1 } })
+                : null;
 
         return {
             count: paginationMeta.count,


### PR DESCRIPTION
This is more of a proof-of-concept until we actually have legacy programmes in the database to show. Pairs with https://github.com/biglotteryfund/craft-dev/pull/109.

It allows passing `?all=true` plus pagination parameters to the API for programmes, which means we can build a list of all current/past funding programmes. The template tweaks mean we can show a generic expiry message for these (and show them different on the listing page if we like).

![image](https://user-images.githubusercontent.com/394376/48771716-f8148780-ecb9-11e8-9efe-3db4ad1fb4e7.png)

Needs some thought on how we'd present these expired programmes but gives us the building blocks to do it.
