### PR TITLE
Add a redirect for archived research page

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -2523,6 +2523,46 @@ Array [
     "to": "/welsh/insights/youth-serious-violence",
   },
   Object {
+    "from": "/research/social-investment/publications",
+    "to": "/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/welsh/research/social-investment/publications",
+    "to": "/welsh/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/england/research/social-investment/publications",
+    "to": "/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/welsh/england/research/social-investment/publications",
+    "to": "/welsh/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/scotland/research/social-investment/publications",
+    "to": "/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/welsh/scotland/research/social-investment/publications",
+    "to": "/welsh/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/northernireland/research/social-investment/publications",
+    "to": "/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/welsh/northernireland/research/social-investment/publications",
+    "to": "/welsh/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/wales/research/social-investment/publications",
+    "to": "/insights/social-investment-publications",
+  },
+  Object {
+    "from": "/welsh/wales/research/social-investment/publications",
+    "to": "/welsh/insights/social-investment-publications",
+  },
+  Object {
     "from": "/funding/awards-for-all",
     "to": "/funding/under10k",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -81,6 +81,7 @@ const aliases = {
     '/research/place-based-working': '/insights/place-based-working',
     '/research/youth-employment': '/insights/youth-employment',
     '/research/youth-serious-violence': '/insights/youth-serious-violence',
+    '/research/social-investment/publications': '/insights/social-investment-publications',
 
     //===== Funding =====//
     '/funding/awards-for-all': '/funding/under10k',


### PR DESCRIPTION
Points the old link at the newly-launched https://www.tnlcommunityfund.org.uk/insights/social-investment-publications