### PR TITLE
Redirect legacy grant search

### DIFF
--- a/assets/js/vue-apps/components/grants-filters.vue
+++ b/assets/js/vue-apps/components/grants-filters.vue
@@ -4,6 +4,7 @@ import FacetDisclose from './facet-disclose.vue';
 import FacetChoice from './facet-choice.vue';
 import FacetSelect from './facet-select.vue';
 import has from 'lodash/has';
+import $ from 'jquery';
 
 export default {
     components: { FacetGroup, FacetDisclose, FacetChoice, FacetSelect },
@@ -11,6 +12,14 @@ export default {
     methods: {
         isActiveFacet(name) {
             return has(this.filters, name);
+        },
+        triggerFeedbackPanel(event) {
+            // Prevent this from updating the window history, which triggers a search
+            event.preventDefault();
+            $('#feedback summary')
+                .click()
+                .get(0)
+                .scrollIntoView();
         }
     }
 };
@@ -20,7 +29,7 @@ export default {
     <fieldset class="search-filters" :class="{ 'search-filters--locked': status.state === 'Loading' }">
         <div class="search-filters__header">
             <legend class="search-filters__title">{{ copy.filters.title }}</legend>
-            <button type="button" class="search-filters__clear-all btn-link" @click="$emit('clear-filters');">
+            <button type="button" class="search-filters__clear-all btn-link" @click="$emit('clear-filters')">
                 {{ copy.filters.reset }}
             </button>
         </div>
@@ -35,7 +44,7 @@ export default {
                 :label="copy.filters.options.amountAwarded.label"
                 :options="facets.amountAwarded"
                 :option-limit="3"
-                @clear-selection="$emit('clear-filters', 'amount');"
+                @clear-selection="$emit('clear-filters', 'amount')"
                 :handle-active-filter="handleActiveFilter"
                 :track-ui="trackUi"
             />
@@ -48,7 +57,7 @@ export default {
                 :label="copy.filters.options.awardDate.label"
                 :options="facets.awardDate"
                 :option-limit="3"
-                @clear-selection="$emit('clear-filters', 'awardDate');"
+                @clear-selection="$emit('clear-filters', 'awardDate')"
                 :handle-active-filter="handleActiveFilter"
                 :track-ui="trackUi"
             />
@@ -60,7 +69,7 @@ export default {
                 :label-any="copy.filters.options.programme.any"
                 :clear-label="copy.filters.clearSelection"
                 :options="facets.grantProgramme"
-                @clear-selection="$emit('clear-filters', 'programme');"
+                @clear-selection="$emit('clear-filters', 'programme')"
                 :handle-active-filter="handleActiveFilter"
             />
         </FacetGroup>
@@ -74,7 +83,7 @@ export default {
                 :copy="copy"
                 :hide-label="true"
                 :options="facets.countries"
-                @clear-selection="$emit('clear-filters', 'country');"
+                @clear-selection="$emit('clear-filters', 'country')"
                 :handle-active-filter="handleActiveFilter"
                 :track-ui="trackUi"
             />
@@ -94,7 +103,7 @@ export default {
                     :label-any="copy.filters.options.localAuthority.any"
                     :clear-label="copy.filters.clearSelection"
                     :options="facets.localAuthorities"
-                    @clear-selection="$emit('clear-filters', 'localAuthority');"
+                    @clear-selection="$emit('clear-filters', 'localAuthority')"
                     :handle-active-filter="handleActiveFilter"
                 />
 
@@ -106,7 +115,7 @@ export default {
                     :label-any="copy.filters.options.westminsterConstituency.any"
                     :clear-label="copy.filters.clearSelection"
                     :options="facets.westminsterConstituencies"
-                    @clear-selection="$emit('clear-filters', 'westminsterConstituency');"
+                    @clear-selection="$emit('clear-filters', 'westminsterConstituency')"
                     :handle-active-filter="handleActiveFilter"
                 />
             </FacetDisclose>
@@ -118,9 +127,14 @@ export default {
                 :label-any="copy.filters.options.organisationType.any"
                 :clear-label="copy.filters.clearSelection"
                 :options="facets.orgType"
-                @clear-selection="$emit('clear-filters', 'orgType');"
+                @clear-selection="$emit('clear-filters', 'orgType')"
                 :handle-active-filter="handleActiveFilter"
             />
         </FacetGroup>
+
+        <p class="u-margin-top-s u-margin-bottom-s">
+            <strong>{{ copy.feedback.title }}</strong>
+        </p>
+        <p v-html="copy.feedback.body" v-on:click="triggerFeedbackPanel($event)"></p>
     </fieldset>
 </template>

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -519,19 +519,6 @@ funding:
       ukWide: Bydd fy mhrosiect yn helpu pobl ar draws y Deyrnas Unedig
     projectExamples: Enghreifftiau o brosiectau sydd wedi eu hariannu
   pastGrants:
-    title: Chwilio Pob Prosiect a Ariannwyd
-    intro: Rydym yn deall bod chwilio trwy grantiau blaenorol y Gronfa Loteri Fawr yn bwysig i lawer o bobl. Rydym wrthi’n gwella’r gwasanaeth a gynigiwn ar hyn o bryd.
-    optionsIntro: Yn y cyfamser, mae dau ddull i chi chwilio trwy ein grantiau blaenorol.
-    grantnav:
-      title: 1. Defnyddio’r wefan GrantNav
-      subtitle: Nid yw’n cael ei rhedeg gan y Gronfa Loteri Fawr ond mae’n gyflym, wedi’i ddylunio’n dda ac yn llawn dop gyda’n data ni. Noder nad yw’r wefan ar gael yn Gymraeg.
-      linkText: Chwilio GrantNav
-    legacy:
-      title: 2. Defnyddio ein cronfa ddata grantiau bresennol
-      linkText: Chwilio grantiau blaenorol
-    survey:
-      prompt: Helpwch ni i wneud chwilio am grantiau blaenorol yn well trwy ateb un cwestiwn
-      label: Dywedwch pam y daethoch i'r dudalen hon heddiw
     search:
       title: Chwilio grantiau a ddyfarnwyd
       survey:
@@ -539,7 +526,7 @@ funding:
         label: Sut brofiad cawsoch chi o chwilio ein grantiau blaenorol heddiw?
       beta: Beta
       intro: >
-        Diolch am ddewis defnyddio ein gwasanaeth "chwilio grantiau a ddyfarnwyd" newydd. Rydym yn gweithio i wella'r gwasanaeth a gynigiwn i chi, bydd eich adborth yn ein helpu gwneud hynny. Gallwch roi cynnig ar ein gwasanaeth newydd mewn Beta nawr, <a href="%s">pori ein data gyda GrantNav</a> neu ddefnyddio ein hen <a href="/welsh/funding/search-past-grants">cronfa ddata grantiau blaenorol</a>.
+        Diolch am ddewis defnyddio ein gwasanaeth "chwilio grantiau a ddyfarnwyd" newydd. Rydym yn gweithio i wella'r gwasanaeth a gynigiwn i chi, bydd eich adborth yn ein helpu gwneud hynny. Gallwch roi cynnig ar ein gwasanaeth newydd mewn Beta nawr neu <a href="%s">pori ein data gyda GrantNav</a>.
       helpText: e.e. allweddair fel "unigrwydd", lleoliad, mudiad neu faes gwaith
       dateRange: >
         Ar hyn o bryd mae ein data grantiau'n cwmpasu <strong>%s - %s</strong>. Rydym yn diweddaru'r data hwn bob mis.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,23 +610,6 @@ funding:
       ukWide: My project will help people right across the UK
     projectExamples: Examples of projects that have been funded
   pastGrants:
-    title: Search all grants
-    intro: We understand that searching through the Big Lottery Fund's past grants is important for many people. We are currently working to improve the service we currently offer.
-    introBeta: >
-      <p>Explore our database to find out what we've funded since 2004.</p>
-      <p>We understand that searching through the Big Lottery Fund's past grants is important for many people. We are currently working to improve the service we currently offer.</p>
-      <p>You can try our new service in Beta now, <a href="%s">explore our data with GrantNav</a> or use our <a href="/funding/search-past-grants">old past grants database</a>.</p>
-    optionsIntro: In the the meantime, there are two ways you can explore our past grants.
-    grantnav:
-      title: 1. Use the GrantNav site
-      subtitle: Not run by the Big Lottery Fund, but quick, nicely designed and full of our data
-      linkText: Search GrantNav
-    legacy:
-      title: 2. Use our current grants database
-      linkText: Search past grants
-    survey:
-      prompt: Please help us make the past grants search better by answering this one question
-      label: Tell us why you came to this page today
     search:
       title: Search all grants
       survey:
@@ -634,7 +617,7 @@ funding:
         label: How was your experience of using our past grants search today?
       beta: Beta
       intro: >
-        Thank you for choosing to use our new “search awarded grants” service. We are working to improve the service we currently offer, your feedback will help us do that. You can try our new service in Beta now, <a href="%s">explore our data with GrantNav</a> or use our <a href="/funding/search-past-grants">old past grants database</a>.
+        Thank you for choosing to use our new “search awarded grants” service. We are working to improve the service we currently offer, your feedback will help us do that. You can try our new service in Beta now or <a href="%s">explore our data with GrantNav</a>.
       helpText: e.g. a keyword such as “loneliness”, a location, an organisation, or an area of work
       dateRange: >
         Our grants data currently runs from <strong>%s - %s</strong>. We update this data on a monthly basis.

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -2043,6 +2043,46 @@ Array [
     "to": "/welsh/funding/grants",
   },
   Object {
+    "from": "/funding/search-past-grants*",
+    "to": "/funding/grants",
+  },
+  Object {
+    "from": "/welsh/funding/search-past-grants*",
+    "to": "/welsh/funding/grants",
+  },
+  Object {
+    "from": "/england/funding/search-past-grants*",
+    "to": "/funding/grants",
+  },
+  Object {
+    "from": "/welsh/england/funding/search-past-grants*",
+    "to": "/welsh/funding/grants",
+  },
+  Object {
+    "from": "/scotland/funding/search-past-grants*",
+    "to": "/funding/grants",
+  },
+  Object {
+    "from": "/welsh/scotland/funding/search-past-grants*",
+    "to": "/welsh/funding/grants",
+  },
+  Object {
+    "from": "/northernireland/funding/search-past-grants*",
+    "to": "/funding/grants",
+  },
+  Object {
+    "from": "/welsh/northernireland/funding/search-past-grants*",
+    "to": "/welsh/funding/grants",
+  },
+  Object {
+    "from": "/wales/funding/search-past-grants*",
+    "to": "/funding/grants",
+  },
+  Object {
+    "from": "/welsh/wales/funding/search-past-grants*",
+    "to": "/welsh/funding/grants",
+  },
+  Object {
     "from": "/funding/programmes/digital-funding",
     "to": "/funding/programmes/digital-fund",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -63,6 +63,7 @@ const aliases = {
     '/funding/funding-guidance/managing-your-funding/self-evaluation': '/funding/funding-guidance/managing-your-funding/evaluation',
     '/funding/past-grants': '/funding/grants',
     '/funding/past-grants/search': '/funding/grants',
+    '/funding/search-past-grants*': '/funding/grants',
     '/funding/programmes/digital-funding': '/funding/programmes/digital-fund',
     '/funding/scotland-portfolio': '/funding/programmes?location=scotland',
     '/funding/search-past-grants-alpha': '/funding/grants',

--- a/controllers/grants/index.js
+++ b/controllers/grants/index.js
@@ -22,7 +22,7 @@ const router = express.Router();
 
 router.use(sMaxAge('7d'), injectBreadcrumbs, (req, res, next) => {
     res.locals.breadcrumbs = concat(res.locals.breadcrumbs, {
-        label: req.i18n.__('funding.pastGrants.title'),
+        label: req.i18n.__('funding.pastGrants.search.title'),
         url: req.baseUrl
     });
     next();

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -169,12 +169,15 @@
 
         {# Related projects widget #}
         {% if appData.config.get('features.enableRelatedGrants') %}
-            <grants-related
-                limit="3"
-                exclude-id="{{ grant.id }}"
-                programme="{{ mainProgramme.title }}"
-                beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
-            />
+            {# This wrapper div must exist or the related component swallows the following component #}
+            <div>
+                <grants-related
+                    limit="3"
+                    exclude-id="{{ grant.id }}"
+                    programme="{{ mainProgramme.title }}"
+                    beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
+                />
+            </div>
         {% endif %}
 
         <div class="u-inner">

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -48,6 +48,15 @@
                         </p>
                     {% endif %}
                 </div>
+
+                <div id="feedback" class="u-margin-top">
+                    {{ inlineFeedback(
+                        description = "past_grants_new",
+                        promptLabel = copy.survey.prompt,
+                        fieldLabel = copy.survey.label,
+                        isToggleable = true
+                    )  }}
+                </div>
             </div>
 
             <form class="u-inner" id="js-past-grants" method="get" action="" v-on:submit.prevent>
@@ -285,6 +294,8 @@
                                     </div>
                                 </noscript>
                             </fieldset>
+
+
                         </div>
                     </div>
                 </div>{# End grants-search #}

--- a/modules/__tests__/__snapshots__/cloudfront.test.js.snap
+++ b/modules/__tests__/__snapshots__/cloudfront.test.js.snap
@@ -663,116 +663,6 @@ Object {
         },
         "MaxTTL": 31536000,
         "MinTTL": 0,
-        "PathPattern": "/funding/search-past-grants",
-        "SmoothStreaming": false,
-        "TargetOriginId": "LEGACY",
-        "TrustedSigners": Object {
-          "Enabled": false,
-          "Items": Array [],
-          "Quantity": 0,
-        },
-        "ViewerProtocolPolicy": "allow-all",
-      },
-      Object {
-        "AllowedMethods": Object {
-          "CachedMethods": Object {
-            "Items": Array [
-              "HEAD",
-              "GET",
-            ],
-            "Quantity": 2,
-          },
-          "Items": Array [
-            "HEAD",
-            "DELETE",
-            "POST",
-            "GET",
-            "OPTIONS",
-            "PUT",
-            "PATCH",
-          ],
-          "Quantity": 7,
-        },
-        "Compress": true,
-        "DefaultTTL": 86400,
-        "FieldLevelEncryptionId": "",
-        "ForwardedValues": Object {
-          "Cookies": Object {
-            "Forward": "all",
-          },
-          "Headers": Object {
-            "Items": Array [
-              "*",
-            ],
-            "Quantity": 1,
-          },
-          "QueryString": true,
-          "QueryStringCacheKeys": Object {
-            "Items": Array [],
-            "Quantity": 0,
-          },
-        },
-        "LambdaFunctionAssociations": Object {
-          "Items": Array [],
-          "Quantity": 0,
-        },
-        "MaxTTL": 31536000,
-        "MinTTL": 0,
-        "PathPattern": "/funding/search-past-grants/*",
-        "SmoothStreaming": false,
-        "TargetOriginId": "LEGACY",
-        "TrustedSigners": Object {
-          "Enabled": false,
-          "Items": Array [],
-          "Quantity": 0,
-        },
-        "ViewerProtocolPolicy": "allow-all",
-      },
-      Object {
-        "AllowedMethods": Object {
-          "CachedMethods": Object {
-            "Items": Array [
-              "HEAD",
-              "GET",
-            ],
-            "Quantity": 2,
-          },
-          "Items": Array [
-            "HEAD",
-            "DELETE",
-            "POST",
-            "GET",
-            "OPTIONS",
-            "PUT",
-            "PATCH",
-          ],
-          "Quantity": 7,
-        },
-        "Compress": true,
-        "DefaultTTL": 86400,
-        "FieldLevelEncryptionId": "",
-        "ForwardedValues": Object {
-          "Cookies": Object {
-            "Forward": "all",
-          },
-          "Headers": Object {
-            "Items": Array [
-              "*",
-            ],
-            "Quantity": 1,
-          },
-          "QueryString": true,
-          "QueryStringCacheKeys": Object {
-            "Items": Array [],
-            "Quantity": 0,
-          },
-        },
-        "LambdaFunctionAssociations": Object {
-          "Items": Array [],
-          "Quantity": 0,
-        },
-        "MaxTTL": 31536000,
-        "MinTTL": 0,
         "PathPattern": "/images/*",
         "SmoothStreaming": false,
         "TargetOriginId": "LEGACY",
@@ -1597,7 +1487,7 @@ Object {
         "ViewerProtocolPolicy": "redirect-to-https",
       },
     ],
-    "Quantity": 26,
+    "Quantity": 24,
   },
   "DefaultCacheBehavior": Object {
     "AllowedMethods": Object {

--- a/modules/cloudfront.js
+++ b/modules/cloudfront.js
@@ -127,9 +127,7 @@ function generateBehaviours(origins, originName) {
         '/images/*',
         '/default.css',
         '/PastGrants.ashx',
-        '/news-and-events',
-        '/funding/search-past-grants',
-        '/funding/search-past-grants/*'
+        '/news-and-events'
     ].map(path =>
         makeBehaviourItem({
             originId: origins.legacy,


### PR DESCRIPTION
Fixes #1553.

This is pretty straightforward really, just redirects the old search to the new one and removes references to it.