### PR TITLE
Update search domain

### DIFF
--- a/controllers/search/index.js
+++ b/controllers/search/index.js
@@ -3,18 +3,13 @@ const querystring = require('querystring');
 const express = require('express');
 
 const { noCache } = require('../../middleware/cached');
-const { normaliseQuery } = require('../../modules/urls');
 
 const router = express.Router();
 
 router.get('/', noCache, (req, res) => {
-    req.query = normaliseQuery(req.query);
-
     if (req.query.q) {
         const term = querystring.escape(req.query.q);
-        res.redirect(
-            `https://www.google.co.uk/search?q=${term}+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`
-        );
+        res.redirect(`https://www.google.co.uk/search?q=site%3Awww.tnlcommunityfund.org.uk+${term}`);
     } else {
         res.redirect('/');
     }

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -21,16 +21,9 @@ describe('common', function() {
     });
 
     it('should redirect search queries to a google site search', () => {
-        const searchDomain = 'https://www.google.co.uk/search';
         cy.checkRedirect({
             from: '/search?q=This is my search query',
-            to: `${searchDomain}?q=This%20is%20my%20search%20query+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`,
-            isRelative: false,
-            status: 302
-        });
-        cy.checkRedirect({
-            from: '/search?lang=en-GB&amp;q=something&amp;type=All&amp;order=r',
-            to: `${searchDomain}?q=something+site%3Awww.biglotteryfund.org.uk+OR+site%3Awww.tnlcommunityfund.org.uk`,
+            to: 'https://www.google.co.uk/search?q=site%3Awww.tnlcommunityfund.org.uk+This%20is%20my%20search%20query',
             isRelative: false,
             status: 302
         });

--- a/modules/__tests__/urls.test.js
+++ b/modules/__tests__/urls.test.js
@@ -7,7 +7,6 @@ const {
     hasTrailingSlash,
     isWelsh,
     localify,
-    normaliseQuery,
     sanitiseUrlPath,
     stripTrailingSlashes
 } = require('../urls');
@@ -145,24 +144,6 @@ describe('URL Helpers', () => {
         it('should sanitise url path', () => {
             expect(sanitiseUrlPath('/about/')).toBe('about');
             expect(sanitiseUrlPath('/welsh/path/to/something/')).toBe('path/to/something');
-        });
-    });
-
-    describe('#normaliseQuery', () => {
-        it('should normalise &amp; encoding in query strings', () => {
-            expect(
-                normaliseQuery({
-                    area: 'England',
-                    'amp;amount': '10001 - 50000',
-                    'amp;org': 'Voluntary or community organisation',
-                    'amp;sc': '1'
-                })
-            ).toEqual({
-                area: 'England',
-                amount: '10001 - 50000',
-                org: 'Voluntary or community organisation',
-                sc: '1'
-            });
         });
     });
 });

--- a/modules/urls.js
+++ b/modules/urls.js
@@ -98,26 +98,6 @@ function sanitiseUrlPath(urlPath) {
 }
 
 /**
- * Normalize query
- * Old format URLs often get passed through as: ?area=Scotland&amp;amount=10001 - 50000
- * urlencoded &amp; needs to be normalised when fetching individual query param
- */
-function normaliseQuery(originalQuery) {
-    function reducer(newQuery, value, key) {
-        const prefix = 'amp;';
-        if (includes(key, prefix)) {
-            newQuery[key.replace(prefix, '')] = value;
-        } else {
-            newQuery[key] = value;
-        }
-
-        return newQuery;
-    }
-
-    return reduce(originalQuery, reducer, {});
-}
-
-/**
  * getCurrentUrl
  * - Look up the current URL and rewrite to another locale
  * - Normalises and prunes query strings
@@ -166,7 +146,6 @@ module.exports = {
     isWelsh,
     localify,
     makeWelsh,
-    normaliseQuery,
     removeWelsh,
     sanitiseUrlPath,
     stripTrailingSlashes,


### PR DESCRIPTION
Updates search domain to use only the new domain.

**Before**

![image](https://user-images.githubusercontent.com/123386/52270026-a3d38800-2937-11e9-8ecb-814a32b8f900.png)

**After**

![image](https://user-images.githubusercontent.com/123386/52270069-c1085680-2937-11e9-8c4c-62bbb916e569.png)

Also noticed that the `normaliseQuery` logic was only needed to handle the search from the legacy website so this can all go now.