### PR TITLE
Add redirect for name change post

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -1123,6 +1123,46 @@ Array [
     "to": "/welsh/about/customer-service/supplier-zone",
   },
   Object {
+    "from": "/about/uks-largest-community-funder-to-change-name",
+    "to": "/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/welsh/about/uks-largest-community-funder-to-change-name",
+    "to": "/welsh/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/england/about/uks-largest-community-funder-to-change-name",
+    "to": "/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/welsh/england/about/uks-largest-community-funder-to-change-name",
+    "to": "/welsh/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/scotland/about/uks-largest-community-funder-to-change-name",
+    "to": "/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/welsh/scotland/about/uks-largest-community-funder-to-change-name",
+    "to": "/welsh/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/northernireland/about/uks-largest-community-funder-to-change-name",
+    "to": "/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/welsh/northernireland/about/uks-largest-community-funder-to-change-name",
+    "to": "/welsh/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/wales/about/uks-largest-community-funder-to-change-name",
+    "to": "/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
+    "from": "/welsh/wales/about/uks-largest-community-funder-to-change-name",
+    "to": "/welsh/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name",
+  },
+  Object {
     "from": "/awardsforall",
     "to": "/funding/under10k",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -39,6 +39,7 @@ const aliases = {
     '/about-big/strategic-framework': '/about/strategic-framework',
     '/about-big/strategic-framework/our-vision': '/about/strategic-framework',
     '/about-big/tender-opportunities': '/about/customer-service/supplier-zone',
+    '/about/uks-largest-community-funder-to-change-name': '/news/press-releases/2018-09-28/uks-largest-community-funder-to-change-name',
     '/awardsforall': '/funding/under10k',
     '/blog': '/news/blog',
     '/blog/digital': '/news/blog?category=digital',


### PR DESCRIPTION
Redirect one-off name change post in about section to the press releases section 🔗 ➡️ 