### PR TITLE
New programme card layout

### DIFF
--- a/assets/sass/components/_cards.scss
+++ b/assets/sass/components/_cards.scss
@@ -85,7 +85,6 @@
 
 .promo-card {
     background-color: get-color('background', 'light-neutral');
-    box-shadow: 0 0 0 1px get-color('border', 'base');
     max-width: 40em;
 
     display: flex;
@@ -122,11 +121,15 @@
     .promo-card__subtitle,
     .promo-card__trail-text,
     .promo-card__meta {
-        font-size: 15px;
+        font-size: 16px;
     }
 
     .promo-card__title {
-        margin-bottom: 3px;
+        margin-bottom: 0.5em;
+
+        a {
+            color: get-color('brand', 'primary');
+        }
     }
 
     .promo-card__subtitle {

--- a/assets/sass/components/_programmes.scss
+++ b/assets/sass/components/_programmes.scss
@@ -3,36 +3,11 @@
    ========================================================================= */
 
 /* =========================================================================
-   Programmes List
-   ========================================================================= */
-
-.programmes-list {
-    @include mq(medium-minor) {
-        display: flex;
-        flex-wrap: wrap;
-        margin: 0 (-($spacingUnit / 2));
-    }
-}
-.programmes-list__item {
-    padding-bottom: $spacingUnit;
-
-    @include mq(medium-minor) {
-        flex: 0 0 50%;
-
-        > .programme-card {
-            margin-left: $spacingUnit / 2;
-            margin-right: $spacingUnit / 2;
-        }
-    }
-}
-
-/* =========================================================================
    Programme Card
    ========================================================================= */
 
 .programme-card {
     background-color: get-color('background', 'light-neutral');
-    padding: $spacingUnit / 2;
 
     @include mq(medium-minor) {
         display: flex;
@@ -41,53 +16,18 @@
         height: 100%;
     }
 
-    @include mq(large) {
-        padding: $spacingUnit;
-    }
-}
-.programme-card__header {
-    display: flex;
-    margin-bottom: $spacingUnit / 2;
-
-    .programme-card__media {
-        order: 1;
-        flex: 0 0 50px;
-        margin-right: $spacingUnit / 2;
-
-        @include mq(medium) {
-            flex: 0 0 80px;
-            margin-right: $spacingUnit;
-        }
-    }
-
-    .programme-card__title {
-        order: 2;
-        flex: 1 1 auto;
-        margin-bottom: $spacingUnit / 2;
-
-        @include mq(medium) {
-            margin-top: 2px;
-        }
-    }
-}
-.programme-card__description {
-    margin-bottom: $spacingUnit / 2;
-}
-
-.programme-card.programme-card--minimal {
-    background-color: transparent;
-    padding: 0;
-
-    @include mq(large) {
-        padding: 0;
-    }
-
-    .programme-card__title,
     .programme-card__body {
-        font-size: 18px;
+        padding: 12px;
+        font-size: 17px;
     }
+
     .programme-card__title {
-        line-height: 1.25;
+        font-size: font-scale('display', 't4');
+        margin-bottom: 0.5em;
+
+        a {
+            color: get-color('brand', 'primary');
+        }
     }
 }
 

--- a/assets/sass/components/_programmes.scss
+++ b/assets/sass/components/_programmes.scss
@@ -3,35 +3,6 @@
    ========================================================================= */
 
 /* =========================================================================
-   Programme Card
-   ========================================================================= */
-
-.programme-card {
-    background-color: get-color('background', 'light-neutral');
-
-    @include mq(medium-minor) {
-        display: flex;
-        flex-direction: column;
-        flex: 1 1 auto;
-        height: 100%;
-    }
-
-    .programme-card__body {
-        padding: 12px;
-        font-size: 17px;
-    }
-
-    .programme-card__title {
-        font-size: font-scale('display', 't4');
-        margin-bottom: 0.5em;
-
-        a {
-            color: get-color('brand', 'primary');
-        }
-    }
-}
-
-/* =========================================================================
    Programme Summary
    ========================================================================= */
 /* Used on region pages (e.g. /wales) */

--- a/controllers/funding/views/funding-landing.njk
+++ b/controllers/funding/views/funding-landing.njk
@@ -18,21 +18,16 @@
             </section>
 
             {% if latestProgrammes.length > 0 %}
-            <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                <h2 class="t1">{{ copy.latestProgrammes }}</h2>
-
-                <ul class="flex-grid flex-grid--3up">
-                    {% for programme in latestProgrammes %}
-                        <li class="flex-grid__item">
-                            {{ programmeCard(
-                                isMinimal = true,
-                                accent = 'pink',
-                                programme = programme
-                            ) }}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </section>
+                <section class="u-inner accent-content--{{ pageAccent }}">
+                    <h2 class="t--underline">{{ copy.latestProgrammes }}</h2>
+                    <ul class="flex-grid flex-grid--3up">
+                        {% for programme in latestProgrammes %}
+                            <li class="flex-grid__item">
+                                {{ programmeCard(programme) }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
             {% endif %}
         </div>
     </main>

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -172,7 +172,7 @@
                             "labelAria": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
                             "url": link
                         }
-                    }, featured = true) %}
+                    }, featured = true, showBorder = true) %}
                         {% if fundingProgramme.hero.caption %}
                             <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
                         {% endif %}

