### PR TITLE
Extract redirectUrlWithFallback method

### DIFF
--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -6,7 +6,8 @@ const passport = require('passport');
 const router = express.Router();
 
 const { csrfProtection } = require('../../middleware/cached');
-const { requireUnauthed } = require('../../middleware/authed');
+const { requireUnauthed, redirectUrlWithFallback } = require('../../middleware/authed');
+const { localify } = require('../../modules/urls');
 
 function renderForm(req, res) {
     let alertMessage;
@@ -50,22 +51,8 @@ router
                     if (loginErr) {
                         next(loginErr);
                     } else {
-                        // User is valid, send them on
-                        let redirectUrl = '/user';
-                        if (req.query.redirectUrl) {
-                            redirectUrl = req.query.redirectUrl;
-                        } else if (req.body.redirectUrl) {
-                            redirectUrl = req.body.redirectUrl;
-                        } else if (req.session.redirectUrl) {
-                            redirectUrl = req.session.redirectUrl;
-                            delete req.session.redirectUrl;
-                        } else if (res.locals.newStatus) {
-                            redirectUrl += `?s=${res.locals.newStatus}`;
-                        }
-
-                        req.session.save(() => {
-                            res.redirect(redirectUrl);
-                        });
+                        const fallbackUrl = localify(req.i18n.getLocale())('/user');
+                        redirectUrlWithFallback(fallbackUrl, req, res);
                     }
                 });
             }

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -4,14 +4,14 @@ const passport = require('passport');
 const path = require('path');
 const Raven = require('raven');
 
-const { csrfProtection } = require('../../middleware/cached');
-const { requireUnauthed } = require('../../middleware/authed');
 const userService = require('../../services/user');
+const { csrfProtection } = require('../../middleware/cached');
+const { requireUnauthed, redirectUrlWithFallback } = require('../../middleware/authed');
+const { localify } = require('../../modules/urls');
+const { normaliseErrors } = require('../../modules/errors');
 
 const { sendActivationEmail } = require('./helpers');
-
 const { accountSchema, errorMessages } = require('./schema');
-const { normaliseErrors } = require('../../modules/errors');
 
 const router = express.Router();
 
@@ -73,7 +73,8 @@ router
                                     if (loginErr) {
                                         next(loginErr);
                                     } else {
-                                        res.redirect('/user?s=activationSent');
+                                        const fallbackUrl = localify(req.i18n.getLocale())('/user?s=activationSent');
+                                        redirectUrlWithFallback(fallbackUrl, req, res);
                                     }
                                 });
                             }


### PR DESCRIPTION
Ran into some issues relying on the query string for the redirect URL. It doesn't account for log in returning errors (the form re-rendering) or the user needing to register instead. Reverting back to using the session.

To make sure we redirect people to their previous location correctly for both log in and register I've extracted out a `redirectUrlWithFallback` method.