### PR TITLE
Add SRI integrity checks to third party (versioned) modules

### DIFF
--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -18,13 +18,7 @@ router.use(
     noCache,
     noindex,
     buildSecurityMiddleware({
-        defaultSrc: [
-            "'self'",
-            'maxcdn.bootstrapcdn.com',
-            'ajax.googleapis.com',
-            'cdnjs.cloudflare.com',
-            'cdn.jsdelivr.net'
-        ]
+        defaultSrc: ["'self'", 'maxcdn.bootstrapcdn.com', 'ajax.googleapis.com', 'cdnjs.cloudflare.com']
     })
 );
 

--- a/controllers/tools/views/layout.njk
+++ b/controllers/tools/views/layout.njk
@@ -4,7 +4,8 @@
         <title>{% block title %}{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
+
         {% block extraHead %}{% endblock %}
     </head>
     <body>

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -4,9 +4,9 @@
 
 {% block extraHead %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js" integrity="sha256-CutOzxCRucUsn6C6TcEYsauvvYilEniTXldPa6/wu0k=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.js" integrity="sha256-cpdGuiwvKhwkQY18xx0CNJBb9AhGOYKsAz6ea7LaB30=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.css" integrity="sha256-DnG3ryf8FsLvOmNjwO9S4+Fpju6QECDbhLbWCtpn7Bc=" crossorigin="anonymous" />
     <script>
         $(function() {
             $('.js-datepicker-trigger')


### PR DESCRIPTION
Just read [this](https://shkspr.mobi/blog/2018/11/major-sites-running-unauthenticated-javascript-on-their-payment-pages/) and realised we had a few things we could fix this for.

The remaining stuff where we can't add these parameters are:

- `https://www.google-analytics.com/cx/api.js` – presumably safe, since it's Google
- `https://www.google-analytics.com/analytics.js` – ditto
- `https://platform.twitter.com/widgets.js` – possibly going soon
- `https://cdn.polyfill.io<snip>` – impossible to SRI...