--- a/controllers/grants/views/grant-results.njk
+++ b/controllers/grants/views/grant-results.njk
@@ -18,7 +18,7 @@
             "url": localify("/funding/grants/" + grant.id),
             "label": copy.viewGrantDetails
         }
-    }) %}
+    }, showBorder = true) %}
         <dl class="o-definition-list o-definition-list--compact">
             {% if grant.beneficiaryLocation %}
                 <dt>{{ copy.grantDetail.fields.location }}</dt>

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -1,8 +1,7 @@
-{% from "components/hero.njk" import hero with context %}
-{% from "components/programmes.njk" import programmeList with context %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-
 {% extends "layouts/main.njk" %}
+{% from "components/hero.njk" import hero with context %}
+{% from "components/programmes.njk" import programmeCard with context %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% block content %}
     <main role="main">
@@ -19,10 +18,22 @@
             {% if groupedProgrammes %}
                 {% for region, regionProgrammes in groupedProgrammes %}
                     <h3>{{ region }}</h3>
-                    {{ programmeList(regionProgrammes, accent = pageAccent) }}
+                    <ol class="flex-grid flex-grid--3up">
+                        {% for programme in regionProgrammes %}
+                            <li class="flex-grid__item">
+                                {{ programmeCard(programme) }}
+                            </li>
+                        {% endfor %}
+                    </ol>
                 {% endfor %}
             {% elseif programmes.length > 0 %}
-                {{ programmeList(programmes, accent = pageAccent) }}
+                <ol class="flex-grid flex-grid--3up">
+                    {% for programme in programmes %}
+                        <li class="flex-grid__item">
+                            {{ programmeCard(programme) }}
+                        </li>
+                    {% endfor %}
+                </ol>
             {% else %}
                 {# @TODO i18n #}
                 <p>No results</p>

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -25,8 +25,7 @@
             "labelAria": __('global.misc.readMore'),
             "url": entry.linkUrl
         }
-    }, showBorder = false) %}
-
+    }) %}
         <div class="blogpost-attribution{% if promoted %} blogpost-attribution--featured{% endif %}">
             {% if showAuthor %}
                 <div class="blogpost-attribution__author">
@@ -73,6 +72,5 @@
                 </ul>
             </div>
         </div>
