### PR TITLE
Archive research section

### DIFF
--- a/bin/run-a11y
+++ b/bin/run-a11y
@@ -12,7 +12,7 @@ urls=(
     "/funding/programmes/national-lottery-awards-for-all-england"
     "/funding/programmes/reaching-communities-england"
     "/funding/under10k"
-    "/research"
+    "/insights"
 )
 
 domain=${1:-http://localhost:8090}

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -25,7 +25,6 @@ global:
     home: Hafan
     funding: Ariannu
     about: Amdanom ni
-    research: Ymchwil
     insights: Mewnwelediad
     blog: Blog
     updates: Newyddion
@@ -193,7 +192,7 @@ toplevel:
     - label: Managing your grant
       href: /funding/funding-guidance/managing-your-funding
     - label: "What we've learned from our funding"
-      href: /research
+      href: /insights
     - label: Talk to us
       href: /contact
     caseStudies:
@@ -351,46 +350,6 @@ toplevel:
     - "national-lottery-awards-for-all-wales"
     - "rural-programme"
     - "people-and-places-medium-grants"
-  research:
-    title: Ymchwil
-    intro: Cael gwybod mwy am beth rydym yn ei ddysgu o’r prosiectau a ariannwn.
-    newReport: Adroddiad newydd
-    sectionLinks:
-    - label: Cymunedau a lleoedd
-      href: "/welsh/research/communities-and-places"
-    - label: Pobl hŷn
-      href: "/welsh/research/older-people"
-    - label: Addysg, dysgu a sgiliau
-      href: "/welsh/research/education-learning-skills-and-employment"
-    - label: Manteisio i’r eithaf ar ariannu
-      href: "/welsh/research/making-the-most-of-funding"
-    - label: Yr amgylchedd
-      href: "/welsh/research/environment"
-    - label: Plant, pobl ifainc a theuluoedd
-      href: "/welsh/research/children-young-people-and-families"
-    - label: Anghenion cymdeithasol sy’n dod i’r amlwg
-      href: "/welsh/research/emerging-social-need"
-    - label: Anghenion lluosog a chymhleth
-      href: "/welsh/research/multiple-and-complex-needs"
-    - label: Iechyd a lles
-      href: "/welsh/research/health-and-well-being"
-    - label: Rhyngwladol
-      href: "/welsh/research/international"
-    - label: Data agored
-      href: "/welsh/research/open-data"
-    - label: Buddsoddi cymdeithasol
-      href: "/welsh/research/social-investment"
-    - label: Cychwyn gwell
-      href: "/welsh/research/a-better-start"
-    downloads:
-      title: Dogfennau
-      links:
-      - label: Buddsoddi yn ein rhaglenni
-        caption: Mwyafu effaith gwneud grantiau (PDF 425KB)
-        href: https://media.biglotteryfund.org.uk/media/documents/research/er_res_investing_report_final.pdf
-      - label: Ateb cwestiynau mawr
-        caption: Effeithiau a gwersi a ddysgwyd o’n gwerthuso ac ymchwil (PDF 1.8MB)
-        href: https://media.biglotteryfund.org.uk/media/documents/research/er_res_answering_big_questions.pdf
   data:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau
@@ -399,6 +358,12 @@ insights:
   intro: >
     <p>Bob dydd mae’r bobl, prosiectau a chymunedau a gefnogwn yn cynhyrchu tystiolaeth, dysgu a data gwerthfawr. Yma fe ddewch o hyd i’n mewnwelediad diweddaraf i’w cyflawniadau, llwyddiannau a heriau.</p>
   moreLinkText: Gweld ymchwil a mewnwelediad wedi’i archifo
+  detail:
+    documents: Dogfennau
+    relatedProgrammes: Rhaglenni cysylltiedig
+    datePublished: Dyddiad cyhoeddi
+    partners: Partneriaid ymchwil
+    contact: Manylion cyswllt
 news:
   title: Newyddion
   allNews: Holl newyddion
@@ -1030,13 +995,6 @@ funding:
           url: 'https://knowhownonprofit.org/tools-resources/building-a-digital-workforce'
         - title: Matrics aeddfedrwydd digidol y sector gwirfoddol (digitalmaturity.co.uk)
           url: 'https://digitalmaturity.co.uk/'
-research:
-  detail:
-    documents: Dogfennau
-    relatedProgrammes: Rhaglenni cysylltiedig
-    datePublished: Dyddiad cyhoeddi
-    researchPartners: Partneriaid ymchwil
-    contact: Manylion cyswllt
 apply:
   error:
     title: Cafwyd problem gyda'ch cyflwyniad

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,6 @@ global:
     home: Home
     funding: Funding
     local: In your area
-    research: Research
     insights: Insights
     about: About
     blog: Blog
@@ -194,7 +193,7 @@ toplevel:
     - label: Managing your grant
       href: /funding/funding-guidance/managing-your-funding
     - label: "What we've learned from our funding"
-      href: /research
+      href: /insights
     - label: Talk to us
       href: /contact
     caseStudies:
@@ -438,46 +437,6 @@ toplevel:
     - "reaching-communities-england"
   local:
     title: In your area
-  research:
-    title: Research
-    intro: Find out more about what we’re learning from the projects we fund.
-    newReport: New report
-    sectionLinks:
-    - label: Communities and places
-      href: "/research/communities-and-places"
-    - label: Older people
-      href: "/research/older-people"
-    - label: Education, learning and skills
-      href: "/research/education-learning-skills-and-employment"
-    - label: Making the most of funding
-      href: "/research/making-the-most-of-funding"
-    - label: Environment
-      href: "/research/environment"
-    - label: Children, young people and families
-      href: "/research/children-young-people-and-families"
-    - label: Emerging social need
-      href: "/research/emerging-social-need"
-    - label: Multiple and complex needs
-      href: "/research/multiple-and-complex-needs"
-    - label: Health and wellbeing
-      href: "/research/health-and-well-being"
-    - label: International
-      href: "/research/international"
-    - label: Open data
-      href: "/research/open-data"
-    - label: Social investment
-      href: "/research/social-investment"
-    - label: A better start
-      href: "/research/a-better-start"
-    downloads:
-      title: Downloads
-      links:
-      - label: Investing in our programmes
-        caption: Maximising the impact of grant-making (PDF 425KB)
-        href: https://media.biglotteryfund.org.uk/media/documents/research/er_res_investing_report_final.pdf
-      - label: Answering big questions
-        caption: Impacts and lessons learned from our evaluation and research (PDF 1.8MB)
-        href: https://media.biglotteryfund.org.uk/media/documents/research/er_res_answering_big_questions.pdf
   data:
     keyStats: Key statistics
     mapTitle: Our Year in Numbers
@@ -486,6 +445,12 @@ insights:
   intro: >
     <p>Every day the people, projects and communities we support generate valuable evidence, learning and data. Here you’ll find our latest insights into their achievements, successes and challenges.</p>
   moreLinkText: View archived research and insights
+  detail:
+    documents: Documents
+    relatedProgrammes: Related programmes
+    datePublished: Date published
+    partners: Research partners
+    contact: Contact
 news:
   title: News
   allNews: All news
@@ -1121,13 +1086,6 @@ funding:
           url: 'https://knowhownonprofit.org/tools-resources/building-a-digital-workforce'
         - title: Voluntary sector digital maturity matrix (digitalmaturity.co.uk)
           url: 'https://digitalmaturity.co.uk/'
-research:
-  detail:
-    documents: Documents
-    relatedProgrammes: Related programmes
-    datePublished: Date published
-    researchPartners: Research partners
-    contact: Contact
 apply:
   error:
     title: There was a problem with your submission

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -2363,6 +2363,46 @@ Array [
     "to": "/welsh/contact#segment-4",
   },
   Object {
+    "from": "/research",
+    "to": "/insights",
+  },
+  Object {
+    "from": "/welsh/research",
+    "to": "/welsh/insights",
+  },
+  Object {
+    "from": "/england/research",
+    "to": "/insights",
+  },
+  Object {
+    "from": "/welsh/england/research",
+    "to": "/welsh/insights",
+  },
+  Object {
+    "from": "/scotland/research",
+    "to": "/insights",
+  },
+  Object {
+    "from": "/welsh/scotland/research",
+    "to": "/welsh/insights",
+  },
+  Object {
+    "from": "/northernireland/research",
+    "to": "/insights",
+  },
+  Object {
+    "from": "/welsh/northernireland/research",
+    "to": "/welsh/insights",
+  },
+  Object {
+    "from": "/wales/research",
+    "to": "/insights",
+  },
+  Object {
+    "from": "/welsh/wales/research",
+    "to": "/welsh/insights",
+  },
+  Object {
     "from": "/research/place-based-working",
     "to": "/insights/place-based-working",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -71,6 +71,7 @@ const aliases = {
     '/home/funding': '/funding',
     '/Home/Funding/Funding*Finder': '/funding/programmes',
     '/news-and-events/contact-press-team': '/contact#segment-4',
+    '/research': '/insights',
     '/research/place-based-working': '/insights/place-based-working',
     '/research/youth-employment': '/insights/youth-employment',
     '/research/youth-serious-violence': '/insights/youth-serious-violence',

--- a/controllers/archived.js
+++ b/controllers/archived.js
@@ -26,7 +26,8 @@ flatMap([
     '/about-big/publications*',
     '/about-big/your-voice',
     '/funding/funding-guidance/applying-for-funding/*',
-    '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*'
+    '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*',
+    '/research*'
 ], urlPath => [urlPath, makeWelsh(urlPath)]).forEach(urlPath => {
     router.get(urlPath, noCache, function(req, res) {
         res.render('static-pages/archived', {

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -19,7 +19,10 @@ router.get('/', injectHeroImage('hapani'), injectCopy('insights'), injectResearc
 router.get('/:slug', injectResearchEntry, injectBreadcrumbs, (req, res, next) => {
     const { researchEntry } = res.locals;
     if (researchEntry) {
-        res.render(path.resolve(__dirname, './views/insights-detail'), { entry: researchEntry });
+        res.render(path.resolve(__dirname, './views/insights-detail'), {
+            extraCopy: req.i18n.__('insights.detail'),
+            entry: researchEntry
+        });
     } else {
         next();
     }

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -9,11 +9,15 @@ const {
     injectResearch,
     injectResearchEntry
 } = require('../../middleware/inject-content');
+const { buildArchiveUrl } = require('../../modules/archived');
+const { localify } = require('../../modules/urls');
 
 const router = express.Router();
 
 router.get('/', injectHeroImage('hapani'), injectCopy('insights'), injectResearch, (req, res) => {
-    res.render(path.resolve(__dirname, './views/insights-landing'));
+    res.render(path.resolve(__dirname, './views/insights-landing'), {
+        researchArchiveUrl: buildArchiveUrl(localify(req.i18n.getLocale())('/research'))
+    });
 });
 
 router.get('/:slug', injectResearchEntry, injectBreadcrumbs, (req, res, next) => {

--- a/controllers/insights/views/insights-detail.njk
+++ b/controllers/insights/views/insights-detail.njk
@@ -33,14 +33,14 @@
 
                         <div class="content-meta">
                             <dl class="o-definition-list o-definition-list--compact">
-                                <dt>{{ __('research.detail.datePublished') }}</dt>
+                                <dt>{{ extraCopy.datePublished }}</dt>
                                 <dd>{{ formatDate(entry.postDate.date, DATE_FORMATS.month) }}</dd>
                                 {% if entry.researchPartners %}
-                                    <dt>{{ __('research.detail.researchPartners') }}</dt>
+                                    <dt>{{ extraCopy.partners }}</dt>
                                     <dd>{{ entry.researchPartners }}</dd>
                                 {% endif %}
                                 {% if entry.contactEmail %}
-                                    <dt>{{ __('research.detail.contact') }}</dt>
+                                    <dt>{{ extraCopy.contact }}</dt>
                                     <dd>{{ entry.contactEmail | mailto | safe }}</dd>
                                 {% endif %}
                             </dl>
@@ -49,7 +49,7 @@
                     <div class="content-sidebar__secondary">
                         {% if entry.documents %}
                             {{ documentsCard(
-                                title = __('research.detail.documents'),
+                                title = extraCopy.documents,
                                 documents = entry.documents,
                                 accent = pageAccent
                             ) }}
@@ -58,7 +58,7 @@
                         {% if entry.relatedFundingProgrammes.length > 0 %}
                             <aside class="card">
                                 <header class="card__header">
-                                    <h3 class="card__title">{{ __('research.detail.relatedProgrammes') }}</h3>
+                                    <h3 class="card__title">{{ extraCopy.relatedProgrammes }}</h3>
                                     <div class="card__body">
                                         {% for programme in entry.relatedFundingProgrammes %}
                                             <a href="{{ programme.linkUrl }}" class="related-programme">

--- a/controllers/insights/views/insights-landing.njk
+++ b/controllers/insights/views/insights-landing.njk
@@ -27,7 +27,7 @@
             </section>
 
             <section class="u-align-center u-margin-bottom-l">
-                <a class="btn btn--medium" href="{{ localify('/research') }}">{{ copy.moreLinkText }}</a>
+                <a class="btn btn--medium" href="{{ researchArchiveUrl }}">{{ copy.moreLinkText }}</a>
             </section>
         </div>
     </main>

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -155,27 +155,6 @@ const insights = {
 };
 
 /**
- * Research section (legacy)
- * @type {Section}
- * @TODO: Remove this when archiving this section completely
- */
-const research = {
-    path: '/research',
-    showInNavigation: false,
-    langTitlePath: 'global.nav.research',
-    pages: [
-        {
-            path: '/',
-            lang: 'toplevel.research',
-            heroSlug: 'hapani',
-            router: staticPage({
-                template: 'static-pages/research'
-            })
-        }
-    ]
-};
-
-/**
  * Talk to us section
  * @type {Section}
  */
@@ -245,7 +224,6 @@ const sections = {
     toplevel: toplevel,
     funding: funding,
     insights: insights,
-    research: research,
     talk: talk,
     about: about,
     updates: updates

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -110,13 +110,6 @@ describe('common', function() {
             });
         });
     });
-
-    it('should serve welsh versions of legacy pages', () => {
-        cy.request('/welsh/research/communities-and-places').then(response => {
-            expect(response.body).to.include('Cymunedau a lleoedd');
-        });
-    });
-
     it('should protect access to staff-only tools', () => {
         cy.checkRedirect({
             from: '/funding/programmes/national-lottery-awards-for-all-england?draft=42',

--- a/modules/__tests__/urls.test.js
+++ b/modules/__tests__/urls.test.js
@@ -18,19 +18,9 @@ const httpMocks = require('node-mocks-http');
 describe('URL Helpers', () => {
     describe('#cleanLinkNoise', () => {
         it('should clean link noise from the URL', () => {
-            expect(cleanLinkNoise('/funding/programmes/reaching-communities-england')).toBe(
-                '/funding/programmes/reaching-communities-england'
-            );
-
+            expect(cleanLinkNoise('/funding/programmes')).toBe('/funding/programmes');
             expect(cleanLinkNoise('/~/link.aspx')).toBe('/');
-
-            expect(cleanLinkNoise('/research/health-and-well-being/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/link.aspx')).toBe(
-                '/research/health-and-well-being/'
-            );
-
-            expect(cleanLinkNoise('/welsh/england/funding/funding-guidance/applying-for-funding/~/link.aspx')).toBe(
-                '/welsh/england/funding/funding-guidance/applying-for-funding/'
-            );
+            expect(cleanLinkNoise('/some/page/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/~/link.aspx')).toBe('/some/page/');
         });
     });
 

--- a/views/components/promo-card/macro.njk
+++ b/views/components/promo-card/macro.njk
@@ -35,7 +35,8 @@ featured: {Boolean} - Use featured style for promo card
                     {% endcall %}
                 </p>
             {% endif %}
-            <h3 class="promo-card__title t4">
+            {% set level = props.headingLevel | default(3, true) %}
+            <h{{ level }} class="promo-card__title t4">
                 {% if props.link.url %}
                     <a
                         class="u-link-minimal"
@@ -45,7 +46,7 @@ featured: {Boolean} - Use featured style for promo card
                 {% endif %}
                 {{ props.title }}
                 {% if props.link.url %}</a>{% endif %}
-            </h3>
+            </h{{ level }}>
             {% if props.subtitle %}
                 <p class="promo-card__subtitle">{{ props.subtitle }}</p>
             {% endif %}

--- a/views/components/promo-card/macro.njk
+++ b/views/components/promo-card/macro.njk
@@ -35,7 +35,11 @@ featured: {Boolean} - Use featured style for promo card
                     {% endcall %}
                 </p>
             {% endif %}
-            {% set level = props.headingLevel | default(3, true) %}
+            {% set level = 3 %}{# Default heading level #}
+            {# Allow heading level to be set by headingLevel only if between 1 and 6 #}
+            {% if props.headingLevel and props.headingLevel < 6 and props.headingLevel > 0 %}
+                {% set level = props.headingLevel %}
+            {% endif %}
             <h{{ level }} class="promo-card__title t4">
                 {% if props.link.url %}
                     <a

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -2,6 +2,7 @@
 
 {% macro researchCard(research) %}
     {% call promoCard({
+        "headingLevel": 2,
         "title": research.title,
         "subtitle": formatDate(research.postDate.date, DATE_FORMATS.month),
         "trailText": research.trailText,


### PR DESCRIPTION
Archives old research pages with the exception of a handful of redirects.

The top-level `/research` url redirects to `/insights` and the three new page redirect to their new home under insights. Plus I've made the following link go explicitly to the national archives.

![image](https://user-images.githubusercontent.com/123386/50905798-83d5a500-141b-11e9-95fe-f525f9cb67e6.png)

I've also taken this as an opportunity to clean up references to research in the code.