### PR TITLE
Cookies tweak

### DIFF
--- a/assets/js/vue-apps/components/cookie-consent.vue
+++ b/assets/js/vue-apps/components/cookie-consent.vue
@@ -24,10 +24,7 @@ export default {
 <template>
     <aside class="cookie-consent" :class="{ 'is-shown': isShown }">
         <div class="cookie-consent__inner">
-            <div class="cookie-consent__content">
-                <h4 class="cookie-consent__title">{{ title }}</h4>
-                <div class="cookie-consent__message" v-html="message"></div>
-            </div>
+            <div class="cookie-consent__content" v-html="message"></div>
             <div class="cookie-consent__actions">
                 <button class="btn btn--small" @click="handleAccept">{{ action }}</button>
             </div>

--- a/assets/sass/components/_messages.scss
+++ b/assets/sass/components/_messages.scss
@@ -62,87 +62,61 @@
 }
 
 /* =========================================================================
-   Messages: Status Banner
-   ========================================================================= */
-/* Used to flag preview mode, environment status etc. */
-
-.status-banner {
-    text-align: center;
-    font-size: 15px;
-    padding: 1em 6px;
-    color: white;
-    background-color: #006f75;
-
-    a {
-        color: white;
-        font-weight: font-weight('body', 'bold');
-    }
-}
-
-/* =========================================================================
    Messages: Cookie Consent
    ========================================================================= */
 
 .cookie-consent {
+    display: none;
+
     color: get-color('text', 'light');
     background-color: get-color('background', 'dark-neutral');
-    font-size: 14px;
-    display: none;
+    font-size: 15px;
+    padding: 8px 6px;
+    box-shadow: 0px -5px 20px 0px rgba(0, 0, 0, 0.15);
+    border-top: 1px solid lighten(get-color('background', 'dark-neutral'), 10%);
 
     &.is-shown {
         display: block;
+        position: fixed;
+        z-index: 100;
+        bottom: 0;
+        width: 100%;
     }
 
     .cookie-consent__inner {
         max-width: $maxWidth;
         margin: 0 auto;
-        padding: $spacingUnit / 2;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
 
         @include mq('medium-minor') {
-            display: flex;
+            flex-direction: row;
         }
     }
 
     .cookie-consent__content {
         margin-right: 2em;
-        margin-bottom: 5px;
+        flex: 1 1 auto;
+
+        @include mq('medium-minor', 'max') {
+            margin-bottom: 3px;
+        }
+    }
+    .cookie-consent__actions {
+        flex: 0 0 auto;
     }
 
     .cookie-consent__actions .btn {
+        font-size: 14px;
         white-space: nowrap;
-    }
-
-    @include mq('medium-minor') {
-        .cookie-consent__content,
-        .cookie-consent__actions {
-            margin: 0;
-            flex: 1 1 auto;
-        }
-        .cookie-consent__actions {
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-        }
-    }
-
-    .cookie-consent__title {
-        font-size: 16px;
-        margin: 0;
-    }
-
-    .cookie-consent__message p {
-        margin-bottom: 3px;
     }
 
     a {
         color: get-color('text', 'light');
         font-weight: font-weight('body', 'bold');
-        text-decoration: none;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.6);
-
-        @include on-interact {
-            border-color: get-color('text', 'light');
-        }
+        text-decoration: underline;
+        border: none;
     }
 }
 
@@ -152,13 +126,17 @@
 
 .announcement-banner {
     text-align: center;
-    font-size: 15px;
-    padding: 1em 6px;
+    font-size: 14px;
+    padding: 12px 6px;
     color: white;
     background-color: get-color('brand', 'primary');
 
     a {
         color: white;
         font-weight: font-weight('body', 'bold');
+    }
+
+    &.announcement-banner--info {
+        background-color: #006f75;
     }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -95,12 +95,9 @@ global:
     previousItem: Eitem flaenorol
     nextItem: Eitem nesaf
   cookieConsent:
-    title: Cwcis ar y wefan hon
     message: >
-      <p>Mae'r wefan hon yn defnyddio cwcis, mae esboniad o'u diben a sut i'w rheoli ar gael yn ein
-      <a href="/welsh/about/customer-service/cookies">Polisi Cwcis</a>.</p>
-      <p>Cadarnhewch eich cydsyniad i ni ddefnyddio nhw trwy glicio parhau.
-        Ar ôl rhoi cydsyniad ni fyddwch yn gweld y neges hon eto.</p>
+      Mae'r wefan hon yn defnyddio cwcis, mae esboniad o'u diben a sut i'w rheoli ar gael yn ein
+      <a href="/welsh/about/customer-service/cookies">Polisi Cwcis</a>.
     action: Derbyn cwcis
   stateAid:
     title: Cymorth Gwladwriaethol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,12 +96,9 @@ global:
     previousItem: Previous item
     nextItem: Next item
   cookieConsent:
-    title: Cookies on this website
     message: >
-      <p>This site uses cookies, an explanation of their purpose and how to manage them can be found within our
-      <a href="/about/customer-service/cookies">Cookies Policy</a>.</p>
-      <p>Please confirm your consent to their use by clicking continue.
-        After consenting you will not see this message again.</p>
+      This site uses cookies. For an explanation of their purpose and how to manage them see our
+      <a href="/about/customer-service/cookies">cookies policy</a>.
     action: Accept cookies
   stateAid:
     title: State Aid

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -16,17 +16,17 @@
 
             {# Status and announcement banners #}
             {% if useNewBrand %}
-                <aside class="status-banner">
+                <aside class="announcement-banner announcement-banner--info">
                     ✋ You are previewing The National Lottery Community Fund branding. Please do not share this page.
                     <a href="/tools/rebrand/off">Revert to Big Lottery Fund branding</a>
                 </aside>
             {% elseif previewStatus.isDraftOrVersion %}
-                <aside class="status-banner">
+                <aside class="announcement-banner announcement-banner--info">
                     ✋ You are viewing a draft (last updated {{ previewStatus.lastUpdated }}).
                     Please do not share this page. <a href="{{ getCurrentUrl() }}">View original</a>
                 </aside>
             {% elseif appData.isNotProduction and not appData.isDev %}
-                <aside class="status-banner">
+                <aside class="announcement-banner announcement-banner--info">
                     ✋ This is a test environment. Please do not share this page.
                 </aside>
             {% elseif enableNameChangeMessage %}


### PR DESCRIPTION
Driven by feedback from recent usability testing sessions it's clear that the current cookie message is too obtrusive and in many cases causes the primary buttons on the homepage to be pushed far enough down a typical screen that they can't be seen in the viewport on page load to the point of creating a false bottom and discoursing them from scrolling further. Participants actively commented on it being intrusive.

We need the message to be persistent and present, but not to the point of notably hindering people's experience.

This PR changes the cookie message to display as a single-line bar at the bottom of the screen. It is fixed to the bottom and remains persistent but avoids pushing important content down the page. We're not changing the main copy but removing the redundant title and "accepting accepts the acceptance" text (I may be paraphrasing).
