### PR TITLE
Fix user controller regressions

### DIFF
--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -43,10 +43,11 @@ function activate(token, user) {
 
 router.route('/').get(requireUserAuth, async (req, res) => {
     const token = req.query.token;
+    const user = req.user.userData;
 
     if (token) {
         try {
-            await activate(token, req.user);
+            await activate(token, user);
             res.redirect('/user');
         } catch (error) {
             Raven.captureException(error);
@@ -54,8 +55,8 @@ router.route('/').get(requireUserAuth, async (req, res) => {
         }
     } else {
         // no token, so send them an activation email
-        if (!req.user.is_active) {
-            await sendActivationEmail(req, req.user);
+        if (!user.is_active) {
+            await sendActivationEmail(req, user);
         }
 
         req.session.save(() => {

--- a/controllers/user/views/dashboard.njk
+++ b/controllers/user/views/dashboard.njk
@@ -9,11 +9,11 @@
             <h1>{{ title }}</h1>
 
             {% if user.userType === 'user' %}
-                {% if not user.is_active %}
+                {% if not user.userData.is_active %}
                     <div class="message" role="alert">
                         <p>You haven't activated your account yet.</p>
                         {% if activationSent %}
-                            <p><strong>We just sent an email to {{ user.username }} with a link to activate your account.</strong></p>
+                            <p><strong>We just sent an email to {{ user.userData.username }} with a link to activate your account.</strong></p>
                         {% endif %}
                         <p>Would you like to <a href="/user/activate">re-send your activation link</a>?</p>
                     </div>

--- a/middleware/passport.js
+++ b/middleware/passport.js
@@ -80,6 +80,9 @@ module.exports = function() {
     }
 
     const makeUserObject = user => {
+        if (!user) {
+            return null;
+        }
         return {
             userType: user.constructor.name,
             userData: user


### PR DESCRIPTION
These issues came up when I was testing the email sending changes: it looks like when we introduced staff login to the site, I forgot to update a few of the references to `req.user.*`, which should have become `req.user.userData.*` – eg. so we could use the top-level object to distinguish between user types.

This issue meant that user activation didn't work properly as the code always regarded the user as inactive. Luckily this is disabled in production, but still worth fixing.

Finally there was a weird edge case bug where a deleted user who was logged in would only see a 500 error as Passport tried to deserialise an account that no longer existed. Admittedly this is unlikely to happen in reality, but the fix was simply returning `null` in a callback.