### PR TITLE
Add styles for CMS-provided image positions

### DIFF
--- a/assets/sass/scopes/_prose.scss
+++ b/assets/sass/scopes/_prose.scss
@@ -186,5 +186,26 @@
         figcaption {
             @include text-caption();
         }
+
+        // Used in conjunction with Redactor's image position settings in the CMS
+        &.image-left {
+            float: left;
+            margin-right: $spacingUnit;
+            margin-bottom: $spacingUnit;
+            margin-top: 0;
+        }
+
+        &.image-right{
+            float: right;
+            margin-left: $spacingUnit;
+            margin-bottom: $spacingUnit;
+            margin-top: 0;
+        }
+
+        &.image-centre {
+            img {
+                margin: auto;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1816 and pairs with https://github.com/biglotteryfund/craft-dev/pull/168

Allows us to wrap text around images in the CMS.