### PR TITLE
Block archived paths

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -49,5 +49,31 @@
     "session": "blf-alpha-session"
   },
   "hotjarId": 1036292,
-  "googleAnalyticsCode": "UA-98908627-1"
+  "googleAnalyticsCode": "UA-98908627-1",
+  "archivedPaths": {
+    "legacyFilesPath": "/-/media/files/*",
+    "legacyPagePaths": [
+      "/about-big/10-big-lottery-fund-facts",
+      "/about-big/big-lottery-fund-in-your-constituency",
+      "/about-big/community-closed",
+      "/about-big/countries*",
+      "/about-big/future-of-doing-good",
+      "/about-big/living-wage",
+      "/about-big/mayors-community-weekend",
+      "/about-big/our-approach/vision-and-principles",
+      "/about-big/publications*",
+      "/about-big/your-voice",
+      "/funding/big-stories*",
+      "/funding/celebrateuk*",
+      "/funding/funding-guidance/applying-for-funding/*",
+      "/funding/funding-guidance/managing-your-funding/about-equalities*",
+      "/funding/funding-guidance/managing-your-funding/reaching-communities-grant-offer",
+      "/funding/joint-funding",
+      "/funding/peoples-projects-resources",
+      "/funding/scotland-portfolio*",
+      "/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*",
+      "/global-content/press-releases/*",
+      "/research*"
+    ]
+  }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -49,31 +49,5 @@
     "session": "blf-alpha-session"
   },
   "hotjarId": 1036292,
-  "googleAnalyticsCode": "UA-98908627-1",
-  "archivedPaths": {
-    "legacyFilesPath": "/-/media/files/*",
-    "legacyPagePaths": [
-      "/about-big/10-big-lottery-fund-facts",
-      "/about-big/big-lottery-fund-in-your-constituency",
-      "/about-big/community-closed",
-      "/about-big/countries*",
-      "/about-big/future-of-doing-good",
-      "/about-big/living-wage",
-      "/about-big/mayors-community-weekend",
-      "/about-big/our-approach/vision-and-principles",
-      "/about-big/publications*",
-      "/about-big/your-voice",
-      "/funding/big-stories*",
-      "/funding/celebrateuk*",
-      "/funding/funding-guidance/applying-for-funding/*",
-      "/funding/funding-guidance/managing-your-funding/about-equalities*",
-      "/funding/funding-guidance/managing-your-funding/reaching-communities-grant-offer",
-      "/funding/joint-funding",
-      "/funding/peoples-projects-resources",
-      "/funding/scotland-portfolio*",
-      "/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*",
-      "/global-content/press-releases/*",
-      "/research*"
-    ]
-  }
+  "googleAnalyticsCode": "UA-98908627-1"
 }

--- a/controllers/archived.js
+++ b/controllers/archived.js
@@ -1,9 +1,8 @@
 'use strict';
 const express = require('express');
-const config = require('config');
 const router = express.Router();
 
-const { buildArchiveUrl, legacyPagePaths } = require('../modules/archived');
+const { buildArchiveUrl, legacyPagePaths, legacyFilesPath } = require('../modules/archived');
 const { noCache } = require('../middleware/cached');
 const metrics = require('../modules/metrics');
 
