### PR TITLE
Disable ebulletin signup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -54,7 +54,6 @@
     "session": "blf-alpha-session"
   },
   "googleAnalyticsCode": "UA-98908627-1",
-  "ebulletinApiEndpoint": "https://apiconnector.com/v2",
   "grants": {
     "dateRange": {
       "start": "2004-04-01",

--- a/controllers/home/views/home.njk
+++ b/controllers/home/views/home.njk
@@ -1,5 +1,4 @@
 {% extends "layouts/main.njk" %}
-{% from "components/ebulletin.njk" import ebulletinForm with context %}
 {% from "components/icons.njk" import iconFacebook, iconInstagram, iconTwitter %}
 {% from "components/latest-updates/macro.njk" import latestUpdates %}
 {% from "components/promo-card/macro.njk" import promoCard %}
@@ -93,8 +92,8 @@
         {% endif %}
 
         {# Social Content #}
-        <section class="social-content u-inner-wide-only u-margin-bottom">
-            <div class="social-content__primary u-accent-border-top-{{ pageAccent }}">
+        <section class="social-content u-inner-wide-only u-margin-bottom u-accent-border-top-{{ pageAccent }}">
+            <div class="social-content__primary">
                 {# Twitter Feed #}
                 <div class="u-padded">
                     {% set twitterAccount = globalCopy.brand.twitter  %}
@@ -107,13 +106,8 @@
                 </div>
             </div>
             <div class="social-content__secondary">
-                {# Ebulletin #}
-                <div class="content-box content-box--tinted">
-                    {{ ebulletinForm() }}
-                </div>
-
                 {# Social links #}
-                <div class="o-button-group-block">
+                <div class="o-button-group-block u-padded">
                     <a class="btn btn--small btn--outline"
                         href="{{ globalCopy.brand.instagram }}">
                         <span class="btn__icon">{{ iconInstagram() }}</span>

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -188,12 +188,6 @@ const about = {
             router: require('./our-people')
         },
         {
-            path: '/ebulletin',
-            lang: 'toplevel.ebulletin',
-            heroSlug: 'the-outdoor-partnership',
-            router: require('./ebulletin')
-        },
-        {
             path: '/*',
             router: basicContent()
         }

--- a/services/newsletter-service.js
+++ b/services/newsletter-service.js
@@ -16,7 +16,7 @@ const { DOTMAILER_API } = require('../modules/secrets');
  * @see https://developer.dotmailer.com/docs/error-response-types
  */
 function subscribe({ addressBookId, subscriptionData }) {
-    const ENDPOINT = `${config.get('ebulletinApiEndpoint')}/address-books/${addressBookId}/contacts`;
+    const ENDPOINT = `https://apiconnector.com/v2/address-books/${addressBookId}/contacts`;
 
     return new Promise((resolve, reject) => {
         request({


### PR DESCRIPTION
Removes the main ebulletin signup form until such time as we have a suitable replacement. Means that until we launch a new design the home page section looks like this.

![image](https://user-images.githubusercontent.com/123386/51479316-d0a76d00-1d85-11e9-9cbc-44881924e084.png)
