### PR TITLE
Add flexible content support for information/listing pages

### DIFF
--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -72,7 +72,7 @@ function basicContent({ customTemplate = null } = {}) {
                 res.render(path.resolve(__dirname, './views/listing-page'), {
                     childrenLayoutMode: childrenLayoutMode
                 });
-            } else if (content.introduction || content.segments.length > 0) {
+            } else if (content.introduction || content.segments.length > 0 || content.flexibleContent.length > 0) {
                 // ↑ information pages must have at least an introduction or some content segments
                 res.render(path.resolve(__dirname, './views/information-page'));
             } else {

--- a/controllers/common/views/information-page.njk
+++ b/controllers/common/views/information-page.njk
@@ -3,9 +3,12 @@
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/segment-links/macro.njk" import segmentLinks %}
 {% from "components/segment/macro.njk" import segment %}
+{% from "components/flexible-content/macro.njk" import flexibleContentPart %}
 
 {% extends "layouts/main.njk" %}
 {% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
+
+{% set flexAnchor = 'item' %}
 
 {% block content %}
     <main id="content">
@@ -23,7 +26,10 @@
                         {% if not pageHero.image %}<h1>{{ content.title }}</h1>{% endif %}
                         {{ content.introduction | safe }}
                     </div>
-                    {{ segmentLinks(customSegmentLinks | default(content.segments)) }}
+                    {{ segmentLinks(content.segments) }}
+                    {% if content.flexibleContent %}
+                        {{ segmentLinks(content.flexibleContent, anchor = flexAnchor) }}
+                    {% endif %}
                 </section>
             {% endif %}
 
@@ -41,6 +47,16 @@
                     {% endfor %}
                 </div>
             {% endif %}
+
+            {# Flexible content #}
+            {% if content.flexibleContent %}
+                {% for part in content.flexibleContent %}
+                    {% call contentBox(id = flexAnchor + '-' + loop.index) %}
+                        {{ flexibleContentPart(part) }}
+                    {% endcall %}
+                {% endfor %}
+            {% endif %}
+
         {% endblock %}
 
         {# Custom content #}

--- a/views/components/flexible-content/macro.njk
+++ b/views/components/flexible-content/macro.njk
@@ -1,39 +1,56 @@
 {% from "components/callout/macro.njk" import callout %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
 
+{% macro flexibleContentPart(part) %}
+    {% if part.title %}
+        <h2 class="t1">{{ part.title }}</h2>
+    {% endif %}
+    {% if part.type === 'mediaAside' %}
+        {% set mediaAsideCounter = mediaAsideCounter + 1 %}
+        {{ mediaAside(
+            quoteText = part.quoteText,
+            link = { "label": part.linkText, "url": part.linkUrl },
+            image = { "url": part.photo, "caption": part.photoCaption },
+            isReversed = mediaAsideCounter % 2 == 0
+        ) }}
+    {% else %}
+        <div class="s-prose u-constrained-content-wide">
+            {% if part.type === 'contentArea' %}
+                {{ part.content | safe }}
+            {% elseif part.type === 'inlineFigure' %}
+                <figure>
+                    <img src="{{ part.photo }}" alt="{{ part.caption }}">
+                    <figcaption>{{ part.photoCaption }}</figcaption>
+                </figure>
+            {% elseif part.type === 'quote' %}
+                <blockquote class="blockquote">
+                    <div class="blockquote__text">
+                        {{ part.quoteText | widont | safe }}
+                    </div>
+                    {% if part.attribution %}
+                        <cite class="blockquote__cite">{{ part.attribution }}</cite>
+                    {% endif %}
+                </blockquote>
+            {% elseif part.type === 'gridBlocks' %}
+                <div class="flex-grid flex-grid--2up">
+                    {% for blockContent in part.content %}
+                        <div class="flex-grid__item">
+                            <div class="u-tone-background-tint u-padded">
+                                {{ blockContent | safe }}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
 {% macro flexibleContent(flexibleContent) %}
     {% if flexibleContent.length > 0 %}
         {% set mediaAsideCounter = 0 %}
         {% for part in flexibleContent %}
-            {% if part.type === 'mediaAside' %}
-                {% set mediaAsideCounter = mediaAsideCounter + 1 %}
-                {{ mediaAside(
-                    quoteText = part.quoteText,
-                    link = { "label": part.linkText, "url": part.linkUrl },
-                    image = { "url": part.photo, "caption": part.photoCaption },
-                    isReversed = mediaAsideCounter % 2 == 0
-                ) }}
-            {% else %}
-                <div class="s-prose u-constrained-content-wide">
-                    {% if part.type === 'contentArea' %}
-                        {{ part.content | safe }}
-                    {% elseif  part.type === 'inlineFigure' %}
-                        <figure>
-                            <img src="{{ part.photo }}" alt="{{ part.caption }}">
-                            <figcaption>{{ part.photoCaption }}</figcaption>
-                        </figure>
-                    {% elseif  part.type === 'quote' %}
-                        <blockquote class="blockquote">
-                            <div class="blockquote__text">
-                                {{ part.quoteText | widont | safe }}
-                            </div>
-                            {% if part.attribution %}
-                                <cite class="blockquote__cite">{{ part.attribution }}</cite>
-                            {% endif %}
-                        </blockquote>
-                    {% endif %}
-                </div>
-            {% endif %}
+            {{ flexibleContentPart(part) }}
         {% endfor %}
     {% endif %}
 {% endmacro %}

--- a/views/components/flexible-content/macro.njk
+++ b/views/components/flexible-content/macro.njk
@@ -1,17 +1,16 @@
 {% from "components/callout/macro.njk" import callout %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
 
-{% macro flexibleContentPart(part) %}
+{% macro flexibleContentPart(part, cycler = null) %}
     {% if part.title %}
         <h2 class="t1">{{ part.title }}</h2>
     {% endif %}
     {% if part.type === 'mediaAside' %}
-        {% set mediaAsideCounter = mediaAsideCounter + 1 %}
         {{ mediaAside(
             quoteText = part.quoteText,
             link = { "label": part.linkText, "url": part.linkUrl },
             image = { "url": part.photo, "caption": part.photoCaption },
-            isReversed = mediaAsideCounter % 2 == 0
+            isReversed = cycler.next() if cycler else false
         ) }}
     {% else %}
         <div class="s-prose u-constrained-content-wide">
@@ -48,9 +47,9 @@
 
 {% macro flexibleContent(flexibleContent) %}
     {% if flexibleContent.length > 0 %}
-        {% set mediaAsideCounter = 0 %}
+        {% set mediaAsideCycler = cycler(true, false) %}
         {% for part in flexibleContent %}
-            {{ flexibleContentPart(part) }}
+            {{ flexibleContentPart(part, cycler = mediaAsideCycler) }}
         {% endfor %}
     {% endif %}
 {% endmacro %}

--- a/views/components/segment-links/macro.njk
+++ b/views/components/segment-links/macro.njk
@@ -1,10 +1,10 @@
-{% macro segmentLinks(segments, prefix = null) %}
+{% macro segmentLinks(segments, prefix = null, anchor = 'segment') %}
     {% if segments.length > 1 %}
         <div class="segment-links">
             {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}</p>{% endif %}
             <ul>
                 {% for segment in segments %}
-                    <li><a href="#segment-{{ loop.index }}">{{ segment.title }}</a></li>
+                    <li><a href="#{{ anchor }}-{{ loop.index }}">{{ segment.title }}</a></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
This allows us to use flexible content for listing pages which behave in the same way as the segments currently do. For now the template will display both types of content, but we could migrate away from one in favour of the other. Probably worth demoing this in person!

![image](https://user-images.githubusercontent.com/394376/55246909-33adf800-523e-11e9-8014-6361adfcb8a9.png)

Also introduces a new block type for Flexible Content (see [corresponding CMS PR here](https://github.com/biglotteryfund/craft-dev/pull/167)):

![image](https://user-images.githubusercontent.com/394376/55246934-41fc1400-523e-11e9-9f8a-d11b0093f5d0.png)
