### PR TITLE
Fixup integration tests

### DIFF
--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -393,7 +393,7 @@ describe('e2e', function() {
         cy.get('h2').should('contain', 'Thank you for your order');
     });
 
-    it.only('should be able to browse grants search results', () => {
+    it('should be able to browse grants search results', () => {
         cy.visit('/funding/grants');
         cy.get('.qa-grant-result').should('have.length', 50);
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -53,7 +53,7 @@ describe('common', function() {
         const urlPath = '/funding/funding-guidance/applying-for-funding/aims-and-outcomes';
         cy.request(urlPath).then(response => {
             expect(response.body).to.include(
-                `http://webarchive.nationalarchives.gov.uk/https://www.biglotteryfund.org.uk${urlPath}`
+                `http://webarchive.nationalarchives.gov.uk/20171011152352/https://www.biglotteryfund.org.uk${urlPath}`
             );
         });
     });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -105,13 +105,6 @@ describe('common', function() {
         });
     });
 
-    it('should follow redirects on the legacy site', () => {
-        cy.checkRedirect({
-            from: '/welshlanguage',
-            to: '/about-big/customer-service/welsh-language-scheme'
-        });
-    });
-
     it('should serve welsh versions of legacy pages', () => {
         cy.request('/welsh/research/communities-and-places').then(response => {
             expect(response.body).to.include('Cymunedau a lleoedd');


### PR DESCRIPTION
Removes a `.only` from the integration tests which was masking a test failure. Thankfully it was an out of date test rather than a regression; but nonetheless I've caught myself out with this enough times that I've added a new eslint rule for it.

![image](https://user-images.githubusercontent.com/123386/50635109-c1808c80-0f48-11e9-8162-b994009f773c.png)

Thanks to https://www.npmjs.com/package/eslint-plugin-no-only-tests