### PR TITLE
Fix news landing

### DIFF
--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -22,13 +22,22 @@ if (appData.isNotProduction) {
         async (req, res, next) => {
             try {
                 const { copy, breadcrumbs } = res.locals;
-                const response = await contentApi.getUpdates({
-                    locale: req.i18n.getLocale()
+
+                const pressReleases = await contentApi.getUpdates({
+                    locale: req.i18n.getLocale(),
+                    type: 'press-releases'
                 });
+
+                const blogposts = await contentApi.getUpdates({
+                    locale: req.i18n.getLocale(),
+                    type: 'blog'
+                });
+
+                const allEntries = concat(pressReleases.result, blogposts.result);
 
                 res.render(path.resolve(__dirname, `./views/landing`), {
                     title: copy.title,
-                    groupedEntries: groupBy(response.result, 'entryType'),
+                    groupedEntries: groupBy(allEntries, 'entryType'),
                     breadcrumbs: concat(breadcrumbs, { label: copy.title })
                 });
             } catch (e) {

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const { concat, groupBy, isArray, pick, get } = require('lodash');
+const { concat, isArray, pick, get } = require('lodash');
 
 const { buildPagination } = require('../../modules/pagination');
 const { injectBreadcrumbs, injectCopy, injectHeroImage } = require('../../middleware/inject-content');
@@ -23,21 +23,14 @@ if (appData.isNotProduction) {
             try {
                 const { copy, breadcrumbs } = res.locals;
 
-                const pressReleases = await contentApi.getUpdates({
-                    locale: req.i18n.getLocale(),
-                    type: 'press-releases'
-                });
-
                 const blogposts = await contentApi.getUpdates({
                     locale: req.i18n.getLocale(),
                     type: 'blog'
                 });
 
-                const allEntries = concat(pressReleases.result, blogposts.result);
-
                 res.render(path.resolve(__dirname, `./views/landing`), {
                     title: copy.title,
-                    groupedEntries: groupBy(allEntries, 'entryType'),
+                    blogposts: blogposts.result,
                     breadcrumbs: concat(breadcrumbs, { label: copy.title })
                 });
             } catch (e) {

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -42,7 +42,7 @@
                 </header>
                 <div class="latest-news__content">
                     <ul class="flex-grid flex-grid--3up">
-                        {% for entry in groupedEntries.blog | take(3) %}
+                        {% for entry in blogposts | take(3) %}
                             <li class="flex-grid__item">
                                 {{ blogTrail(entry) }}
                             </li>

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -8,6 +8,8 @@
 {% from "components/card/macro.njk" import card %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
 
+{% from "../view-helpers.njk" import relatedProgrammes with context %}
+
 {% extends "layouts/main.njk" %}
 
 {% macro articleMeta(entry) %}
@@ -133,25 +135,7 @@
                     </a>
                 </div>
 
-                {% if entry.relatedFundingProgrammes.length > 0 %}
-                    <div class="u-tone-background-tint u-padded u-margin-top-l">
-                        {% for programme in entry.relatedFundingProgrammes %}
-                            <div class="o-media u-margin-bottom">
-                                {% if programme.photo %}
-                                    <img src="{{ programme.thumbnail }}"
-                                         alt="{{ programme.title }}"
-                                         class="o-media-figure"
-                                         width="100" />
-                                {% endif %}
-                                <div class="o-media-body">
-                                    <h4 class="a--text accent--{{ pageAccent }}">{{ programme.title }}</h4>
-                                    {{ programme.intro | safe }}
-                                    <p class="u-no-margin"><a href="{{ programme.linkUrl }}">{{ copy.readMoreAboutProgramme }}</a></p>
-                                </div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
+                {{ relatedProgrammes(entry) }}
 
                 {% if entry.siblings.next or entry.siblings.prev %}
                     {% set prevLink = {

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -7,8 +7,7 @@
 {% from "components/split-nav/macro.njk" import splitNav %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
-
-{% from "../view-helpers.njk" import relatedProgrammes with context %}
+{% from "components/programmes.njk" import relatedProgrammes with context %}
 
 {% extends "layouts/main.njk" %}
 
@@ -135,7 +134,7 @@
                     </a>
                 </div>
 
-                {{ relatedProgrammes(entry) }}
+                {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
 
                 {% if entry.siblings.next or entry.siblings.prev %}
                     {% set prevLink = {

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -3,8 +3,9 @@
 {% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/card/macro.njk" import card %}
+{% from "components/programmes.njk" import relatedProgrammes with context %}
 
-{% from "../view-helpers.njk" import entryRegions, relatedProgrammes with context %}
+{% from "../view-helpers.njk" import entryRegions with context %}
 
 {% set bodyClass = 'has-static-header' %}
 {% extends "layouts/main.njk" %}
@@ -50,7 +51,7 @@
                         </aside>
                     {% endif %}
 
-                    {{ relatedProgrammes(entry) }}
+                    {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
                 </div>
 
                 <div class="content-sidebar__secondary">

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -4,7 +4,7 @@
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/card/macro.njk" import card %}
 
-{% from "../view-helpers.njk" import entryRegions with context %}
+{% from "../view-helpers.njk" import entryRegions, relatedProgrammes with context %}
 
 {% set bodyClass = 'has-static-header' %}
 {% extends "layouts/main.njk" %}
@@ -49,6 +49,8 @@
                             {{ entry.notesToEditors | safe }}
                         </aside>
                     {% endif %}
+
+                    {{ relatedProgrammes(entry) }}
                 </div>
 
                 <div class="content-sidebar__secondary">

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -76,3 +76,26 @@
 
     {% endcall %}
 {% endmacro %}
+
+
+{% macro relatedProgrammes(entry) %}
+    {% if entry.relatedFundingProgrammes.length > 0 %}
+        <div class="u-tone-background-tint u-padded u-margin-top-l">
+            {% for programme in entry.relatedFundingProgrammes %}
+                <div class="o-media u-margin-bottom">
+                    {% if programme.photo %}
+                        <img src="{{ programme.thumbnail }}"
+                             alt="{{ programme.title }}"
+                             class="o-media-figure"
+                             width="100" />
+                    {% endif %}
+                    <div class="o-media-body">
+                        <h4 class="a--text accent--{{ pageAccent }}">{{ programme.title }}</h4>
+                        {{ programme.intro | safe }}
+                        <p class="u-no-margin"><a href="{{ programme.linkUrl }}">{{ copy.readMoreAboutProgramme }}</a></p>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -76,26 +76,3 @@
 
     {% endcall %}
 {% endmacro %}
-
-
-{% macro relatedProgrammes(entry) %}
-    {% if entry.relatedFundingProgrammes.length > 0 %}
-        <div class="u-tone-background-tint u-padded u-margin-top-l">
-            {% for programme in entry.relatedFundingProgrammes %}
-                <div class="o-media u-margin-bottom">
-                    {% if programme.photo %}
-                        <img src="{{ programme.thumbnail }}"
-                             alt="{{ programme.title }}"
-                             class="o-media-figure"
-                             width="100" />
-                    {% endif %}
-                    <div class="o-media-body">
-                        <h4 class="a--text accent--{{ pageAccent }}">{{ programme.title }}</h4>
-                        {{ programme.intro | safe }}
-                        <p class="u-no-margin"><a href="{{ programme.linkUrl }}">{{ copy.readMoreAboutProgramme }}</a></p>
-                    </div>
-                </div>
-            {% endfor %}
-        </div>
-    {% endif %}
-{% endmacro %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -70,3 +70,25 @@
         {% endfor %}
     </ol>
 {% endmacro %}
+
+{% macro relatedProgrammes(programmes) %}
+    {% if programmes.length > 0 %}
+        <div class="u-tone-background-tint u-padded u-margin-top-l">
+            {% for programme in programmes %}
+                <div class="o-media u-margin-bottom">
+                    {% if programme.photo %}
+                        <img src="{{ programme.thumbnail }}"
+                             alt="{{ programme.title }}"
+                             class="o-media-figure"
+                             width="100" />
+                    {% endif %}
+                    <div class="o-media-body">
+                        <h4 class="a--text accent--{{ pageAccent }}">{{ programme.title }}</h4>
+                        {{ programme.intro | safe }}
+                        <p class="u-no-margin"><a href="{{ programme.linkUrl }}">{{ __('news.readMoreAboutProgramme') }}</a></p>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
Spotted an issue where a lot of new posts in one category over another means there's a chance one category will be empty, eg:

![image](https://user-images.githubusercontent.com/394376/49813708-ede92480-fd5f-11e8-91db-dcb1c3e7fbfc.png)

This is also partly due to a bug in https://github.com/biglotteryfund/blf-alpha/pull/1527 which changes the format (eg. we now need to use `.result` for the entries, though I can't work out why we didn't need this before...).