### PR TITLE
Translate Updates section

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -371,17 +371,54 @@ toplevel:
     mapTitle: Ein blwyddyn mewn Rhifau
 news:
   title: Newyddion
+  # @TODO
   allNews: All news
+  author:
+    singular: Awdur
+    plural: Awduron
+    seeAllPosts: Gweld yr holl byst gan yr awdur hwn
+    aboutAuthor: Ynglŷn â’r awdur
+    # @TODO all of this
   types:
     blog:
       singular: Blog
       plural: Blog posts
     press-releases:
-      singular: Press release
-      plural: Press releases
+      singular: Press Release
+      plural: Datganiadau i’r wasg
     updates:
       singular: Updates
       plural: Updates
+  datePublished: Dyddiad cyhoeddi
+  readMoreAboutProgramme: Darllen mwy am y rhaglen hon
+  blogpost:
+    aboutThisBlogPost: Ynglŷn â’r blog postio hwn
+  pressRelease:
+    region: Rhanbarth
+    notesToEditors: Nodiadau i Olygyddion
+    aboutThisPressRelease: About this press release
+    contacts: Cysylltiadau
+    viewingPressReleasesIn: Gweld yr holl ddatganiadau i’r wasg yn
+    viewAllPressReleases: gweld yr holl ddatganiadau i’r wasg
+    filterByRegion: Filter press releases by region
+    allPosts: Yr holl byst
+    allPostsIn: Yr holl byst yn
+    filter: Hidlwr
+    in: yn
+    noResultsFor: Dim canlyniadau ar gyfer
+  viewAll: Gweld y cyfan
+  viewLatest: Gweld y diweddaraf
+  introductions:
+    newsLanding: >
+      Os ydych eisiau dod i wybod beth sy’n digwydd yn y Gronfa Loteri Fawr, rydych wedi dod i’r lle iawn.  Gallwch ddarllen y newyddion diweddaraf ar: y grwpiau cymunedol ac elusennau yr ydym yn eu hariannu, sut yr ydym yn gweithio gyda’r Llywodraeth ac ariannwyr eraill i ddosbarthu arian y Loteri Genedlaethol a sut yr ydym yn cefnogi cymunedau lleol ar draws y DU i ddod yn fwy gweithgar, bywiog ac yn gryfach gyda’i gilydd.
+    pressReleases: >
+      Bydd ein datganiadau i’r wasg yn rhoi’r prif ffeithiau i chi am gyhoeddiadau ariannu, grantiau neu ymchwil newydd, digwyddiadau arbennig, digwyddiadau lansio, pa elusennau y gwobrwywyd arian iddynt, prosiectau dyfeisgar, arfer gorau yn y sector a mwy.
+    blog: >
+      Chwilio am liw, cyd-destun a phersbectif ar waith y Gronfa Loteri Fawr, ei effaith ar gymunedau a’r pynciau sydd yn y newyddion ar hyn o bryd? Mae’r cyfan yma. Bydd y blog hwn yn esbonio, ymchwilio, arddangos ac archwilio ffyrdd y mae cymdeithas sifil, ac o ganlyniad i hynny, y sector, yn newid. Darllenwch am yr hyn yr oedd pobl mewn cymunedau led led y DU a’r sector yn ei feddwl yr oedd gan arweinyddion i’w ddweud a ffurfio eich barn eich hunan.
+  filters:
+    viewPostsTagged: Gweld yr holl byst sydd wedi’u tagio gyda
+    viewPostsIn: Gweld yr holl byst o fewn
+    showingPostsBy: Dangos yr holl byst gan
 ourPeople:
   title: Ein pobl
   introduction: >

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -371,21 +371,20 @@ toplevel:
     mapTitle: Ein blwyddyn mewn Rhifau
 news:
   title: Newyddion
-  # @TODO
-  allNews: All news
+  allNews: Holl newyddion
   author:
     singular: Awdur
     plural: Awduron
     seeAllPosts: Gweld yr holl byst gan yr awdur hwn
     aboutAuthor: Ynglŷn â’r awdur
-    # @TODO all of this
   types:
     blog:
       singular: Blog
-      plural: Blog posts
+      plural: Postiadau blog
     press-releases:
-      singular: Press Release
+      singular: Datganiad i’r wasg
       plural: Datganiadau i’r wasg
