### PR TITLE
Add redirect for FMS-linked contact URL

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -1643,6 +1643,46 @@ Array [
     "to": "/welsh/news/blog?tag=place-based-funding",
   },
   Object {
+    "from": "/contact-us",
+    "to": "/contact",
+  },
+  Object {
+    "from": "/welsh/contact-us",
+    "to": "/welsh/contact",
+  },
+  Object {
+    "from": "/england/contact-us",
+    "to": "/contact",
+  },
+  Object {
+    "from": "/welsh/england/contact-us",
+    "to": "/welsh/contact",
+  },
+  Object {
+    "from": "/scotland/contact-us",
+    "to": "/contact",
+  },
+  Object {
+    "from": "/welsh/scotland/contact-us",
+    "to": "/welsh/contact",
+  },
+  Object {
+    "from": "/northernireland/contact-us",
+    "to": "/contact",
+  },
+  Object {
+    "from": "/welsh/northernireland/contact-us",
+    "to": "/welsh/contact",
+  },
+  Object {
+    "from": "/wales/contact-us",
+    "to": "/contact",
+  },
+  Object {
+    "from": "/welsh/wales/contact-us",
+    "to": "/welsh/contact",
+  },
+  Object {
     "from": "/funding/awards-for-all",
     "to": "/funding/under10k",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -52,6 +52,7 @@ const aliases = {
     '/blog/insight': '/news/blog?category=insight',
     '/blog/tags/digital-fund': '/news/blog?tag=digital-fund',
     '/blog/tags/place-based-funding': '/news/blog?tag=place-based-funding',
+    '/contact-us': '/contact',
     '/funding/awards-for-all': '/funding/under10k',
     '/funding/Awards-For-All': '/funding/under10k',
     '/funding/funding-guidance': '/funding',


### PR DESCRIPTION
Harpreet spotted that this link currently breaks from the Welsh site (eg. http://www.cronfagymunedolylg.org.uk/welsh/contact-us – it's used in FMS) so this fixes it.