### PR TITLE
Rework date validator

### DIFF
--- a/controllers/apply-next/simple/fields.js
+++ b/controllers/apply-next/simple/fields.js
@@ -182,8 +182,8 @@ const allFields = {
         schema: commonValidators.futureDate({ amount: '12', unit: 'weeks' }),
         messages: {
             base: { en: 'Enter a date', cy: '' },
-            'date.isoDate': { en: 'Enter a real date', cy: '' },
-            'date.min': { en: 'Date must be at least 12 weeks into the future', cy: '' }
+            'any.invalid': { en: 'Enter a real date', cy: '' },
+            'dateParts.futureDate': { en: 'Date must be at least 12 weeks into the future', cy: '' }
         }
     },
     projectPostcode: postcodeField({
@@ -441,8 +441,8 @@ const allFields = {
         schema: commonValidators.futureDate(),
         messages: {
             base: { en: 'Enter a date', cy: '' },
-            'date.isoDate': { en: 'Enter a real date', cy: '' },
-            'date.min': { en: 'Date must be in the future', cy: '' }
+            'any.invalid': { en: 'Enter a real date', cy: '' },
+            'dateParts.futureDate': { en: 'Date must be in the future', cy: '' }
         }
     },
     totalIncomeYear: {
@@ -485,7 +485,7 @@ const allFields = {
         schema: commonValidators.dateOfBirth(MIN_APPLICANT_AGE),
         messages: {
             base: { en: 'Enter a date of birth', cy: '' },
-            'date.max': { en: 'Main contact must be at least 18 years old', cy: '' }
+            'dateParts.dob': { en: `Main contact must be at least ${MIN_APPLICANT_AGE} years old`, cy: '' }
         }
     },
     mainContactAddressBuildingStreet: {
@@ -619,7 +619,7 @@ const allFields = {
         schema: commonValidators.dateOfBirth(MIN_APPLICANT_AGE),
         messages: {
             base: { en: 'Enter a date of birth', cy: '' },
-            'date.max': { en: 'Legal contact must be at least 18 years old', cy: '' }
+            'dateParts.dob': { en: `Legal contact must be at least ${MIN_APPLICANT_AGE} years old`, cy: '' }
         }
     },
     legalContactAddressBuildingStreet: {

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -76,35 +76,37 @@
                 <span class="ff-label">{{ __('global.misc.day') }}</span>
                 <input
                     class="ff-text ff-width-2"
-                    type="number" pattern="[0-9]*"  min="1"
                     name="{{ field.name }}[day]"
+                    type="number"
+                    pattern="[0-9]*"  min="1"
                     autocomplete="off"
-                    value="{{ field.value.day }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
+                    value="{{ field.value.day }}"
                 />
             </label>
             <label class="ff-inline">
                 <span class="ff-label">{{ __('global.misc.month') }}</span>
                 <input
                     class="ff-text ff-width-2"
-                    type="number" pattern="[0-9]*"  min="1"
                     name="{{ field.name }}[month]"
+                    type="number"
+                    pattern="[0-9]*"  min="1"
                     autocomplete="off"
-                    value="{{ field.value.month }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
+                    value="{{ field.value.month }}"
                 />
             </label>
             <label class="ff-inline">
                 <span class="ff-label">{{ __('global.misc.year') }}</span>
                 <input
                     class="ff-text ff-width-4"
+                    name="{{ field.name }}[year]"
                     type="number"
                     pattern="[0-9]*" min="{{ field.settings.minYear | default(1900) }}"
-                    name="{{ field.name }}[year]"
                     autocomplete="off"
                     size="20"
-                    value="{{ field.value.year }}"
                     {% if field.isRequired %}required aria-required="true"{% endif %}
+                    value="{{ field.value.year }}"
                 />
             </label>
         </div>


### PR DESCRIPTION
Reworks date validate to validate directly against separate parts rather than coercing to a date. This avoids ambiguity around which format the date available as at any given point. It is now always stored as an object of date parts.

Follows the format of the budget field / joi extensions and defines `futureDate` and `dob` as additional validators.