### PR TITLE
Document archive 404

### DIFF
--- a/controllers/__tests__/__snapshots__/aliases.test.js.snap
+++ b/controllers/__tests__/__snapshots__/aliases.test.js.snap
@@ -3483,6 +3483,46 @@ Array [
     "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
   },
   Object {
+    "from": "/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/england/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/england/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/scotland/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/scotland/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/northernireland/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/northernireland/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/wales/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
+    "from": "/welsh/wales/global-content/programmes/england/awards-for-all-england/a4alightpilotintro",
+    "to": "/welsh/funding/programmes/national-lottery-awards-for-all-england",
+  },
+  Object {
     "from": "/global-content/programmes/england/building-better-opportunities/black-country",
     "to": "/funding/programmes/building-better-opportunities/black-country",
   },

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -109,6 +109,7 @@ const aliases = {
 
     //===== Funding programmes =====//
     '/global-content/programmes/england/awards-for-all-england': '/funding/programmes/national-lottery-awards-for-all-england',
+    '/global-content/programmes/england/awards-for-all-england/a4alightpilotintro': '/funding/programmes/national-lottery-awards-for-all-england',
     '/global-content/programmes/england/building-better-opportunities/black-country': '/funding/programmes/building-better-opportunities/black-country',
     '/global-content/programmes/england/building-better-opportunities/buckinghamshire': '/funding/programmes/building-better-opportunities/buckinghamshire',
     '/global-content/programmes/england/building-better-opportunities/building-better-opportunities-case-studies': '/funding/programmes/building-better-opportunities/case-studies',

--- a/controllers/archived.js
+++ b/controllers/archived.js
@@ -35,7 +35,8 @@ router.get(legacyFilesPath, (req, res) => {
         dimension: 'DOWNLOADED',
         value: 'REQUEST_COUNT'
     });
-    res.render('static-pages/legacy-file', {
+
+    res.status(404).render('static-pages/legacy-file', {
         title: 'Document archived',
         filePath: filePath
     });


### PR DESCRIPTION
Pointed out by @LynseyJReynolds that old documents are showing too prominently in search results. Spotted that we are not returning an explicit 404 response for archived documents, so whilst the file has been removed we're probably signalling to google that there's still content at the URL. Making this a 404.

Once this is out we can submit some removal requests for the most accessed old documents by submitting a removal request through webmaster tools (there's about a dozen that make up the majority of traffic to archived documents). This tool requires that page is already 404ing for a request to be successful so this needs to go out first.