### PR TITLE
Remove inline styles from embedded videos

### DIFF
--- a/assets/js/bootstraps/common.js
+++ b/assets/js/bootstraps/common.js
@@ -2,13 +2,14 @@
  * Common modules that are run across the site.
  * (Non-Vue components)
  */
+import $ from 'jquery';
 import fitvids from 'fitvids';
 import tabs from '../modules/tabs';
 import forms from '../modules/forms';
 
 function init() {
     fitvids();
-
+    $('.fluid-width-video-wrapper iframe').removeAttr('style');
     tabs.init();
     forms.init();
 }


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1789

This removes inline `width/height` style attributes which prevent fitvids from working properly.

We could remove this at embed time but I'm wary of that breaking other things that might need those attributes, whereas this change only targets things that fitvids has already manipulated.