### PR TITLE
Remove hero images from blogs

### DIFF
--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -2,13 +2,14 @@
 {% from "components/card/macro.njk" import card %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
-{% from "components/hero.njk" import hero with context %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
 {% from "components/inline-links/macro.njk" import inlineLinks %}
+{% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/split-nav/macro.njk" import splitNav %}
 
+{% set bodyClass = 'has-static-header' %}
 {% extends "layouts/main.njk" %}
 
 {% macro articleMeta(entry) %}
@@ -76,82 +77,76 @@
 
 {% block content %}
     <main role="main">
-        {{ hero(
-            titleText = title,
-            image = pageHero.image,
-            accent = pageAccent
-        ) }}
+        {{ pageTitle(title) }}
 
-        <div class="nudge-up">
-            <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
-                {{ breadcrumbTrail(breadcrumbs) }}
+        <section class="content-box u-inner-wide-only accent--{{ pageAccent }} a--border-top">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-                <div class="content-sidebar">
-                    <div class="content-sidebar__primary s-prose">
-                        {% if entry.body %}
-                            <div class="s-prose">
-                                {{ entry.body | safe }}
-                            </div>
-                        {% else %}
-                            {{ flexibleContent(entry.content, pageAccent) }}
-                        {% endif %}
-                    </div>
-
-                    <div class="content-sidebar__secondary">
-                        {{ articleMeta(entry) }}
-                    </div>
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary s-prose">
+                    {% if entry.body %}
+                        <div class="s-prose">
+                            {{ entry.body | safe }}
+                        </div>
+                    {% else %}
+                        {{ flexibleContent(entry.content, pageAccent) }}
+                    {% endif %}
                 </div>
 
-                {% if entry.tags.length > 0 %}
-                    <aside class="article__topics" role="aside">
-                        {% set links = [] %}
-                        {% for tag in entry.tags %}
-                            {% set links = (links.push({ "label": tag.title, "url": localify('/news/blog?tag=' + tag.slug) }), links) %}
-                        {% endfor %}
-                        {{ inlineLinks(prefix = __('global.misc.topics') | title, links = links) }}
-                    </aside>
-                {% endif %}
-
-                <div class="o-button-group-flex u-gutter-half u-margin-top">
-                    <a class="btn btn--small btn--outline accent--{{ pageAccent }}"
-                       href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
-                       data-ga-on="click"
-                       data-ga-event-category="Facebook"
-                       data-ga-event-action="Share blogpost">
-                        <span class="btn__icon">{{ iconFacebook() }}</span>
-                        {{ __('global.misc.share.facebook') }}
-                    </a>
-                    <a class="btn btn--small btn--outline accent--{{ pageAccent }}"
-                       href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ entry.title }}&via={{ globalCopy.brand.twitter }}"
-                       data-ga-on="click"
-                       data-ga-event-category="Twitter"
-                       data-ga-event-action="Share blogpost">
-                        <span class="btn__icon">{{ iconTwitter() }}</span>
-                        {{ __('global.misc.share.twitter')  }}
-                    </a>
+                <div class="content-sidebar__secondary">
+                    {{ articleMeta(entry) }}
                 </div>
+            </div>
 
-                {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
+            {% if entry.tags.length > 0 %}
+                <aside class="article__topics" role="aside">
+                    {% set links = [] %}
+                    {% for tag in entry.tags %}
+                        {% set links = (links.push({ "label": tag.title, "url": localify('/news/blog?tag=' + tag.slug) }), links) %}
+                    {% endfor %}
+                    {{ inlineLinks(prefix = __('global.misc.topics') | title, links = links) }}
+                </aside>
+            {% endif %}
 
-                {% if entry.siblings.next or entry.siblings.prev %}
-                    {% set prevLink = {
-                        "label": entry.siblings.prev.title,
-                        "url": entry.siblings.prev.linkUrl
-                    } if entry.siblings.prev else false %}
-                    {% set nextLink = {
-                        "label": entry.siblings.next.title,
-                        "url": entry.siblings.next.linkUrl
-                    } if entry.siblings.next else false %}
+            <div class="o-button-group-flex u-gutter-half u-margin-top">
+                <a class="btn btn--small btn--outline accent--{{ pageAccent }}"
+                    href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
+                    data-ga-on="click"
+                    data-ga-event-category="Facebook"
+                    data-ga-event-action="Share blogpost">
+                    <span class="btn__icon">{{ iconFacebook() }}</span>
+                    {{ __('global.misc.share.facebook') }}
+                </a>
+                <a class="btn btn--small btn--outline accent--{{ pageAccent }}"
+                    href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ entry.title }}&via={{ globalCopy.brand.twitter }}"
+                    data-ga-on="click"
+                    data-ga-event-category="Twitter"
+                    data-ga-event-action="Share blogpost">
+                    <span class="btn__icon">{{ iconTwitter() }}</span>
+                    {{ __('global.misc.share.twitter')  }}
+                </a>
+            </div>
 
-                    <div class="u-margin-top-l">
-                        {{ splitNav(
-                            prevLink = prevLink,
-                            nextLink = nextLink
-                        ) }}
-                    </div>
-                {% endif %}
+            {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
 
-            </section>
-        </div>
+            {% if entry.siblings.next or entry.siblings.prev %}
+                {% set prevLink = {
+                    "label": entry.siblings.prev.title,
+                    "url": entry.siblings.prev.linkUrl
+                } if entry.siblings.prev else false %}
+                {% set nextLink = {
+                    "label": entry.siblings.next.title,
+                    "url": entry.siblings.next.linkUrl
+                } if entry.siblings.next else false %}
+
+                <div class="u-margin-top-l">
+                    {{ splitNav(
+                        prevLink = prevLink,
+                        nextLink = nextLink
+                    ) }}
+                </div>
+            {% endif %}
+
+        </section>
     </main>
 {% endblock %}


### PR DESCRIPTION
Currently we show a default hero images for all blog posts (inherited from the main router). e.g. https://www.biglotteryfund.org.uk/news/blog/2018-10-26/our-new-digital-fund

We need to remove this is the image doesn't have any connection to the post. The simplest thing to do in the meantime is to remove hero images from blog posts.

There is a slightly bigger bit of work to rejig the controller logic to allow (re)support hero images without inheriting the parent image. Needs more rejigging that I'd like to do at this stage. I've raised a ticket to reinstate images for blogs as soon as we're able (#1678)

Best viewed with https://github.com/biglotteryfund/blf-alpha/pull/1679/files?w=1