### PR TITLE
Redirect legacy programmes

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`alises should export mappedAliases 1`] = `
+exports[`aliases should export mappedAliases 1`] = `
 Array [
   Object {
     "from": "/about-big/contact-us",

--- a/controllers/__tests__/aliases.test.js
+++ b/controllers/__tests__/aliases.test.js
@@ -2,7 +2,7 @@
 'use strict';
 const aliases = require('../aliases');
 
-describe('alises', () => {
+describe('aliases', () => {
     it('should export mappedAliases', () => {
         expect(aliases).toMatchSnapshot();
     });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -85,6 +85,32 @@ describe('common', function() {
         });
     });
 
+    it('should redirect legacy funding programmes', () => {
+        [
+            {
+                originalPath: '/global-content/programmes/england/acitve-england',
+                redirectedPath: '/funding/programmes/acitve-england'
+            },
+            {
+                originalPath: '/global-content/programmes/uk-wide/green-spaces-and-sustainable-communities',
+                redirectedPath: '/funding/programmes/green-spaces-and-sustainable-communities'
+            },
+            {
+                originalPath: '/global-content/programmes/northern-ireland/young-peoples-fund-change-ur-future',
+                redirectedPath: '/funding/programmes/young-peoples-fund-change-ur-future'
+            },
+            {
+                originalPath: '/welsh/global-content/programmes/wales/young-peoples-fund-bridging-the-gap',
+                redirectedPath: '/welsh/funding/programmes/young-peoples-fund-bridging-the-gap'
+            }
+        ].forEach(page => {
+            cy.checkRedirect({
+                from: page.originalPath,
+                to: page.redirectedPath
+            });
+        });
+    });
+
     it('should serve welsh versions of legacy pages', () => {
         cy.request('/welsh/research/communities-and-places').then(response => {
             expect(response.body).to.include('Cymunedau a lleoedd');

--- a/server.js
+++ b/server.js
@@ -191,6 +191,15 @@ aliases.forEach(redirect => {
 });
 
 /**
+ * Handle legacy programme pages as wildcards
+ * (eg. redirect them to /funding/programmes/<slug>)
+ */
+app.get('/:region?/global-content/programmes/:country/:slug', (req, res) => {
+    const locale = req.params.region === 'welsh' ? '/welsh' : '';
+    res.redirect(301, `${locale}/funding/programmes/${req.params.slug}`);
+});
+
+/**
  * Archived paths
  * Handles archived pages (eg. redirect to National Archives)
  * and legacy files (eg. show a message about removed documents)


### PR DESCRIPTION
This adds a wildcard redirect to all legacy funding pages which sends them to the new, archived versions. 

Pairs with https://github.com/biglotteryfund/grants-service/pull/51 which updates the grants API to use the new programme slugs rather than the legacy ones.