-
     {% endcall %}
 {% endmacro %}

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -264,7 +264,7 @@ describe('e2e', function() {
         // Step: Navigate to funding programme
         // ================================================ //
 
-        cy.get('.qa-programme-card')
+        cy.get('.promo-card')
             .contains('Reaching Communities')
             .click();
         cy.checkActiveSection('funding');

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -5,6 +5,7 @@
             <dt>{{ labels.area }}</dt>
             <dd>{{ programme.area.label }}</dd>
         {% endif %}
+        
         {% if programme.organisationType %}
             <dt>{{ labels.organisationTypes }}</dt>
             <dd>{{ programme.organisationType }}</dd>
@@ -30,22 +31,21 @@
     </dl>
 {% endmacro %}
 
-{% macro programmeCard(programme, accent, isMinimal) %}
-    <article
-        class="programme-card{% if isMinimal %} programme-card--minimal{% else %} accent--{{ accent }} a--border-top a--border-color{% endif %} qa-programme-card">
-        <header class="programme-card__header">
-            <h3 class="programme-card__title t1">
-                <a class="u-link-minimal{% if not isMinimal %} accent--{{ accent }} a--text{% endif %}" href="{{ programme.linkUrl }}">
-                    {{ programme.title }}
-                </a>
-            </h3>
-            {% if programme.thumbnail %}
-                <div class="programme-card__media">
-                    <img src="{{ programme.thumbnail }}" alt=""/>
-                </div>
-            {% endif %}
-        </header>
+{% macro programmeCard(programme) %}
+    <article class="programme-card qa-programme-card">
+        {% if programme.trailImage %}
+            <div class="programme-card__media">
+                <img src="{{ programme.trailImageNew if useNewBrand and programme.trailImageNew else programme.trailImage }}" alt="{{ programme.hero.caption }}"/>
+            </div>
+        {% endif %}
         <div class="programme-card__body">
+            <header class="programme-card__header">
+                <h3 class="programme-card__title">
+                    <a class="u-link-minimal" href="{{ programme.linkUrl }}">
+                        {{ programme.title }}
+                    </a>
+                </h3>
+            </header>
             {% if programme.description %}
                 <div class="programme-card__description">
                     {{ programme.description | safe }}
@@ -58,18 +58,6 @@
     </article>
 {% endmacro %}
 
-{% macro programmeList(programmes, accent) %}
-    <ol class="programmes-list">
-        {% for programme in programmes %}
-            <li class="programmes-list__item">
-                {{ programmeCard(
-                    programme = programme,
-                    accent = accent
-                ) }}
-            </li>
-        {% endfor %}
-    </ol>
-{% endmacro %}
 
 {% macro relatedProgrammes(programmes) %}
     {% if programmes.length > 0 %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -1,3 +1,5 @@
+{% from "components/promo-card/macro.njk" import promoCard with context %}
+
 {% macro programmeStats(programme, isCompact) %}
     {% set labels = __('global.programmes.programmeLabels') %}
     <dl class="o-definition-list{% if isCompact %} o-definition-list--compact{% endif %}">
@@ -32,30 +34,21 @@
 {% endmacro %}
 
 {% macro programmeCard(programme) %}
-    <article class="programme-card qa-programme-card">
-        {% if programme.trailImage %}
-            <div class="programme-card__media">
-                <img src="{{ programme.trailImageNew if useNewBrand and programme.trailImageNew else programme.trailImage }}" alt="{{ programme.hero.caption }}"/>
-            </div>
-        {% endif %}
-        <div class="programme-card__body">
-            <header class="programme-card__header">
-                <h3 class="programme-card__title">
-                    <a class="u-link-minimal" href="{{ programme.linkUrl }}">
-                        {{ programme.title }}
-                    </a>
-                </h3>
-            </header>
-            {% if programme.description %}
-                <div class="programme-card__description">
-                    {{ programme.description | safe }}
-                </div>
-            {% endif %}
-            <div class="programme-card__details">
-                {{ programmeStats(programme) }}
-            </div>
-        </div>
-    </article>
+    {% set description %}
+        {{ programme.description | safe }}
+        {{ programmeStats(programme) }}
+    {% endset %}
+    {{ promoCard({
+        "title": programme.title,
+        "trailText": description | safe,
+        "image": {
+            "url": programme.trailImageNew if useNewBrand and programme.trailImageNew else programme.trailImage,
+            "alt": programme.hero.caption
+        },
+        "link": {
+            "url": programme.linkUrl
+        }
+    }) }}
 {% endmacro %}
 
 

--- a/views/components/promo-card/macro.njk
+++ b/views/components/promo-card/macro.njk
@@ -14,7 +14,7 @@ accent: {String} - Accent colour to use
 featured: {Boolean} - Use featured style for promo card
 showBorder: {Boolean} - Show a border above this card
 #}
-{% macro promoCard(props, accent = 'pink', featured = false, showBorder = true) %}
+{% macro promoCard(props, accent = 'pink', featured = false, showBorder = false) %}
     <div class="promo-card{% if featured %} promo-card--featured{% endif %}{% if showBorder %} u-accent-border-top-{{ accent }}{% endif %}">
         {% if props.image.url %}
             <div class="promo-card__media">
@@ -23,7 +23,7 @@ showBorder: {Boolean} - Show a border above this card
                 {% if props.link.url %}</a>{% endif %}
                 {% if props.kicker %}
                     <span class="promo-card__kicker">
-                        {% call overlayText(accent = accent) %}
+                        {% call overlayText(accent) %}
                             {{ props.kicker }}
                         {% endcall %}
                     </span>
@@ -33,22 +33,24 @@ showBorder: {Boolean} - Show a border above this card
         <div class="promo-card__body">
             {% if props.kicker and not props.image.url %}
                 <p class="promo-card__kicker">
-                    {% call overlayText(accent = accent) %}
+                    {% call overlayText(accent) %}
                         {{ props.kicker }}
                     {% endcall %}
                 </p>
             {% endif %}
-            <h3 class="promo-card__title t5">
+            <h3 class="promo-card__title t4">
                 {% if props.link.url %}<a class="u-link-minimal" href="{{ props.link.url }}">{% endif %}
                 {{ props.title }}
                 {% if props.link.url %}</a>{% endif %}
             </h3>
-            <p class="promo-card__subtitle">{{ props.subtitle }}</p>
+            {% if props.subtitle %}
+                <p class="promo-card__subtitle">{{ props.subtitle }}</p>
+            {% endif %}
             <div class="promo-card__trail-text s-prose">
                 {% if props.trailText %}
                     {{ props.trailText | safe }}
                 {% endif %}
-                {% if props.link.url %}
+                {% if props.link.url and props.link.label %}
                     <a href="{{ props.link.url }}"{% if props.link.labelAria %} aria-label="{{ props.link.labelAria }}"{% endif %}>
                         {{ props.link.label }}
                     </a>


### PR DESCRIPTION
One of the proposed changes as part of the rebrand is to make programme cards look like this.

![image](https://user-images.githubusercontent.com/123386/49993615-071bec00-ff7f-11e8-9137-2737e2569a28.png)

I'd rather not maintain multiple templates for this for current and rebranded styles so have updated these across the board. 💭 Thoughts welcome.