### PR TITLE
Remove js-tab classes from region links

### DIFF
--- a/views/static-pages/logos.njk
+++ b/views/static-pages/logos.njk
@@ -113,13 +113,13 @@
     <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top" id="segment-1">
         <p><strong>{{ copy.locationPrompt }}</strong></p>
         <div class="o-button-group-flex">
-                <a href="#region1" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
-                    {{ copy.locations.monolingual }}
-                </a>
-                <a href="#region2" class="btn btn--small accent--{{ pageAccent }} a--btn js-tab">
-                    {{ copy.locations.bilingual }}
-                </a>
-            </div>
+            <a href="#region1" class="btn btn--small">
+                {{ copy.locations.monolingual }}
+            </a>
+            <a href="#region2" class="btn btn--small">
+                {{ copy.locations.bilingual }}
+            </a>
+        </div>
     </div>
 
     <div class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top" id="segment-1">


### PR DESCRIPTION
Remove js-tab classes from logos page. Fixes anchor behaviour.