### PR TITLE
Template and trail image cleanup

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -349,6 +349,7 @@ news:
     allPostsIn: Yr holl byst yn
     filter: Hidlwr
     in: yn
+    noResults: Dim canlyniadau
     noResultsFor: Dim canlyniadau ar gyfer
     pressReleaseArchive: Archif datganiadau i’r wasg
     viewOldPressReleases: Gweld hen ddatganiadau i’r wasg

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -438,6 +438,7 @@ news:
     allPostsIn: All posts in
     filter: Filter
     in: in
+    noResults: No results
     noResultsFor: No results for
     pressReleaseArchive: Press release archive
     viewOldPressReleases: View older press releases

--- a/controllers/common/views/listing-page.njk
+++ b/controllers/common/views/listing-page.njk
@@ -38,7 +38,7 @@
                             {{ miniatureHero({
                                 "title": page.trailText | default(page.title, true),
                                 "linkUrl": page.linkUrl,
-                                "image": { "url": page.trailImage if page.trailImage else page.photo }
+                                "image": { "url": page.trailImage }
                             }, isLarge = true) }}
                         </li>
                     {% endfor %}

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -162,7 +162,7 @@
 
                     {% call promoCard({
                         "title": copy.grantDetail.fundedBy + ' ' + mainProgramme.title,
-                        "trailText": fundingProgramme.description,
+                        "summary": fundingProgramme.description,
                         "image": image,
                         "link": {
                             "label": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -153,9 +153,9 @@
                         "alt": mainProgramme.title
                     } %}
 
-                    {% if fundingProgramme and fundingProgramme.heroNew %}
+                    {% if fundingProgramme and fundingProgramme.hero %}
                         {% set image = {
-                            "url": fundingProgramme.heroNew.image.large,
+                            "url": fundingProgramme.hero.image.large,
                             "alt": mainProgramme.title
                         } %}
                     {% endif %}
@@ -170,8 +170,8 @@
                             "url": link
                         }
                     }) %}
-                        {% if fundingProgramme.hero.caption %}
-                            <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
+                        {% if fundingProgramme.hero.image.caption %}
+                            <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.image.caption }}</p>
                         {% endif %}
                     {% endcall %}
                 </div>

