### PR TITLE
Add talent match redirect

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -3043,6 +3043,46 @@ Array [
     "to": "/welsh/funding/programmes/reaching-communities-england",
   },
   Object {
+    "from": "/global-content/programmes/england/talent-match",
+    "to": "/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/talent-match",
+    "to": "/welsh/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/talent-match",
+    "to": "/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/talent-match",
+    "to": "/welsh/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/talent-match",
+    "to": "/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/talent-match",
+    "to": "/welsh/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/talent-match",
+    "to": "/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/talent-match",
+    "to": "/welsh/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/talent-match",
+    "to": "/funding/strategic-investments/talent-match",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/talent-match",
+    "to": "/welsh/funding/strategic-investments/talent-match",
+  },
+  Object {
     "from": "/global-content/programmes/northern-ireland/awards-for-all-northern-ireland",
     "to": "/funding/programmes/awards-for-all-northern-ireland",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -87,6 +87,7 @@ const aliases = {
     '/global-content/programmes/england/multiple-and-complex-needs': '/funding/strategic-investments/multiple-needs',
     '/global-content/programmes/england/place-based-social-action': '/funding/programmes/place-based-social-action',
     '/global-content/programmes/england/reaching-communities-england': '/funding/programmes/reaching-communities-england',
+    '/global-content/programmes/england/talent-match' : '/funding/strategic-investments/talent-match',
     '/global-content/programmes/northern-ireland/awards-for-all-northern-ireland': '/funding/programmes/awards-for-all-northern-ireland',
     '/global-content/programmes/northern-ireland/empowering-young-people': '/funding/programmes/empowering-young-people',
     '/global-content/programmes/northern-ireland/people-and-communities': '/funding/programmes/people-and-communities',


### PR DESCRIPTION
Redirects https://www.biglotteryfund.org.uk/global-content/programmes/england/talent-match to the new talent match page

Also added `/talentmatch` to the aliases list in the CMS.