### PR TITLE
Use correct syntax for fp/get

### DIFF
--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -37,7 +37,7 @@ function setCommonLocals({ res, entry }) {
     res.locals.title = entry.title;
 
     res.locals.isBilingual = entry.availableLanguages.length === 2;
-    res.locals.openGraph = get(entry, 'openGraph', false);
+    res.locals.openGraph = get('openGraph')(entry);
 
     res.locals.previewStatus = {
         isDraftOrVersion: entry.status === 'draft' || entry.status === 'version',


### PR DESCRIPTION
We use the `lodash/fp` version of `get` in `inject-content` so the method signature for the open graph data was wrong.