+    # @TODO decide on the name for this and get it translated
     updates:
       singular: Updates
       plural: Updates
@@ -396,11 +395,11 @@ news:
   pressRelease:
     region: Rhanbarth
     notesToEditors: Nodiadau i Olygyddion
-    aboutThisPressRelease: About this press release
+    aboutThisPressRelease: Ynghylch y datganiad i’r wasg hwn
     contacts: Cysylltiadau
     viewingPressReleasesIn: Gweld yr holl ddatganiadau i’r wasg yn
     viewAllPressReleases: gweld yr holl ddatganiadau i’r wasg
-    filterByRegion: Filter press releases by region
+    filterByRegion: Hidlo datganiadau i’r wasg fesul rhanbarth
     allPosts: Yr holl byst
     allPostsIn: Yr holl byst yn
     filter: Hidlwr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -464,6 +464,11 @@ toplevel:
 news:
   title: News
   allNews: All news
+  author:
+    singular: Author
+    plural: Authors
+    seeAllPosts: See all posts by this author
+    aboutAuthor: About the author
   types:
     blog:
       singular: Blog
@@ -474,6 +479,36 @@ news:
     updates:
       singular: Updates
       plural: Updates
+  datePublished: Date published
+  readMoreAboutProgramme: Read more about this programme
+  blogpost:
+    aboutThisBlogPost: About this blog post
+  pressRelease:
+    region: Region
+    notesToEditors: Notes to Editors
+    aboutThisPressRelease: About this press release
+    contacts: Contacts
+    viewingPressReleasesIn: Viewing all press releases in
+    viewAllPressReleases: view all press releases
+    filterByRegion: Filter press releases by region
+    allPosts: All posts
+    allPostsIn: All posts in
+    filter: Filter
+    in: in
+    noResultsFor: No results for
+  viewAll: View all
+  viewLatest: View latest
+  introductions:
+    newsLanding: >
+      If you want to find out about what’s happening at the Big Lottery Fund, you’ve come to the right place. You can read the latest news on: the community groups and charities we fund, how we work with the Government and other funders to distribute National Lottery money and how we support local communities across the UK to become more active, vibrant and stronger together.
+    pressReleases: >
+      Our press releases will give you the key facts about funding announcements, new grants or research, special events, launches, which charities have been awarded funding, innovative projects, best practice in the sector and more.
+    blog: >
+      Looking for colour, context and perspective about the work of the Big Lottery Fund, its impact on communities and topics currently in the news? It’s all here. This blog will explain, explore, showcase and examine the ways in which civil society, and as a result the sector, is changing. Read about what people in communities across the UK and sector thought leaders have to say and form your own opinion.
+  filters:
+    viewPostsTagged: Viewing all posts tagged
+    viewPostsIn: Viewing all posts in
+    showingPostsBy: Showing all posts by
 ourPeople:
   title: Our People
   introduction: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,7 @@ news:
     press-releases:
       singular: Press Release
       plural: Press Releases
