### PR TITLE
Use a single API call for homepage

### DIFF
--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -1,41 +1,30 @@
 'use strict';
-const Raven = require('raven');
 const path = require('path');
 const express = require('express');
 const contentApi = require('../../services/content-api');
 
 const router = express.Router();
 
-const injectHomepage = async (req, res, next) => {
-    res.locals.homepageContent = await contentApi.getHomepage({
-        locale: req.i18n.getLocale()
-    });
-    next();
-};
-
-router.get('/', injectHomepage, async (req, res) => {
-    let promotedUpdates;
+router.get('/', async (req, res, next) => {
     try {
-        promotedUpdates = await contentApi.getUpdates({
-            locale: req.i18n.getLocale(),
-            query: {
-                promoted: true
+        const { featuredLinks, promotedUpdates } = await contentApi.getHomepage({
+            locale: req.i18n.getLocale()
+        });
+
+        res.render(path.resolve(__dirname, './views/home'), {
+            featuredLinks,
+            promotedUpdates,
+            heroImage: {
+                small: '/assets/images/home/superhero-small.jpg',
+                medium: '/assets/images/home/superhero-medium.jpg',
+                large: '/assets/images/home/superhero-large.jpg',
+                default: '/assets/images/home/superhero-medium.jpg',
+                caption: 'Superstars Club'
             }
         });
     } catch (error) {
-        Raven.captureException(error);
+        next(error);
     }
-
-    res.render(path.resolve(__dirname, './views/home'), {
-        promotedUpdates: promotedUpdates,
-        heroImage: {
-            small: '/assets/images/home/superhero-small.jpg',
-            medium: '/assets/images/home/superhero-medium.jpg',
-            large: '/assets/images/home/superhero-large.jpg',
-            default: '/assets/images/home/superhero-medium.jpg',
-            caption: 'Superstars Club'
-        }
-    });
 });
 
 module.exports = router;

--- a/controllers/home/views/home.njk
+++ b/controllers/home/views/home.njk
@@ -50,7 +50,7 @@
         {# Featured sections #}
         <section class="u-inner u-margin-bottom">
             <ul class="flex-grid flex-grid--3up">
-                {% for item in homepageContent.featuredLinks %}
+                {% for item in featuredLinks %}
                     <li class="flex-grid__item">
                         {{ miniatureHero({
                             "title": item.label,
@@ -63,10 +63,10 @@
         </section>
 
         {# Latest News #}
-        {% if promotedUpdates.result.length > 1 %}
+        {% if promotedUpdates.length > 1 %}
             <section class="u-border-top u-inner u-padded u-margin-bottom">
                 {{ latestUpdates(
-                    articles = promotedUpdates.result,
+                    articles = promotedUpdates,
                     title = __('global.misc.latestNews'),
                     allLink = {
                         "url": localify('/news'),


### PR DESCRIPTION
We currently make two content API calls for the homepage. This reduces it to 1. See https://github.com/biglotteryfund/craft-dev/pull/151