### PR TITLE
Fixup issue with unwanted search icon

### DIFF
--- a/assets/sass/components/_global-header.scss
+++ b/assets/sass/components/_global-header.scss
@@ -183,6 +183,10 @@ $breakpointLarge: 840px;
     }
 
     @media only screen and (min-width: $breakpointSmall + 1px) and (max-width: $breakpointLarge) {
+        .global-header__toggle-search {
+            display: none;
+        }
+
         .global-header__search {
             position: absolute;
             top: 50%;


### PR DESCRIPTION
It feels good to be able to post screenshots of this now.

**Before**

<img width="838" alt="screenshot 2019-01-31 at 12 48 39" src="https://user-images.githubusercontent.com/123386/52055400-369aae00-2557-11e9-83da-27bc3f1d2be7.png">

**After**

<img width="838" alt="screenshot 2019-01-31 at 12 49 23" src="https://user-images.githubusercontent.com/123386/52055407-3ac6cb80-2557-11e9-9fee-0988a5434e0d.png">

Now only shows when the search bar dissapears

![image](https://user-images.githubusercontent.com/123386/52055444-55994000-2557-11e9-98a8-dffd7fc5e38c.png)
