### PR TITLE
New domain

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -44,7 +44,7 @@
     "enableRelatedGrants": true,
     "enableSurvey": true,
     "enableTimingMetrics": false,
-    "enableNewDomainStaffAuth": false
+    "enableNewDomainStaffAuth": true
   },
   "cookies": {
     "contrast": "contrastMode",

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,6 @@
     "enableHotjar": false,
     "enableMailSendMetrics": false,
     "enableNameChangeMessage": true,
-    "enableOldDomainRedirect": false,
     "enablePrompt": false,
     "enableRelatedGrants": true,
     "enableSurvey": true,

--- a/config/default.json
+++ b/config/default.json
@@ -21,7 +21,7 @@
     }
   },
   "domains": {
-    "indexable": ["www.biglotteryfund.org.uk"]
+    "indexable": ["www.biglotteryfund.org.uk", "www.tnlcommunityfund.org.uk"]
   },
   "dateFormats": {
     "month": "MMMM YYYY",

--- a/controllers/apply/__tests__/__snapshots__/processors.test.js.snap
+++ b/controllers/apply/__tests__/__snapshots__/processors.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Digital fund should create success emails 1`] = `
 "Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: Example Person <example@example.com>
 Subject: Thank you for getting in touch with The National Lottery Community
  Fund!
@@ -281,7 +281,7 @@ uk/data-protection</a> or contact us to request a hard copy. The Notice may=
 
 exports[`Digital fund should create success emails 2`] = `
 "Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: Example Person <example@example.com>
 Subject: New submission for Digital Fund Strand 1 from Test Organisation
 MIME-Version: 1.0
@@ -549,7 +549,7 @@ uk/data-protection</a> or contact us to request a hard copy. The Notice may=
 
 exports[`Reaching communities should create success emails 1`] = `
 "Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: Example Person <example@example.com>
 Subject: Thank you for getting in touch with The National Lottery Community
  Fund!
@@ -946,7 +946,7 @@ uk/data-protection</a> or contact us to request a hard copy. The Notice may=
 
 exports[`Reaching communities should create success emails 2`] = `
 "Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: Example Person <example@example.com>
 Subject: New idea submission from website: Test Organisation
 MIME-Version: 1.0

--- a/server.js
+++ b/server.js
@@ -78,11 +78,9 @@ i18n.expressBind(app, {
 
 /**
  * Old domain redirect
- * @TODO: Enable this flag when making www.tnlcommunityfund.org.uk the primary domain
+ * Redirect requests from www.biglotteryfund.org.uk
  */
-if (config.get('features.enableOldDomainRedirect')) {
-    app.use(domainRedirectMiddleware);
-}
+app.use(domainRedirectMiddleware);
 
 /**
  * Robots

--- a/services/__tests__/__snapshots__/mail.test.js.snap
+++ b/services/__tests__/__snapshots__/mail.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`buildMailOptions should build mail options for a html email 1`] = `
 Object {
-  "from": "The National Lottery Community Fund <noreply@biglotteryfund.org.uk>",
+  "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "html": "<p>This is a test</p>",
   "subject": "Test",
   "text": "This is a test",
@@ -16,7 +16,7 @@ Object {
 
 exports[`buildMailOptions should build mail options for a text email 1`] = `
 Object {
-  "from": "The National Lottery Community Fund <noreply@biglotteryfund.org.uk>",
+  "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "subject": "Test",
   "text": "This is a test",
   "to": Array [
@@ -29,7 +29,7 @@ Object {
 
 exports[`buildMailOptions should build mail options for a text email with a name 1`] = `
 Object {
-  "from": "The National Lottery Community Fund <noreply@biglotteryfund.org.uk>",
+  "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "subject": "Test",
   "text": "This is a test",
   "to": Array [
@@ -79,7 +79,7 @@ exports[`generateHtmlEmail should generate html email content 1`] = `
 
 exports[`sendEmail should create a html email response to be sent 1`] = `
 Object {
-  "from": "noreply@biglotteryfund.org.uk",
+  "from": "noreply@tnlcommunityfund.org.uk",
   "to": Array [
     "example@example.com",
   ],
@@ -88,7 +88,7 @@ Object {
 
 exports[`sendEmail should create a html email response to be sent 2`] = `
 "Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: example@example.com
 Subject: Mock email
 MIME-Version: 1.0
@@ -109,7 +109,7 @@ Content-Transfer-Encoding: 7bit
 
 exports[`sendEmail should create a text email response to be sent 1`] = `
 Object {
-  "from": "noreply@biglotteryfund.org.uk",
+  "from": "noreply@tnlcommunityfund.org.uk",
   "to": Array [
     "example@example.com",
   ],
@@ -118,7 +118,7 @@ Object {
 
 exports[`sendEmail should create a text email response to be sent 2`] = `
 "Content-Type: text/plain
-From: The National Lottery Community Fund <noreply@biglotteryfund.org.uk>
+From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
 To: example@example.com
 Subject: Mock email
 Content-Transfer-Encoding: 7bit

--- a/services/__tests__/mail.test.js
+++ b/services/__tests__/mail.test.js
@@ -130,7 +130,7 @@ describe('generateHtmlEmail', () => {
 });
 
 describe('getSendAddress', () => {
-    const expectedDefault = `noreply@biglotteryfund.org.uk`;
+    const expectedDefault = `noreply@tnlcommunityfund.org.uk`;
     const expectedInternal = `noreply@blf.digital`;
 
     it('should return default send from address for external send to addresses', () => {

--- a/services/mail.js
+++ b/services/mail.js
@@ -78,12 +78,7 @@ function getSendAddress(recipients) {
     ) {
         return 'noreply@blf.digital';
     } else {
-        // @TODO remove this switch post-rebrand in favour of the new domain
-        if (config.get('features.enableOldDomainRedirect')) {
-            return 'noreply@tnlcommunityfund.org.uk';
-        } else {
-            return 'noreply@biglotteryfund.org.uk';
-        }
+        return 'noreply@tnlcommunityfund.org.uk';
     }
 }
 


### PR DESCRIPTION
Enables relevant flags to begin using the new domain

- Remove guard from domain redirect middleware
- Use new domain for send-from address and update tests to match
- Enable the new domain for staff authentication
- Allow the new domain to be indexable by search engines