### PR TITLE
Hero image simplify

### DIFF
--- a/assets/sass/_vars-rebrand.scss
+++ b/assets/sass/_vars-rebrand.scss
@@ -26,7 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
-$nudgeOffset: 60px;
+$nudgeOffset: 125px;
 
 /* =========================================================================
    Global Variables: Typography

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -26,7 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
-$nudgeOffset: 25px;
+$nudgeOffset: 100px;
 
 /* =========================================================================
    Global Variables: Typography

--- a/assets/sass/components/_heroes.scss
+++ b/assets/sass/components/_heroes.scss
@@ -78,6 +78,28 @@
 }
 
 /* =========================================================================
+   Hero Image
+   ========================================================================= */
+
+.hero-image {
+    color: white;
+    position: relative;
+
+    .hero-image__image img {
+        display: block;
+    }
+
+    .hero-image__caption {
+        position: absolute;
+        top: $spacingUnit;
+        right: $spacingUnit;
+
+        @include mq('medium', 'max') {
+            display: none;
+        }
+    }
+}
+/* =========================================================================
    Super Hero
    ========================================================================= */
 /* Larger hero image (see: Homepage) */

--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -9,6 +9,7 @@
 .page-title {
     width: 100%;
     font-size: font-scale('display', 't4');
+    margin: $spacingUnit;
 
     @include mq('medium') {
         max-width: 26em;

--- a/assets/sass/scaffolding/_layout.scss
+++ b/assets/sass/scaffolding/_layout.scss
@@ -45,11 +45,19 @@
     margin-right: $spacingUnit / 2;
 }
 
+// @TODO: Deprecated in favour of u-nudge-up
 .nudge-up {
     @include mq('medium') {
-        top: -$nudgeOffset;
-        margin-bottom: -$nudgeOffset;
+        top: -25px;
+        margin-bottom: -25px;
         position: relative;
         z-index: 10;
     }
+}
+
+.u-nudge-up {
+    top: -$nudgeOffset;
+    margin-bottom: -$nudgeOffset;
+    position: relative;
+    z-index: 10;
 }

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -1,17 +1,16 @@
 {% extends "layouts/main.njk" %}
-{% from "components/hero.njk" import hero with context %}
-{% from "components/programmes.njk" import programmeCard with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/hero-image/macro.njk" import heroImage with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
+{% from "components/programmes.njk" import programmeCard with context %}
 
 {% block content %}
-    <main role="main">
-        {{ hero(
-            titleText = title,
-            image = pageHero.image,
-            accent = pageAccent
-        ) }}
+    {{ heroImage(pageHero.image) }}
 
-        <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top nudge-up">
+    <main class="u-nudge-up" id="content">
+        {{ pageTitle(title) }}
+
+        <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
             {{ breadcrumbTrail(breadcrumbs) }}
             <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
 

--- a/views/components/hero-image/macro.njk
+++ b/views/components/hero-image/macro.njk
@@ -1,0 +1,23 @@
+
+{% macro heroImage(image) %}
+    <aside class="hero-image">
+        <figure class="hero-image__figure">
+            <picture class="hero-image__picture">
+                <source srcset="{{ image.large }}" media="(min-width: 980px)">
+                <source srcset="{{ image.medium }}" media="(min-width: 600px)">
+                <source srcset="{{ image.small }}">
+                <img src="{{ image.default }}" alt="{{ image.caption }}" />
+            </picture>
+            {% if image.caption %}
+                <figcaption class="hero-image__caption u-caption">
+                    {# @TODO: Generalise this as image.linkUrl #}
+                    {% if image.grantId %}
+                        <a href="{{ localify("/funding/grants/" + image.grantId) }}" class="u-link-unstyled">
+                    {% endif %}
+                    {{ image.caption }}
+                    {% if image.grantId %}</a>{% endif %}
+                </figcaption>
+            {% endif %}
+        </figure>
+    </aside>
+{% endmacro %}

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -13,7 +13,7 @@
         <div class="hero__content">
             <div class="hero__header u-inner" id="content">
                 <div class="hero__header__inner">
-                    {{ pageTitle(titleText, accent) }}
+                    {{ pageTitle(titleText, accent, isConstrained = false) }}
                 </div>
             </div>
             {% if image.caption %}

--- a/views/components/page-title/macro.njk
+++ b/views/components/page-title/macro.njk
@@ -1,5 +1,8 @@
 {% from "components/overlay-text/macro.njk" import overlayText %}
 
-{% macro pageTitle(title, accent = 'pink') %}
+{# @TODO: Remove isConstrained flag once fully migrated #}
+{% macro pageTitle(title, accent = 'pink', isConstrained = true) %}
+    {% if isConstrained %}<div class="u-inner">{% endif %}
     <h1 class="page-title">{% call overlayText(accent) %}{{ title | widont | safe }}{% endcall %}</h1>
+    {% if isConstrained %}</div>{% endif %}
 {% endmacro %}

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -3,16 +3,16 @@
 
 {% macro globalSearch() %}
     <form class="global-search-next js-global-search-form" role="search" action="/search">
-        <label class="u-visually-hidden" for="global-search-input">
-            {{ __("global.misc.search") }}
+        <label>
+            <span class="u-visually-hidden">{{ __("global.misc.search") }}</span>
+            <input
+                class="global-search-next__input ff-text"
+                id="global-search-input"
+                name="q"
+                type="search"
+                placeholder="{{ __("global.misc.search") }}"
+            >
         </label>
-        <input
-            class="global-search-next__input ff-text"
-            id="global-search-input"
-            name="q"
-            type="search"
-            placeholder="{{ __("global.misc.search") }}"
-        >
         <button class="global-search-next__submit" type="submit">
             <span class="global-search-next__icon">{{ iconSearch() }}</span>
             <span class="global-search-next__label">{{ __("global.misc.search") }}</span>
@@ -20,7 +20,7 @@
     </form>
 {% endmacro %}
 
-<header class="global-header-next js-global-header" role="banner">
+<header class="global-header-next js-global-header">
     <div class="global-header-next__inner">
         <div class="global-header-next__extra">
             <ul class="global-header-next__navigation-secondary">


### PR DESCRIPTION
Last PR of the year…

This is a little prep I realised we'll need to support the new hero images in the new year.

- The current hero image is hard-coded to fixed aspect ratios. But with new images we are likely to have a couple different sizes (shallow for listing pages and deeper for content pages) so it's easier to drop the fixed aspect ratios and let the img element do it's thing.
- A fair amount of extra logic is needed to support pages with no hero images

By removing the page title from the hero image and treating it as an `<aside>` (these heroes are content but not essential content) we can simplify the markup necessary to support pages with and without hero images.

This means a little churn whilst we migrate over to the new macro, but I've attempted to do this in such a way that we can gradually migrate (although post-Christmas clear-brained David might disagree with this) we'll need to review all the pages as we update hero images anyway.
