### PR TITLE
Our people cleanup

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -465,28 +465,6 @@ ourPeople:
   title: Ein pobl
   introduction: >
     <p>Cwrdd â'n bwrdd, UDRh a phwyllgorau cenedlaethol</p>
-  legacyNavigation:
-  - label: Y Bwrdd
-    match: board
-    href: /welsh/about-big/our-people/board
-  - label: Uwch dîm rheoli
-    match: senior-management-team
-    href: /about/our-people/senior-management-team
-  - label: England committee members
-    match: england
-    href: /about/our-people/england-committee
-  - label: NI committee members
-    match: northern-ireland
-    href: /about/our-people/northern-ireland-committee
-  - label: Scotland committee members
-    match: scotland
-    href: /about/our-people/scotland-committee
-  - label: Aelodau pwyllgor Cymru
-    match: wales
-    href: /welsh/about/our-people/wales-committee
-  - label: Pwyllgor Ariannu’r Deyrnas Unedig’
-    match: uk-funding-committee
-    href: /welsh/about/our-people/uk-funding-committee
 funding:
   under10k:
     title: Arian i Bawb y Loteri Genedlaethol - Sut i gael grant o hyd at £10,000

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -557,28 +557,6 @@ ourPeople:
   title: Our People
   introduction: >
     <p>Meet our board, Senior management team, and national committees.</p>
-  legacyNavigation:
-  - label: Board
-    match: board
-    href: /about-big/our-people/board
-  - label: Senior management team
-    match: senior-management-team
-    href: /about/our-people/senior-management-team
-  - label: England committee members
-    match: england
-    href: /about/our-people/england-committee
-  - label: Northern Ireland committee
-    match: northern-ireland
-    href: /about/our-people/northern-ireland-committee
-  - label: Scotland committee members
-    match: scotland
-    href: /about/our-people/scotland-committee
-  - label: Wales committee members
-    match: wales
-    href: /about/our-people/wales-committee
-  - label: UK funding committee
-    match: uk-funding
-    href: /about/our-people/uk-funding-committee
 funding:
   thinkingOfApplying:
     title: "Thinking of applying"

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -1283,6 +1283,46 @@ Array [
     "to": "/welsh/about/our-people/",
   },
   Object {
+    "from": "/about-big/our-people/board",
+    "to": "/about/our-people/board",
+  },
+  Object {
+    "from": "/welsh/about-big/our-people/board",
+    "to": "/welsh/about/our-people/board",
+  },
+  Object {
+    "from": "/england/about-big/our-people/board",
+    "to": "/about/our-people/board",
+  },
+  Object {
+    "from": "/welsh/england/about-big/our-people/board",
+    "to": "/welsh/about/our-people/board",
+  },
+  Object {
+    "from": "/scotland/about-big/our-people/board",
+    "to": "/about/our-people/board",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/our-people/board",
+    "to": "/welsh/about/our-people/board",
+  },
+  Object {
+    "from": "/northernireland/about-big/our-people/board",
+    "to": "/about/our-people/board",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/our-people/board",
+    "to": "/welsh/about/our-people/board",
+  },
+  Object {
+    "from": "/wales/about-big/our-people/board",
+    "to": "/about/our-people/board",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/our-people/board",
+    "to": "/welsh/about/our-people/board",
+  },
+  Object {
     "from": "/about-big/our-people/england-committee-members",
     "to": "/about/our-people/england-committee",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -46,6 +46,7 @@ const aliases = {
     '/about-big/our-approach/international-funding': '/funding/funding-guidance/international-funding',
     '/about-big/our-approach/non-lotttery-funding': '/funding/funding-guidance/non-lottery-funding',
     '/about-big/our-people/': '/about/our-people/',
+    '/about-big/our-people/board': '/about/our-people/board',
     '/about-big/our-people/england-committee-members': '/about/our-people/england-committee',
     '/about-big/our-people/northern-ireland-committee-members': '/about/our-people/northern-ireland-committee',
     '/about-big/our-people/scotland-committee-members': '/about/our-people/scotland-committee',

--- a/controllers/our-people/index.js
+++ b/controllers/our-people/index.js
@@ -8,22 +8,16 @@ const { injectCopy, injectHeroImage, injectOurPeople, setCommonLocals } = requir
 const router = express.Router();
 
 router.use(injectCopy('ourPeople'), injectOurPeople, function(req, res, next) {
-    const { title, legacyNavigation } = res.locals.copy;
+    const { title } = res.locals.copy;
 
     res.locals.sectionTitle = title;
 
-    const links = res.locals.ourPeople.map(item => {
+    res.locals.ourPeopleLinks = res.locals.ourPeople.map(item => {
         return {
             label: item.title,
             slug: item.slug,
             href: item.linkUrl
         };
-    });
-
-    // Merge items with legacy navigation to allow gradual migration
-    res.locals.ourPeopleLinks = legacyNavigation.map(legacy => {
-        const match = find(links, link => link.slug.indexOf(legacy.match) !== -1);
-        return match ? match : legacy;
     });
 
     next();

--- a/controllers/our-people/index.js
+++ b/controllers/our-people/index.js
@@ -27,7 +27,7 @@ router.get('/', injectHeroImage('mental-health-foundation'), (req, res) => {
     res.render(path.resolve(__dirname, './views/our-people'));
 });
 
-router.get('/:slug', injectOurPeople, (req, res, next) => {
+router.get('/:slug', (req, res, next) => {
     const entry = find(res.locals.ourPeople, item => item.slug === req.params.slug);
     if (entry) {
         setCommonLocals({ res, entry });


### PR DESCRIPTION
Cleans up the our people controller to:

- remove migration / legacy links, only show pages from the API
- Avoid a duplicate call to the API on detail pages
- Add redirect for board page (final page to migrated in people section)

Pending launch of board page.

Closes #1280