### PR TITLE
Add dormant accounts redirects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -473,10 +473,6 @@ toplevel:
       href: "/funding/grants"
     - label: Help with managing your grant
       href: "/funding/funding-guidance/managing-your-funding"
-    - label: International funding
-      href: "/funding/funding-guidance/international-funding"
-    - label: "Non-Lottery funding"
-      href: "/funding/funding-guidance/non-lottery-funding"
     recentProgrammes:
     - "rural-programme"
     - "digital-fund"

--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -643,6 +643,86 @@ Array [
     "to": "/welsh/about/customer-service/welsh-language-scheme",
   },
   Object {
+    "from": "/about-big/dormant-account-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/about-big/dormant-account-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/england/about-big/dormant-account-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/england/about-big/dormant-account-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/scotland/about-big/dormant-account-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/dormant-account-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/northernireland/about-big/dormant-account-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/dormant-account-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/wales/about-big/dormant-account-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/dormant-account-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-account-statement-of-intent",
+  },
+  Object {
+    "from": "/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/england/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/england/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/scotland/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/scotland/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/northernireland/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/northernireland/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/wales/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
+    "from": "/welsh/wales/about-big/dormant-accounts-financial-inclusion-statement-of-intent",
+    "to": "/welsh/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent",
+  },
+  Object {
     "from": "/about-big/ebulletin-subscription",
     "to": "/about/ebulletin",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -30,6 +30,8 @@ const aliases = {
     '/about-big/customer-service/privacy-policy': '/about/customer-service/privacy-policy',
     '/about-big/customer-service/terms-of-use': '/about/customer-service/terms-of-use',
     '/about-big/customer-service/welsh-language-scheme': '/about/customer-service/welsh-language-scheme',
+    '/about-big/dormant-account-statement-of-intent': '/funding/funding-guidance/dormant-account-statement-of-intent',
+    '/about-big/dormant-accounts-financial-inclusion-statement-of-intent': '/funding/funding-guidance/dormant-accounts-financial-inclusion-statement-of-intent',
     '/about-big/ebulletin-subscription': '/about/ebulletin',
     '/about-big/ebulletin': '/about/ebulletin',
     '/about-big/helping-millions-change-their-lives': '/about/strategic-framework',


### PR DESCRIPTION
Adds redirects. Also removes statement related pages from the funding landing page, these are primarily linked to in context and confuse things when listed on the main landing page.

Closes #1631