### PR TITLE
Close digital fund

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -31,6 +31,7 @@
     }
   },
   "features": {
+    "enableDigitalFundApplications": true,
     "enablePrompt": false,
     "enableSurvey": true,
     "enableAbTests": true,

--- a/config/development.json
+++ b/config/development.json
@@ -1,5 +1,6 @@
 {
   "features": {
+    "enableDigitalFundApplications": false,
     "useRemoteAssets": false
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -707,6 +707,7 @@ funding:
     title: Y Gronfa Ddigidol
     intro: Mae'r Gronfa Ddigidol yn rhaglen ariannu £15 miliwn newydd i gefnogi elusennau a mudiadau cymunedol. Mae'n ymwneud â helpu'r sector elusennol a gwirfoddol i ddefnyddio offer a dulliau digidol i gefnogi pobl a chymunedau i ffynnu.
     openingDates: Gallwch gyflwyno ceisiadau amlinellol rhwng 22 Hydref 2018 a 5PM ar 3 Rhagfyr 2018. Bydd cyfleoedd pellach i ymgeisio yn 2019.
+    openingDatesClosed: Daeth rownd gyntaf y Gronfa Ddigidol i ben ar 3 Rhagfyr 2018 am 5pm. Bydd cyfleoedd pellach i ymgeisio yn 2019.
     aboutStrandLabel: Mwy o wybodaeth am yr edefyn hwn
     strand1:
       title: Rydym eisiau defnyddio digidol i newid ein gwaith
@@ -721,8 +722,9 @@ funding:
     getStarted:
       title: Cychwyn arni
       intro: "Mae'r Gronfa Ddigidol yn cynnig dau edefyn ariannu ar hyn o bryd. I ddod o hyd i'r math iawn o gefnogaeth ar gyfer eich mudiad chi, dewiswch un o'r opsiynau a ganlyn:"
+      introClosed: "Ar hyn o bryd mae’r Gronfa Ddigidol yn cefnogi dau edefyn ariannu."
       assistance:
-        title: "Ddim yn siŵr bod hwn yn addas i chi?"
+        title: "Mwy o gyfleoedd ariannu"
         body: >
           <p>Os nad yw'r naill na'r llall o'r edafedd ariannu'n gweithio i'ch prosiect neu syniad, mae hynny'n iawn.
             <a href="/welsh/funding/programmes">Mae rhaglenni ariannu eraill sy'n agored i geisiadau</a>.</p>
@@ -733,7 +735,14 @@ funding:
       introduction: Nid ydym eisiau i chi dreulio llawer o amser yn paratoi i gael sgwrs gychwynnol gyda ni. Hoffem siarad a chi am eich syniad cyn i chi ddechrau datblygu cais manwl am grant.
       steps:
       - title: Cyflwynwch fraslun o’ch syniad trwy’r dudalen hon—sy’n mynd yn fyw ar 22 Hydref
-        description: O 22 Hydref byddwch yn gallu defnyddio’r dudalen we hon i yrru braslun o’ch syniad atom
+        description: Gyrrwch fraslun byr o’ch syniad ar-lein
+      - title: "Siarad â ni"
+        description: Os yw’n ymddangos bod eich syniad yn cyfateb i feini prawf y Gronfa Ddigidol, byddwn yn trefnu galwad gyda chi
+      - title: Cyflwyno cais llawn
+        description: Os ydym yn teimlo y gallai'r Gronfa Ddigidol weithio i chi, byddwn yn gofyn i chi  gyflwyno cais llawn
+      stepsClosed:
+      - title: Cyflwynwch fraslun o’ch syniad—daeth i ben ar 3 Rhagfyr am 5pm 
+        description: Gyrrwch fraslun byr o’ch syniad ar-lein
       - title: "Siarad â ni"
         description: Os yw’n ymddangos bod eich syniad yn cyfateb i feini prawf y Gronfa Ddigidol, byddwn yn trefnu galwad gyda chi
       - title: Cyflwyno cais llawn
@@ -753,7 +762,7 @@ funding:
         <strong>Cyfnewid testun</strong>: 18001 plws 0300 123 0735 (ar gyfer pobl sydd â nam ar y clyw neu'r lleferydd)<br/>
         <strong>E-bost</strong>: <a href="mailto:cymru@cronfaloterifawr.org.uk">cymru@cronfaloterifawr.org.uk</a></p>
     wayfinding:
-      title: Ddim yn siŵr bod hwn yn addas i chi?
+      title: Mwy o gyfleoedd ariannu
       description: Dewiswch un o'r opsiynau a ganlyn yn lle.
       assistance: Rydym eisiau cymorth i gychwyn arni gyda digidol
       strand1: Rydym eisiau defnyddio digidol i newid ein gwaith

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -809,6 +809,7 @@ funding:
     title: Digital Fund
     intro: The Digital Fund is a new UK wide £15 million funding programme to support charities and community organisations. It is about helping the charity and voluntary sector to use digital tools and approaches to support people and communities to thrive.
     openingDates: You can submit outline proposals from 22nd October 2018 until 5pm 3rd December 2018. There will be further opportunities to apply in 2019.
+    openingDatesClosed: The first round of Digital Funding closed on 3rd December 2018 at 5pm. There will be further opportunities to apply in 2019.
     aboutStrandLabel: Find out more about this strand
     strand1:
       title: We want to use digital to change our work
@@ -823,11 +824,10 @@ funding:
     getStarted:
       title: Get started
       intro: "The Digital Fund is currently offering two strands of funding. To find the right kind of support for your organisation, choose one of the following options:"
+      introClosed: "The Digital Fund is currently supporting two strands of funding."
       assistance:
-        title: Not sure this is for you?
+        title: More funding opportunities
         body: >
-          <p>If either strand of funding doesn’t work for your project or idea, that’s ok.
-            There are <a href="/funding/programmes">other funding programmes</a> open for applications.</p>
           <p>There will be further funding opportunities within the Digital Fund in 2019.
             <a href="https://en-gb.facebook.com/BigLotteryFund/">Follow us on social media</a> or keep checking our website for up-to-date information.</p>
     process:
@@ -835,7 +835,14 @@ funding:
       introduction: We don’t want you to spend a huge amount of time preparing to have an initial conversation with us. We would like to talk to you about your outline proposal before you start developing a detailed funding proposal.
       steps:
       - title: Submit an outline of your idea via this page—goes live on 22nd October
-        description: From 22nd October you’ll be able to use this web page to send us a brief outline of your idea
+        description: Send us a brief outline of your idea online
+      - title: Talk to us
+        description: If your idea looks like it fits with the Digital Fund criteria, we’ll arrange a call with you
+      - title: Submit a full proposal
+        description: If we feel the Digital Fund could work for you, we’ll ask you to submit a full proposal
+      stepsClosed:
+      - title: Submit an outline of your idea—closed on 3rd December at 5pm 
+        description: Send us a brief outline of your idea online
       - title: Talk to us
         description: If your idea looks like it fits with the Digital Fund criteria, we’ll arrange a call with you
       - title: Submit a full proposal
@@ -850,12 +857,11 @@ funding:
       title: Have any questions?
       body: >
         <p>If you have any questions about eligibility, get in touch with us.</p>
-        <p>Please note, we can’t give you any feedback on ideas at this stage. The only way of getting feedback will be to return to this page from 22nd October and submit an outline.</p>
         <p><strong>Phone</strong>: <a href="tel:03454102030">0345 4 10 20 30</a><br/>
         <strong>Text relay</strong>: 18001 plus 0345 4 10 20 30 (for those with a hearing or speech impairment)<br/>
         <strong>Email</strong>: <a href="mailto:general.enquiries@biglotteryfund.org.uk">general.enquiries@biglotteryfund.org.uk</a></p>
     wayfinding:
-      title: Not sure this is for you?
+      title: More funding opportunities
       description: Choose one of the following options instead.
       assistance: We want help getting started with digital
       strand1: We want to use digital to change our work

--- a/config/test.json
+++ b/config/test.json
@@ -1,6 +1,7 @@
 {
   "hotjarId": 1036292,
   "features": {
+    "enableDigitalFundApplications": false,
     "enableHotjar": true,
     "enableMailSendMetrics": true
   }

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const express = require('express');
+const config = require('config');
 
 const { initFormRouter } = require('./form-router');
 const appData = require('../../modules/appData');
@@ -8,12 +9,21 @@ const digitalFundForm = require('./digital-fund/form-model');
 const reachingCommunitiesForm = require('./reaching-communities/form-model');
 const buildingConnectionsTempForm = require('./building-connections/form-model');
 
+const features = config.get('features');
+
 const router = express.Router();
 
 router.get('/', (req, res) => res.redirect('/'));
-router.use('/digital-fund-strand-1', initFormRouter(digitalFundForm.strand1));
-router.use('/digital-fund-strand-2', initFormRouter(digitalFundForm.strand2));
 router.use('/your-idea', initFormRouter(reachingCommunitiesForm));
+
+if (features.enableDigitalFundApplications) {
+    router.use('/digital-fund-strand-1', initFormRouter(digitalFundForm.strand1));
+    router.use('/digital-fund-strand-2', initFormRouter(digitalFundForm.strand2));
+} else {
+    const redirectToProgramme = (req, res) => res.redirect('/funding/programmes/digital-fund');
+    router.use('/digital-fund-strand-1', redirectToProgramme);
+    router.use('/digital-fund-strand-2', redirectToProgramme);
+}
 
 if (appData.isNotProduction) {
     router.use('/building-connections-temporary', initFormRouter(buildingConnectionsTempForm));

--- a/controllers/digital-fund/index.js
+++ b/controllers/digital-fund/index.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const path = require('path');
 const { concat } = require('lodash');
+const config = require('config');
 const { injectCopy, injectHeroImage } = require('../../middleware/inject-content');
 
 const router = express.Router();
@@ -9,6 +10,7 @@ const router = express.Router();
 router.use(injectHeroImage('digital-buddies-2'), injectCopy('funding.digitalFund'));
 
 router.use((req, res, next) => {
+    res.locals.enableDigitalFundApplications = config.get('features.enableDigitalFundApplications');
     res.locals.breadcrumbs = concat(res.locals.breadcrumbs, [
         {
             label: res.locals.title,

--- a/controllers/digital-fund/strand-1.js
+++ b/controllers/digital-fund/strand-1.js
@@ -2,8 +2,11 @@
 const path = require('path');
 const express = require('express');
 const { concat } = require('lodash');
+const config = require('config');
 
 const { localify } = require('../../modules/urls');
+
+const features = config.get('features');
 
 const router = express.Router();
 
@@ -21,31 +24,35 @@ router.get('/', (req, res) => {
     });
 });
 
-router.get('/eligibility', (req, res) => {
-    const { copy } = res.locals;
-    const title = copy.eligibilityChecker.title;
-    res.render(path.resolve(__dirname, './views/eligibility-checker'), {
-        title: title,
-        strandCopy: copy.eligibilityChecker.strand1,
-        yesUrl: localify(req.i18n.getLocale())('/apply/digital-fund-strand-1/1'),
-        noUrl: req.baseUrl + '/eligibility/ineligible',
-        breadcrumbs: concat(res.locals.breadcrumbs, [
-            { label: res.locals.copy.strand1.shortTitle, url: './' },
-            { label: title }
-        ])
+if (features.enableDigitalFundApplications) {
+    router.get('/eligibility', (req, res) => {
+        const { copy } = res.locals;
+        const title = copy.eligibilityChecker.title;
+        res.render(path.resolve(__dirname, './views/eligibility-checker'), {
+            title: title,
+            strandCopy: copy.eligibilityChecker.strand1,
+            yesUrl: localify(req.i18n.getLocale())('/apply/digital-fund-strand-1/1'),
+            noUrl: req.baseUrl + '/eligibility/ineligible',
+            breadcrumbs: concat(res.locals.breadcrumbs, [
+                { label: res.locals.copy.strand1.shortTitle, url: './' },
+                { label: title }
+            ])
+        });
     });
-});
 
-router.get('/eligibility/ineligible', (req, res) => {
-    const title = res.locals.copy.eligibilityChecker.ineligibleTitle;
-    res.render(path.resolve(__dirname, './views/ineligible'), {
-        title: title,
-        strandCopy: res.locals.copy.eligibilityChecker.strand1,
-        breadcrumbs: concat(res.locals.breadcrumbs, [
-            { label: res.locals.copy.strand1.shortTitle, url: './' },
-            { label: title }
-        ])
+    router.get('/eligibility/ineligible', (req, res) => {
+        const title = res.locals.copy.eligibilityChecker.ineligibleTitle;
+        res.render(path.resolve(__dirname, './views/ineligible'), {
+            title: title,
+            strandCopy: res.locals.copy.eligibilityChecker.strand1,
+            breadcrumbs: concat(res.locals.breadcrumbs, [
+                { label: res.locals.copy.strand1.shortTitle, url: './' },
+                { label: title }
+            ])
+        });
     });
-});
+} else {
+    router.get('/eligibility*', (req, res) => res.redirect(req.baseUrl));
+}
 
 module.exports = router;

--- a/controllers/digital-fund/strand-2.js
+++ b/controllers/digital-fund/strand-2.js
@@ -1,9 +1,12 @@
 'use strict';
 const path = require('path');
+const config = require('config');
 const express = require('express');
 const { concat } = require('lodash');
 
 const { localify } = require('../../modules/urls');
+
+const features = config.get('features');
 
 const router = express.Router();
 
@@ -21,32 +24,35 @@ router.get('/', (req, res) => {
     });
 });
 
-
-router.get('/eligibility', (req, res) => {
-    const { copy } = res.locals;
-    const title = copy.eligibilityChecker.title;
-    res.render(path.resolve(__dirname, './views/eligibility-checker'), {
-        title: title,
-        strandCopy: copy.eligibilityChecker.strand2,
-        yesUrl: localify(req.i18n.getLocale())('/apply/digital-fund-strand-2/1'),
-        noUrl: req.baseUrl + '/eligibility/ineligible',
-        breadcrumbs: concat(res.locals.breadcrumbs, [
-            { label: res.locals.copy.strand2.shortTitle, url: './' },
-            { label: title }
-        ])
+if (features.enableDigitalFundApplications) {
+    router.get('/eligibility', (req, res) => {
+        const { copy } = res.locals;
+        const title = copy.eligibilityChecker.title;
+        res.render(path.resolve(__dirname, './views/eligibility-checker'), {
+            title: title,
+            strandCopy: copy.eligibilityChecker.strand2,
+            yesUrl: localify(req.i18n.getLocale())('/apply/digital-fund-strand-2/1'),
+            noUrl: req.baseUrl + '/eligibility/ineligible',
+            breadcrumbs: concat(res.locals.breadcrumbs, [
+                { label: res.locals.copy.strand2.shortTitle, url: './' },
+                { label: title }
+            ])
+        });
     });
-});
 
-router.get('/eligibility/ineligible', (req, res) => {
-    const title = res.locals.copy.eligibilityChecker.ineligibleTitle;
-    res.render(path.resolve(__dirname, './views/ineligible'), {
-        title: title,
-        strandCopy: res.locals.copy.eligibilityChecker.strand2,
-        breadcrumbs: concat(res.locals.breadcrumbs, [
-            { label: res.locals.copy.strand2.shortTitle, url: './' },
-            { label: title }
-        ])
+    router.get('/eligibility/ineligible', (req, res) => {
+        const title = res.locals.copy.eligibilityChecker.ineligibleTitle;
+        res.render(path.resolve(__dirname, './views/ineligible'), {
+            title: title,
+            strandCopy: res.locals.copy.eligibilityChecker.strand2,
+            breadcrumbs: concat(res.locals.breadcrumbs, [
+                { label: res.locals.copy.strand2.shortTitle, url: './' },
+                { label: title }
+            ])
+        });
     });
-});
+} else {
+    router.get('/eligibility*', (req, res) => res.redirect(req.baseUrl));
+}
 
 module.exports = router;

--- a/controllers/digital-fund/views/landing.njk
+++ b/controllers/digital-fund/views/landing.njk
@@ -15,12 +15,20 @@
         <div class="nudge-up">
             {% call contentBoxIntro(breadcrumbs, pageAccent, heroCredit = entry.heroCredit) %}
                 <p>{{ copy.intro }}</p>
-                <p><strong>{{ copy.openingDates }}</strong></p>
+                {% if enableDigitalFundApplications %}
+                    <p><strong>{{ copy.openingDates }}</strong></p>
+                {% else %}
+                    <p><strong>{{ copy.openingDatesClosed }}</strong></p>
+                {% endif %}
             {% endcall %}
 
             {% call contentBox(pageAccent, id="get-started") %}
                 <h2>{{ copy.getStarted.title }}</h2>
-                <p>{{ copy.getStarted.intro }}</p>
+                {% if enableDigitalFundApplications %}
+                    <p>{{ copy.getStarted.intro }}</p>
+                {% else %}
+                    <p>{{ copy.getStarted.introClosed }}</p>
+                {% endif %}
 
                 <div class="flex-grid">
                     <div class="flex-grid__item">

--- a/controllers/digital-fund/views/strand.njk
+++ b/controllers/digital-fund/views/strand.njk
@@ -23,7 +23,11 @@
                 </div>
 
                 <div class="message">
-                    {{ copy.openingDates }}
+                    {% if enableDigitalFundApplications %}
+                        {{ copy.openingDates }}
+                    {% else %}
+                        {{ copy.openingDatesClosed }}
+                    {% endif %}
                 </div>
 
                 {{ segmentLinks([
@@ -39,22 +43,28 @@
                     <div class="content-sidebar__primary accent-content--{{ pageAccent }}">
                         <h2 class="t2 t--underline">{{ copy.process.title }}</h2>
                         <p>{{ copy.process.introduction }}</p>
-                        {{ stepProgress(copy.process.steps)}}
+                        {% if enableDigitalFundApplications %}
+                            {{ stepProgress(copy.process.steps)}}
+                        {% else %}
+                            {{ stepProgress(copy.process.stepsClosed)}}
+                        {% endif %}
                     </div>
 
-                    <div class="content-sidebar__secondary">
-                        <div class="u-sticky-offset">
-                            {% call actionCard({
-                                title: copy.process.getStarted.title,
-                                link: {
-                                    url: eligibilityLink,
-                                    label: copy.process.getStarted.linkText
-                                }
-                            }, accent = pageAccent) %}
-                                {{ copy.process.getStarted.body | safe }}
-                            {% endcall %}
+                    {% if enableDigitalFundApplications %}
+                        <div class="content-sidebar__secondary">
+                            <div class="u-sticky-offset">
+                                {% call actionCard({
+                                    title: copy.process.getStarted.title,
+                                    link: {
+                                        url: eligibilityLink,
+                                        label: copy.process.getStarted.linkText
+                                    }
+                                }, accent = pageAccent) %}
+                                    {{ copy.process.getStarted.body | safe }}
+                                {% endcall %}
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                 </div>
             </section>
 
@@ -78,16 +88,18 @@
                 {{ copy.successFactors[currentStrand] | safe }}
             {% endcall %}
 
-            {% call contentBox(pageAccent, id="segment-5") %}
-                <h2>{{ copy.process.getStarted.title }}</h2>
-                <p>{{ copy.process.getStarted.teaser }}</p>
-                <p>
-                    <a href="{{ eligibilityLink }}"
-                        class="btn btn--medium accent--{{ pageAccent }} a--btn">
-                        {{ copy.process.getStarted.linkText }}
-                    </a>
-                </p>
-            {% endcall %}
+            {% if enableDigitalFundApplications %}
+                {% call contentBox(pageAccent, id="segment-5") %}
+                    <h2>{{ copy.process.getStarted.title }}</h2>
+                    <p>{{ copy.process.getStarted.teaser }}</p>
+                    <p>
+                        <a href="{{ eligibilityLink }}"
+                            class="btn btn--medium accent--{{ pageAccent }} a--btn">
+                            {{ copy.process.getStarted.linkText }}
+                        </a>
+                    </p>
+                {% endcall %}
+            {% endif %}
 
             {% call contentBox(pageAccent, id="segment-6") %}
                 <h2>{{ copy.questions.title }}</h2>
@@ -102,17 +114,20 @@
                     {{ copy.wayfinding.assistance }}
                 </a></p>
 
-                {% if currentStrand === 'strand1' %}
-                    <p><a href="{{ localify('/funding/programmes/digital-fund/strand-2') }}"
-                        class="btn btn--medium accent--cyan a--btn">
-                        {{ copy.wayfinding.strand2 }}
-                    </a></p>
-                {% else %}
-                    <p><a href="{{ localify('/funding/programmes/digital-fund/strand-1') }}"
-                        class="btn btn--medium accent--blue a--btn">
-                        {{ copy.wayfinding.strand1 }}
-                    </a></p>
+                {% if enableDigitalFundApplications %}
+                    {% if currentStrand === 'strand1' %}
+                        <p><a href="{{ localify('/funding/programmes/digital-fund/strand-2') }}"
+                            class="btn btn--medium accent--cyan a--btn">
+                            {{ copy.wayfinding.strand2 }}
+                        </a></p>
+                    {% else %}
+                        <p><a href="{{ localify('/funding/programmes/digital-fund/strand-1') }}"
+                            class="btn btn--medium accent--blue a--btn">
+                            {{ copy.wayfinding.strand1 }}
+                        </a></p>
+                    {% endif %}
                 {% endif %}
+
                 <p>{{ copy.wayfinding.otherProgrammes | safe }}</p>
             {% endcall %}
         </div>

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -347,40 +347,6 @@ describe('e2e', function() {
         cy.get('@feedbackForm').should('contain', 'Thank you for sharing');
     });
 
-    it('should submit a digital fund application form', () => {
-        cy.visit('/apply/digital-fund-strand-1/1/');
-
-        cy.get('#field-name').type('Example Name', { delay: 0 });
-        cy.get('#field-email').type('example@example.com', { delay: 0 });
-        cy.get('#field-organisation-name').type('Test Organisation', { delay: 0 });
-        cy.get('#field-your-idea')
-            .invoke('val', loremLong)
-            .trigger('change');
-
-        cy.get('input[type="submit"]').click();
-        cy.get('h1').should('contain', 'Check this is right');
-        cy.get('input[type="submit"]').click();
-        cy.get('h1').should('contain', 'Thank you for getting in touch');
-
-        cy.visit('/apply/digital-fund-strand-2/1/');
-
-        cy.get('#field-name').type('Example Name', { delay: 0 });
-        cy.get('#field-email').type('example@example.com', { delay: 0 });
-        cy.get('#field-organisation-name').type('Test Organisation', { delay: 0 });
-        cy.get('#field-your-idea-product')
-            .invoke('val', loremLong)
-            .trigger('change');
-
-        cy.get('#field-technology')
-            .invoke('val', loremLong)
-            .trigger('change');
-
-        cy.get('input[type="submit"]').click();
-        cy.get('h1').should('contain', 'Check this is right');
-        cy.get('input[type="submit"]').click();
-        cy.get('h1').should('contain', 'Thank you for getting in touch');
-    });
-
     it('should submit materials order', () => {
         cy.visit('/funding/funding-guidance/managing-your-funding/ordering-free-materials');
         cy.get('a[href="#monolingual"]').click();


### PR DESCRIPTION
Closes digital fund and redirects all application pages to the programme landing page. Adds new copy to explain that the programme is closed (but there will be further opportunities in the new year).

![image](https://user-images.githubusercontent.com/123386/49300097-45160c00-f4b9-11e8-83a4-3ededfd6d431.png)

Put this all behind a flag so a) we can make a single config change to close the programme on monday and b) because it will re-open again in the new year so it will be useful to be able to toggle between open and closed states.