### PR TITLE
Refine dashboard components

### DIFF
--- a/assets/sass/components/_applications.scss
+++ b/assets/sass/components/_applications.scss
@@ -1,13 +1,12 @@
 $statuses: (
     'complete': #55ac3b,
     'incomplete': #fd992b,
-    'empty': #7b7b7b,
+    'empty': #7b7b7b
 );
 
 $statusColumnWidth: 160px;
 
 .application-summary {
-
     // Grid of buttons at the top of the summary
     .application-summary__actions {
         display: flex;
@@ -71,7 +70,6 @@ $statusColumnWidth: 160px;
                 vertical-align: middle;
             }
         }
-
     }
 
     // A link wrapped in square brackets to indicate form editing
@@ -81,8 +79,12 @@ $statusColumnWidth: 160px;
         font-weight: normal !important;
         text-decoration: none;
         margin-left: $spacingUnit;
-        &:before { content: '['; }
-        &:after { content: ']'; }
+        &:before {
+            content: '[';
+        }
+        &:after {
+            content: ']';
+        }
     }
 
     // The contents of each application summary section
@@ -138,54 +140,61 @@ $statusColumnWidth: 160px;
         font-size: 14px;
         font-weight: bold;
     }
-
 }
 
-.application-dashboard {
+/* =========================================================================
+   Application Card
+   ========================================================================= */
 
-    .application-dashboard__minor-title {
+.application-card {
+    background-color: get-color('background', 'light-neutral');
+    margin-bottom: $spacingUnit;
+    font-size: 16px;
+
+    .application-card__minor-title {
+        font-family: font-stack('display');
+        font-weight: font-weight('display', 'semibold');
         margin-bottom: 3px;
-        font-size: 13px;
+        font-size: 16px;
     }
 
-    .application-dashboard__item {
+    .application-card__summary {
+        padding: $spacingUnit;
+        margin-right: $spacingUnit;
+        flex-shrink: 0;
+        flex-basis: 60%;
+    }
+
+    .application-card__progress {
+        padding: $spacingUnit / 2;
+        background-color: #eeeeee;
+    }
+    .application-card__progress__status {
+        background-color: get-color('background', 'light-neutral');
+        padding: $spacingUnit / 2;
+        margin-bottom: 5px;
+    }
+
+    @include mq('medium') {
         display: flex;
         justify-content: space-between;
-        background-color: get-color('background', 'light-neutral');
-        margin-bottom: $spacingUnit;
 
-        p, ul {
-            font-size: 15px;
+        .application-card__progress {
+            display: flex;
+            flex-direction: column;
         }
-
-        .application-dashboard__summary {
-            padding: $spacingUnit;
-            margin-right: $spacingUnit;
-            flex-shrink: 0;
-            flex-basis: 60%;
-
-            .application-summary__links p {
-                font-size: 14px;
-                line-height: 1.6;
-            }
-        }
-
-        .application-dashboard__progress {
-            padding: $spacingUnit;
-            background-color: #eeeeee;
-
-            .application-dashboard__progress__inner {
-                background-color: get-color('background', 'light-neutral');
-                padding: $spacingUnit;
-                margin-bottom: 5px;
-            }
+        .application-card__progress__status {
+            flex: 1 1 0;
         }
     }
-
 }
 
 .application-data-missing {
-    &:before {content: '<';}
-    &:after {content: '>';}
+    &:before {
+        content: '<';
+    }
+    &:after {
+        content: '>';
+    }
     color: lighten(get-color('text', 'base'), 50%);
 }

--- a/assets/sass/components/_buttons.scss
+++ b/assets/sass/components/_buttons.scss
@@ -336,13 +336,13 @@ $buttonColor: get-color('brand', 'primary');
     display: inline-block;
 
     &.o-button-group-separated--left {
-        border-left: 1px solid get-color('border', 'base');;
+        border-left: 1px solid get-color('border', 'base');
         padding-left: $spacingUnit;
         margin-left: $spacingUnit;
     }
 
     &.o-button-group-separated--right {
-        border-right: 1px solid get-color('border', 'base');;
+        border-right: 1px solid get-color('border', 'base');
         padding-right: $spacingUnit;
         margin-right: $spacingUnit;
     }

--- a/controllers/apply-next/views/dashboard.njk
+++ b/controllers/apply-next/views/dashboard.njk
@@ -1,157 +1,32 @@
-{% from "components/buttons.njk" import startButton, startButtonSubmit %}
+{% from "components/application-card/macro.njk" import applicationCard with context %}
 {% from "components/content-box/macro.njk" import contentBox %}
-{% from "components/form-header/macro.njk" import formHeader with context %}
-{% from "components/form-fields/macros.njk" import formErrors, formField with context %}
-{% from "components/icons.njk" import iconBin %}
-{% from "./view-helpers.njk" import showSectionProgress with context %}
 
 {% extends "layouts/main.njk" %}
 
-{% set fieldMissing %}<span class="application-data-missing">not yet completed</span>{% endset %}
-
-{% macro getStartDate(dateParts) %}
-    {% if dateParts.day and dateParts.month and dateParts.year %}
-        {{ dateParts.day }}/{{ dateParts.month }}/{{ dateParts.year }}
-    {% else %}
-        {{ fieldMissing | safe }}
-    {% endif %}
-{% endmacro %}
-
-{% macro getFriendlyStatus(status) %}
-    {% set friendlyStatus = 'Not submitted' %}
-    {% if status === 'ineligible' %}{% set friendlyStatus = 'Ineligible' %}{% endif %}
-    {% if status === 'complete' %}{% set friendlyStatus = 'Submitted for consideration' %}{% endif %}
-    {{ friendlyStatus }}
-{% endmacro %}
-
-{% macro getApplicationSummary(application) %}
-    <ul class="u-margin-top">
-        <li>
-            Proposed start date:
-            {% if application.application_data['project-start-date'] %}
-                {{ getStartDate(application.application_data['project-start-date']) }}
-            {% else %}
-                {{ fieldMissing | safe }}
-            {% endif %}
-        </li>
-        <li>
-            Grant amount:
-            {% if application.grantAmount %}
-                £{{ application.grantAmount }}
-            {% else %}
-                {{ fieldMissing | safe }}
-            {% endif %}
-        </li>
-        <li>
-            Organisation:
-            {% if application.application_data['organisation-legal-name'] %}
-                {{ application.application_data['organisation-legal-name'] }}
-            {% else %}
-                {{ fieldMissing | safe }}
-            {% endif %}
-        </li>
-        <li>
-            Project location:
-            {% if application.application_data['project-postcode'] %}
-                {{ application.application_data['project-postcode'] }}
-            {% else %}
-                {{ fieldMissing | safe }}
-            {% endif %}
-        </li>
-    </ul>
-{% endmacro %}
-
 {% block content %}
     <main role="main" id="content">
-        {% call contentBox() %}
-            <h1>Your applications</h1>
-            <p>
-                Here you can check the status of an online application in progress.<br />
-                You can also <a href="{{ formBaseUrl }}/new">start a brand new application</a> and see any applications you've previously submitted online.
-            </p>
+        <section class="content-box u-inner-wide-only">
+            <div class="s-prose">
+                <h1 class="t--underline">Your applications</h1>
+                <p>
+                    Here you can check the status of an online application in progress.<br />
+                    You can also <a href="{{ formBaseUrl }}/new">start a brand new application</a> and see any applications you've previously submitted online.
+                </p>
+            </div>
 
             {% if applications.length > 0 %}
-
-                <h2 class="t2 t--underline">In progress</h2>
-
-                <div class="application-dashboard">
-                    {% for application in applications %}
-                        <div class="application-dashboard__item">
-
-                            {# Application summary info #}
-                            <div class="application-dashboard__summary">
-                                <h6 class="application-dashboard__minor-title">{{ formTitle }}</h6>
-                                <h3 class="t3 t--underline u-tone-brand-primary">{{ application.application_title }}</h3>
-                                {{ getApplicationSummary(application) }}
-                                <div class="o-button-group-flex">
-                                    {% if application.status === 'complete' %}
-                                        <a class="btn btn--small btn--outline" href="{{ formBaseUrl }}/edit/{{ application.id }}">
-                                            View application
-                                        </a>
-                                        <a class="btn btn--small btn--outline" href="#">
-                                            Download (PDF)
-                                        </a>
-                                    {% else %}
-                                        <a class="btn btn--medium" href="{{ formBaseUrl }}/edit/{{ application.id }}">
-                                            Continue with this application
-                                        </a>
-                                        <a class="btn btn--medium btn--outline btn--reversed"
-                                           href="{{ formBaseUrl }}/delete/{{ application.id }}">
-                                            {{ iconBin() }}
-                                            Delete application
-                                        </a>
-                                    {% endif %}
-                                </div>
-
-                                <aside class="application-summary__links u-margin-top-l">
-                                    <h6 class="application-dashboard__minor-title">Guidance for this programme:</h6>
-                                    <p>
-                                        <a href="{{ form.programmePage }}">{{ formTitle }} guidance</a><br />
-                                    </p>
-                                </aside>
-                            </div>
-
-                            {# Section progress #}
-                            <div class="application-dashboard__progress">
-
-                                <div class="application-dashboard__progress__inner">
-                                    <h6 class="application-dashboard__minor-title">Application status:</h6>
-                                    <h3 class="t3">{{ getFriendlyStatus(application.status) }}</h3>
-                                    {% if application.status === 'complete' %}
-                                        <p>We aim to let you know our decision in about 14 weeks. If you have any questions, <a href="#">contact a member of our advice team</a>.</p>
-                                    {% else %}
-                                        <p>
-                                            You started your application on {{ formatDate(application.createdAt.toISOString(), DATE_FORMATS.numeric) }}. <strong>It must be completed by {{ formatDate(application.expiryDate, DATE_FORMATS.numeric) }}</strong>
-                                        </p>
-                                        <p><a href="#">Need help with your application?</a></p>
-                                    {% endif %}
-                                </div>
-
-                                <div class="application-summary">
-                                    {% for section in form.sections %}
-                                        {% set sectionProgress = application.progress.sections[section.slug] %}
-                                        <header class="application-summary__status application-summary__status--mini application-summary__status--{{ sectionProgress }} u-tone-background-tint">
-                                            {{ loop.index }}: {{ section.title }}
-                                            {{ showSectionProgress(sectionProgress) }}
-                                        </header>
-                                    {% endfor %}
-                                </div>
-                            </div>
-
-                        </div>
-                    {% endfor %}
-                </div>
+                <h2 class="t--underline">In progress</h2>
+                {% for application in applications %}
+                    {{ applicationCard(application) }}
+                {% endfor %}
             {% endif %}
-
-        {% endcall %}
+        </section>
 
         {% call contentBox() %}
             <h2>New application</h2>
             <p>You can create a new funding application for {{ formTitle }} here after completing our eligibility checks.</p>
-            {# @TODO: Should this go to the start page? #}
             <p><a href="{{ formBaseUrl }}/new" class="btn btn--outline">Start new application</a></p>
         {% endcall %}
-
 
     </main>
 {% endblock %}

--- a/controllers/apply-next/views/summary.njk
+++ b/controllers/apply-next/views/summary.njk
@@ -3,7 +3,7 @@
 {% from "components/icons.njk" import iconArrowDown, iconTick, iconBin %}
 {% from "components/form-header/macro.njk" import formHeader with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-{% from "./view-helpers.njk" import showSectionProgress with context %}
+{% from "components/progress-marker/macro.njk" import progressMarker with context %}
 
 {% block title %}Summary | {{ formTitle }} | {% endblock %}
 
@@ -56,7 +56,7 @@
                                 <a href="{{ formBaseUrl }}/{{ section.slug }}">{{ editWord }}</a>
                             </span>
                         </h3>
-                        {{ showSectionProgress(sectionProgress) }}
+                        {{ progressMarker(sectionProgress) }}
                     </header>
                     <article class="application-summary__status__content">
                         {% if section.introduction %}

--- a/controllers/apply-next/views/view-helpers.njk
+++ b/controllers/apply-next/views/view-helpers.njk
@@ -1,4 +1,3 @@
-{% from "components/icons.njk" import iconTick %}
 
 {% macro emailSummary(stepsCopy, fieldsCopy, summary) %}
     <div class="summary">
@@ -68,19 +67,3 @@
     {% endfor %}
 {% endmacro %}
 
-
-{% macro showSectionProgress(sectionProgress) %}
-    {% if sectionProgress %}
-        <div class="application-status-label application-status-label--{{ sectionProgress }} u-padded-vertical-s">
-            {% if sectionProgress === FORM_STATES.complete %}
-                {{ iconTick() }} Complete
-            {% elseif sectionProgress === FORM_STATES.incomplete %}
-                In progress
-            {% elseif sectionProgress === FORM_STATES.invald %}
-                Invalid
-            {% else %}
-                Not started
-            {% endif %}
-        </div>
-    {% endif %}
-{% endmacro %}

--- a/views/components/application-card/macro.njk
+++ b/views/components/application-card/macro.njk
@@ -19,17 +19,23 @@
             {% if dateParts.day and dateParts.month and dateParts.year %}
                 {{ dateParts.day }}/{{ dateParts.month }}/{{ dateParts.year }}
             {% else %}
-                not yet completed
+                <span class="application-data-missing">not yet completed</span>
             {% endif %}
         </dd>
         <dt>Grant amount</dt>
-        <dd>{% if application.grantAmount %}£{{ application.grantAmount }}{% else %}not yet completed{% endif %}</dd>
+        <dd>
+            {% if application.grantAmount %}
+                £{{ application.grantAmount }}
+            {% else %}
+                <span class="application-data-missing">not yet completed</span>
+            {% endif %}
+        </dd>
         <dt>Organisation</dt>
         <dd>
             {% if application.application_data['organisation-legal-name'] %}
                 {{ application.application_data['organisation-legal-name'] }}
             {% else %}
-                not yet completed
+                <span class="application-data-missing">not yet completed</span>
             {% endif %}
         </dd>
         <dt>Project location</dt>
@@ -37,7 +43,7 @@
             {% if application.application_data['project-postcode'] %}
                 {{ application.application_data['project-postcode'] }}
             {% else %}
-                not yet completed
+                <span class="application-data-missing">not yet completed</span>
             {% endif %}
         </dd>
     </dl>

--- a/views/components/application-card/macro.njk
+++ b/views/components/application-card/macro.njk
@@ -1,0 +1,114 @@
+{% from "components/icons.njk" import iconBin %}
+{% from "components/progress-marker/macro.njk" import progressMarker with context %}
+
+{% macro statusMessage(status) %}
+    {% if status === 'ineligible' %}
+        Ineligible
+    {% elseif status === 'complete' %}
+        Submitted for consideration
+    {% else %}
+        Not submitted
+    {% endif %}
+{% endmacro %}
+
+{% macro applicationOverview(application) %}
+    <dl class="o-definition-list o-definition-list--compact u-margin-top">
+        <dt>Proposed start date</dt>
+        <dd>
+            {% set dateParts = application.application_data['project-start-date'] %}
+            {% if dateParts.day and dateParts.month and dateParts.year %}
+                {{ dateParts.day }}/{{ dateParts.month }}/{{ dateParts.year }}
+            {% else %}
+                not yet completed
+            {% endif %}
+        </dd>
+        <dt>Grant amount</dt>
+        <dd>{% if application.grantAmount %}£{{ application.grantAmount }}{% else %}not yet completed{% endif %}</dd>
+        <dt>Organisation</dt>
+        <dd>
+            {% if application.application_data['organisation-legal-name'] %}
+                {{ application.application_data['organisation-legal-name'] }}
+            {% else %}
+                not yet completed
+            {% endif %}
+        </dd>
+        <dt>Project location</dt>
+        <dd>
+            {% if application.application_data['project-postcode'] %}
+                {{ application.application_data['project-postcode'] }}
+            {% else %}
+                not yet completed
+            {% endif %}
+        </dd>
+    </dl>
+{% endmacro %}
+
+{% macro applicationCard(application) %}
+    {% set inProgress = application.status !== 'complete' %}
+    {# @TODO: Can action URLs come from router? #}
+    {% set editAction = formBaseUrl + "/edit/" + application.id %}
+    {% set deleteAction =  formBaseUrl + "/delete/" + application.id %}
+    <article class="application-card">
+        <div class="application-card__summary">
+            <p class="application-card__minor-title">{{ formTitle }}</p>
+            <h3 class="t3 t--underline u-tone-brand-primary">
+                {% if inProgress %}<a href="{{ editAction }}" class="u-link-unstyled">{% endif %}
+                {{ application.application_title }}
+                {% if inProgress %}</a>{% endif %}
+            </h3>
+
+            {{ applicationOverview(application) }}
+
+            {% if inProgress %}
+                <div class="o-button-group u-margin-bottom">
+                    <a class="btn btn--medium" href="{{ editAction }}">Continue with this application</a>
+                    <a class="btn btn--small btn--outline" href="{{ deleteAction }}">
+                        <span class="btn__icon btn__icon-left">{{ iconBin() }}</span>
+                        Delete
+                    </a>
+                </div>
+            {% else %}
+                {# @TODO: Where does view application go? Needs to be read-only #}
+                <div class="o-button-group u-margin-bottom">
+                    <a class="btn btn--small btn--outline" href="#">
+                        View this application
+                    </a>
+                </div>
+            {% endif %}
+
+            <aside class="application-summary__links">
+                <h4 class="application-card__minor-title">Guidance for this programme:</h4>
+                <p><a href="{{ form.programmePage }}">{{ formTitle }} guidance</a><br /></p>
+            </aside>
+        </div>
+
+        <div class="application-card__progress">
+            <div class="application-card__progress__status s-prose">
+                <p class="application-card__minor-title">Application status:</p>
+                <h4>{{ statusMessage(application.status) }}</h4>
+
+                {% if inProgress %}
+                    <p>You started your application on {{ formatDate(application.createdAt.toISOString(), DATE_FORMATS.numeric) }}.
+                    <strong>It must be completed by {{ formatDate(application.expiryDate, DATE_FORMATS.numeric) }}</strong></p>
+                    <p><a href="#">Need help with your application?</a></p>
+                {% else %}
+                    {# TODO: Submitted on date #}
+                    <p>We aim to let you know our decision in about 14 weeks. If you have any questions,
+                    <a href="#">contact a member of our advice team</a>.</p>
+                {% endif %}
+            </div>
+        
+            {% if inProgress %}
+                <ol class="application-summary">
+                    {% for section in form.sections %}
+                        {% set sectionProgress = application.progress.sections[section.slug] %}
+                        <li class="application-summary__status application-summary__status--mini application-summary__status--{{ sectionProgress }} u-tone-background-tint">
+                            {{ loop.index }}: {{ section.title }}
+                            {{ progressMarker(sectionProgress) }}
+                        </li>
+                    {% endfor %}
+                </ol>
+            {% endif %}
+        </div>
+    </article>
+{% endmacro %}

--- a/views/components/progress-marker/macro.njk
+++ b/views/components/progress-marker/macro.njk
@@ -1,0 +1,17 @@
+{% from "components/icons.njk" import iconTick %}
+
+{% macro progressMarker(sectionProgress) %}
+    {% if sectionProgress %}
+        <div class="application-status-label application-status-label--{{ sectionProgress }} u-padded-vertical-s">
+            {% if sectionProgress === FORM_STATES.complete %}
+                {{ iconTick() }} Complete
+            {% elseif sectionProgress === FORM_STATES.incomplete %}
+                In progress
+            {% elseif sectionProgress === FORM_STATES.invald %}
+                Invalid
+            {% else %}
+                Not started
+            {% endif %}
+        </div>
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
Cleans up the dashboard. Extracts application card component and updates the template to match the latest designs (only shows status breakdown for non-submitted applications).

![image](https://user-images.githubusercontent.com/123386/54833059-414f0500-4cb5-11e9-9ad1-ff52ea54b645.png)
