### PR TITLE
Allow querystrings on document links for tracking downloads

### DIFF
--- a/assets/js/bootstraps/analytics.js
+++ b/assets/js/bootstraps/analytics.js
@@ -4,7 +4,7 @@ import forEach from 'lodash/forEach';
 import { trackEvent } from '../helpers/metrics';
 
 function trackDocumentDownloads() {
-    const links = document.querySelectorAll('.content-box a[href]');
+    const links = document.querySelectorAll('a[href]');
     forEach(links, function(link) {
         if (/\.(pdf|doc|docx|xls|xlsx)/i.test(link.href)) {
             link.addEventListener('click', () => {

--- a/assets/js/bootstraps/analytics.js
+++ b/assets/js/bootstraps/analytics.js
@@ -6,7 +6,7 @@ import { trackEvent } from '../helpers/metrics';
 function trackDocumentDownloads() {
     const links = document.querySelectorAll('.content-box a[href]');
     forEach(links, function(link) {
-        if (/\.(pdf|doc|docx|xls|xlsx)$/i.test(link.href)) {
+        if (/\.(pdf|doc|docx|xls|xlsx)/i.test(link.href)) {
             link.addEventListener('click', () => {
                 trackEvent('Documents', 'Downloaded a document', link.href);
             });


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1741 (eg. clicks on Insights pages weren't being tracked because of a `?mtime=` query at the end of the link)