### PR TITLE
Redirect full cost recovery

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -2243,6 +2243,46 @@ Array [
     "to": "/welsh/funding/funding-guidance/information-checks",
   },
   Object {
+    "from": "/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/welsh/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/welsh/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/england/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/welsh/england/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/welsh/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/scotland/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/welsh/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/northernireland/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/welsh/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/wales/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
+    "from": "/welsh/wales/funding/funding-guidance/applying-for-funding/full-cost-recovery",
+    "to": "/welsh/funding/funding-guidance/full-cost-recovery",
+  },
+  Object {
     "from": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads",
     "to": "/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -67,6 +67,7 @@ const aliases = {
     '/funding/funding-guidance/applying-for-funding': '/funding',
     '/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms': '/funding-guidance/help-using-our-application-forms',
     '/funding/funding-guidance/applying-for-funding/information-checks': '/funding/funding-guidance/information-checks',
+    '/funding/funding-guidance/applying-for-funding/full-cost-recovery': '/funding/funding-guidance/full-cost-recovery',
     '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/logodownloads': '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
     '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos/LogoDownloads': '/funding/funding-guidance/managing-your-funding/grant-acknowledgement-and-logos',
     '/funding/funding-guidance/managing-your-funding/help-with-publicity': '/funding/funding-guidance/managing-your-funding',


### PR DESCRIPTION
Stops [this page](http://www.biglotteryfund.org.uk/funding/funding-guidance/applying-for-funding/full-cost-recovery) from being redirected to the national archives – I've already set up the [new one](http://www.biglotteryfund.org.uk/full-cost-recovery).