### PR TITLE
Archive press releases

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -5922,5 +5922,45 @@ Array [
     "from": "/welsh/wales/contact-us",
     "to": "/welsh/contact",
   },
+  Object {
+    "from": "/news-and-events",
+    "to": "/news",
+  },
+  Object {
+    "from": "/welsh/news-and-events",
+    "to": "/welsh/news",
+  },
+  Object {
+    "from": "/england/news-and-events",
+    "to": "/news",
+  },
+  Object {
+    "from": "/welsh/england/news-and-events",
+    "to": "/welsh/news",
+  },
+  Object {
+    "from": "/scotland/news-and-events",
+    "to": "/news",
+  },
+  Object {
+    "from": "/welsh/scotland/news-and-events",
+    "to": "/welsh/news",
+  },
+  Object {
+    "from": "/northernireland/news-and-events",
+    "to": "/news",
+  },
+  Object {
+    "from": "/welsh/northernireland/news-and-events",
+    "to": "/welsh/news",
+  },
+  Object {
+    "from": "/wales/news-and-events",
+    "to": "/news",
+  },
+  Object {
+    "from": "/welsh/wales/news-and-events",
+    "to": "/welsh/news",
+  },
 ]
 `;

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -172,6 +172,7 @@ const aliases = {
 
     //===== Misc/other =====//
     '/contact-us': '/contact',
+    '/news-and-events': '/news',
 
 };
 

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -4,6 +4,8 @@ const express = require('express');
 const { concat, isArray, pick, get } = require('lodash');
 
 const { buildPagination } = require('../../modules/pagination');
+const { buildArchiveUrl } = require('../../modules/archived');
+const { localify } = require('../../modules/urls');
 const { injectBreadcrumbs, injectCopy, injectHeroImage } = require('../../middleware/inject-content');
 const contentApi = require('../../services/content-api');
 
@@ -60,11 +62,16 @@ router.get(
             }
 
             if (isArray(response.result)) {
+                const finalPressReleaseArchiveDate = '20181001120823';
                 res.render(path.resolve(__dirname, './views/listing/press-releases'), {
                     title: typeCopy.plural,
                     entries: response.result,
                     entriesMeta: response.meta,
                     pagination: buildPagination(response.meta.pagination),
+                    pressReleaseArchiveUrl: buildArchiveUrl(
+                        localify(req.i18n.getLocale())('/news-and-events'),
+                        finalPressReleaseArchiveDate
+                    ),
                     breadcrumbs: concat(breadcrumbs, { label: typeCopy.plural })
                 });
             } else {

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -97,7 +97,7 @@
 
                     {% call card(copy.pressRelease.pressReleaseArchive) %}
                         <div class="s-prose">
-                            <a href="{{ localify('/news-and-events') }}">
+                            <a href="{{ pressReleaseArchiveUrl }}">
                                 {{ copy.pressRelease.viewOldPressReleases }}
                             </a>
                         </div>

--- a/modules/archived.js
+++ b/modules/archived.js
@@ -2,9 +2,9 @@
 
 const LAST_GOOD_CRAWL_DATE = '20171011152352';
 
-function buildArchiveUrl(urlPath) {
+function buildArchiveUrl(urlPath, crawlDate = LAST_GOOD_CRAWL_DATE) {
     const fullUrl = `https://www.biglotteryfund.org.uk${urlPath}`;
-    return `http://webarchive.nationalarchives.gov.uk/${LAST_GOOD_CRAWL_DATE}/${fullUrl}`;
+    return `http://webarchive.nationalarchives.gov.uk/${crawlDate}/${fullUrl}`;
 }
 
 module.exports = {


### PR DESCRIPTION
Redirects `/news-and-events` to `/news` and sends old press releases to the archives.

One thing we could consider doing is redirecting old press releases themselves to the archives, eg. [this](https://www.biglotteryfund.org.uk/global-content/press-releases/wales/060818_wal_a-dream-come-true-for-margaret-and-sarah) to [here](https://webarchive.nationalarchives.gov.uk/20181001135409tf_/https://www.biglotteryfund.org.uk/global-content/press-releases/wales/060818_wal_a-dream-come-true-for-margaret-and-sarah) – worth considering?