### PR TITLE
Redirect corporate documents page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -62,7 +62,7 @@ global:
     - label: Rhyddid Gwybodaeth
       href: "/welsh/about/customer-service/freedom-of-information"
     - label: Dogfennau corfforaethol
-      href: "/welsh/about-big/publications/corporate-documents"
+      href: "/welsh/about/customer-service/corporate-documents"
     - label: Polisi Preifatrwydd
       href: "/welsh/about/customer-service/privacy-policy"
     - label: Diogelu Data
@@ -868,7 +868,7 @@ funding:
       equalities: >
         <p>Mae'n bwysig i ni hefyd eich bod yn ymroddedig i gydraddoldeb a'r amgylchedd. Byddwn eisiau gwybod am eich polisïau cydraddoldeb ac amgylcheddol os bydd gennym ddiddordeb yn eich syniad.</p>
         <ul>
-          <li><a href="/welsh/about-big/our-approach/equalities">Ein hegwyddorion cydraddoldeb</a></li>
+          <li><a href="/welsh/about/customer-service/equalities">Ein hegwyddorion cydraddoldeb</a></li>
           <li><a href="https://www.gov.uk/government/publications/environmental-responsibility-for-charities">Ewch i gov.uk i gael mwy o wybodaeth am gyfrifoldeb amgylcheddol</a></li>
         </ul>
     fullEligiblity:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ global:
     - label: Freedom of Information
       href: "/about/customer-service/freedom-of-information"
     - label: Corporate documents
-      href: "/about-big/publications/corporate-documents"
+      href: "/about/customer-service/corporate-documents"
     - label: Privacy Policy
       href: "/about/customer-service/privacy-policy"
     - label: Data Protection
@@ -960,7 +960,7 @@ funding:
       equalities: >
         <p>It is also important to us that you are committed to equalities and the environment. We’ll want to know about your equalities and environmental policies if we are interested in your idea.</p>
         <ul>
-          <li><a href="/about-big/our-approach/equalities">Our equality principles</a></li>
+          <li><a href="/about/customer-service/equalities">Our equality principles</a></li>
           <li><a href="https://www.gov.uk/government/publications/environmental-responsibility-for-charities">Visit gov.uk for more information on environmental responsibility</a></li>
         </ul>
     fullEligiblity:

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -1203,6 +1203,46 @@ Array [
     "to": "/welsh/about/our-people/wales-committee",
   },
   Object {
+    "from": "/about-big/publications/corporate-documents",
+    "to": "/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/welsh/about-big/publications/corporate-documents",
+    "to": "/welsh/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/england/about-big/publications/corporate-documents",
+    "to": "/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/welsh/england/about-big/publications/corporate-documents",
+    "to": "/welsh/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/scotland/about-big/publications/corporate-documents",
+    "to": "/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/publications/corporate-documents",
+    "to": "/welsh/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/northernireland/about-big/publications/corporate-documents",
+    "to": "/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/publications/corporate-documents",
+    "to": "/welsh/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/wales/about-big/publications/corporate-documents",
+    "to": "/about/customer-service/corporate-documents",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/publications/corporate-documents",
+    "to": "/welsh/about/customer-service/corporate-documents",
+  },
+  Object {
     "from": "/about-big/strategic-framework",
     "to": "/about/strategic-framework",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -41,6 +41,7 @@ const aliases = {
     '/about-big/our-people/northern-ireland-committee-members': '/about/our-people/northern-ireland-committee',
     '/about-big/our-people/senior-management-team': '/about/our-people/senior-management-team',
     '/about-big/our-people/wales-committee-members': '/about/our-people/wales-committee',
+    '/about-big/publications/corporate-documents': '/about/customer-service/corporate-documents',
     '/about-big/strategic-framework': '/about/strategic-framework',
     '/about-big/strategic-framework/our-vision': '/about/strategic-framework',
     '/about-big/tender-opportunities': '/about/customer-service/supplier-zone',


### PR DESCRIPTION
Migrated to https://www.biglotteryfund.org.uk/about/customer-service/corporate-documents