### PR TITLE
Fixup regression to large miniature heroes

### DIFF
--- a/assets/sass/components/_heroes.scss
+++ b/assets/sass/components/_heroes.scss
@@ -344,10 +344,25 @@
 }
 
 .miniature-hero--large {
-    .miniature-hero__title {
-        @include mq('large') {
-            font-size: 20px;
-            width: 100%;
+    @if $useNewBrand == true {
+        .miniature-hero__title {
+            @include mq('large') {
+                font-size: 18px;
+                line-height: 1.3;
+                width: 100%;
+            }
+        }
+        .miniature-hero__title-text {
+            @include mq('large') {
+                width: 80%;
+            }
+        }
+    } @else {
+        .miniature-hero__title {
+            @include mq('large') {
+                font-size: 18px;
+                width: 80%;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a small regression to listing pages introduced in #1615 

<img width="1065" alt="screenshot 2019-01-10 at 09 24 14" src="https://user-images.githubusercontent.com/123386/50959466-ec279380-14ba-11e9-877e-484adb14be29.png">

![image](https://user-images.githubusercontent.com/123386/50959435-dd40e100-14ba-11e9-9458-ce1507789972.png)