### PR TITLE
Fetch only what we need for funding programmes from the API

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -284,10 +284,6 @@ toplevel:
       href: "/welsh/funding/grants"
     - label: Cymorth rheoli’ch grant
       href: "/welsh/funding/funding-guidance/managing-your-funding"
-    recentProgrammes:
-    - "national-lottery-awards-for-all-wales"
-    - "rural-programme"
-    - "people-and-places-medium-grants"
   data:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -371,10 +371,6 @@ toplevel:
       href: "/funding/grants"
     - label: Help with managing your grant
       href: "/funding/funding-guidance/managing-your-funding"
-    recentProgrammes:
-    - "rural-programme"
-    - "digital-fund"
-    - "reaching-communities-england"
   local:
     title: In your area
   data:

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -18,17 +18,12 @@ router.get('/', sMaxAge('30m'), injectHeroImage('funding-letterbox-new'), async 
      * Hardcoded for now but we may want to fetch these dynamically.
      */
     try {
-        const programmeSlugs = get(res.locals.copy, 'recentProgrammes', []);
-
         const fundingProgrammes = await contentApi.getFundingProgrammes({
-            locale: req.i18n.getLocale()
+            locale: req.i18n.getLocale(),
+            pageLimit: 3,
+            newestFirst: true
         });
-
-        if (fundingProgrammes.result) {
-            latestProgrammes = programmeSlugs.map(slug =>
-                find(fundingProgrammes.result, programme => programme.linkUrl.indexOf(slug) !== -1)
-            );
-        }
+        latestProgrammes = fundingProgrammes.result ? fundingProgrammes.result : null;
     } catch (error) {} // eslint-disable-line no-empty
 
     res.render(path.resolve(__dirname, './views/funding-landing'), { latestProgrammes });

--- a/services/content-api.js
+++ b/services/content-api.js
@@ -128,9 +128,9 @@ function getUpdates({ locale, type = null, date = null, slug = null, query = {},
     }
 }
 
-function getFundingProgrammes({ locale, page = 1, pageLimit = 100, showAll = false }) {
+function getFundingProgrammes({ locale, page = 1, pageLimit = 100, showAll = false, newestFirst = false }) {
     return fetchAllLocales(reqLocale => `/v2/${reqLocale}/funding-programmes`, {
-        qs: { page: page, 'page-limit': pageLimit, all: showAll === true }
+        qs: { page: page, 'page-limit': pageLimit, all: showAll === true, newest: newestFirst === true }
     }).then(responses => {
         const [enResults, cyResults] = responses.map(mapAttrs);
         return {


### PR DESCRIPTION
This just fetches the latest funding programmes (via a new endpoint [here](https://github.com/biglotteryfund/craft-dev/pull/166)) rather than filtering all of them down into three. If we really need to have control about which programmes appear on the Funding landing page, we should make this a selection field in the CMS and get them there instead. This improves loading time of the landing page:

|                               | Load time (ms) |
|-------------------------------|----------------|
| Funding landing page (before) | 2230           |
| Funding landing page (after)  | 976            |