### PR TITLE
Add support for conditional options, for legal contact role

### DIFF
--- a/controllers/apply-next/helpers.js
+++ b/controllers/apply-next/helpers.js
@@ -60,6 +60,12 @@ function prepareDisplayValue(value, field) {
     }
 }
 
+function filterOptionsBy(data = {}) {
+    return function(option) {
+        return option.showWhen ? option.showWhen(data) : true;
+    };
+}
+
 /**
  * Enhances a form object by:
  * - Localising all labels and messages
@@ -90,7 +96,7 @@ function enhanceForm({ locale, baseForm, data = {} }) {
         field.explanation = localise(field.explanation);
 
         if (field.options) {
-            field.options = field.options.map(option => {
+            field.options = field.options.filter(filterOptionsBy(data)).map(option => {
                 option.label = localise(option.label);
                 option.explanation = localise(option.explanation);
                 return option;
@@ -270,9 +276,10 @@ module.exports = {
     FORM_STATES,
     calculateFormProgress,
     enhanceForm,
-    mapFields,
     fieldsForStep,
+    filterOptionsBy,
     findNextMatchingUrl,
     findPreviousMatchingUrl,
+    mapFields,
     nextAndPrevious
 };

--- a/controllers/apply-next/simple/fields.test.js
+++ b/controllers/apply-next/simple/fields.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+'use strict';
+
+const { filterOptionsBy } = require('../helpers');
+const { legalContactRoles } = require('./fields');
+
+describe('legalContactRoles', () => {
+    test('return default roles', () => {
+        expect(legalContactRoles.filter(filterOptionsBy()).map(option => option.value)).toEqual([
+            'chair',
+            'vice-chair',
+            'treasurer',
+            'trustee'
+        ]);
+    });
+
+    test('add options based on data', () => {
+        const resultA = legalContactRoles
+            .filter(filterOptionsBy({ 'organisation-type': 'school' }))
+            .map(option => option.value);
+
+        expect(resultA).toEqual(['head-teacher', 'chair', 'vice-chair', 'treasurer', 'trustee']);
+
+        const resultB = legalContactRoles
+            .filter(filterOptionsBy({ 'organisation-type': 'statutory-body' }))
+            .map(option => option.value);
+
+        expect(resultB).toEqual(['clerk', 'chair', 'vice-chair', 'treasurer', 'trustee']);
+
+        const resultC = legalContactRoles
+            .filter(filterOptionsBy({ 'company-number': '12345678' }))
+            .map(option => option.value);
+
+        expect(resultC).toEqual(['director', 'company-secretary', 'chair', 'vice-chair', 'treasurer', 'trustee']);
+    });
+});

--- a/controllers/apply-next/simple/form-model.js
+++ b/controllers/apply-next/simple/form-model.js
@@ -182,16 +182,7 @@ const sectionLegalContact = {
             fieldsets: [
                 {
                     legend: { en: 'Who is your legally responsible contact?', cy: '' },
-                    introduction: {
-                        en: `
-<p>This person will be legally responsible for the funding and must be unconnected to the main contact. By ‘unconnected’ we mean not related by blood, marriage, in a long-term relationship or people living together at the same address.</p>
-
-<p>They must be at least 18 years old and are responsible for ensuring that this application is supported by the organisation applying, any funding is delivered as set out in the application form, and that the funded organisation meets our monitoring requirements.</p>
-
-<p>The position held by the legally responsible contact is dependent on the type of organisation you are applying on behalf of. The options given to you for selection are based on this.</p>`,
-                        cy: ''
-                    },
-                    fields: [allFields.legalContactName, allFields.legalContactDob]
+                    fields: [allFields.legalContactName, allFields.legalContactRole, allFields.legalContactDob]
                 },
                 {
                     legend: { en: 'Address', cy: '' },


### PR DESCRIPTION
Add support for conditional options, for legal contact role. Filters options based on a `matchesCondition` function (same idea as conditional steps). Mapping of values is based

- Always show chair, vice-chair, treasurer, trustee
- If a company number has been provided show director and company-secretary
- If a statutory body show clerk
- If a school show head teacher

This mapping is based on the current form as a starting point. Still needs thought about how to flag that options may be limited if you've not answered the organisation type yet (i.e. done steps out of order)