### PR TITLE
Remove default flex styles from wildcard

### DIFF
--- a/assets/sass/scaffolding/_grid.scss
+++ b/assets/sass/scaffolding/_grid.scss
@@ -28,9 +28,6 @@ $flexGridSpacing: $spacingUnit;
             flex: 0 0 50%;
 
             > * {
-                display: flex;
-                flex-direction: column;
-                flex: 1 1 auto;
                 height: 100%;
                 margin-left: $flexGridSpacing;
             }


### PR DESCRIPTION
Turns out the change to our flex grid styles in https://github.com/biglotteryfund/blf-alpha/pull/1455 was overzealous and adding default flex styles causes a couple of layout bugs on some detail pages (notably strategic programmes). 

Realised that the original change was a bit whack-a-mole and the change that actually fixed the original collapsing layout bug was the removal of the default `display: flex` on `flex__item` https://github.com/biglotteryfund/blf-alpha/pull/1455/files#diff-bde1fa37382f6129d0bb10c21900284bL28

Tested this again more and removing these extra styles fixes the current bug without regressing the original one. One day I'll be able to write flexbox successfully in the first try.