### PR TITLE
Prune client-side code

### DIFF
--- a/assets/js/bootstraps/common.js
+++ b/assets/js/bootstraps/common.js
@@ -7,7 +7,7 @@ import tabs from '../modules/tabs';
 import forms from '../modules/forms';
 
 function init() {
-    fitvids('.video-container');
+    fitvids();
 
     tabs.init();
     forms.init();

--- a/assets/js/helpers/features.js
+++ b/assets/js/helpers/features.js
@@ -23,11 +23,6 @@ export const FEATURES = [
         id: 'analytics',
         description: 'Enable Google Analytics',
         isEnabled: !window.AppConfig.blockAnalytics && !isDoNotTrack
-    }),
-    createFeature({
-        id: 'review-abandonment-message',
-        description: 'Show abandonment message on the review step',
-        isEnabled: true
     })
 ];
 

--- a/assets/js/modules/forms.js
+++ b/assets/js/modules/forms.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import { featureIsEnabled } from '../helpers/features';
 import { trackEvent } from '../helpers/metrics';
 
 function handleAbandonmentMessage(formEl) {

--- a/assets/js/modules/forms.js
+++ b/assets/js/modules/forms.js
@@ -2,40 +2,8 @@ import $ from 'jquery';
 import { featureIsEnabled } from '../helpers/features';
 import { trackEvent } from '../helpers/metrics';
 
-// Materials form logic
-function initLegacyForms() {
-    // Handle making "other" inputs required for radio sets
-    const classes = {
-        radioContainer: 'js-has-radios',
-        otherTrigger: 'js-other-trigger'
-    };
-
-    // We bind to the body element like this because these
-    // fields are rendered by Vue and not always in the DOM
-    $('body').on('click', `.${classes.radioContainer} input[type="radio"]`, function() {
-        const $clickedRadio = $(this);
-        // find the corresponding <input> field for this radio set
-        const $other = $('#' + $clickedRadio.parents(`.${classes.radioContainer}`).data('other-id'));
-        if ($other.length === 0) {
-            return;
-        }
-        // is the clicked element an "other" trigger?
-        if ($clickedRadio.hasClass(classes.otherTrigger)) {
-            $other.attr('required', true);
-        } else {
-            // they clicked on one of the regular radio options
-            $other.attr('required', false);
-        }
-    });
-}
-
 function handleAbandonmentMessage(formEl) {
-    if (!featureIsEnabled('review-abandonment-message')) {
-        return;
-    }
-
     let recordUnload = true;
-
     function handleBeforeUnload(e) {
         // Message cannot be customised in Chrome 51+
         // https://developers.google.com/web/updates/2016/04/chrome-51-deprecations?hl=en
@@ -77,7 +45,7 @@ function toggleReviewAnswers() {
     });
 }
 
-function initApplicationForms() {
+function init() {
     /**
      * Review–step–specific logic
      */
@@ -86,11 +54,6 @@ function initApplicationForms() {
         handleAbandonmentMessage(formReviewEl);
         toggleReviewAnswers();
     }
-}
-
-function init() {
-    initLegacyForms();
-    initApplicationForms();
 }
 
 export default {

--- a/assets/js/vue-apps/materials.js
+++ b/assets/js/vue-apps/materials.js
@@ -3,6 +3,26 @@ import Vue from 'vue';
 import queryString from 'query-string';
 
 function init() {
+    // Handle making "other" inputs required for radio sets
+    // We bind to the body element like this because these
+    // fields are rendered by Vue and not always in the DOM
+    $('body').on('click', `.js-has-radios input[type="radio"]`, function() {
+        const $clickedRadio = $(this);
+        // find the corresponding <input> field for this radio set
+        const $other = $('#' + $clickedRadio.parents(`.js-has-radios`).data('other-id'));
+        if ($other.length === 0) {
+            return;
+        }
+
+        // is the clicked element an "other" trigger?
+        if ($clickedRadio.hasClass('js-other-trigger')) {
+            $other.attr('required', true);
+        } else {
+            // they clicked on one of the regular radio options
+            $other.attr('required', false);
+        }
+    });
+
     const mountEl = document.getElementById('js-vue');
     if (!mountEl) {
         return;


### PR DESCRIPTION
- Move "legacy" form JS into materials module as it only relates to that form.
- Remove a feature flag which was always `true`
- Don't scope fitvids to `.video-container` class, we don't always know this will be applied as it comes from the CMS.