### PR TITLE
Add S3 origin to Cloudfront

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -1421,8 +1421,114 @@
           "Quantity": 0
         },
         "PathPattern": "/welsh/search"
+      },
+      {
+        "TargetOriginId": "S3-blf-assets",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature"
+            ],
+            "Quantity": 4
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "none"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "assets/*"
+      },
+      {
+        "TargetOriginId": "S3-blf-assets",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature"
+            ],
+            "Quantity": 4
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "none"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "media/*"
       }
     ],
-    "Quantity": 22
+    "Quantity": 24
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -1421,8 +1421,114 @@
           "Quantity": 0
         },
         "PathPattern": "/welsh/search"
+      },
+      {
+        "TargetOriginId": "S3-blf-assets",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature"
+            ],
+            "Quantity": 4
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "none"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "assets/*"
+      },
+      {
+        "TargetOriginId": "S3-blf-assets",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature"
+            ],
+            "Quantity": 4
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "none"
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "media/*"
       }
     ],
-    "Quantity": 22
+    "Quantity": 24
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -38,7 +38,6 @@
     "enableSurvey": true,
     "enableAbTests": true,
     "enableHotjar": false,
-    "useRemoteAssets": true,
     "enableTimingMetrics": false,
     "enableMailSendMetrics": false,
     "enableRelatedGrants": false

--- a/config/default.json
+++ b/config/default.json
@@ -6,14 +6,16 @@
         "distributionId": "E3D5QJTWAG3GDP",
         "origins": {
           "legacy": "LEGACY",
-          "newSite": "ELB-TEST"
+          "newSite": "ELB-TEST",
+          "s3Assets": "S3-blf-assets"
         }
       },
       "live": {
         "distributionId": "E2WYWBLMWIN5U1",
         "origins": {
           "legacy": "LEGACY",
-          "newSite": "ELB_LIVE"
+          "newSite": "ELB_LIVE",
+          "s3Assets": "S3-blf-assets"
         }
       }
     }

--- a/config/development.json
+++ b/config/development.json
@@ -1,6 +1,5 @@
 {
   "features": {
-    "enableDigitalFundApplications": false,
-    "useRemoteAssets": false
+    "enableDigitalFundApplications": false
   }
 }

--- a/controllers/apply/__tests__/__snapshots__/processors.test.js.snap
+++ b/controllers/apply/__tests__/__snapshots__/processors.test.js.snap
@@ -159,7 +159,8 @@ read the full Notice which is published on our website at <a =
 href=3D\\"https://www.biglotteryfund.org.uk/data-protection\\" style=3D\\"color: =
 #365cc9;\\">www.biglotteryfund.org.uk/data-protection</a> or contact us to =
 request a hard copy. The Notice may be updated from time to time.</small>
-</body></html>
+    </body>
+</html>
 
 "
 `;
@@ -313,7 +314,8 @@ read the full Notice which is published on our website at <a =
 href=3D\\"https://www.biglotteryfund.org.uk/data-protection\\" style=3D\\"color: =
 #365cc9;\\">www.biglotteryfund.org.uk/data-protection</a> or contact us to =
 request a hard copy. The Notice may be updated from time to time.</small>
-</body></html>
+    </body>
+</html>
 
 "
 `;

--- a/controllers/apply/views/email-layout.njk
+++ b/controllers/apply/views/email-layout.njk
@@ -24,4 +24,5 @@
         <small>The Big Lottery Fund is a public body with a duty to distribute National Lottery and other money in grants for good causes. We use the personal data you provide, such as contact details for individuals at your organisation, to help you apply for a grant and to assess your application.</small>
         <small>We may share your personal data with organisations which help us with our grant making activities or others which have a legitimate interest in our work or have funded your grant. We will only share personal data which they need to carry out their work and subject to appropriate safety measures.</small>
         <small>Our Data Protection and Privacy Notice gives more information about how we store and use personal data and the lawful basis for this. Please read the full Notice which is published on our website at <a href="https://www.biglotteryfund.org.uk/data-protection">www.biglotteryfund.org.uk/data-protection</a> or contact us to request a hard copy. The Notice may be updated from time to time.</small>
+    </body>
 </html>

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -1356,8 +1356,114 @@ Object {
         },
         "ViewerProtocolPolicy": "redirect-to-https",
       },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "none",
