### PR TITLE
Send emails to suppliers and RC teams regardless of environment

### DIFF
--- a/controllers/apply/reaching-communities/processor.js
+++ b/controllers/apply/reaching-communities/processor.js
@@ -79,7 +79,7 @@ module.exports = async function processor({ data, stepsWithValues, copy, useNewB
         sendEmail({
             name: 'reaching_communities_internal',
             mailConfig: {
-                sendTo: appData.isNotProduction ? customerSendTo : determineInternalSendTo(data.location),
+                sendTo: determineInternalSendTo(data.location),
                 subject: `New idea submission from website: ${organisationName}`,
                 type: 'html',
                 content: internalHtml

--- a/controllers/materials/index.js
+++ b/controllers/materials/index.js
@@ -184,7 +184,7 @@ router
                     .then(async () => {
                         const { useNewBrand } = res.locals;
                         const customerSendTo = details.yourEmail;
-                        const supplierSendTo = appData.isNotProduction ? customerSendTo : MATERIAL_SUPPLIER;
+                        const supplierSendTo = MATERIAL_SUPPLIER;
 
                         const customerHtml = await generateHtmlEmail({
                             template: path.resolve(__dirname, './views/order-email.njk'),


### PR DESCRIPTION
This is solely so we can submit some test RC ideas and verify we can send to the new mailboxes, and also so we can send some test merchandise orders and verify that they send correctly too. We can revert this once we're happy.