### PR TITLE
Update to search against both new and old domain

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -21,8 +21,7 @@
     }
   },
   "domains": {
-    "indexable": ["www.biglotteryfund.org.uk"],
-    "searchDomain": "www.biglotteryfund.org.uk"
+    "indexable": ["www.biglotteryfund.org.uk"]
   },
   "dateFormats": {
     "month": "MMMM YYYY",

--- a/controllers/search/index.js
+++ b/controllers/search/index.js
@@ -14,7 +14,7 @@ router.get('/', noCache, (req, res) => {
         const term = querystring.escape(req.query.q);
         // @TODO: Remove www.biglotteryfund.org.uk from search domains once new domain has been indexed.
         res.redirect(
-            `https://www.google.co.uk/search?q=${term}+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`
+            `https://www.google.co.uk/search?q=${term}+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`
         );
     } else {
         res.redirect('/');

--- a/controllers/search/index.js
+++ b/controllers/search/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const querystring = require('querystring');
 const express = require('express');
-const domains = require('config').get('domains');
 
 const { noCache } = require('../../middleware/cached');
 const { normaliseQuery } = require('../../modules/urls');
@@ -9,11 +8,14 @@ const { normaliseQuery } = require('../../modules/urls');
 const router = express.Router();
 
 router.get('/', noCache, (req, res) => {
-    const queryBase = `https://www.google.co.uk/search?q=site%3A${domains.searchDomain}`;
     req.query = normaliseQuery(req.query);
 
     if (req.query.q) {
-        res.redirect(`${queryBase}+${querystring.escape(req.query.q)}`);
+        const term = querystring.escape(req.query.q);
+        // @TODO: Remove www.biglotteryfund.org.uk from search domains once new domain has been indexed.
+        res.redirect(
+            `https://www.google.co.uk/search?q=${term}+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`
+        );
     } else {
         res.redirect('/');
     }

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -23,14 +23,16 @@ describe('common', function() {
     it('should redirect search queries to a google site search', () => {
         cy.checkRedirect({
             from: '/search?q=This is my search query',
-            to: 'https://www.google.co.uk/search?q=site%3Awww.biglotteryfund.org.uk+This%20is%20my%20search%20query',
+            to:
+                'https://www.google.co.uk/search?q=This%20is%20my%20search%20query+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk',
             isRelative: false,
             status: 302
         });
 
         cy.checkRedirect({
             from: '/search?lang=en-GB&amp;q=something&amp;type=All&amp;order=r',
-            to: 'https://www.google.co.uk/search?q=site%3Awww.biglotteryfund.org.uk+something',
+            to:
+                'https://www.google.co.uk/search?q=something+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk',
             isRelative: false,
             status: 302
         });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -21,18 +21,16 @@ describe('common', function() {
     });
 
     it('should redirect search queries to a google site search', () => {
+        const searchDomain = 'https://www.google.co.uk/search';
         cy.checkRedirect({
             from: '/search?q=This is my search query',
-            to:
-                'https://www.google.co.uk/search?q=This%20is%20my%20search%20query+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk',
+            to: `${searchDomain}?q=This%20is%20my%20search%20query+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`,
             isRelative: false,
             status: 302
         });
-
         cy.checkRedirect({
             from: '/search?lang=en-GB&amp;q=something&amp;type=All&amp;order=r',
-            to:
-                'https://www.google.co.uk/search?q=something+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk&btnK=Google+Search&oq=national+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk',
+            to: `${searchDomain}?q=something+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`,
             isRelative: false,
             status: 302
         });


### PR DESCRIPTION
Extracted from #1660

On suggestion from @mattandrews, updates the site search to use site:www.biglotteryfund.org.uk OR site:www.tnlcommunityfund.org.uk as the query so we can start picking up results from the new domain straight away once we enable search indexing.

Decided to make this a separate PR as I think this should go out post-domain-move as we're better off not showing the new domain in the search UI just yet.