### PR TITLE
Add word wrap helper

### DIFF
--- a/assets/sass/_mixins.scss
+++ b/assets/sass/_mixins.scss
@@ -93,3 +93,17 @@
     margin-left: -50vw;
     margin-right: -50vw;
 }
+
+// https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/
+@mixin wrap-words() {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+
+    /* This is the dangerous one in WebKit, as it breaks things wherever */
+    word-break: break-all;
+    /* Instead use this non-standard one: */
+    word-break: break-word;
+
+    /* Adds a hyphen where the word breaks, if supported (No Blink) */
+    hyphens: auto;
+}

--- a/assets/sass/components/_cards.scss
+++ b/assets/sass/components/_cards.scss
@@ -133,6 +133,10 @@
         color: palette('charcoal-note');
         margin-bottom: 0.5em;
     }
+
+    .promo-card__trail-text {
+        @include wrap-words();
+    }
 }
 
 .promo-card--featured {

--- a/assets/sass/utilities/_utilities-text.scss
+++ b/assets/sass/utilities/_utilities-text.scss
@@ -26,6 +26,10 @@
     text-decoration: none;
 }
 
+.u-wrap-words {
+    @include wrap-words();
+}
+
 .u-prefix {
     font-size: 16px;
     font-style: italic;

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -22,7 +22,7 @@
 
                         {% if grant.description !== grant.title %}
                             <h2 class="t3 t--underline accent--pink">{{ copy.grantDetail.projectOverview }}</h2>
-                            <p>{{ grant.description }}</p>
+                            <p class="u-wrap-words">{{ grant.description }}</p>
                         {% endif %}
 
                         <grants-back-to-search


### PR DESCRIPTION
Some grant results have some unusual space characters in the source data. It's probably worth trying to normalise this at the source end, but in the meantime this set of CSS properties helps.

Before:

![image](https://user-images.githubusercontent.com/123386/48841221-bd2d5500-ed88-11e8-970d-ebbf32d31b38.png)

After:

![image](https://user-images.githubusercontent.com/123386/48841235-c6b6bd00-ed88-11e8-88dd-843a527ed188.png)