--- a/controllers/grants/views/grant-results.njk
+++ b/controllers/grants/views/grant-results.njk
@@ -9,11 +9,11 @@
         <strong><a href="{{ localify("/funding/grants/recipients/" + mainRecipient.id) }}">{{ mainRecipient.name | striptags }}</a></strong>
         {{ __('global.misc.on') }} {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
     {% endset %}
-    {% set description = false if grant.description === grant.title else grant.description %}
+
     {% call promoCard({
         "title": grant.title,
         "subtitle": subtitle | safe,
-        "trailText": description,
+        "summary": false if grant.description === grant.title else grant.description,
         "link": {
             "url": localify("/funding/grants/" + grant.id),
             "label": copy.viewGrantDetails

--- a/controllers/programmes/views/programmes-list.njk
+++ b/controllers/programmes/views/programmes-list.njk
@@ -36,8 +36,7 @@
                     <a href="{{ localify('/funding/programmes/all') }}" class="btn btn--medium btn--outline">{{ copy.allProgrammes }}</a>
                 </div>
             {% else %}
-                {# @TODO i18n #}
-                <p>No results</p>
+                <p>{{ __('global.misc.noResults') }}</p>
             {% endif %}
         </section>
     </main>

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -15,7 +15,6 @@ const { basicContent, flexibleContent, staticPage } = require('./common');
  * @typedef {object} Section
  * @property {string} path
  * @property {boolean} showInNavigation
- * @property {string} [langTitlePath]
  * @property {Array<Route>} pages
  */
 
@@ -26,7 +25,6 @@ const { basicContent, flexibleContent, staticPage } = require('./common');
 const toplevel = {
     path: '',
     showInNavigation: true,
-    langTitlePath: 'global.nav.home',
     pages: [
         {
             path: '/',
@@ -78,7 +76,6 @@ const toplevel = {
 const funding = {
     path: '/funding',
     showInNavigation: true,
-    langTitlePath: 'global.nav.funding',
     pages: [
         {
             path: '/',
@@ -140,7 +137,6 @@ const funding = {
 const insights = {
     path: '/insights',
     showInNavigation: true,
-    langTitlePath: 'global.nav.insights',
     pages: [
         {
             path: '/',
@@ -171,7 +167,6 @@ const talk = {
 const about = {
     path: '/about',
     showInNavigation: true,
-    langTitlePath: 'global.nav.about',
     pages: [
         {
             path: '/',
@@ -196,7 +191,6 @@ const about = {
 const updates = {
     path: '/news',
     showInNavigation: false,
-    langTitlePath: 'global.nav.updates',
     pages: [
         {
             path: '/',
@@ -205,19 +199,13 @@ const updates = {
     ]
 };
 
-/**
- * Sections
- * The order here defines the order of the navigation
- */
-const sections = {
-    toplevel: toplevel,
-    funding: funding,
-    insights: insights,
-    talk: talk,
-    about: about,
-    updates: updates
-};
-
 module.exports = {
-    sections
+    sections: {
+        toplevel,
+        funding,
+        insights,
+        talk,
+        about,
+        updates
+    }
 };

--- a/controllers/strategic-investments/views/strategic-investments.njk
+++ b/controllers/strategic-investments/views/strategic-investments.njk
@@ -12,7 +12,7 @@
                     <li class="flex-grid__item">
                         {{ promoCard({
                             "title": programme.title,
-                            "trailText": programme.trailText,
+                            "summary": programme.trailText,
                             "image": {
                                 "url": programme.trailImage if programme.trailImage else programme.thumbnail,
                                 "alt": programme.title

--- a/controllers/strategic-investments/views/strategic-investments.njk
+++ b/controllers/strategic-investments/views/strategic-investments.njk
@@ -14,7 +14,7 @@
                             "title": programme.title,
                             "summary": programme.trailText,
                             "image": {
-                                "url": programme.trailImage if programme.trailImage else programme.thumbnail,
+                                "url": programme.trailImage,
                                 "alt": programme.title
                             },
                             "link": { "url": programme.linkUrl, "label": "Learn more" }

--- a/controllers/strategic-investments/views/strategic-programme.njk
+++ b/controllers/strategic-investments/views/strategic-programme.njk
@@ -104,7 +104,7 @@
                                 {% call promoCard({
                                     "title": research.title,
                                     "subtitle": research.datePublished,
-                                    "trailText": research.trailText,
+                                    "summary": research.trailText,
                                     "image": {
                                         "url": research.imageUrl,
                                         "alt": research.title

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -15,7 +15,7 @@
     {% call promoCard({
         "title": entry.trailText or entry.title,
         subtitle: formatDate(entry.postDate.date, DATE_FORMATS.short),
-        "trailText": entry.summary,
+        "summary": entry.summary,
         "image": {
             "url": entry.thumbnail.large,
             "alt": entry.title

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -10,16 +10,9 @@ const contentApi = require('../services/content-api');
  * Populate hero image (with social image URLs too)
  * */
 function setHeroLocals({ res, entry }) {
-    // @TODO: Rename this once API has been updated back to `hero`
-    const heroImage = get('heroNew.image')(entry);
-    const heroCredit = get('heroNew.credit')(entry);
-
-    if (heroImage) {
-        res.locals.pageHero = {
-            image: heroImage,
-            credit: heroCredit
-        };
-        res.locals.socialImage = heroImage;
+    if (entry.hero) {
+        res.locals.pageHero = entry.hero;
+        res.locals.socialImage = get('image.default')(entry.hero);
     } else {
         res.locals.pageHero = null;
     }
@@ -53,7 +46,7 @@ function injectHeroImage(heroSlug) {
 
             // Set defaults
             res.locals.pageHero = { image: fallbackHeroImage };
-            res.locals.socialImage = fallbackHeroImage;
+            res.locals.socialImage = fallbackHeroImage.default;
 
             try {
                 const image = await contentApi.getHeroImage({

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -1,7 +1,6 @@
 'use strict';
 const config = require('config');
 const moment = require('moment');
-const { isString } = require('lodash');
 
 const { getCurrentUrl, getAbsoluteUrl, localify } = require('../modules/urls');
 

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -80,14 +80,6 @@ module.exports = function(req, res, next) {
         caption: 'The Outdoor Partnership'
     };
 
-    res.locals.getSocialImageUrl = function(socialImage) {
-        if (isString(socialImage)) {
-            return socialImage.indexOf('://') !== -1 ? socialImage : getAbsoluteUrl(socialImage);
-        } else {
-            return getAbsoluteUrl(req, socialImage.default);
-        }
-    };
-
     /**
      * Get normalised page title for metadata
      */

--- a/server.js
+++ b/server.js
@@ -224,7 +224,6 @@ forEach(routes.sections, function(section, sectionId) {
      */
     router.use(function(req, res, next) {
         const locale = req.i18n.getLocale();
-        res.locals.sectionId = sectionId;
         res.locals.sectionTitle = req.i18n.__(`global.nav.${sectionId}`);
         res.locals.sectionUrl = localify(locale)(req.baseUrl);
         next();

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -42,8 +42,8 @@
         "title": programme.title,
         "summary": description | safe,
         "image": {
-            "url": programme.trailImageNew if programme.trailImageNew else programme.trailImage,
-            "alt": programme.hero.caption or programme.title
+            "url": programme.trailImage,
+            "alt": programme.hero.image.caption or programme.title
         },
         "link": {
             "url": programme.linkUrl
@@ -57,11 +57,8 @@
         <div class="u-tone-background-tint u-padded u-margin-top-l">
             {% for programme in programmes %}
                 <div class="o-media u-margin-bottom">
-                    {% if programme.thumbnail or programme.thumbnailNew %}
-                        <img src="{{ programme.thumbnailNew if programme.thumbnailNew else programme.thumbnail }}"
-                             alt="{{ programme.title }}"
-                             class="o-media__figure"
-                             width="100" />
+                    {% if programme.thumbnail %}
+                        <img src="{{ programme.thumbnail }}" alt="{{ programme.title }}" class="o-media__figure" width="100" />
                     {% endif %}
                     <div class="o-media__body">
                         <h4 class="u-tone-brand-primary">{{ programme.title }}</h4>

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -40,7 +40,7 @@
     {% endset %}
     {{ promoCard({
         "title": programme.title,
-        "trailText": description | safe,
+        "summary": description | safe,
         "image": {
             "url": programme.trailImageNew if programme.trailImageNew else programme.trailImage,
             "alt": programme.hero.caption or programme.title

--- a/views/components/promo-card/examples.njk
+++ b/views/components/promo-card/examples.njk
@@ -5,7 +5,7 @@
     {% call promoCard({
         "title": "Promo card",
         "subtitle": "Subtitle text",
-        "trailText": "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab, ratione accusamus? Enim minima tempora in ipsum nesciunt",
+        "summary": "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab, ratione accusamus? Enim minima tempora in ipsum nesciunt",
         "image": { "url": "https://via.placeholder.com/640x280?text=Placeholder", "alt": "" },
         "link": { "url": "https://example.com/", "label": "Read more" }
     }) %}
@@ -17,7 +17,7 @@
     {{ promoCard({
         "kicker": "Kicker text",
         "title": "Promo card",
-        "trailText": "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab, ratione accusamus? Enim minima tempora in ipsum nesciunt",
+        "summary": "Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ab, ratione accusamus? Enim minima tempora in ipsum nesciunt",
         "image": { "url": "https://via.placeholder.com/640x280?text=Placeholder", "alt": "" },
         "link": { "url": "https://example.com/", "label": "Read more" }
     }, featured = true) }}

--- a/views/components/promo-card/macro.njk
+++ b/views/components/promo-card/macro.njk
@@ -53,11 +53,8 @@ props: {Object}
                 <p class="promo-card__subtitle">{{ props.subtitle }}</p>
             {% endif %}
             <div class="promo-card__summary s-prose">
-                {# @TODO: Use summary prop instead of trailText #}
                 {% if props.summary %}
                     {{ props.summary | safe }}
-                {% elseif props.trailText %}
-                    {{ props.trailText | safe }}
                 {% endif %}
                 {% if props.link.url and props.link.label %}
                     <a href="{{ props.link.url }}"{% if props.link.labelAria %} aria-label="{{ props.link.labelAria }}"{% endif %}>

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -6,7 +6,7 @@
         "title": research.title,
         "subtitle": formatDate(research.postDate.date, DATE_FORMATS.month),
         "summary": research.trailText,
-        "image": { "url": research.trailImage if research.trailImage else research.thumbnail, "alt": research.title },
+        "image": { "url": research.trailImage, "alt": research.title },
         "link": { "url": research.linkUrl, "label": __('global.misc.readMore') }
     }) %}
         {% if research.documents %}

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -5,7 +5,7 @@
         "headingLevel": 2,
         "title": research.title,
         "subtitle": formatDate(research.postDate.date, DATE_FORMATS.month),
-        "trailText": research.trailText,
+        "summary": research.trailText,
         "image": { "url": research.trailImage if research.trailImage else research.thumbnail, "alt": research.title },
         "link": { "url": research.linkUrl, "label": __('global.misc.readMore') }
     }) %}

--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -18,8 +18,8 @@
 <meta name="twitter:site" content="@{{ globalCopy.brand.twitter }}" />
 
 {% if socialImage %}
-<meta property="twitter:image" content="{{ getSocialImageUrl(socialImage) | safe }}">
-<meta property="og:image" content="{{ getSocialImageUrl(socialImage) | safe }}">
+    <meta property="twitter:image" content="{{ socialImage | safe }}">
+    <meta property="og:image" content="{{ socialImage | safe }}">
 {% endif %}
 
 <meta name="google-site-verification" content="YJm5YK8XXPjyF0oyks3mvJ2P2qc1mwm9GyF7OlyNl9A" />


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/142 which must go out before this can be deployed.

Updates references to old field names in templates, notably trail and hero images.