### PR TITLE
The case of the missing funding programmes

### DIFF
--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -24,9 +24,9 @@ router.get('/', sMaxAge('30m'), injectHeroImage('manchester-cares'), async (req,
             locale: req.i18n.getLocale()
         });
 
-        if (fundingProgrammes) {
+        if (fundingProgrammes.result) {
             latestProgrammes = programmeSlugs.map(slug =>
-                find(fundingProgrammes, programme => programme.linkUrl.indexOf(slug) !== -1)
+                find(fundingProgrammes.result, programme => programme.linkUrl.indexOf(slug) !== -1)
             );
         }
     } catch (error) {} // eslint-disable-line no-empty


### PR DESCRIPTION
🔍 👁 

The content-api service now returns data with an extra `result` property, and I forgot to update the funding landing page. This change fixes that.

![image](https://user-images.githubusercontent.com/123386/50778937-008b4680-1297-11e9-9519-1e6f1a27982f.png)
