### PR TITLE
Support new hero images for grant detail pages

### DIFF
--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -156,8 +156,9 @@
                     } %}
 
                     {% if fundingProgramme and fundingProgramme.hero %}
+                        {% set imageField = fundingProgramme.heroNew.image if useNewBrand else fundingProgramme.hero %}
                         {% set image = {
-                            "url": fundingProgramme.hero.large,
+                            "url": imageField.large,
                             "alt": mainProgramme.title
                         } %}
                     {% endif %}


### PR DESCRIPTION
Did an extra pass through trail images and spotted one remaining location which didn't support new images. Slightly awkward logic, but can go post-rebrand.