### PR TITLE
Archive a few about pages

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -43,6 +43,46 @@ Array [
     "to": "/welsh/about",
   },
   Object {
+    "from": "/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/funding/strategic-investments",
+  },
+  Object {
+    "from": "/welsh/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/welsh/funding/strategic-investments",
+  },
+  Object {
+    "from": "/england/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/funding/strategic-investments",
+  },
+  Object {
+    "from": "/welsh/england/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/welsh/funding/strategic-investments",
+  },
+  Object {
+    "from": "/scotland/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/funding/strategic-investments",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/welsh/funding/strategic-investments",
+  },
+  Object {
+    "from": "/northernireland/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/funding/strategic-investments",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/welsh/funding/strategic-investments",
+  },
+  Object {
+    "from": "/wales/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/funding/strategic-investments",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/countries/about-england/strategic-investments-in-england",
+    "to": "/welsh/funding/strategic-investments",
+  },
+  Object {
     "from": "/about-big/customer-service/bogus-lottery-emails",
     "to": "/about/customer-service/bogus-lottery-emails",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -13,6 +13,7 @@ const { makeWelsh } = require('../modules/urls');
 const aliases = {
     // CLEANUP
     '/about-big/contact-us': '/about',
+    '/about-big/countries/about-england/strategic-investments-in-england': '/funding/strategic-investments',
     '/about-big/customer-service/bogus-lottery-emails': '/about/customer-service/bogus-lottery-emails',
     '/about-big/customer-service/cookies': '/about/customer-service/cookies',
     '/about-big/customer-service/customer-feedback': '/about/customer-service/customer-feedback',

--- a/controllers/archived.js
+++ b/controllers/archived.js
@@ -19,6 +19,12 @@ const metrics = require('../modules/metrics');
 // prettier-ignore
 flatMap([
     '/about-big/10-big-lottery-fund-facts',
+    '/about-big/countries*',
+    '/about-big/living-wage',
+    '/about-big/mayors-community-weekend',
+    '/about-big/our-approach/vision-and-principles',
+    '/about-big/publications*',
+    '/about-big/your-voice',
     '/funding/funding-guidance/applying-for-funding/*',
     '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*'
 ], urlPath => [urlPath, makeWelsh(urlPath)]).forEach(urlPath => {


### PR DESCRIPTION
Added tasks for all about section pages to https://github.com/biglotteryfund/blf-alpha/issues/1561

This PR starts redirecting pages to the national archives. Also adds one strategic programmes redirect. 