### PR TITLE
Allow staff to sign in with new email addresses

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -45,7 +45,8 @@
     "enablePrompt": false,
     "enableRelatedGrants": true,
     "enableSurvey": true,
-    "enableTimingMetrics": false
+    "enableTimingMetrics": false,
+    "enableNewDomainStaffAuth": false
   },
   "cookies": {
     "contrast": "contrastMode",

--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -2,6 +2,7 @@
 const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
 const OIDCStrategy = require('passport-azure-ad').OIDCStrategy;
+const config = require('config');
 
 const userService = require('../services/user');
 const { AZURE_AUTH } = require('../modules/secrets');
@@ -35,11 +36,14 @@ module.exports = function() {
      * Only initialise this auth strategy if secrets exist (eg. not on CI)
      */
     if (AZURE_AUTH.MS_CLIENT_ID) {
+        // @TODO remove this switch post-rebrand in favour of new domain by default
+        const identityEndpoint = config.get('features.enableNewDomainStaffAuth')
+            ? 'https://login.microsoftonline.com/tnlcommunityfund.onmicrosoft.com/.well-known/openid-configuration'
+            : 'https://login.microsoftonline.com/biglotteryfund.onmicrosoft.com/.well-known/openid-configuration';
         passport.use(
             new OIDCStrategy(
                 {
-                    identityMetadata:
-                        'https://login.microsoftonline.com/biglotteryfund.onmicrosoft.com/.well-known/openid-configuration',
+                    identityMetadata: identityEndpoint,
                     clientID: AZURE_AUTH.MS_CLIENT_ID,
                     allowHttpForRedirectUrl: appData.isDev,
                     redirectUrl: AZURE_AUTH.MS_REDIRECT_URL,

--- a/modules/secrets.js
+++ b/modules/secrets.js
@@ -1,5 +1,7 @@
 'use strict';
 const appData = require('./appData');
+const config = require('config');
+
 const { getSecret } = require('./parameter-store');
 
 /**
@@ -54,9 +56,11 @@ const SENTRY_DSN = getSecret('sentry.dsn');
 /**
  * Azure authentication secrets (optional, used for tools sign-in)
  */
+// @TODO remove this switch post-rebrand in favour of new domain by default
+const useNewDomainAuth = config.get('features.enableNewDomainStaffAuth');
 const AZURE_AUTH = {
-    MS_CLIENT_ID: getSecret('ms.auth.clientId'),
-    MS_CLIENT_SECRET: getSecret('ms.auth.clientSecret'),
+    MS_CLIENT_ID: useNewDomainAuth ? getSecret('ms.auth.tnlcf.clientId') : getSecret('ms.auth.clientId'),
+    MS_CLIENT_SECRET: useNewDomainAuth ? getSecret('ms.auth.tnlcf.clientSecret') : getSecret('ms.auth.clientSecret'),
     MS_REDIRECT_URL: process.env.MS_REDIRECT_URL || getSecret('ms.auth.redirectUrl')
 };
 


### PR DESCRIPTION
Off by default, but we can enable from next Monday.

I've updated the app secrets (well, added two new ones) to allow this to work and have tested it locally and confirm it's fine. 

The other place using this logic is the application dashboard – that uses environment variables (eg. defined in Elastic Beanstalk) so we can just change the same three things (client secret/ID and identity domain) and deploy new versions as/when).