### PR TITLE
Format date as object rather than handling in template/globally

### DIFF
--- a/controllers/apply-next/helpers.js
+++ b/controllers/apply-next/helpers.js
@@ -1,7 +1,18 @@
 'use strict';
-const { cloneDeep, find, findIndex, findLastIndex, flatMap, flatMapDeep, includes, isEmpty, pick } = require('lodash');
-const { get, getOr } = require('lodash/fp');
 const moment = require('moment');
+const { get, getOr } = require('lodash/fp');
+const {
+    cloneDeep,
+    find,
+    findIndex,
+    findLastIndex,
+    flatMap,
+    flatMapDeep,
+    includes,
+    isEmpty,
+    isString,
+    pick
+} = require('lodash');
 
 const FORM_STATES = {
     empty: 'empty',
@@ -9,6 +20,23 @@ const FORM_STATES = {
     incomplete: 'incomplete',
     complete: 'complete'
 };
+
+function prepareValue(value, field) {
+    if (field.type === 'date') {
+        if (isString(value)) {
+            const dt = moment(value);
+            return {
+                day: dt.format('DD'),
+                month: dt.format('MM'),
+                year: dt.format('YYYY')
+            };
+        } else {
+            return value;
+        }
+    } else {
+        return value;
+    }
+}
 
 /**
  * Format field values for display in views
@@ -19,7 +47,7 @@ const FORM_STATES = {
  * @param {any} value
  * @param {object} field
  */
-function toDisplayValue(value, field) {
+function prepareDisplayValue(value, field) {
     if (field.displayFormat) {
         return field.displayFormat.call(field, value);
     } else if (field.type === 'radio') {
@@ -69,8 +97,8 @@ function enhanceForm(locale, form, data) {
         // Assign value to field if present
         const fieldValue = find(data, (value, name) => name === field.name);
         if (fieldValue) {
-            field.value = fieldValue;
-            field.displayValue = toDisplayValue(fieldValue, field);
+            field.value = prepareValue(fieldValue, field);
+            field.displayValue = prepareDisplayValue(fieldValue, field);
         }
 
         return field;

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -139,13 +139,9 @@ module.exports = function(req, res, next) {
      * @return {String}
      */
     res.locals.formatDate = function(dateString, format) {
-        if (dateString && isString(dateString)) {
-            return moment(dateString)
-                .locale(locale)
-                .format(format);
-        } else {
-            return '';
-        }
+        return moment(dateString)
+            .locale(locale)
+            .format(format);
     };
 
     /**

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -68,6 +68,7 @@
             {{ fieldLabelText(field) }}
         </legend>
         {{ fieldHelpText(field, fieldCopy) }}
+
         <div id="field-{{ field.name }}">
             <label class="ff-inline">
                 <span class="ff-label">{{ __('global.misc.day') }}</span>
@@ -75,7 +76,7 @@
                     class="ff-text ff-width-2"
                     type="number" pattern="[0-9]*"  min="1"
                     name="{{ field.name }}[day]"
-                    value="{{ field.value.day or formatDate(field.value, 'D') }}"
+                    value="{{ field.value.day }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
                 />
             </label>
@@ -85,7 +86,7 @@
                     class="ff-text ff-width-2"
                     type="number" pattern="[0-9]*"  min="1"
                     name="{{ field.name }}[month]"
-                    value="{{ field.value.month or formatDate(field.value, 'M') }}"
+                    value="{{ field.value.month }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
                 />
             </label>
@@ -97,7 +98,7 @@
                     pattern="[0-9]*" min="{{ field.settings.minYear | default(1900) }}"
                     name="{{ field.name }}[year]"
                     size="20"
-                    value="{{ field.value.year or formatDate(field.value, 'YYYY') }}"
+                    value="{{ field.value.year }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
                 />
             </label>


### PR DESCRIPTION
My recent work on date inputs made a global change to `formatDate`. This ended up not displaying dates if a `Date` was passed, which we do with `createdAt` dates for example. 

Rather than handling this formatting logic for date inputs in templates and global methods, I've instead added a function similar to the one for display values which always formats dates as `{ day, month, year }` parts when the field is a date input.

This avoids any weird template logic, date input values will always be in parts, and avoids handling lots of conditions in global methods.