+          },
+          "Headers": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "assets/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "S3-blf-assets",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "none",
+          },
+          "Headers": Object {
+            "Items": Array [],
+            "Quantity": 0,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+            ],
+            "Quantity": 4,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "media/*",
+        "SmoothStreaming": false,
+        "TargetOriginId": "S3-blf-assets",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
     ],
-    "Quantity": 22,
+    "Quantity": 24,
   },
   "DefaultCacheBehavior": Object {
     "AllowedMethods": Object {

--- a/modules/__tests__/filters.test.js
+++ b/modules/__tests__/filters.test.js
@@ -29,7 +29,7 @@ describe('getCachebustedPath', () => {
 
     it('should get external url for cachebusted asset', () => {
         const result = getCachebustedPath('stylesheets/style.css', true);
-        expect(result).toMatch(/^https:\/\/media.biglotteryfund.org.uk\/assets\/build\/\w+\/stylesheets\/style.css$/);
+        expect(result).toMatch(/^https:\/\/www.biglotteryfund.org.uk\/assets\/build\/\w+\/stylesheets\/style.css$/);
     });
 });
 

--- a/modules/__tests__/filters.test.js
+++ b/modules/__tests__/filters.test.js
@@ -29,7 +29,7 @@ describe('getCachebustedPath', () => {
 
     it('should get external url for cachebusted asset', () => {
         const result = getCachebustedPath('stylesheets/style.css', true);
-        expect(result).toMatch(/^https:\/\/www.biglotteryfund.org.uk\/assets\/build\/\w+\/stylesheets\/style.css$/);
+        expect(result).toMatch(/^\/assets\/build\/\w+\/stylesheets\/style.css$/);
     });
 });
 

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -42,7 +42,9 @@ const LEGACY_PATHS = [
 /**
  * S3 static file route paths
  * Paths in this list will be routed to an S3 bucket
- * either for CMS uploads or app-generated static files
+ * either for CMS uploads or app-generated static files.
+ * NOTE: they should _not_ start with leading slashes
+ * otherwise they fail to match directory names in S3.
  */
 const S3_PATHS = ['assets/*', 'media/*'];
 

--- a/modules/filters.js
+++ b/modules/filters.js
@@ -17,11 +17,9 @@ try {
     assets = JSON.parse(fs.readFileSync(path.join(__dirname, '../config/assets.json'), 'utf8'));
 } catch (e) {} // eslint-disable-line no-empty
 
-function getCachebustedPath(urlPath, useRemoteAssets = config.get('features.useRemoteAssets')) {
-    const version = assets.version || 'latest';
-    const baseUrl = useRemoteAssets ? 'https://www.biglotteryfund.org.uk/assets' : `/assets`;
-    return `${baseUrl}/build/${version}/${urlPath}`;
-}
+const version = assets.version || 'latest';
+
+const getCachebustedPath = urlPath => `/assets/build/${version}/${urlPath}`;
 
 function appendUuid(str) {
     return str + uuid();

--- a/modules/filters.js
+++ b/modules/filters.js
@@ -19,7 +19,7 @@ try {
 
 function getCachebustedPath(urlPath, useRemoteAssets = config.get('features.useRemoteAssets')) {
     const version = assets.version || 'latest';
-    const baseUrl = useRemoteAssets ? 'https://media.biglotteryfund.org.uk/assets' : `/assets`;
+    const baseUrl = useRemoteAssets ? 'https://www.biglotteryfund.org.uk/assets' : `/assets`;
     return `${baseUrl}/build/${version}/${urlPath}`;
 }
 

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -1,5 +1,3 @@
-<link href='https://media.biglotteryfund.org.uk' rel='preconnect'>
-
 {% if useNewBrand %}
     <link rel="stylesheet" type="text/css" href="{{ 'stylesheets/style-rebrand.css' | getCachebustedPath }}">
     <link rel="stylesheet" href="https://use.typekit.net/yyc1dgh.css">


### PR DESCRIPTION
This configures `/media/*` (for CMS files) and `/assets/*` to serve from S3 directly via Cloudfront, so we can move off `media.biglotteryfund.org.uk` (which we won't have a certificate for post-rebrand).