### PR TITLE
Fixup page title spacing

### DIFF
--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -26,16 +26,6 @@
         color: white;
         background-color: get-color('brand', 'primary');
     }
-
-    &.page-title--constrained {
-        margin: 0 auto;
-        max-width: $maxWidth;
-        padding: $spacingUnit / 2;
-
-        @include mq('medium') {
-            padding: $spacingUnit;
-        }
-    }
 }
 
 /* =========================================================================

--- a/views/components/page-title/macro.njk
+++ b/views/components/page-title/macro.njk
@@ -1,6 +1,6 @@
 {# https://css-tricks.com/multi-line-padded-text/#article-header-id-3 #}
 {% macro pageTitle(title, isConstrained = true) %}
-    <h1 class="page-title{% if isConstrained %} page-title--constrained{% endif %}">
+    <h1 class="page-title{% if isConstrained %} u-padded u-inner-wide-only{% endif %}">
         <span class="page-title__text"><span class="page-title__text-inner">{{ title | widont | safe }}</span></span>
     </h1>
 {% endmacro %}


### PR DESCRIPTION
Fixes this issue by making sure the page-title styles match the content box / constrained styles. 

![image](https://user-images.githubusercontent.com/123386/51601910-821cde80-1efd-11e9-8b5f-6ef2b69579bd.png)
