### PR TITLE
Specify a different type of Twitter card if we have an image

### DIFF
--- a/views/includes/metadata.njk
+++ b/views/includes/metadata.njk
@@ -14,12 +14,14 @@
 <meta property="og:description" content="{{ metaDescription }}">
 <meta property="og:url" content="{{ getCurrentAbsoluteUrl() }}">
 
-<meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@{{ globalCopy.brand.twitter }}" />
 
 {% if socialImage %}
+<meta name="twitter:card" content="summary_large_image" />
 <meta property="twitter:image" content="{{ getSocialImageUrl(socialImage) | safe }}">
 <meta property="og:image" content="{{ getSocialImageUrl(socialImage) | safe }}">
+{% else %}
+<meta name="twitter:card" content="summary" />
 {% endif %}
 
 <meta name="google-site-verification" content="YJm5YK8XXPjyF0oyks3mvJ2P2qc1mwm9GyF7OlyNl9A" />


### PR DESCRIPTION
If we specify a trail image on a press release, we produce a 2:1 crop for Twitter cards which results in this output:

![image](https://user-images.githubusercontent.com/394376/54193589-51dfce00-44b2-11e9-9b04-85e38bcc005e.png)

Turns out we should be using a different type of card in this instance.