### PR TITLE
Cloudfront rules

### DIFF
--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -619,6 +619,72 @@
         "PathPattern": "/funding/programmes"
       },
       {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "location"
+            ],
+            "Quantity": 5
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session"
+              ],
+              "Quantity": 4
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/all"
+      },
+      {
         "TargetOriginId": "LEGACY",
         "ViewerProtocolPolicy": "allow-all",
         "MinTTL": 0,
@@ -1331,6 +1397,72 @@
               "version",
               "enable-feature",
               "disable-feature",
+              "location"
+            ],
+            "Quantity": 5
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session"
+              ],
+              "Quantity": 4
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/all"
+      },
+      {
+        "TargetOriginId": "ELB_LIVE",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
               "page",
               "tag",
               "author",
@@ -1531,6 +1663,6 @@
         "PathPattern": "media/*"
       }
     ],
-    "Quantity": 24
+    "Quantity": 26
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -679,6 +679,72 @@
         "PathPattern": "/funding/programmes"
       },
       {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "location"
+            ],
+            "Quantity": 5
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session"
+              ],
+              "Quantity": 4
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/funding/programmes/all"
+      },
+      {
         "TargetOriginId": "LEGACY",
         "ViewerProtocolPolicy": "allow-all",
         "MinTTL": 0,
@@ -1391,6 +1457,72 @@
               "version",
               "enable-feature",
               "disable-feature",
+              "location"
+            ],
+            "Quantity": 5
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session"
+              ],
+              "Quantity": 4
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/welsh/funding/programmes/all"
+      },
+      {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
               "page",
               "tag",
               "author",
@@ -1591,6 +1723,6 @@
         "PathPattern": "media/*"
       }
     ],
-    "Quantity": 25
+    "Quantity": 27
   }
 }

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -191,6 +191,66 @@
         "PathPattern": "/-/*"
       },
       {
+        "TargetOriginId": "ELB-TEST",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "MinTTL": 0,
+        "MaxTTL": 31536000,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "Compress": true,
+        "SmoothStreaming": false,
+        "AllowedMethods": {
+          "Items": [
+            "HEAD",
+            "GET"
+          ],
+          "Quantity": 2,
+          "CachedMethods": {
+            "Items": [
+              "HEAD",
+              "GET"
+            ],
+            "Quantity": 2
+          }
+        },
+        "ForwardedValues": {
+          "Headers": {
+            "Items": [
+              "Accept",
+              "Host"
+            ],
+            "Quantity": 2
+          },
+          "QueryStringCacheKeys": {
+            "Items": [],
+            "Quantity": 0
+          },
+          "QueryString": true,
+          "Cookies": {
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session"
+              ],
+              "Quantity": 4
+            }
+          }
+        },
+        "TrustedSigners": {
+          "Enabled": false,
+          "Items": [],
+          "Quantity": 0
+        },
+        "LambdaFunctionAssociations": {
+          "Items": [],
+          "Quantity": 0
+        },
+        "PathPattern": "/-/media/files/*"
+      },
+      {
         "TargetOriginId": "LEGACY",
         "ViewerProtocolPolicy": "allow-all",
         "MinTTL": 0,
@@ -1531,6 +1591,6 @@
         "PathPattern": "media/*"
       }
     ],
