### PR TITLE
Render funding programme child pages using flexible content

### DIFF
--- a/controllers/common/views/flexible-content.njk
+++ b/controllers/common/views/flexible-content.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/main.njk" %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% block content %}
     <main role="main" id="content">
@@ -8,6 +9,7 @@
 
         <div class="nudge-up">
             <section class="content-box u-inner-wide-only">
+                {{ breadcrumbTrail(breadcrumbs) }}
                 {{ flexibleContent(content.flexibleContent) }}
             </section>
         </div>

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -182,7 +182,7 @@ async function injectFundingProgramme(req, res, next) {
         }
 
         const entry = await contentApi.getFundingProgramme({
-            slug: req.params.slug,
+            slug: req.params.childPageSlug ? req.params.childPageSlug : req.params.programmeSlug,
             locale: req.i18n.getLocale(),
             previewMode: res.locals.PREVIEW_MODE || false,
             query: query

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -181,8 +181,13 @@ async function injectFundingProgramme(req, res, next) {
             query.social = req.query.social;
         }
 
+        let slug = req.params.programmeSlug;
+        if (req.params.childPageSlug) {
+            slug += `/${req.params.childPageSlug}`;
+        }
+
         const entry = await contentApi.getFundingProgramme({
-            slug: req.params.childPageSlug ? req.params.childPageSlug : req.params.programmeSlug,
+            slug: slug,
             locale: req.i18n.getLocale(),
             previewMode: res.locals.PREVIEW_MODE || false,
             query: query

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -11,7 +11,9 @@ const { sanitiseUrlPath } = require('../modules/urls');
 let { CONTENT_API_URL } = require('../modules/secrets');
 
 function fetch(urlPath, options) {
-    debug(`Fetching ${urlPath}${options && options.qs ? '?' + querystring.stringify(options.qs) : ''}`);
+    debug(
+        `Fetching ${CONTENT_API_URL}${urlPath}${options && options.qs ? '?' + querystring.stringify(options.qs) : ''}`
+    );
     const defaults = {
         url: `${CONTENT_API_URL}${urlPath}`,
         json: true


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/165

This renders child pages using the generic flexible content template (with added breadcrumbs).