@@ -28,8 +27,7 @@ legacyPagePaths.forEach(urlPath => {
  * along with a feedback form to explain what they were looking for.
  * We also log all requests for these files to ensure we can update anything missing.
  */
-const filePathPattern = config.get('archivedPaths.legacyFilesPath');
-router.get(filePathPattern, (req, res) => {
+router.get(legacyFilesPath, (req, res) => {
     const filePath = req.originalUrl;
     metrics.count({
         name: filePath,

--- a/controllers/robots/index.js
+++ b/controllers/robots/index.js
@@ -3,10 +3,12 @@ const express = require('express');
 const moment = require('moment');
 const sitemap = require('sitemap');
 const domains = require('config').get('domains');
-const { includes } = require('lodash');
+const legacyFilesPath = require('config').get('archivedPaths.legacyFilesPath');
+const { includes, concat } = require('lodash');
 
 const { getBaseUrl, getAbsoluteUrl } = require('../../modules/urls');
 const { getCanonicalRoutes } = require('../../modules/route-helpers');
+const { legacyPagePaths } = require('../../modules/archived');
 const { noCache, sMaxAge } = require('../../middleware/cached');
 const appData = require('../../modules/appData');
 
@@ -31,7 +33,14 @@ router.get('/status', (req, res) => {
 
 router.get('/robots.txt', noCache, (req, res) => {
     const isIndexable = includes(domains.indexable, req.get('host')) === true;
-    const disallowList = ['/api/', '/funding/grants/', '/welsh/funding/grants/'];
+
+    // Merge archived paths with internal / deliberately excluded URLs
+    const disallowList = concat(
+        ['/api/', '/funding/grants/', '/welsh/funding/grants/'],
+        legacyFilesPath,
+        legacyPagePaths
+    );
+
     const text = [
         `user-agent: *`,
         `sitemap: ${getAbsoluteUrl(req, '/sitemap.xml')}`,

--- a/controllers/robots/index.js
+++ b/controllers/robots/index.js
@@ -3,12 +3,11 @@ const express = require('express');
 const moment = require('moment');
 const sitemap = require('sitemap');
 const domains = require('config').get('domains');
-const legacyFilesPath = require('config').get('archivedPaths.legacyFilesPath');
 const { includes, concat } = require('lodash');
 
 const { getBaseUrl, getAbsoluteUrl } = require('../../modules/urls');
 const { getCanonicalRoutes } = require('../../modules/route-helpers');
-const { legacyPagePaths } = require('../../modules/archived');
+const { legacyPagePaths, legacyFilesPath } = require('../../modules/archived');
 const { noCache, sMaxAge } = require('../../middleware/cached');
 const appData = require('../../modules/appData');
 

--- a/modules/archived.js
+++ b/modules/archived.js
@@ -1,4 +1,8 @@
 'use strict';
+const config = require('config');
+const { flatMap } = require('lodash');
+
+const { makeWelsh } = require('./urls');
 
 // We default to a 2017 crawl because it's the last date before we began
 // redirecting pages to the archives, meaning we can no longer send old pages there.
@@ -7,6 +11,11 @@ function buildArchiveUrl(urlPath, crawlDate = '20171011152352') {
     return `http://webarchive.nationalarchives.gov.uk/${crawlDate}/${fullUrl}`;
 }
 
+// Construct a list of legacy page paths (prefixed with welsh equivalents)
+// in order to archive them and block them from search engines.
+const legacyPagePaths = flatMap(config.get('archivedPaths.legacyPagePaths'), urlPath => [urlPath, makeWelsh(urlPath)]);
+
 module.exports = {
-    buildArchiveUrl
+    buildArchiveUrl,
+    legacyPagePaths
 };

--- a/modules/archived.js
+++ b/modules/archived.js
@@ -1,5 +1,4 @@
 'use strict';
-const config = require('config');
 const { flatMap } = require('lodash');
 
 const { makeWelsh } = require('./urls');
@@ -11,11 +10,33 @@ function buildArchiveUrl(urlPath, crawlDate = '20171011152352') {
     return `http://webarchive.nationalarchives.gov.uk/${crawlDate}/${fullUrl}`;
 }
 
-// Construct a list of legacy page paths (prefixed with welsh equivalents)
-// in order to archive them and block them from search engines.
-const legacyPagePaths = flatMap(config.get('archivedPaths.legacyPagePaths'), urlPath => [urlPath, makeWelsh(urlPath)]);
+// A list of legacy page paths which we archive and block from search engines.
+const legacyPagePaths = [
+    '/about-big/10-big-lottery-fund-facts',
+    '/about-big/big-lottery-fund-in-your-constituency',
+    '/about-big/community-closed',
+    '/about-big/countries*',
+    '/about-big/future-of-doing-good',
+    '/about-big/living-wage',
+    '/about-big/mayors-community-weekend',
+    '/about-big/our-approach/vision-and-principles',
+    '/about-big/publications*',
+    '/about-big/your-voice',
+    '/funding/big-stories*',
+    '/funding/celebrateuk*',
+    '/funding/funding-guidance/applying-for-funding/*',
+    '/funding/funding-guidance/managing-your-funding/about-equalities*',
+    '/funding/funding-guidance/managing-your-funding/reaching-communities-grant-offer',
+    '/funding/joint-funding',
+    '/funding/peoples-projects-resources',
+    '/funding/scotland-portfolio*',
+    '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-qa*',
+    '/global-content/press-releases/*',
+    '/research*'
+];
 
 module.exports = {
     buildArchiveUrl,
-    legacyPagePaths
+    legacyPagePaths: flatMap(legacyPagePaths, urlPath => [urlPath, makeWelsh(urlPath)]),
+    legacyFilesPath: '/-/media/files/*'
 };


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1690

This prevents any page we no longer serve from appearing in Google (or indeed the National Archives), which should gradually reduce the occurrence of random old document links still showing up in results. This should also prevent circular redirects happening where we send people to NA pages which in turn redirect them... back to the NA.