### PR TITLE
Moves search domain to config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -20,6 +20,9 @@
       }
     }
   },
+  "domains": {
+    "searchDomain": "www.biglotteryfund.org.uk"
+  },
   "siteDomain": "www.biglotteryfund.org.uk",
   "dateFormats": {
     "month": "MMMM YYYY",

--- a/controllers/search/index.js
+++ b/controllers/search/index.js
@@ -1,13 +1,15 @@
 'use strict';
 const querystring = require('querystring');
 const express = require('express');
+const domains = require('config').get('domains');
+
 const { noCache } = require('../../middleware/cached');
 const { normaliseQuery } = require('../../modules/urls');
 
 const router = express.Router();
 
 router.get('/', noCache, (req, res) => {
-    const queryBase = 'https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk';
+    const queryBase = `https://www.google.co.uk/search?q=site%3A${domains.searchDomain}`;
     req.query = normaliseQuery(req.query);
 
     if (req.query.q) {

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -23,14 +23,14 @@ describe('common', function() {
     it('should redirect search queries to a google site search', () => {
         cy.checkRedirect({
             from: '/search?q=This is my search query',
-            to: 'https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk+This%20is%20my%20search%20query',
+            to: 'https://www.google.co.uk/search?q=site%3Awww.biglotteryfund.org.uk+This%20is%20my%20search%20query',
             isRelative: false,
             status: 302
         });
 
         cy.checkRedirect({
             from: '/search?lang=en-GB&amp;q=something&amp;type=All&amp;order=r',
-            to: 'https://www.google.co.uk/search?q=site%3Abiglotteryfund.org.uk+something',
+            to: 'https://www.google.co.uk/search?q=site%3Awww.biglotteryfund.org.uk+something',
             isRelative: false,
             status: 302
         });


### PR DESCRIPTION
Moves the search domain to config. Keeps it configured as a distinct setting as we'll likely want to keep site search using the old/current domain after the domain switchover to allow search indexes to catch up.