### PR TITLE
Add grant case studies

### DIFF
--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -90,6 +90,11 @@
         @include mq('medium-major') {
             flex: 0 0 320px;
         }
+
+        // Prevent sidebar from stretching to match primary content height
+        &.content-sidebar__secondary--minimal {
+           align-self: flex-start;
+        }
     }
 }
 

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,7 @@
     "enableHotjar": false,
     "enableTimingMetrics": false,
     "enableMailSendMetrics": false,
-    "enableRelatedGrants": false
+    "enableRelatedGrants": true
   },
   "imgix": {
     "mediaDomain": "biglotteryfund-assets.imgix.net"

--- a/controllers/grants/index.js
+++ b/controllers/grants/index.js
@@ -11,7 +11,7 @@ const nspell = require('nspell');
 const cyGB = require('dictionary-cy-gb');
 const enGB = require('dictionary-en-gb');
 
-const { injectBreadcrumbs, injectCopy, injectHeroImage } = require('../../middleware/inject-content');
+const { injectBreadcrumbs, injectCopy, injectHeroImage, setHeroLocals } = require('../../middleware/inject-content');
 const { sMaxAge } = require('../../middleware/cached');
 const contentApi = require('../../services/content-api');
 const grantsService = require('../../services/grants');
@@ -265,6 +265,15 @@ router.get('/:id', injectCopy('funding.pastGrants.search'), async (req, res, nex
     try {
         const data = await grantsService.getById({ id: req.params.id, locale: req.i18n.getLocale() });
 
+        let caseStudy;
+        try {
+            caseStudy = await contentApi.getCaseStudyByGrantId({
+                locale: req.i18n.getLocale(),
+                grantId: req.params.id
+            });
+            setHeroLocals({ res, entry: caseStudy });
+        } catch (e) {} // eslint-disable-line no-empty
+
         if (data && data.result) {
             let fundingProgramme;
             const grant = data.result;
@@ -281,6 +290,7 @@ router.get('/:id', injectCopy('funding.pastGrants.search'), async (req, res, nex
             res.render(path.resolve(__dirname, './views/grant-detail'), {
                 title: data.result.title,
                 grant: grant,
+                caseStudy: caseStudy,
                 fundingProgramme: fundingProgramme,
                 breadcrumbs: concat(res.locals.breadcrumbs, { label: data.result.title })
             });

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -3,16 +3,28 @@
 {% from "components/feedback.njk" import inlineFeedback with context %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/promo-card/macro.njk" import promoCard %}
+{% from "components/content.njk" import flexibleContent %}
+
 {% from './helpers.njk' import pgLink, buildLocationList, buildOrgTypeList with context %}
 
-{% set bodyClass = 'has-static-header' %}
+{% if not pageHero %}
+    {% set bodyClass = 'has-static-header' %}
+{% endif %}
 
 {% block content %}
     {% set mainProgramme = grant.grantProgramme[0] %}
 
     <main role="main" id="content" class="js-past-grants-detail">
 
-        <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+        {% if pageHero %}
+            {{ hero(
+                titleText = title,
+                image = pageHero.image,
+                accent = pageAccent
+            ) }}
+        {% endif %}
+
+        <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top{% if pageHero %} nudge-up{% endif %}">
             {{ breadcrumbTrail(breadcrumbs) }}
 
             <div class="content-sidebar">
@@ -20,9 +32,15 @@
                     <div class="u-constrained-wide accent--pink">
                         <h1>{{ title }}</h1>
 
-                        {% if grant.description !== grant.title %}
-                            <h2 class="t3 t--underline accent--pink">{{ copy.grantDetail.projectOverview }}</h2>
-                            <p class="u-wrap-words">{{ grant.description }}</p>
+                        {% if caseStudy %}
+                            <div class="s-prose">
+                                {{ flexibleContent(caseStudy.content, pageAccent) }}
+                            </div>
+                        {% else %}
+                            {% if grant.description !== grant.title %}
+                                <h2 class="t3 t--underline accent--pink">{{ copy.grantDetail.projectOverview }}</h2>
+                                <p class="u-wrap-words">{{ grant.description }}</p>
+                            {% endif %}
                         {% endif %}
 
                         <grants-back-to-search
@@ -32,7 +50,7 @@
                     </div>
                 </div>
 
-                <div class="content-sidebar__secondary u-tone-background-tint u-padded">
+                <div class="content-sidebar__secondary{% if caseStudy %} content-sidebar__secondary--minimal{% endif %} u-tone-background-tint u-padded u-accent-border-top-{{ pageAccent }}">
                     <aside class="u-align-center accent--pink a--text">
                         <p class="t1 u-no-margin">£{{ grant.amountAwarded | numberWithCommas }}</p>
                         <p class="t5">

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -159,6 +159,16 @@
             </div>
         </div>
 
+        {# Related projects widget #}
+        {% if appData.config.get('features.enableRelatedGrants') %}
+            <grants-related
+                limit="3"
+                exclude-id="{{ grant.id }}"
+                programme="{{ mainProgramme.title }}"
+                beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
+            />
+        {% endif %}
+
         <div class="u-inner">
             <div id="feedback">
                 {{ inlineFeedback(

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -3,6 +3,7 @@
 {% from "components/feedback.njk" import inlineFeedback with context %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/promo-card/macro.njk" import promoCard %}
+{% from "components/card/macro.njk" import card %}
 {% from "components/content.njk" import flexibleContent %}
 
 {% from './helpers.njk' import pgLink, buildLocationList, buildOrgTypeList with context %}
@@ -50,33 +51,36 @@
                     </div>
                 </div>
 
-                <div class="content-sidebar__secondary{% if caseStudy %} content-sidebar__secondary--minimal{% endif %} u-tone-background-tint u-padded u-accent-border-top-{{ pageAccent }}">
-                    <aside class="u-align-center accent--pink a--text">
-                        <p class="t1 u-no-margin">£{{ grant.amountAwarded | numberWithCommas }}</p>
-                        <p class="t5">
-                            {{ title }}<br/>
-                            {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
-                        </p>
-                    </aside>
+                <div class="content-sidebar__secondary{% if caseStudy %} content-sidebar__secondary--minimal{% endif %}">
+                    {% call card(aboutTitle, pageAccent) %}
+                        <aside class="u-align-center accent--pink a--text">
+                            <p class="t1 u-no-margin">£{{ grant.amountAwarded | numberWithCommas }}</p>
+                            <p class="t5">
+                                {{ title }}<br/>
+                                {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
+                            </p>
+                        </aside>
 
-                    <dl class="o-definition-list o-definition-list--compact u-text-small">
-                        {% if grant.plannedDates %}
-                            <dt>{{ copy.grantDetail.fields.duration }}</dt>
-                            {% for dates in grant.plannedDates %}
-                                <dd>
-                                    {{ fields.area.label }}
-                                    {{ formatDate(dates.startDate, DATE_FORMATS.short) }}
-                                    {% if dates.endDate %}
-                                        – {{ formatDate(dates.endDate, DATE_FORMATS.short) }}
-                                    {% endif %}
-                                </dd>
-                            {% endfor %}
+                        <dl class="o-definition-list o-definition-list--compact u-text-small">
+                            {% if grant.plannedDates %}
+                                <dt>{{ copy.grantDetail.fields.duration }}</dt>
+                                {% for dates in grant.plannedDates %}
+                                    <dd>
+                                        {{ fields.area.label }}
+                                        {{ formatDate(dates.startDate, DATE_FORMATS.short) }}
+                                        {% if dates.endDate %}
+                                            – {{ formatDate(dates.endDate, DATE_FORMATS.short) }}
+                                        {% endif %}
+                                    </dd>
+                                {% endfor %}
+                            {% endif %}
+                        </dl>
+
+                        {% if grant.isActive %}
+                            <p class="active-badge">{{ copy.grantDetail.statuses.activeProject }}</p>
                         {% endif %}
-                    </dl>
+                    {% endcall %}
 
-                    {% if grant.isActive %}
-                        <p class="active-badge">{{ copy.grantDetail.statuses.activeProject }}</p>
-                    {% endif %}
                 </div>
 
             </div>

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -16,16 +16,6 @@ const contentApi = require('../services/content-api');
  */
 function setCommonLocals({ res, entry, withFallbackHero = false }) {
     const { useNewBrand, fallbackHeroImage } = res.locals;
-
-    res.locals.title = entry.title;
-
-    res.locals.isBilingual = entry.availableLanguages.length === 2;
-
-    res.locals.previewStatus = {
-        isDraftOrVersion: entry.status === 'draft' || entry.status === 'version',
-        lastUpdated: moment(entry.dateUpdated.date).format('Do MMM YYYY [at] h:mma')
-    };
-
     const newHeroImage = get('heroNew.image')(entry);
     const newHeroCredit = get('heroNew.credit')(entry);
 
@@ -51,6 +41,27 @@ function setCommonLocals({ res, entry, withFallbackHero = false }) {
     if (res.locals.pageHero) {
         res.locals.socialImage = res.locals.pageHero.image;
     }
+}
+
+/**
+ * Sets locals that are common to many entries.
+ * - title based on content
+ * - isBilingual based on availableLanguages property
+ * - preview status metadata
+ * - pageHero (with optional fallback)
+ * - optional custom theme colour
+ */
+function setCommonLocals({ res, entry, withFallbackHero = false }) {
+    res.locals.title = entry.title;
+
+    res.locals.isBilingual = entry.availableLanguages.length === 2;
+
+    res.locals.previewStatus = {
+        isDraftOrVersion: entry.status === 'draft' || entry.status === 'version',
+        lastUpdated: moment(entry.dateUpdated.date).format('Do MMM YYYY [at] h:mma')
+    };
+
+    setHeroLocals({ res, entry, withFallbackHero });
 
     if (entry.themeColour) {
         res.locals.pageAccent = entry.themeColour;
@@ -392,5 +403,6 @@ module.exports = {
     injectResearchEntry,
     injectStrategicProgramme,
     injectStrategicProgrammes,
-    setCommonLocals
+    setCommonLocals,
+    setHeroLocals
 };

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -6,15 +6,10 @@ const Raven = require('raven');
 const { localify } = require('../modules/urls');
 const contentApi = require('../services/content-api');
 
-/**
- * Sets locals that are common to many entries.
- * - title based on content
- * - isBilingual based on availableLanguages property
- * - preview status metadata
- * - pageHero (with optional fallback)
- * - optional custom theme colour
- */
-function setCommonLocals({ res, entry, withFallbackHero = false }) {
+/*
+ * Populate hero image (with social image URLs too)
+ * */
+function setHeroLocals({ res, entry, withFallbackHero = false }) {
     const { useNewBrand, fallbackHeroImage } = res.locals;
     const newHeroImage = get('heroNew.image')(entry);
     const newHeroCredit = get('heroNew.credit')(entry);

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -3,6 +3,7 @@ const { find, filter, get, getOr, map, sortBy, take } = require('lodash/fp');
 const { isArray } = require('lodash');
 const request = require('request-promise-native');
 const debug = require('debug')('biglotteryfund:content-api');
+const querystring = require('querystring');
 
 const mapAttrs = response => map('attributes')(response.data);
 
@@ -10,7 +11,7 @@ const { sanitiseUrlPath } = require('../modules/urls');
 let { CONTENT_API_URL } = require('../modules/secrets');
 
 function fetch(urlPath, options) {
-    debug(`Fetching ${urlPath} ${options ? JSON.stringify(options) : ''}`);
+    debug(`Fetching ${urlPath}${options && options.qs ? '?' + querystring.stringify(options.qs) : ''}`);
     const defaults = {
         url: `${CONTENT_API_URL}${urlPath}`,
         json: true

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -223,6 +223,9 @@ function getCaseStudies({ locale, slugs = [] }) {
     });
 }
 
+const getCaseStudyByGrantId = ({ locale, grantId }) =>
+    fetch(`/v1/${locale}/case-studies/${grantId}`).then(r => r.data.attributes);
+
 function getOurPeople({ locale, previewMode = null }) {
     return fetch(`/v1/${locale}/our-people`, {
         qs: addPreviewParams(previewMode)
@@ -251,6 +254,7 @@ module.exports = {
     getBlogDetail,
     getBlogPosts,
     getCaseStudies,
+    getCaseStudyByGrantId,
     getDataStats,
     getFlexibleContent,
     getFundingProgramme,


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/127

Allows us to add content to a case study which will then appear on its associated grant detail page:

![image](https://user-images.githubusercontent.com/394376/49936371-b303ff80-fecb-11e8-8719-5ee97bfa7870.png)
