### PR TITLE
Extract out error code

### DIFF
--- a/controllers/apply-next/form-router.js
+++ b/controllers/apply-next/form-router.js
@@ -1,5 +1,5 @@
 'use strict';
-const { concat, flatMap, isEmpty, omit, set } = require('lodash');
+const { concat, isEmpty, omit, set } = require('lodash');
 const { get, getOr } = require('lodash/fp');
 const express = require('express');
 const path = require('path');
@@ -9,14 +9,8 @@ const cached = require('../../middleware/cached');
 const { requireUserAuth } = require('../../middleware/authed');
 const applicationsService = require('../../services/applications');
 
-const {
-    FORM_STATES,
-    calculateFormProgress,
-    enhanceForm,
-    filterErrors,
-    nextAndPrevious,
-    normaliseErrors
-} = require('./helpers');
+const { normaliseErrors } = require('../../modules/errors');
+const { FORM_STATES, calculateFormProgress, enhanceForm, fieldsForStep, nextAndPrevious } = require('./helpers');
 
 function initFormRouter(formModel) {
     const router = express.Router();
@@ -143,8 +137,7 @@ function initFormRouter(formModel) {
         currentSection.steps.forEach((currentStep, currentStepIndex) => {
             const currentStepNumber = currentStepIndex + 1;
             const numSteps = currentSection.steps.length;
-            const fieldsForStep = flatMap(currentStep.fieldsets, 'fields');
-            const fieldNamesForStep = fieldsForStep.map(field => field.name);
+            const stepFields = fieldsForStep(currentStep);
 
             function renderStep(req, res, data, errors = []) {
                 const form = enhanceForm(req.i18n.getLocale(), formModel, data);
@@ -206,14 +199,18 @@ function initFormRouter(formModel) {
                      * Get the errors for the current step
                      * We validate against the whole form schema so need to limit the errors to the current step
                      */
-                    const errorsForStep = filterErrors(validationResult.error, fieldNamesForStep);
-                    const errorKeysForStep = errorsForStep.map(detail => detail.context.key);
+                    const errors = normaliseErrors({
+                        validationError: validationResult.error,
+                        errorMessages: stepFields.messages,
+                        fieldNames: stepFields.names,
+                        locale: req.i18n.getLocale()
+                    });
 
                     /**
                      * Prepare data for storage
                      * Exclude any values in the current submission which have errors
                      */
-                    const newFormData = omit(validationResult.value, errorKeysForStep);
+                    const newFormData = omit(validationResult.value, errors.map(err => err.param));
 
                     try {
                         await applicationsService.updateApplication(currentlyEditingId, newFormData);
@@ -223,12 +220,7 @@ function initFormRouter(formModel) {
                          * - Pass the full data object from validationResult to the view. Including invalid values.
                          * Otherwise, find the next suitable step and redirect there.
                          */
-                        if (errorsForStep.length > 0) {
-                            const errors = normaliseErrors({
-                                fields: fieldsForStep,
-                                errors: errorsForStep,
-                                locale: req.i18n.getLocale()
-                            });
+                        if (errors.length > 0) {
                             renderStep(req, res, validationResult.value, errors);
                         } else {
                             const { nextUrl } = nextAndPrevious({

--- a/controllers/apply-next/helpers.js
+++ b/controllers/apply-next/helpers.js
@@ -1,6 +1,6 @@
 'use strict';
-const { cloneDeep, find, findIndex, findLastIndex, flatMapDeep, includes, isEmpty, pick } = require('lodash');
-const { get, getOr, uniqBy } = require('lodash/fp');
+const { cloneDeep, find, findIndex, findLastIndex, flatMap, flatMapDeep, includes, isEmpty, pick } = require('lodash');
+const { get, getOr } = require('lodash/fp');
 const moment = require('moment');
 
 const FORM_STATES = {
@@ -113,6 +113,19 @@ function enhanceForm(locale, form, data) {
     return clonedForm;
 }
 
+// @TODO: Add tests for this
+function fieldsForStep(step) {
+    const fields = flatMap(step.fieldsets, 'fields');
+    return {
+        fields: fields,
+        names: fields.map(field => field.name),
+        messages: fields.reduce((obj, field) => {
+            obj[field.name] = field.messages;
+            return obj;
+        }, {})
+    };
+}
+
 /**
  * Determine status from data and validation errors
  * @param {Object} data
@@ -223,46 +236,12 @@ function nextAndPrevious(options) {
     };
 }
 
-/**
- * Filter joi error object by given field names
- * In order to avoid showing multiple validation errors per field we find the first error per field name
- * @param {Object} validationError
- * @param {Array<String>} fieldNames
- */
-function filterErrors(validationError, fieldNames) {
-    const errorDetails = getOr([], 'details')(validationError);
-    return uniqBy(detail => detail.context.key)(
-        errorDetails.filter(detail => includes(fieldNames, detail.context.key))
-    );
-}
-
-/**
- * Normalise errors for use in views
- * Maps raw joi error objects to a simplified format and
- * determines the appropriate translated error message to
- * use based on a fields current error type.
- *
- * @param {Object} options
- * @param {Array<Object>} options.fields
- * @param {Array<Object>} options.errors
- * @param {String} options.locale
- */
-function normaliseErrors({ fields, errors, locale }) {
-    return errors.map(detail => {
-        const name = detail.context.key;
-        const match = find(fields, field => field.name === name);
-        const localeString = get(detail.type)(match.messages) || get('base')(match.messages);
-        return { param: name, msg: get(locale)(localeString) };
-    });
-}
-
 module.exports = {
     FORM_STATES,
     calculateFormProgress,
     enhanceForm,
-    filterErrors,
+    fieldsForStep,
     findNextMatchingUrl,
     findPreviousMatchingUrl,
-    nextAndPrevious,
-    normaliseErrors
+    nextAndPrevious
 };

--- a/modules/__tests__/errors.test.js
+++ b/modules/__tests__/errors.test.js
@@ -1,0 +1,79 @@
+/* eslint-env jest */
+'use strict';
+
+const Joi = require('joi');
+const { normaliseErrors } = require('../errors');
+
+const mockSchema = Joi.object({
+    a: Joi.string()
+        .min(10)
+        .invalid(Joi.ref('b'))
+        .required(),
+    b: Joi.string()
+        .min(12)
+        .required()
+});
+
+const mockErrorMessages = {
+    a: {
+        base: { en: 'Please enter A', cy: '(cy) Please enter A' },
+        'string.min': { en: 'A must be at least 10 characters', cy: '(cy) A must be at least 10 characters' },
+        'any.invalid': { en: 'A must not be the same as B', cy: '(cy) A must not be the same as B' }
+    },
+    b: {
+        base: { en: 'Please enter B', cy: '(cy) Please enter B' }
+    }
+};
+
+describe('normaliseErrors', () => {
+    test('normalise errors', () => {
+        const validationResult = mockSchema.validate({ a: 'tooshort' }, { abortEarly: false });
+
+        const normalised = normaliseErrors({
+            validationError: validationResult.error,
+            errorMessages: mockErrorMessages,
+            locale: 'cy'
+        });
+
+        expect(normalised).toEqual([
+            { param: 'b', msg: '(cy) Please enter B' },
+            { param: 'a', msg: '(cy) A must be at least 10 characters' }
+        ]);
+    });
+
+    test('returns first error per field', () => {
+        const validationResult = mockSchema.validate({ a: 'same', b: 'same' }, { abortEarly: false });
+
+        const normalised = normaliseErrors({
+            validationError: validationResult.error,
+            errorMessages: mockErrorMessages,
+            locale: 'en'
+        });
+
+        expect(validationResult.error.details.length).toBe(3);
+        expect(normalised).toEqual([
+            { param: 'b', msg: 'Please enter B' },
+            { param: 'a', msg: 'A must not be the same as B' }
+        ]);
+    });
+
+    test('can filter errors by name', () => {
+        const validationResult = mockSchema.validate({}, { abortEarly: false });
+
+        const normalised = normaliseErrors({
+            validationError: validationResult.error,
+            errorMessages: mockErrorMessages,
+            locale: 'en'
+        });
+
+        const normalisedFiltered = normaliseErrors({
+            validationError: validationResult.error,
+            errorMessages: mockErrorMessages,
+            locale: 'en',
+            fieldNames: ['a']
+        });
+
+        expect(normalised).toEqual([{ param: 'b', msg: 'Please enter B' }, { param: 'a', msg: 'Please enter A' }]);
+        expect(normalisedFiltered).toEqual([{ param: 'a', msg: 'Please enter A' }]);
+    });
+});

--- a/modules/errors.js
+++ b/modules/errors.js
@@ -1,0 +1,35 @@
+'use strict';
+const { includes } = require('lodash');
+const { getOr, uniqBy } = require('lodash/fp');
+
+/**
+ * Normalise errors for use in views
+ * - Maps raw joi error objects to a simplified format and
+ * - In order to avoid showing multiple validation errors per field we find the first error per field name
+ * - Determines the appropriate translated error message to use based on current error type.
+ *
+ * @param {Object} options
+ * @param {Object} options.validationError
+ * @param {Object} options.errorMessages
+ * @param {String} options.locale
+ * @param {Array<String>} [options.fieldNames]
+ */
+function normaliseErrors({ validationError, errorMessages, locale, fieldNames = [] }) {
+    const errors = getOr([], 'details')(validationError);
+
+    const filteredErrors =
+        fieldNames.length > 0 ? errors.filter(detail => includes(fieldNames, detail.context.key)) : errors;
+
+    const uniqueFilteredErrors = uniqBy(detail => detail.context.key)(filteredErrors);
+
+    return uniqueFilteredErrors.map(detail => {
+        const name = detail.context.key;
+        const fieldMessages = errorMessages[name];
+        const fieldMessage = fieldMessages[detail.type] || fieldMessages['base'];
+        return { param: name, msg: fieldMessage[locale] };
+    });
+}
+
+module.exports = {
+    normaliseErrors
+};


### PR DESCRIPTION
This PR does a little prep for updating other controllers to use `joi` for error handling. Namely extracting out the `normaliseErrors` function. I realised as part of this that it makes sense to combine the filter step into the same function as it's part of the same process. Adds unit tests.