### PR TITLE
 Alternate approach to digital assistance sign-up

### DIFF
--- a/controllers/digital-fund/assistance.js
+++ b/controllers/digital-fund/assistance.js
@@ -1,12 +1,15 @@
 'use strict';
-const path = require('path');
-const express = require('express');
-const { concat } = require('lodash');
 const { body, validationResult } = require('express-validator/check');
+const { concat } = require('lodash');
 const { matchedData } = require('express-validator/filter');
+const express = require('express');
+const moment = require('moment');
+const path = require('path');
 
-const newsletterService = require('../../services/newsletter-service');
+const { DIGITAL_FUND_EMAIL } = require('../../modules/secrets');
 const { errorTranslator } = require('../../modules/validators');
+const { sendEmail } = require('../../services/mail');
+const appData = require('../../modules/appData');
 
 const translateError = errorTranslator('toplevel.ebulletin.errors');
 
@@ -38,11 +41,15 @@ router
 
         if (formErrors.isEmpty()) {
             try {
-                await newsletterService.subscribe({
-                    addressBookId: '10926987',
-                    subscriptionData: {
-                        email: formData.email,
-                        emailType: 'Html'
+                await sendEmail({
+                    name: 'digital_fund_assistance',
+                    mailConfig: {
+                        sendTo: appData.isNotProduction ? formData.email : DIGITAL_FUND_EMAIL,
+                        subject: `New subscription: Help getting started with digital (${moment().format(
+                            'Do MMMM YYYY, h:mm a'
+                        )})`,
+                        type: 'text',
+                        content: `${formData.email} has requested more information about free digital assistance`
                     }
                 });
 

--- a/services/newsletter-service.js
+++ b/services/newsletter-service.js
@@ -1,5 +1,4 @@
 'use strict';
-const config = require('config');
 const request = require('request-promise-native');
 const debug = require('debug')('biglotteryfund:newsletter-service');
 const raven = require('raven');


### PR DESCRIPTION
Follow up to https://github.com/biglotteryfund/blf-alpha/pull/1659

Updates the digital fund assistance sign-up so that it sends an internal email rather than signing up to a soon to be non-existent list.