### PR TITLE
Simplified hero

### DIFF
--- a/assets/sass/_vars-rebrand.scss
+++ b/assets/sass/_vars-rebrand.scss
@@ -26,7 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
-$nudgeOffset: 60px;
+$nudgeOffset: 125px;
 
 /* =========================================================================
    Global Variables: Typography

--- a/assets/sass/_vars-rebrand.scss
+++ b/assets/sass/_vars-rebrand.scss
@@ -26,6 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
+$nudgeOffsetOld: 25px;
 $nudgeOffset: 125px;
 
 /* =========================================================================

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -26,7 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
-$nudgeOffset: 25px;
+$nudgeOffset: 100px;
 
 /* =========================================================================
    Global Variables: Typography

--- a/assets/sass/_vars.scss
+++ b/assets/sass/_vars.scss
@@ -26,6 +26,7 @@ $constrained: 700px;
 $constrainedWide: 840px;
 
 // Nudge offset, used to nudge content areas above hero images
+$nudgeOffsetOld: 25px;
 $nudgeOffset: 100px;
 
 /* =========================================================================

--- a/assets/sass/components/_heroes.scss
+++ b/assets/sass/components/_heroes.scss
@@ -38,7 +38,7 @@
     }
 
     @include mq('medium') {
-        margin-bottom: $nudgeOffset + $spacingUnit;
+        margin-bottom: $nudgeOffsetOld + $spacingUnit;
     }
 }
 .hero__header__inner {
@@ -58,7 +58,7 @@
     }
 
     @include mq('medium') {
-        bottom: $nudgeOffset + $spacingUnit;
+        bottom: $nudgeOffsetOld + $spacingUnit;
     }
 
     @include mq('large') {

--- a/assets/sass/components/_heroes.scss
+++ b/assets/sass/components/_heroes.scss
@@ -78,6 +78,28 @@
 }
 
 /* =========================================================================
+   Hero Image
+   ========================================================================= */
+
+.hero-image {
+    color: white;
+    position: relative;
+
+    .hero-image__image img {
+        display: block;
+    }
+
+    .hero-image__caption {
+        position: absolute;
+        top: $spacingUnit;
+        right: $spacingUnit;
+
+        @include mq('medium', 'max') {
+            display: none;
+        }
+    }
+}
+/* =========================================================================
    Super Hero
    ========================================================================= */
 /* Larger hero image (see: Homepage) */

