### PR TITLE
More about redirects

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -68,6 +68,8 @@ global:
       href: "/welsh/about/customer-service/privacy-policy"
     - label: Diogelu Data
       href: "/welsh/about/customer-service/data-protection"
+    - label: Safonau'r Gymraeg
+      href: "/welsh/about/customer-service/welsh-language-scheme"
     - label: Cwcis
       href: "/welsh/about/customer-service/cookies"
     - label: Telerau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,8 @@ global:
       href: "/about/customer-service/privacy-policy"
     - label: Data Protection
       href: "/about/customer-service/data-protection"
+    - label: Welsh Language Standards
+      href: "/about/customer-service/welsh-language-scheme"
     - label: Cookies
       href: "/about/customer-service/cookies"
     - label: Terms

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -763,6 +763,46 @@ Array [
     "to": "/welsh/jobs",
   },
   Object {
+    "from": "/about-big/our-approach/about-big-lottery-fund",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/about-big/our-approach/about-big-lottery-fund",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/england/about-big/our-approach/about-big-lottery-fund",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/england/about-big/our-approach/about-big-lottery-fund",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/scotland/about-big/our-approach/about-big-lottery-fund",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/our-approach/about-big-lottery-fund",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/northernireland/about-big/our-approach/about-big-lottery-fund",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/our-approach/about-big-lottery-fund",
+    "to": "/welsh/about",
+  },
+  Object {
+    "from": "/wales/about-big/our-approach/about-big-lottery-fund",
+    "to": "/about",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/our-approach/about-big-lottery-fund",
+    "to": "/welsh/about",
+  },
+  Object {
     "from": "/about-big/our-approach/accessibility",
     "to": "/about/customer-service/accessibility",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -11,7 +11,6 @@ const { makeWelsh } = require('../modules/urls');
  */
 // prettier-ignore
 const aliases = {
-    // CLEANUP
     '/about-big/contact-us': '/about',
     '/about-big/countries/about-england/strategic-investments-in-england': '/funding/strategic-investments',
     '/about-big/customer-service/bogus-lottery-emails': '/about/customer-service/bogus-lottery-emails',
@@ -31,6 +30,7 @@ const aliases = {
     '/about-big/jobs/benefits': '/jobs/benefits',
     '/about-big/jobs/current-vacancies': '/jobs',
     '/about-big/jobs/how-to-apply': '/jobs',
+    '/about-big/our-approach/about-big-lottery-fund': '/about',
     '/about-big/our-approach/accessibility': '/about/customer-service/accessibility',
     '/about-big/our-people/northern-ireland-committee-members': '/about/our-people/northern-ireland-committee',
     '/about-big/our-people/senior-management-team': '/about/our-people/senior-management-team',

--- a/controllers/archived.js
+++ b/controllers/archived.js
@@ -19,11 +19,12 @@ const metrics = require('../modules/metrics');
 // prettier-ignore
 flatMap([
     '/about-big/10-big-lottery-fund-facts',
+    '/about-big/big-lottery-fund-in-your-constituency',
     '/about-big/countries*',
+    '/about-big/future-of-doing-good',
     '/about-big/living-wage',
     '/about-big/mayors-community-weekend',
     '/about-big/our-approach/vision-and-principles',
-    '/about-big/publications*',
     '/about-big/your-voice',
     '/funding/funding-guidance/applying-for-funding/*',
     '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*'


### PR DESCRIPTION
Removes publications from archived list until https://www.biglotteryfund.org.uk/about-big/publications/corporate-documents has been migrated. Otherwise adds a few more redirects.