### PR TITLE
Minor fixes

### DIFF
--- a/middleware/securityHeaders.js
+++ b/middleware/securityHeaders.js
@@ -47,6 +47,8 @@ function defaultSecurityHeaders() {
         '*.biglotteryfund.org.uk',
         '*.tnlcommunityfund.org.uk',
         '*.google.com',
+        '*.facebook.com',
+        '*.twitter.com',
         '*.gstatic.com',
         '*.twimg.com',
         '*.youtube.com',

--- a/middleware/vanity.js
+++ b/middleware/vanity.js
@@ -9,7 +9,7 @@ const contentApi = require('../services/content-api');
  * - Call next() and passthrough on any failures
  */
 module.exports = async function vanityLookup(req, res, next) {
-    const findAlias = find(alias => alias.from === req.path);
+    const findAlias = find(alias => alias.from.toLowerCase() === req.path.toLowerCase());
     try {
         const enAliases = await contentApi.getAliases({ locale: 'en' });
         const enMatch = findAlias(enAliases);


### PR DESCRIPTION
A few things:

As requested on... Yammer(!), allow URL aliases to be in any case (eg. right now `/AwardsForAllScotland` fails while `/awardsforallscotland` works – there's no reason to enforce lowercase here).

Adds CSP whitelisting for Youtube/Facebook, eg. video/tweet embeds (see [corresponding CMS PR here](https://github.com/biglotteryfund/craft-dev/pull/160))