+    # @TODO decide on the name for this and get it translated
     updates:
       singular: Updates
       plural: Updates

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -77,6 +77,7 @@ if (appData.isNotProduction) {
                     } else if (entry.articleLink) {
                         res.redirect(entry.articleLink);
                     } else if (entry.content.length > 0) {
+                        res.locals.isBilingual = entry.availableLanguages.length === 2;
                         return res.render(path.resolve(__dirname, './views/post/press-release'), {
                             title: entry.title,
                             description: entry.summary,
@@ -139,6 +140,7 @@ if (appData.isNotProduction) {
                     if (req.baseUrl + req.path !== entry.linkUrl) {
                         res.redirect(entry.linkUrl);
                     } else if (entry.content.length > 0) {
+                        res.locals.isBilingual = entry.availableLanguages.length === 2;
                         return res.render(path.resolve(__dirname, './views/post/blogpost'), {
                             title: entry.title,
                             description: entry.summary,

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -22,7 +22,7 @@
         <div class="nudge-up">
 
             <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                <p>If you want to find out about what’s happening at the Big Lottery Fund, you’ve come to the right place. You can read the latest news on: the community groups and charities we fund, how we work with the Government and other funders to distribute National Lottery money and how we support local communities across the UK to become more active, vibrant and stronger together.</p>
+                <p>{{ copy.introductions.newsLanding }}</p>
             </div>
 
             <div class="u-inner-wide-only u-padded-top u-padded-bottom">
@@ -51,7 +51,7 @@
                 </div>
                 <footer class="latest-news__footer">
                     <a class="latest-news__more" href="{{ localify('/news/blog') }}">
-                        View all {{ copy.types.blog.plural | lower }} &rarr;
+                        {{ copy.viewAll }} {{ copy.types.blog.plural | lower }} &rarr;
                     </a>
                 </footer>
             </section>
@@ -61,11 +61,11 @@
                 <h2 class="t3 t--underline accent--{{ pageAccent }}">
                     {{ copy.types['press-releases'].plural }}
                 </h2>
-                <p>Our press releases will give you the key facts about funding announcements, new grants or research, special events, launches, which charities have been awarded funding, innovative projects, best practice in the sector and more.</p>
+                <p>{{ copy.introductions.pressReleases }}</p>
                 <p>
                     <a href="{{ localify('/news/press-releases') }}"
                        class="btn accent--{{ pageAccent }} a--btn btn--medium">
-                        View latest {{ copy.types['press-releases'].plural | lower }}
+                        {{ copy.viewLatest }} {{ copy.types['press-releases'].plural | lower }}
                     </a>
                 </p>
             </div>

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -25,7 +25,7 @@
 
                 {% if entriesMeta.pageType === 'author' %}
                     {% set author = entriesMeta.activeAuthor %}
-                    <h2 class="t4">About the author</h2>
+                    <h2 class="t4">{{ copy.author.aboutAuthor }}</h2>
                     <aside class="o-media">
                         {% if author.photo %}
                             <img src="{{ author.photo }}"
@@ -45,13 +45,13 @@
                     </aside>
                 {% elseif entriesMeta.pageType === 'tag' %}
                     {% set activeTag = entriesMeta.activeTag %}
-                    <h1>Viewing all posts tagged {{ activeTag.title }}</h1>
+                    <h1>{{ copy.filters.viewPostsTagged }} "{{ activeTag.title }}"</h1>
                 {% elseif entriesMeta.pageType === 'category' %}
                     {% set activeCategory = entriesMeta.activeCategory %}
-                    <h1>Viewing all posts in {{ activeCategory.title }}</h1>
+                    <h1>{{ copy.filters.viewPostsIn }} {{ activeCategory.title }}</h1>
                 {% else %}
                     <h1>{{ title }}</h1>
-                    <p>Looking for colour, context and perspective about the work of the Big Lottery Fund, its impact on communities and topics currently in the news? It’s all here. This blog will explain, explore, showcase and examine the ways in which civil society, and as a result the sector, is changing. Read about what people in communities across the UK and sector thought leaders have to say and form your own opinion.</p>
+                    <p>{{ copy.introductions.blog }}</p>
                 {% endif %}
             </div>
         </div>
@@ -59,7 +59,7 @@
         <section class="u-inner">
             {% if entriesMeta.pageType === 'author' %}
                 {% set activeAuthor = entriesMeta.activeAuthor %}
-                <h1>Showing all posts by {{ activeAuthor.title }}</h1>
+                <h1>{{ copy.filters.showingPostsBy }} {{ activeAuthor.title }}</h1>
             {% endif %}
             <ul class="flex-grid flex-grid--3up">
                 {% set lastEntryWasPromoted = false %}
@@ -91,11 +91,11 @@
 
             {{ splitNav(
                 prevLink = {
-                    "label": "Previous page",
+                    "label": __('global.misc.pagination.prev'),
                     "url": pagination.prevLink
                 },
                 nextLink = {
-                    "label": "Next page",
+                    "label": __('global.misc.pagination.next'),
                     "url": pagination.nextLink
                 },
                 innerContent = innerContent

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -23,7 +23,7 @@
                 <div class="content-sidebar__primary">
                     {% if entries.length > 0 %}
                         {% if entriesMeta.activeRegion %}
-                            <p>Viewing all press releases in <strong>{{ entriesMeta.activeRegion.title }}</strong></p>
+                            <p>{{ copy.pressRelease.viewingPressReleasesIn }} <strong>{{ entriesMeta.activeRegion.title }}</strong></p>
                         {% endif %}
 
                         <ol class="article-listing">
@@ -35,7 +35,7 @@
                                         </time>
 
                                         {% if entry.regions.length > 0 %}
-                                            in {{ entryRegions(entry, currentPath) }}
+                                            {{ copy.pressRelease.in }} {{ entryRegions(entry, currentPath) }}
                                         {% endif %}
                                     {% endset %}
                                     {{ articleTeaser({
@@ -51,18 +51,19 @@
                         {% if pagination %}
                             {{ splitNav(
                                 prevLink = {
-                                    "label": "Previous page",
+                                    "label": __('global.misc.pagination.prev'),
                                     "url": pagination.prevLink
                                 },
                                 nextLink = {
-                                    "label": "Next page",
+                                    "label": __('global.misc.pagination.next'),
                                     "url": pagination.nextLink
                                 }
                             ) }}
                         {% endif %}
                     {% else %}
                         <p class="message s-prose">
-                            No results for "{{ entriesMeta.activeRegion.title }}", <a href="{{ currentPath }}">view all press releases</a>
+                            {{ copy.pressRelease.noResultsFor }} "{{ entriesMeta.activeRegion.title }}",
+                            <a href="{{ currentPath }}">{{ copy.pressRelease.viewAllPressReleases }}</a>
                         </p>
                     {% endif %}        
                 </div>
@@ -72,15 +73,15 @@
                     {% call card(accent = pageAccent) %}
                         <form action="" method="get">
                             {% set activeRegion = entriesMeta.activeRegion.slug if entriesMeta.activeRegion %}
-                            <label class="ff-label" for="field-region">Filter press releases by region</label>
+                            <label class="ff-label" for="field-region">{{ copy.pressRelease.filterByRegion }}</label>
                             <select class="ff-select u-margin-bottom-s" name="region" id="field-region">
                                 <option value=""{% if not activeRegion %} selected{% endif %}>
-                                    All posts
+                                    {{ copy.pressRelease.allPosts }}
                                 </option>
                                 {% for region in entriesMeta.regions %}
                                     <optgroup label="{{ region.title }}">
                                         <option value="{{ region.slug }}"{% if activeRegion === region.slug %} selected{% endif %}>
-                                            All posts in {{ region.title }}
+                                            {{ copy.pressRelease.allPostsIn }} {{ region.title }}
                                         </option>
                                         {% for childRegion in region.children %}
                                             <option value="{{ childRegion.slug }}"{% if activeRegion === childRegion.slug %} selected{% endif %}>
@@ -90,7 +91,7 @@
                                     </optgroup>
                                 {% endfor %}
                             </select>
-                            <input type="submit" value="Filter" class="btn btn--small" />
+                            <input type="submit" value="{{ copy.pressRelease.filter }}" class="btn btn--small" />
                         </form>
                     {% endcall %}
 

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -11,7 +11,7 @@
 
 {% macro articleMeta(entry) %}
 
-    {% set aboutTitle = "Authors" if entry.authors.length > 1  else "Author" %}
+    {% set aboutTitle = copy.author.plural  if entry.authors.length > 1  else copy.author.singular %}
     {% call card(aboutTitle, pageAccent) %}
         {% for author in entry.authors -%}
             <aside class="o-media">
@@ -34,14 +34,14 @@
                     {% endif %}
                 </div>
             </aside>
-            <p class="u-margin-top-s"><a href="{{ localify('/news/blog?author=' + author.slug) }}">See all posts by this author</a></p>
+            <p class="u-margin-top-s"><a href="{{ localify('/news/blog?author=' + author.slug) }}">{{ copy.author.seeAllPosts }}</a></p>
         {% endfor %}
     {% endcall %}
 
-    {% call card("About this blog post", pageAccent) %}
+    {% call card(copy.blogpost.aboutThisBlogPost, pageAccent) %}
 
         <p class="u-margin-bottom-s">
-            <strong>Date published:</strong>
+            <strong>{{ copy.datePublished }}:</strong>
             <time datetime="{{ entry.postDate.date }}">
                 {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
             </time>
@@ -61,7 +61,7 @@
             </li>
             {% for tag in entry.tags %}
                 <li class="tag tag--secondary">
-                    <a href="{{ localify('/news?tag=' + tag.slug) }}">
+                    <a href="{{ localify('/news/blog?tag=' + tag.slug) }}">
                         {{ tag.title }}
                     </a>
                 </li>
@@ -107,7 +107,7 @@
                     <aside class="article__topics" role="aside">
                         {% set links = [] %}
                         {% for tag in entry.tags %}
-                            {% set links = (links.push({ "label": tag.title, "url": localify('/news?tag=' + tag.slug) }), links) %}
+                            {% set links = (links.push({ "label": tag.title, "url": localify('/news/blog?tag=' + tag.slug) }), links) %}
                         {% endfor %}
                         {{ inlineLinks(prefix = __('global.misc.topics') | title, links = links) }}
                     </aside>
@@ -126,7 +126,7 @@
                                 <div class="o-media-body">
                                     <h4 class="a--text accent--{{ pageAccent }}">{{ programme.title }}</h4>
                                     {{ programme.intro | safe }}
-                                    <p><a href="{{ programme.linkUrl }}">Read more about this programme</a></p>
+                                    <p><a href="{{ programme.linkUrl }}">{{ copy.readMoreAboutProgramme }}</a></p>
                                 </div>
                             </div>
                         {% endfor %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -11,14 +11,14 @@
 
 {% macro entryMeta(entry) %}
     <dl class="o-definition-list o-definition-list--compact">
-        <dt>Date published</dt>
+        <dt>{{ copy.datePublished }}</dt>
         <dd>
             <time datetime="{{ entry.postDate.date }}">
                 {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
             </time>
         </dd>
         {% if entry.regions.length > 0 %}
-            <dt>Region</dt>
+            <dt>{{ copy.pressRelease.region }}</dt>
             <dd>{{ entryRegions(entry, '../') }}</dd>
         {% endif %}
     </dl>
@@ -45,24 +45,24 @@
 
                     {% if entry.notesToEditors %}
                         <aside class="u-tone-background-tint u-padded" id="notes">
-                            <h3 class="accent--{{ pageAccent }} a--text">Notes to Editors</h3>
+                            <h3 class="accent--{{ pageAccent }} a--text">{{ copy.pressRelease.notesToEditors }}</h3>
                             {{ entry.notesToEditors | safe }}
                         </aside>
                     {% endif %}
                 </div>
 
                 <div class="content-sidebar__secondary">
-                    {% call card("About this press release", pageAccent) %}
+                    {% call card(copy.pressRelease.aboutThisPressRelease, pageAccent) %}
                         <div class="u-text-small">
                             {{ entryMeta(entry) }}
                             {% if entry.notesToEditors %}
-                                <p><a href="#notes">Notes to editors</a></p>
+                                <p><a href="#notes">{{ copy.pressRelease.notesToEditors }}</a></p>
                             {% endif %}
                         </div>
                     {% endcall %}
 
                     {% if entry.contacts %}
-                        {% call card("Contacts") %}
+                        {% call card(copy.pressRelease.contacts) %}
                             <div class="s-prose u-text-small">
                                 {{ entry.contacts | safe }}
                             </div>

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -21,8 +21,8 @@
             "alt": entry.title
         },
         "link": {
-            "label": "Read more",
-            "labelAria": "Read more",
+            "label": __('global.misc.readMore'),
+            "labelAria": __('global.misc.readMore'),
             "url": entry.linkUrl
         }
     }, showBorder = false) %}
@@ -59,13 +59,13 @@
             <div class="blogpost-attribution__tags">
                 <ul class="tags-list">
                     <li class="tag">
-                        <a href="{{ localify('/news/blog/?category=' + entry.category.slug) }}">
+                        <a href="{{ localify('/news/blog?category=' + entry.category.slug) }}">
                             {{ entry.category.title }}
                         </a>
                     </li>
                     {% for tag in entry.tags %}
                         <li class="tag tag--secondary">
-                            <a href="{{ localify('/news?tag=' + tag.slug) }}">
+                            <a href="{{ localify('/news/blog?tag=' + tag.slug) }}">
                                 {{ tag.title }}
                             </a>
                         </li>


### PR DESCRIPTION
Adds translations for the Updates section and disables Welsh links for content (eg. press releases/blogs) that isn't translated.

Note: this experience is a bit weird: if you're on a Welsh listing page and click a link to a (merged-in) English press release, you're back on the English version of the site and the only way to get back to Welsh is to click a link to a page that has a translation, then toggle back to Welsh again. Should we be showing these English entries here?