--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -9,6 +9,7 @@
 .page-title {
     width: 100%;
     font-size: font-scale('display', 't4');
+    margin: $spacingUnit;
 
     @include mq('medium') {
         max-width: 26em;

--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -9,10 +9,22 @@
 .page-title {
     width: 100%;
     font-size: font-scale('display', 't4');
-    margin: $spacingUnit;
+    margin-bottom: 0;
 
-    @include mq('medium') {
-        max-width: 26em;
+    .overlay-text {
+        @include mq('medium') {
+            max-width: 26em;
+        }
+    }
+
+    &.page-title--constrained {
+        margin: 0 auto;
+        max-width: $maxWidth;
+        padding: $spacingUnit / 2;
+
+        @include mq('medium') {
+            padding: $spacingUnit;
+        }
     }
 }
 

--- a/assets/sass/scaffolding/_layout.scss
+++ b/assets/sass/scaffolding/_layout.scss
@@ -45,11 +45,19 @@
     margin-right: $spacingUnit / 2;
 }
 
+// @TODO: Deprecated in favour of u-nudge-up
 .nudge-up {
     @include mq('medium') {
-        top: -$nudgeOffset;
-        margin-bottom: -$nudgeOffset;
+        top: -25px;
+        margin-bottom: -25px;
         position: relative;
         z-index: 10;
     }
+}
+
+.u-nudge-up {
+    top: -$nudgeOffset;
+    margin-bottom: -$nudgeOffset;
+    position: relative;
+    z-index: 10;
 }

--- a/assets/sass/scaffolding/_layout.scss
+++ b/assets/sass/scaffolding/_layout.scss
@@ -48,8 +48,8 @@
 // @TODO: Deprecated in favour of u-nudge-up
 .nudge-up {
     @include mq('medium') {
-        top: -25px;
-        margin-bottom: -25px;
+        top: -$nudgeOffsetOld;
+        margin-bottom: -$nudgeOffsetOld;
         position: relative;
         z-index: 10;
     }

--- a/controllers/programmes/views/archived-programme.njk
+++ b/controllers/programmes/views/archived-programme.njk
@@ -14,9 +14,7 @@
 
 {% block content %}
     <main role="main">
-        <div class="u-inner">
-            {{ pageTitle(title) }}
-        </div>
+        {{ pageTitle(title) }}
 
         {% call contentBoxIntro(breadcrumbs, pageAccent) %}
             {% if entry.description %}

--- a/controllers/programmes/views/programme.njk
+++ b/controllers/programmes/views/programme.njk
@@ -22,9 +22,7 @@
         {% if pageHero %}<div class="nudge-up">{% endif %}
         
         {% if not pageHero %}
-            <div class="u-inner">
-                {{ pageTitle(title) }}
-            </div>
+            {{ pageTitle(title) }}
         {% endif %}
         
         {% call contentBoxIntro(breadcrumbs, pageAccent, heroCredit = pageHero.credit) %}

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -1,17 +1,16 @@
 {% extends "layouts/main.njk" %}
-{% from "components/hero.njk" import hero with context %}
-{% from "components/programmes.njk" import programmeCard with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/hero-image/macro.njk" import heroImage with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
+{% from "components/programmes.njk" import programmeCard with context %}
 
 {% block content %}
-    <main role="main">
-        {{ hero(
-            titleText = title,
-            image = pageHero.image,
-            accent = pageAccent
-        ) }}
+    {{ heroImage(pageHero.image) }}
 
-        <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top nudge-up">
+    <main class="u-nudge-up" id="content">
+        {{ pageTitle(title) }}
+
+        <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
             {{ breadcrumbTrail(breadcrumbs) }}
             <h2 class="u-visually-hidden">{{ activeBreadcrumbsSummary }}</h2>
 

--- a/controllers/research/views/research-detail.njk
+++ b/controllers/research/views/research-detail.njk
@@ -22,9 +22,7 @@
         {% if pageHero %}<div class="nudge-up">{% endif %}
         
         {% if not pageHero %}
-            <div class="u-inner">
-                {{ pageTitle(title) }}
-            </div>
+            {{ pageTitle(title) }}
         {% endif %}
 
         {# Intro #}

--- a/controllers/research/views/research-detail.njk
+++ b/controllers/research/views/research-detail.njk
@@ -1,125 +1,141 @@
 {% extends "layouts/main.njk" %}
-{% from "components/hero.njk" import hero with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/callout/macro.njk" import callout %}
 {% from "components/documents-card/macro.njk" import documentsCard with context %}
+{% from "components/hero.njk" import hero with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/print-button/macro.njk" import printButton %}
 {% from "components/segment-links/macro.njk" import segmentLinks %}
 
+{% if not pageHero %}{% set bodyClass = 'has-static-header' %}{% endif %}
+
 {% block content %}
     <main role="main">
-        {{ hero(
-            titleText = title,
-            image = pageHero.image,
-            accent = pageAccent
-        ) }}
+        {% if pageHero %}
+            {{ hero(
+                titleText = title,
+                image = pageHero.image,
+                accent = pageAccent
+            ) }}
+        {% endif %}
 
-        <div class="nudge-up">
-            {# Intro #}
-            <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
-                {{ breadcrumbTrail(breadcrumbs) }}
+        {% if pageHero %}<div class="nudge-up">{% endif %}
+        
+        {% if not pageHero %}
+            <div class="u-inner">
+                {{ pageTitle(title) }}
+            </div>
+        {% endif %}
 
-                <div class="content-sidebar">
-                    <div class="content-sidebar__primary">
-                        <div class="s-prose u-text-medium">
-                            {{ entry.introduction | safe }}
-                            <p>{{ printButton(label = __('global.misc.printThisPage')) }}</p>
-                        </div>
+        {# Intro #}
+        <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-                        {{ segmentLinks(
-                            prefix = entry.sectionsPrefix,
-                            segments = entry.sections
-                        ) }}
-
-                        <div class="content-meta">
-                            <dl class="o-definition-list o-definition-list--compact">
-                                <dt>{{ __('research.detail.datePublished') }}</dt>
-                                <dd>{{ formatDate(entry.postDate.date, DATE_FORMATS.month) }}</dd>
-                                {% if entry.researchPartners %}
-                                    <dt>{{ __('research.detail.researchPartners') }}</dt>
-                                    <dd>{{ entry.researchPartners }}</dd>
-                                {% endif %}
-                                {% if entry.contactEmail %}
-                                    <dt>{{ __('research.detail.contact') }}</dt>
-                                    <dd>{{ entry.contactEmail | mailto | safe }}</dd>
-                                {% endif %}
-                            </dl>
-                        </div>
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    <div class="s-prose">
+                        {{ entry.introduction | safe }}
                     </div>
-                    <div class="content-sidebar__secondary">
-                        {% if entry.documents %}
-                            {{ documentsCard(
-                                title = __('research.detail.documents'),
-                                documents = entry.documents,
-                                accent = pageAccent
-                            ) }}
-                        {% endif %}
 
-                        {% if entry.relatedFundingProgrammes.length > 0 %}
-                            <aside class="card">
-                                <header class="card__header">
-                                    <h3 class="card__title">{{ __('research.detail.relatedProgrammes') }}</h3>
-                                    <div class="card__body">
-                                        {% for programme in entry.relatedFundingProgrammes %}
-                                            <a href="{{ programme.linkUrl }}" class="related-programme">
-                                                {% if programme.thumbnail %}
-                                                    <span class="related-programme__media">
-                                                        <img src="{{ programme.thumbnail }}"
-                                                            alt="{{ programme.title }}" />
-                                                    </span>
-                                                {% endif %}
-                                                <span class="related-programme__label">{{ programme.title }}</span>
-                                            </a>
-                                        {% endfor %}
-                                    </div>
-                                </header>
-                            </aside>
+                    <div class="u-margin-bottom">
+                        {{ printButton(label = __('global.misc.printThisPage')) }}
+                    </div>
+
+                    {{ segmentLinks(
+                        prefix = entry.sectionsPrefix,
+                        segments = entry.sections
+                    ) }}
+
+                    <div class="content-meta">
+                        <dl class="o-definition-list o-definition-list--compact">
+                            <dt>{{ __('research.detail.datePublished') }}</dt>
+                            <dd>{{ formatDate(entry.postDate.date, DATE_FORMATS.month) }}</dd>
+                            {% if entry.researchPartners %}
+                                <dt>{{ __('research.detail.researchPartners') }}</dt>
+                                <dd>{{ entry.researchPartners }}</dd>
+                            {% endif %}
+                            {% if entry.contactEmail %}
+                                <dt>{{ __('research.detail.contact') }}</dt>
+                                <dd>{{ entry.contactEmail | mailto | safe }}</dd>
+                            {% endif %}
+                        </dl>
+                    </div>
+                </div>
+                <div class="content-sidebar__secondary">
+                    {% if entry.documents %}
+                        {{ documentsCard(
+                            title = __('research.detail.documents'),
+                            documents = entry.documents,
+                            accent = pageAccent
+                        ) }}
+                    {% endif %}
+
+                    {% if entry.relatedFundingProgrammes.length > 0 %}
+                        <aside class="card">
+                            <header class="card__header">
+                                <h3 class="card__title">{{ __('research.detail.relatedProgrammes') }}</h3>
+                                <div class="card__body">
+                                    {% for programme in entry.relatedFundingProgrammes %}
+                                        <a href="{{ programme.linkUrl }}" class="related-programme">
+                                            {% if programme.thumbnail %}
+                                                <span class="related-programme__media">
+                                                    <img src="{{ programme.thumbnail }}"
+                                                        alt="{{ programme.title }}" />
+                                                </span>
+                                            {% endif %}
+                                            <span class="related-programme__label">{{ programme.title }}</span>
+                                        </a>
+                                    {% endfor %}
+                                </div>
+                            </header>
+                        </aside>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+
+        {# Content #}
+        {% for section in entry.sections %}
+            <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}" id="segment-{{ loop.index }}">
+                {% if section.prefix %}<p class="u-prefix">{{ section.prefix }}</p>{% endif %}
+                <h2 class="t--underline">{{ section.title }}</h2>
+
+                <div class="research-sections">
+                    {% for part in section.parts %}
+                        {% if part.type === 'contentArea' %}
+                            <div class="research-sections__content s-prose">
+                                <p><strong>{{ part.title }}</strong></p>
+                                {{ part.content | safe }}
+                            </div>
+                        {% elseif part.type === 'callout' %}
+                            <div class="research-sections__callout">
+                                {{ callout(
+                                    content = part.content,
+                                    citation = part.credit,
+                                    isQuote = part.isQuote
+                                ) }}
+                            </div>
                         {% endif %}
+                    {% endfor %}
+
+                    <div class="research-sections__meta content-meta">
+                        {% if entry.documentsPrefix %}
+                            <p><strong>{{ entry.documentsPrefix }}</strong></p>
+                        {% endif %}
+                        {% for document in entry.documents %}
+                            <p><a class="btn btn--medium btn--outline" href="{{ document.url }}">
+                                {{ document.title }}
+                                {% if document.filetype or document.filesize %}
+                                    <small>({{ document.filetype | upper }} {{ document.filesize }})</small>
+                                {% endif %}
+                            </a></p>
+                        {% endfor %}
+                        <p><a href="#content">↑ {{ __('global.misc.backToTop') }}</a>
                     </div>
                 </div>
             </section>
+        {% endfor %}
 
-            {# Content #}
-            {% for section in entry.sections %}
-                <section class="content-box u-inner-wide-only u-accent-border-top-{{ pageAccent }}" id="segment-{{ loop.index }}">
-                    {% if section.prefix %}<p class="u-prefix">{{ section.prefix }}</p>{% endif %}
-                    <h2 class="t--underline">{{ section.title }}</h2>
-
-                    <div class="research-sections">
-                        {% for part in section.parts %}
-                            {% if part.type === 'contentArea' %}
-                                <div class="research-sections__content s-prose">
-                                    <p><strong>{{ part.title }}</strong></p>
-                                    {{ part.content | safe }}
-                                </div>
-                            {% elseif part.type === 'callout' %}
-                                <div class="research-sections__callout">
-                                    {{ callout(
-                                        content = part.content,
-                                        citation = part.credit,
-                                        isQuote = part.isQuote
-                                    ) }}
-                                </div>
-                            {% endif %}
-                        {% endfor %}
-
-                        <div class="research-sections__meta content-meta">
-                            {% if entry.documentsPrefix %}
-                                <p><strong>{{ entry.documentsPrefix }}</strong></p>
-                            {% endif %}
-                            {% for document in entry.documents %}
-                                <p><a class="btn btn--medium btn--outline" href="{{ document.url }}">
-                                    {{ document.title }}
-                                    {% if document.filetype or document.filesize %}
-                                        <small>({{ document.filetype | upper }} {{ document.filesize }})</small>
-                                    {% endif %}
-                                </a></p>
-                            {% endfor %}
-                            <p><a href="#content">↑ {{ __('global.misc.backToTop') }}</a>
-                        </div>
-                    </div>
-                </section>
-            {% endfor %}
-        </div>
+        {% if pageHero %}</div>{% endif %}
     </main>
 {% endblock %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -27,9 +27,7 @@
 
 {% block content %}
     <main role="main">
-        <div class="u-inner">
-            {{ pageTitle(entry.title, pageAccent) }}
-        </div>
+        {{ pageTitle(entry.title) }}
     
         <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
             {{ breadcrumbTrail(breadcrumbs) }}

--- a/views/components/hero-image/macro.njk
+++ b/views/components/hero-image/macro.njk
@@ -1,0 +1,23 @@
+
+{% macro heroImage(image) %}
+    <aside class="hero-image">
+        <figure class="hero-image__figure">
+            <picture class="hero-image__picture">
+                <source srcset="{{ image.large }}" media="(min-width: 980px)">
+                <source srcset="{{ image.medium }}" media="(min-width: 600px)">
+                <source srcset="{{ image.small }}">
+                <img src="{{ image.default }}" alt="{{ image.caption }}" />
+            </picture>
+            {% if image.caption %}
+                <figcaption class="hero-image__caption u-caption">
+                    {# @TODO: Generalise this as image.linkUrl #}
+                    {% if image.grantId %}
+                        <a href="{{ localify("/funding/grants/" + image.grantId) }}" class="u-link-unstyled">
+                    {% endif %}
+                    {{ image.caption }}
+                    {% if image.grantId %}</a>{% endif %}
+                </figcaption>
+            {% endif %}
+        </figure>
+    </aside>
+{% endmacro %}

--- a/views/components/hero.njk
+++ b/views/components/hero.njk
@@ -13,7 +13,7 @@
         <div class="hero__content">
             <div class="hero__header u-inner" id="content">
                 <div class="hero__header__inner">
-                    {{ pageTitle(titleText, accent) }}
+                    {{ pageTitle(titleText, accent, isConstrained = false) }}
                 </div>
             </div>
             {% if image.caption %}

--- a/views/components/page-title/macro.njk
+++ b/views/components/page-title/macro.njk
@@ -1,5 +1,8 @@
 {% from "components/overlay-text/macro.njk" import overlayText %}
 
-{% macro pageTitle(title, accent = false) %}
-    <h1 class="page-title">{% call overlayText(accent) %}{{ title | widont | safe }}{% endcall %}</h1>
+{# @TODO: Remove isConstrained flag once fully migrated #}
+{% macro pageTitle(title, accent = 'pink', isConstrained = true) %}
+    <h1 class="page-title{% if isConstrained %} page-title--constrained{% endif %}">
+        {% call overlayText(accent) %}{{ title | widont | safe }}{% endcall %}
+    </h1>
 {% endmacro %}

--- a/views/includes/global-header-next.njk
+++ b/views/includes/global-header-next.njk
@@ -3,16 +3,16 @@
 
 {% macro globalSearch() %}
     <form class="global-search-next js-global-search-form" role="search" action="/search">
-        <label class="u-visually-hidden" for="global-search-input">
-            {{ __("global.misc.search") }}
+        <label>
+            <span class="u-visually-hidden">{{ __("global.misc.search") }}</span>
+            <input
+                class="global-search-next__input ff-text"
+                id="global-search-input"
+                name="q"
+                type="search"
+                placeholder="{{ __("global.misc.search") }}"
+            >
         </label>
-        <input
-            class="global-search-next__input ff-text"
-            id="global-search-input"
-            name="q"
-            type="search"
-            placeholder="{{ __("global.misc.search") }}"
-        >
         <button class="global-search-next__submit" type="submit">
             <span class="global-search-next__icon">{{ iconSearch() }}</span>
             <span class="global-search-next__label">{{ __("global.misc.search") }}</span>
@@ -20,7 +20,7 @@
     </form>
 {% endmacro %}
 
-<header class="global-header-next js-global-header" role="banner">
+<header class="global-header-next js-global-header">
     <div class="global-header-next__inner">
         <div class="global-header-next__extra">
             <ul class="global-header-next__navigation-secondary">


### PR DESCRIPTION
Last PR of the year…

This is a little prep I realised we'll need to support the new hero images in the new year.

- The current hero image is hard-coded to fixed aspect ratios. But with new images we are likely to have a couple different sizes (shallow for listing pages and deeper for content pages) so it's easier to drop the fixed aspect ratios and let the img element do it's thing.
- A fair amount of extra logic is needed to support pages with no hero images

By removing the page title from the hero image and treating it as an `<aside>` (these heroes are content but not essential content) we can simplify the markup necessary to support pages with and without hero images.

This means a little churn whilst we migrate over to the new macro, but I've attempted to do this in such a way that we can gradually migrate (although post-Christmas clear-brained David might disagree with this) we'll need to review all the pages as we update hero images anyway.
