### PR TITLE
Move domainRedirectMiddleware up

### DIFF
--- a/server.js
+++ b/server.js
@@ -77,6 +77,14 @@ i18n.expressBind(app, {
 });
 
 /**
+ * Old domain redirect
+ * @TODO: Enable this flag when making www.tnlcommunityfund.org.uk the primary domain
+ */
+if (config.get('features.enableOldDomainRedirect')) {
+    app.use(domainRedirectMiddleware);
+}
+
+/**
  * Robots
  * status endpoint, sitemap, robots.txt
  * Mount early to avoid being processed by any middleware
@@ -160,14 +168,6 @@ function initViewEngine() {
 }
 
 initViewEngine();
-
-/**
- * Old domain redirect
- * @TODO: Enable this flag when making www.tnlcommunityfund.org.uk the primary domain
- */
-if (config.get('features.enableOldDomainRedirect')) {
-    app.use(domainRedirectMiddleware);
-}
 
 /**
  * Register global middlewares


### PR DESCRIPTION
Small tweak to the domain redirect middleware to make sure it comes first our of any route handlers (previously robots.txt and a few api/tools handlers came before this so would not be redirected).