-    "Quantity": 24
+    "Quantity": 25
   }
 }

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -3683,6 +3683,46 @@ Array [
     "to": "/welsh/insights/place-based-working",
   },
   Object {
+    "from": "/research/youth-employment",
+    "to": "/insights/youth-employment",
+  },
+  Object {
+    "from": "/welsh/research/youth-employment",
+    "to": "/welsh/insights/youth-employment",
+  },
+  Object {
+    "from": "/england/research/youth-employment",
+    "to": "/insights/youth-employment",
+  },
+  Object {
+    "from": "/welsh/england/research/youth-employment",
+    "to": "/welsh/insights/youth-employment",
+  },
+  Object {
+    "from": "/scotland/research/youth-employment",
+    "to": "/insights/youth-employment",
+  },
+  Object {
+    "from": "/welsh/scotland/research/youth-employment",
+    "to": "/welsh/insights/youth-employment",
+  },
+  Object {
+    "from": "/northernireland/research/youth-employment",
+    "to": "/insights/youth-employment",
+  },
+  Object {
+    "from": "/welsh/northernireland/research/youth-employment",
+    "to": "/welsh/insights/youth-employment",
+  },
+  Object {
+    "from": "/wales/research/youth-employment",
+    "to": "/insights/youth-employment",
+  },
+  Object {
+    "from": "/welsh/wales/research/youth-employment",
+    "to": "/welsh/insights/youth-employment",
+  },
+  Object {
     "from": "/research/youth-serious-violence",
     "to": "/insights/youth-serious-violence",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -104,6 +104,7 @@ const aliases = {
     '/Home/Funding/Funding*Finder': '/funding/programmes',
     '/news-and-events/contact-press-team': '/contact#segment-4',
     '/research/place-based-working': '/insights/place-based-working',
+    '/research/youth-employment': '/insights/youth-employment',
     '/research/youth-serious-violence': '/insights/youth-serious-violence',
 
     // BBO region redirects

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -563,6 +563,72 @@ Object {
           },
           "Items": Array [
             "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session",
+              ],
+              "Quantity": 4,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
+              "location",
+            ],
+            "Quantity": 5,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/funding/programmes/all",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
             "DELETE",
             "POST",
             "GET",
@@ -1273,6 +1339,72 @@ Object {
               "version",
               "enable-feature",
               "disable-feature",
+              "location",
+            ],
+            "Quantity": 5,
+          },
+        },
+        "LambdaFunctionAssociations": Object {
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "MaxTTL": 31536000,
+        "MinTTL": 0,
+        "PathPattern": "/welsh/funding/programmes/all",
+        "SmoothStreaming": false,
+        "TargetOriginId": "ELB_LIVE",
+        "TrustedSigners": Object {
+          "Enabled": false,
+          "Items": Array [],
+          "Quantity": 0,
+        },
+        "ViewerProtocolPolicy": "redirect-to-https",
+      },
+      Object {
+        "AllowedMethods": Object {
+          "CachedMethods": Object {
+            "Items": Array [
+              "HEAD",
+              "GET",
+            ],
+            "Quantity": 2,
+          },
+          "Items": Array [
+            "HEAD",
+            "GET",
+          ],
+          "Quantity": 2,
+        },
+        "Compress": true,
+        "DefaultTTL": 86400,
+        "FieldLevelEncryptionId": "",
+        "ForwardedValues": Object {
+          "Cookies": Object {
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "contrastMode",
+                "blf-features",
+                "tnlcf-rebrand",
+                "blf-alpha-session",
+              ],
+              "Quantity": 4,
+            },
+          },
+          "Headers": Object {
+            "Items": Array [
+              "Accept",
+              "Host",
+            ],
+            "Quantity": 2,
+          },
+          "QueryString": true,
+          "QueryStringCacheKeys": Object {
+            "Items": Array [
+              "draft",
+              "version",
+              "enable-feature",
+              "disable-feature",
               "page",
               "tag",
               "author",
@@ -1465,7 +1597,7 @@ Object {
         "ViewerProtocolPolicy": "redirect-to-https",
       },
     ],
-    "Quantity": 24,
+    "Quantity": 26,
   },
   "DefaultCacheBehavior": Object {
     "AllowedMethods": Object {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -1,53 +1,8 @@
 'use strict';
-const config = require('config');
+const cookies = require('config').get('cookies');
 const { assign, compact, concat, flatten, flatMap, get, sortBy, uniq } = require('lodash');
 
 const { makeWelsh, stripTrailingSlashes } = require('./urls');
-
-const cookies = config.get('cookies');
-
-/**
- * Custom cloudfront rules
- * If any cached url paths need custom cloudfront rules like query strings
- * or custom cookies to be whitelisted you must define those rules here.
- */
-let CLOUDFRONT_PATHS = [
-    { path: '*~/link.aspx', isPostable: true, allowAllQueryStrings: true },
-    { path: '/api/*', isPostable: true, allowAllQueryStrings: true },
-    { path: '/funding/funding-finder', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
-    { path: '/funding/grants*', isPostable: true, allowAllQueryStrings: true, isBilingual: true, noSession: true },
-    { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
-    { path: '/news/*', queryStrings: ['page', 'tag', 'author', 'category', 'region'], isBilingual: true },
-    { path: '/search', allowAllQueryStrings: true, isBilingual: true },
-    { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }
-];
-
-/**
- * Legacy route paths
- * Paths in this list will be routed
- * directly to the legacy site origin
- */
-
-const LEGACY_PATHS = [
-    '/-/*',
-    '/js/*',
-    '/css/*',
-    '/images/*',
-    '/default.css',
-    '/PastGrants.ashx',
-    '/news-and-events',
-    '/funding/search-past-grants',
-    '/funding/search-past-grants/*'
-];
-
-/**
- * S3 static file route paths
- * Paths in this list will be routed to an S3 bucket
- * either for CMS uploads or app-generated static files.
- * NOTE: they should _not_ start with leading slashes
- * otherwise they fail to match directory names in S3.
- */
-const S3_PATHS = ['assets/*', 'media/*'];
 
 const makeBehaviourItem = ({
     originId,
@@ -160,8 +115,22 @@ function generateBehaviours(origins, originName) {
         cookiesInUse: [cookies.contrast, cookies.features, cookies.rebrand, cookies.session]
     });
 
-    // Serve legacy static files
-    const customBehaviours = LEGACY_PATHS.map(path =>
+    /**
+     * Legacy route paths
+     * Paths in this list will be routed
+     * directly to the legacy site origin
+     */
+    const customBehaviours = [
+        '/-/*',
+        '/js/*',
+        '/css/*',
+        '/images/*',
+        '/default.css',
+        '/PastGrants.ashx',
+        '/news-and-events',
+        '/funding/search-past-grants',
+        '/funding/search-past-grants/*'
+    ].map(path =>
         makeBehaviourItem({
             originId: origins.legacy,
             pathPattern: path,
@@ -173,7 +142,14 @@ function generateBehaviours(origins, originName) {
         })
     );
 
-    const s3Behaviours = S3_PATHS.map(path =>
+    /**
+     * S3 static file route paths
+     * Paths in this list will be routed to an S3 bucket
+     * either for CMS uploads or app-generated static files.
+     * NOTE: they should _not_ start with leading slashes
+     * otherwise they fail to match directory names in S3.
+     */
+    const s3Behaviours = ['assets/*', 'media/*'].map(path =>
         makeBehaviourItem({
             originId: origins.s3Assets,
             pathPattern: path,
@@ -182,19 +158,34 @@ function generateBehaviours(origins, originName) {
         })
     );
 
+    /**
+     * Custom cloudfront rules
+     * If any cached url paths need custom cloudfront rules like query strings
+     * or custom cookies to be whitelisted you must define those rules here.
+     */
+    let customPaths = [
+        { path: '*~/link.aspx', isPostable: true, allowAllQueryStrings: true },
+        { path: '/api/*', isPostable: true, allowAllQueryStrings: true },
+        { path: '/funding/funding-finder', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
+        { path: '/funding/grants*', isPostable: true, allowAllQueryStrings: true, isBilingual: true, noSession: true },
+        { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
+        { path: '/news/*', queryStrings: ['page', 'tag', 'author', 'category', 'region'], isBilingual: true },
+        { path: '/search', allowAllQueryStrings: true, isBilingual: true },
+        { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }
+    ];
+
     // @TODO – when enabling enableLegacyFileArchiving, remove this switch
     // so that the live Cloudfront distribution also routes these files
     if (originName === 'test') {
         // Add the legacy files path so it gets routed to our archive page
-        CLOUDFRONT_PATHS.unshift({
+        customPaths.unshift({
             path: '/-/media/files/*',
             isPostable: false,
             allowAllQueryStrings: true
         });
     }
 
-    // direct all custom routes (eg. with non-standard config) to Express
-    const primaryBehaviours = flatMap(CLOUDFRONT_PATHS, rule => {
+    const primaryBehaviours = flatMap(customPaths, rule => {
         // Merge default cookies with rule specific cookie
         const cookiesInUse = uniq(
             compact(

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -169,6 +169,7 @@ function generateBehaviours(origins, originName) {
         { path: '/funding/funding-finder', isPostable: true, allowAllQueryStrings: true, isBilingual: true },
         { path: '/funding/grants*', isPostable: true, allowAllQueryStrings: true, isBilingual: true, noSession: true },
         { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
+        { path: '/funding/programmes/all', queryStrings: ['location'], isBilingual: true },
         { path: '/news/*', queryStrings: ['page', 'tag', 'author', 'category', 'region'], isBilingual: true },
         { path: '/search', allowAllQueryStrings: true, isBilingual: true },
         { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }


### PR DESCRIPTION
Fixes an issue where cloudfront paths are defined outside of `generateBehaviours` so this block of code was mutating the list and applying in both environments.

```
    if (originName === 'test') {
        // Add the legacy files path so it gets routed to our archive page
        customPaths.unshift({
            path: '/-/media/files/*',
            isPostable: false,
            allowAllQueryStrings: true
        });
    }
```

Also adds a rule for all funding programmes.