### PR TITLE
Use the correct classname for top borders

### DIFF
--- a/views/components/media-figure/macro.njk
+++ b/views/components/media-figure/macro.njk
@@ -1,5 +1,5 @@
 {% macro mediaFigure(imageUrl, caption, accent = 'pink') %}
-    <figure class="media-figure u-accent-border-{{ accent }}">
+    <figure class="media-figure u-accent-border-top-{{ accent }}">
         <img class="media-figure__image" src="{{ imageUrl }}" alt="{{ caption }}">
         <figcaption class="media-figure__caption">{{ caption }}</figcaption>
     </figure>


### PR DESCRIPTION
Fixes this regression:

![image](https://user-images.githubusercontent.com/394376/50337534-562ac980-0509-11e9-836a-f2653c804abe.png)
