### PR TITLE
Refactor conditional fields

### DIFF
--- a/controllers/apply-next/lib/enhance-form.js
+++ b/controllers/apply-next/lib/enhance-form.js
@@ -1,6 +1,6 @@
 'use strict';
 const { get } = require('lodash/fp');
-const { cloneDeep, find } = require('lodash');
+const { cloneDeep, find, flatMap, isFunction, reject } = require('lodash');
 
 const {
     formatOptions,
@@ -33,7 +33,6 @@ function displayValue(field, value) {
  * Enhances a form object by:
  * - Localising all labels and messages
  * - Assigning values to fields, along with a display value for views
- * - Marking steps as notRequired if matchesCondition is currently false
  *
  * @param {Object} options
  * @param {String} options.locale
@@ -59,15 +58,16 @@ module.exports = function enhanceForm({ locale, baseForm, data = {} }) {
         field.explanation = localise(field.explanation);
 
         if (field.options) {
-            field.options = field.options
-                .filter(function(option) {
-                    return option.showWhen ? option.showWhen(data || {}) : true;
-                })
-                .map(option => {
-                    option.label = localise(option.label);
-                    option.explanation = localise(option.explanation);
-                    return option;
-                });
+            const options = isFunction(field.options) ? field.options(data || {}) : field.options;
+            field.options = options.map(option => {
+                option.label = localise(option.label);
+                option.explanation = localise(option.explanation);
+                return option;
+            });
+        }
+
+        if (isFunction(field.isRequired)) {
+            field.isRequired = field.isRequired(data || {});
         }
 
         // Assign value to field if present
@@ -86,14 +86,16 @@ module.exports = function enhanceForm({ locale, baseForm, data = {} }) {
         step.fieldsets = step.fieldsets.map(fieldset => {
             fieldset.legend = localise(fieldset.legend);
             fieldset.introduction = localise(fieldset.introduction);
-            fieldset.fields = fieldset.fields.map(enhanceField);
+            fieldset.fields = reject(
+                fieldset.fields,
+                field => field.shouldShow && field.shouldShow(data || {}) === false
+            ).map(enhanceField);
             return fieldset;
         });
 
         // Handle steps that don't need to be completed based on current form data
-        if (step.matchesCondition && step.matchesCondition(data) === false) {
-            step.notRequired = true;
-        }
+        const stepFields = flatMap(step.fieldsets, 'fields');
+        step.isRequired = stepFields.length > 0;
 
         return step;
     };

--- a/controllers/apply-next/lib/pagination.js
+++ b/controllers/apply-next/lib/pagination.js
@@ -7,22 +7,17 @@ const { findIndex, findLastIndex } = require('lodash');
  * @property {Array} sections
  * @property {Number} currentSectionIndex
  * @property {Number} currentStepIndex
- * @property {Object} formData
  */
 
 /**
  * Find next matching URL
  * @param {MatchOptions} options
  */
-function findNextMatchingUrl({ baseUrl, sections, currentSectionIndex, currentStepIndex, formData }) {
+function findNextMatchingUrl({ baseUrl, sections, currentSectionIndex, currentStepIndex }) {
     const currentSection = sections[currentSectionIndex];
     const nextSection = sections[currentSectionIndex + 1];
 
-    const targetStepIndex = findIndex(
-        currentSection.steps,
-        step => (step.matchesCondition ? step.matchesCondition(formData) === true : true),
-        currentStepIndex + 1
-    );
+    const targetStepIndex = findIndex(currentSection.steps, step => step.isRequired === true, currentStepIndex + 1);
 
     if (targetStepIndex !== -1 && targetStepIndex <= currentSection.steps.length) {
         return `${baseUrl}/${currentSection.slug}/${targetStepIndex + 1}`;
@@ -37,14 +32,14 @@ function findNextMatchingUrl({ baseUrl, sections, currentSectionIndex, currentSt
  * Find previous matching URL
  * @param {MatchOptions} options
  */
-function findPreviousMatchingUrl({ baseUrl, sections, currentSectionIndex, currentStepIndex, formData }) {
+function findPreviousMatchingUrl({ baseUrl, sections, currentSectionIndex, currentStepIndex }) {
     const currentSection = sections[currentSectionIndex];
     const previousSection = sections[currentSectionIndex - 1];
 
     if (currentStepIndex !== 0) {
         const targetStepIndex = findLastIndex(
             currentSection.steps,
-            step => (step.matchesCondition ? step.matchesCondition(formData) === true : true),
+            step => step.isRequired === true,
             currentStepIndex - 1
         );
         return `${baseUrl}/${currentSection.slug}/${targetStepIndex + 1}`;

--- a/controllers/apply-next/lib/pagination.test.js
+++ b/controllers/apply-next/lib/pagination.test.js
@@ -6,19 +6,24 @@ describe('nextAndPrevious', () => {
     const mockSections = [
         {
             slug: 'section-a',
-            steps: [{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }, { title: 'Step 4' }]
+            steps: [
+                { title: 'Step 1', isRequired: true },
+                { title: 'Step 2', isRequired: true },
+                { title: 'Step 3', isRequired: true },
+                { title: 'Step 4', isRequired: true }
+            ]
         },
         {
             slug: 'section-b',
             steps: [
-                { title: 'Step 1' },
-                { title: 'Step 2', matchesCondition: formData => formData.name === 'example' },
-                { title: 'Step 3' }
+                { title: 'Step 1', isRequired: true },
+                { title: 'Step 2', isRequired: false },
+                { title: 'Step 3', isRequired: true }
             ]
         },
         {
             slug: 'section-c',
-            steps: [{ title: 'Step 1' }, { title: 'Step 2' }]
+            steps: [{ title: 'Step 1', isRequired: true }, { title: 'Step 2', isRequired: true }]
         }
     ];
 
@@ -27,8 +32,7 @@ describe('nextAndPrevious', () => {
             baseUrl: '/example',
             sections: mockSections,
             currentSectionIndex: 0,
-            currentStepIndex: 0,
-            formData: {}
+            currentStepIndex: 0
         });
         expect(nextUrl).toBe('/example/section-a/2');
         expect(previousUrl).toBe('/example');
@@ -39,8 +43,7 @@ describe('nextAndPrevious', () => {
             baseUrl: '/example',
             sections: mockSections,
             currentSectionIndex: 0,
-            currentStepIndex: 3,
-            formData: {}
+            currentStepIndex: 3
         });
         expect(nextUrl).toBe('/example/section-b');
         expect(previousUrl).toBe('/example/section-a/3');
@@ -51,8 +54,7 @@ describe('nextAndPrevious', () => {
             baseUrl: '/example',
             sections: mockSections,
             currentSectionIndex: 2,
-            currentStepIndex: 0,
-            formData: {}
+            currentStepIndex: 0
         });
         expect(nextUrl).toBe('/example/section-c/2');
         expect(previousUrl).toBe('/example/section-b/3');
@@ -63,8 +65,7 @@ describe('nextAndPrevious', () => {
             baseUrl: '/example',
             sections: mockSections,
             currentSectionIndex: 2,
-            currentStepIndex: 2,
-            formData: {}
+            currentStepIndex: 2
         });
         expect(nextUrl).toBe('/example/summary');
         expect(previousUrl).toBe('/example/section-c/2');
@@ -75,22 +76,9 @@ describe('nextAndPrevious', () => {
             baseUrl: '/example',
             sections: mockSections,
             currentSectionIndex: 1,
-            currentStepIndex: 0,
-            formData: {}
+            currentStepIndex: 0
         });
         expect(nextUrl).toBe('/example/section-b/3');
-        expect(previousUrl).toBe('/example/section-a/4');
-    });
-
-    it('should include steps where matchesCondition is true', () => {
-        const { nextUrl, previousUrl } = nextAndPrevious({
-            baseUrl: '/example',
-            sections: mockSections,
-            currentSectionIndex: 1,
-            currentStepIndex: 0,
-            formData: { name: 'example' }
-        });
-        expect(nextUrl).toBe('/example/section-b/2');
         expect(previousUrl).toBe('/example/section-a/4');
     });
 });

--- a/controllers/apply-next/lib/validate-model.js
+++ b/controllers/apply-next/lib/validate-model.js
@@ -35,7 +35,7 @@ module.exports = function validateModel(formModel) {
             ])
             .required(),
         attributes: Joi.object().optional(),
-        isRequired: Joi.boolean().required(),
+        isRequired: Joi.alternatives().try(Joi.boolean(), Joi.func()),
         schema: Joi.object()
             .schema()
             .required(),

--- a/controllers/apply-next/lib/validators.js
+++ b/controllers/apply-next/lib/validators.js
@@ -98,6 +98,10 @@ const dateParts = joi => {
                 .integer()
                 .required()
         }),
+        language: {
+            futureDate: 'Date must be at least {{min}}',
+            dob: 'Must be at least {{minAge}} years old'
+        },
         pre(value, state, options) {
             const date = dateFromParts(value);
             if (date.isValid()) {
@@ -117,12 +121,7 @@ const dateParts = joi => {
                     if (date.isValid() && date.isSameOrAfter(params.min)) {
                         return value;
                     } else {
-                        return this.createError(
-                            'dateParts.futureDate',
-                            { v: value, number: params.number },
-                            state,
-                            options
-                        );
+                        return this.createError('dateParts.futureDate', { v: value, min: params.min }, state, options);
                     }
                 }
             },
@@ -137,7 +136,7 @@ const dateParts = joi => {
                     if (date.isValid() && date.isSameOrBefore(maxDate)) {
                         return value;
                     } else {
-                        return this.createError('dateParts.dob', { v: value, number: params.number }, state, options);
+                        return this.createError('dateParts.dob', { v: value, minAge: params.minAge }, state, options);
                     }
                 }
             }

--- a/controllers/apply-next/simple/fields.js
+++ b/controllers/apply-next/simple/fields.js
@@ -15,7 +15,7 @@ const countries = {
 };
 
 const organisationTypes = {
-    unregisterdVco: {
+    unregisteredVco: {
         value: 'unregistered-vco',
         label: { en: 'Unregistered voluntary or community organisation', cy: '' },
         explanation: {
@@ -577,11 +577,11 @@ const allFields = {
         options(formData) {
             let options = [];
             switch (get(formData, 'organisation-type')) {
-                case organisationTypes.unregisterdVco.value:
+                case organisationTypes.unregisteredVco.value:
                     options = [
                         { value: 'chair', label: { en: 'Chair', cy: '' } },
                         { value: 'vice-chair', label: { en: 'Vice-chair', cy: '' } },
-                        { value: 'cecretary', label: { en: 'Secretary', cy: '' } },
+                        { value: 'secretary', label: { en: 'Secretary', cy: '' } },
                         { value: 'treasurer', label: { en: 'Treasurer', cy: '' } }
                     ];
                     break;

--- a/controllers/apply-next/simple/fields.test.js
+++ b/controllers/apply-next/simple/fields.test.js
@@ -1,12 +1,10 @@
 'use strict';
 /* eslint-env jest */
-/* @TODO: It would be nice to also validate the messages from `normaliseErrors` here. */
-
 const faker = require('faker');
-const Joi = require('joi');
 const moment = require('moment');
+const Joi = require('joi');
+
 const { allFields } = require('./fields');
-const { applicationTitle, applicationCountry, projectStartDate, mainContactDob } = allFields;
 
 const toDateParts = dt => ({
     day: dt.get('day'),
@@ -16,27 +14,26 @@ const toDateParts = dt => ({
 
 describe('applicationTitle', () => {
     test('valid', () => {
-        const { error } = Joi.validate(faker.lorem.words(5), applicationTitle.schema);
+        const { error } = allFields.applicationTitle.schema.validate(faker.lorem.words(5));
         expect(error).toBeNull();
     });
 
     test('invalid', () => {
-        const { error } = Joi.validate('', applicationTitle.schema);
+        const { error } = allFields.applicationTitle.schema.validate('');
         expect(error.message).toContain('not allowed to be empty');
     });
 });
 
 describe('applicationCountry', () => {
     test('valid', () => {
-        const { error } = Joi.validate(
-            faker.random.arrayElement(['england', 'northern-ireland', 'scotland', 'wales']),
-            applicationCountry.schema
+        const { error } = allFields.applicationCountry.schema.validate(
+            faker.random.arrayElement(['england', 'northern-ireland', 'scotland', 'wales'])
         );
         expect(error).toBeNull();
     });
 
     test('invalid', () => {
-        const { error } = Joi.validate('not-a-country', applicationCountry.schema);
+        const { error } = allFields.applicationCountry.schema.validate('not-a-country');
         expect(error.message).toContain('must be one of [england, northern-ireland, scotland, wales]');
     });
 });
@@ -44,45 +41,574 @@ describe('applicationCountry', () => {
 describe('projectStartDate', () => {
     test('valid', () => {
         const dt = moment().add(12, 'weeks');
-        const { error } = Joi.validate(toDateParts(dt), projectStartDate.schema);
+        const { error } = allFields.projectStartDate.schema.validate(toDateParts(dt));
         expect(error).toBeNull();
     });
 
     test('missing', () => {
-        const { error } = Joi.validate(null, projectStartDate.schema);
+        const { error } = allFields.projectStartDate.schema.validate(null);
         expect(error.message).toContain('must be an object');
     });
 
     test('invalid', () => {
-        const { error } = Joi.validate({ day: 31, month: 2, year: 2030 }, projectStartDate.schema);
+        const { error } = allFields.projectStartDate.schema.validate({ day: 31, month: 2, year: 2030 });
         expect(error.message).toContain('contains an invalid value');
     });
 
     test('less than 12 weeks in the future', () => {
         const dt = moment().add(6, 'weeks');
-        const { error } = Joi.validate(toDateParts(dt), projectStartDate.schema);
+        const { error } = allFields.projectStartDate.schema.validate(toDateParts(dt));
         expect(error.message).toContain('Date must be at least');
+    });
+});
+
+describe('projectPostcode', () => {
+    test('valid', () => {
+        const { error } = allFields.projectPostcode.schema.validate('B15 1TR');
+        expect(error).toBeNull();
+    });
+
+    test('missing', () => {
+        const { error } = allFields.projectPostcode.schema.validate(null);
+        expect(error.message).toContain('must be a string');
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.projectPostcode.schema.validate('not a postcode');
+        expect(error.message).toContain('fails to match the required pattern');
+    });
+});
+
+describe('yourIdea', () => {
+    test('valid', () => {
+        const { error } = allFields.yourIdea.schema.validate(faker.lorem.paragraphs(4));
+        expect(error).toBeNull();
+    });
+
+    test('at least 50 workds', () => {
+        const { error } = allFields.yourIdea.schema.validate(faker.lorem.words(49));
+        expect(error.message).toContain('must have at least 50 words');
+    });
+
+    test('no more than 500 words', () => {
+        const { error } = allFields.yourIdea.schema.validate(faker.lorem.words(550));
+        expect(error.message).toContain('must have less than 500 words');
+    });
+});
+
+describe('projectBudget', () => {
+    test('valid', () => {
+        const { error } = allFields.projectBudget.schema.validate(
+            new Array(5).fill(null).map(() => {
+                return {
+                    item: faker.lorem.words(5),
+                    cost: faker.random.number({ min: 100, max: 1000 })
+                };
+            })
+        );
+        expect(error).toBeNull();
+    });
+
+    test('over budget', () => {
+        const { error } = allFields.projectBudget.schema.validate(
+            new Array(10).fill(null).map(() => {
+                return {
+                    item: faker.lorem.words(5),
+                    cost: 1100
+                };
+            })
+        );
+        expect(error.message).toContain('over maximum budget');
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.projectBudget.schema.validate([{ item: faker.lorem.words(5) }]);
+        expect(error.message).toContain('"cost" is required');
+    });
+
+    test('missing', () => {
+        const { error } = allFields.projectBudget.schema.validate([]);
+        expect(error.message).toContain('must contain at least 1 items');
+    });
+});
+
+describe('projectTotalCosts', () => {
+    test('valid', () => {
+        const { error } = allFields.projectTotalCosts.schema.validate(1000);
+        expect(error).toBeNull();
+    });
+
+    test('missing', () => {
+        const { error } = allFields.projectTotalCosts.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.projectTotalCosts.schema.validate(Infinity);
+        expect(error.message).toContain('contains an invalid value');
+    });
+});
+
+describe('organisationLegalName', () => {
+    test.todo('valid');
+    test.todo('invalid');
+});
+
+describe('organisationAlias', () => {
+    test.todo('valid');
+    test.todo('optional');
+});
+
+describe('organisationAddress', () => {
+    test('valid', () => {
+        const { error } = allFields.organisationAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        });
+        expect(error).toBeNull();
+    });
+
+    test('missing', () => {
+        const { error } = allFields.organisationAddress.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+
+    test('partial address fields', () => {
+        const { error } = allFields.organisationAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        });
+        expect(error.message).toEqual('child "town-city" fails because ["town-city" is required]');
+    });
+
+    test('invalid postcode', () => {
+        const { error } = allFields.organisationAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'not a postcode'
+        });
+        expect(error.message).toContain('fails to match the required pattern');
+    });
+});
+
+describe('organisationType', () => {
+    test('valid', () => {
+        const { error } = allFields.organisationType.schema.validate('unregistered-vco');
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.organisationType.schema.validate('not-an-option');
+        expect(error.message).toContain(
+            'must be one of [unregistered-vco, unincorporated-registered-charity, charitable-incorporated-organisation, not-for-profit-company, school, statutory-body]'
+        );
+    });
+
+    test('missing', () => {
+        const { error } = allFields.organisationType.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+});
+
+describe('companyNumber', () => {
+    test('valid', () => {
+        const { error } = allFields.companyNumber.schema.validate('CE002712');
+        expect(error).toBeNull();
+    });
+
+    test('optional by default', () => {
+        const { error } = allFields.companyNumber.schema.validate();
+        expect(error).toBeNull();
+    });
+
+    test('conditionally required', () => {
+        const { error } = Joi.validate(
+            { 'organisation-type': 'not-for-profit-company' },
+            { 'organisation-type': allFields.organisationType.schema, 'company-number': allFields.companyNumber.schema }
+        );
+
+        expect(error.message).toContain('is required');
+
+        expect(allFields.companyNumber.shouldShow()).toBeFalsy();
+        expect(allFields.companyNumber.shouldShow({ 'organisation-type': 'not-for-profit-company' })).toBeTruthy();
+        expect(allFields.companyNumber.shouldShow({ 'organisation-type': 'school' })).toBeFalsy();
+    });
+});
+
+describe('charityNumber', () => {
+    const schemaWithOrgType = {
+        'organisation-type': allFields.organisationType.schema,
+        'charity-number': allFields.charityNumber.schema
+    };
+
+    test('valid', () => {
+        const { error } = allFields.charityNumber.schema.validate('1160580');
+        expect(error).toBeNull();
+    });
+
+    test('optional by default', () => {
+        const { error } = allFields.charityNumber.schema.validate();
+        expect(error).toBeNull();
+    });
+
+    test('required if unincorporated registered charity', () => {
+        const { error } = Joi.validate({ 'organisation-type': 'unincorporated-registered-charity' }, schemaWithOrgType);
+
+        expect(error.message).toContain('is required');
+
+        expect(allFields.charityNumber.shouldShow()).toBeFalsy();
+        expect(
+            allFields.charityNumber.shouldShow({ 'organisation-type': 'unincorporated-registered-charity' })
+        ).toBeTruthy();
+    });
+
+    test('required if cio', () => {
+        const { error } = Joi.validate(
+            { 'organisation-type': 'charitable-incorporated-organisation' },
+            schemaWithOrgType
+        );
+
+        expect(error.message).toContain('is required');
+
+        expect(allFields.charityNumber.shouldShow()).toBeFalsy();
+        expect(
+            allFields.charityNumber.shouldShow({ 'organisation-type': 'charitable-incorporated-organisation' })
+        ).toBeTruthy();
+    });
+
+    test('shown but optional when a not for profit company', () => {
+        const { error } = Joi.validate({ 'organisation-type': 'not-for-profit-company' }, schemaWithOrgType);
+
+        expect(error).toBeNull();
+
+        expect(allFields.charityNumber.shouldShow()).toBeFalsy();
+        expect(allFields.charityNumber.shouldShow({ 'organisation-type': 'not-for-profit-company' })).toBeTruthy();
+    });
+});
+
+describe('accountingYearDate', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('totalIncomeYear', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('mainContactName', () => {
+    test('valid', () => {
+        const { error } = allFields.mainContactName.schema.validate(faker.name.findName());
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.mainContactName.schema.validate(Infinity);
+        expect(error.message).toContain('must be a string');
+    });
+
+    test('missing', () => {
+        const { error } = allFields.mainContactName.schema.validate();
+        expect(error.message).toContain('is required');
     });
 });
 
 describe('mainContactDob', () => {
     test('valid', () => {
         const dt = moment().subtract(18, 'years');
-        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema);
+        const { error } = allFields.mainContactDob.schema.validate(toDateParts(dt));
         expect(error).toBeNull();
     });
 
     test('under 18', () => {
         const dt = moment().subtract(16, 'years');
-        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema);
+        const { error } = allFields.mainContactDob.schema.validate(toDateParts(dt));
         expect(error.message).toContain('Must be at least 18 years old');
     });
 
     test('not required if organisation-type is a school', () => {
-        const dt = moment().subtract(18, 'years');
-        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema, {
-            context: { 'organisation-type': 'school' }
+        const { error } = Joi.validate(
+            { 'organisation-type': 'school' },
+            {
+                'organisation-type': allFields.organisationType.schema,
+                'main-contact-dob': allFields.mainContactDob.schema
+            }
+        );
+
+        expect(error).toBeNull();
+
+        expect(allFields.mainContactDob.shouldShow()).toBeTruthy();
+        expect(allFields.mainContactDob.shouldShow({ 'organisation-type': 'unregistered-vco' })).toBeTruthy();
+        expect(allFields.mainContactDob.shouldShow({ 'organisation-type': 'school' })).toBeFalsy();
+    });
+});
+
+describe('mainContactAddress', () => {
+    test('valid', () => {
+        const { error } = allFields.mainContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
         });
         expect(error).toBeNull();
     });
+
+    test('missing', () => {
+        const { error } = allFields.mainContactAddress.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+
+    test('partial address fields', () => {
+        const { error } = allFields.mainContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        });
+        expect(error.message).toEqual('child "town-city" fails because ["town-city" is required]');
+    });
+
+    test('invalid postcode', () => {
+        const { error } = allFields.mainContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'not a postcode'
+        });
+        expect(error.message).toContain('fails to match the required pattern');
+    });
+
+    test('not required if organisation-type is a school', () => {
+        const schemaWithOrgType = {
+            'organisation-type': allFields.organisationType.schema,
+            'main-contact-dob': allFields.mainContactAddress.schema
+        };
+
+        const { error } = Joi.validate(
+            {
+                'organisation-type': 'school',
+                'main-contact-dob': null
+            },
+            schemaWithOrgType
+        );
+
+        expect(error).toBeNull();
+
+        expect(allFields.mainContactAddress.shouldShow()).toBeTruthy();
+        expect(allFields.mainContactAddress.shouldShow({ 'organisation-type': 'unregistered-vco' })).toBeTruthy();
+        expect(allFields.mainContactAddress.shouldShow({ 'organisation-type': 'school' })).toBeFalsy();
+    });
+});
+
+describe('mainContactEmail', () => {
+    test('valid', () => {
+        const { error } = allFields.mainContactEmail.schema.validate(faker.internet.exampleEmail());
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.mainContactName.schema.validate(Infinity);
+        expect(error.message).toContain('must be a string');
+    });
+
+    test('missing', () => {
+        const { error } = allFields.mainContactName.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+});
+
+describe('mainContactPhone', () => {
+    test('valid', () => {
+        const { error } = allFields.mainContactPhone.schema.validate('0345 4 10 20 30');
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.mainContactPhone.schema.validate('not a phone number');
+        expect(error.message).toContain('did not seem to be a phone number');
+    });
+
+    test('missing', () => {
+        const { error } = allFields.mainContactPhone.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+});
+
+describe('mainContactCommunicationNeeds', () => {
+    test('valid', () => {
+        const { error } = allFields.mainContactCommunicationNeeds.schema.validate('audiotape');
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.mainContactCommunicationNeeds.schema.validate('invalid');
+        expect(error.message).toContain('must be one of [audiotape, braille, large-print]');
+    });
+
+    test('optional', () => {
+        const { error } = allFields.mainContactCommunicationNeeds.schema.validate();
+        expect(error).toBeNull();
+    });
+});
+
+describe('legalContactName', () => {
+    test('valid', () => {
+        const { error } = allFields.legalContactName.schema.validate(faker.name.findName());
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = allFields.legalContactName.schema.validate(Infinity);
+        expect(error.message).toContain('must be a string');
+    });
+
+    test('missing', () => {
+        const { error } = allFields.legalContactName.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+});
+
+describe('legalContactDob', () => {
+    test('valid', () => {
+        const dt = moment().subtract(18, 'years');
+        const { error } = allFields.legalContactDob.schema.validate(toDateParts(dt));
+        expect(error).toBeNull();
+    });
+
+    test('under 18', () => {
+        const dt = moment().subtract(16, 'years');
+        const { error } = allFields.legalContactDob.schema.validate(toDateParts(dt));
+        expect(error.message).toContain('Must be at least 18 years old');
+    });
+
+    test('not required if organisation-type is a school', () => {
+        const schemaWithOrgType = {
+            'organisation-type': allFields.organisationType.schema,
+            'main-contact-dob': allFields.legalContactDob.schema
+        };
+
+        const { error } = Joi.validate(
+            {
+                'organisation-type': 'school',
+                'main-contact-dob': null
+            },
+            schemaWithOrgType
+        );
+
+        expect(error).toBeNull();
+
+        expect(allFields.legalContactDob.shouldShow()).toBeTruthy();
+        expect(allFields.legalContactDob.shouldShow({ 'organisation-type': 'unregistered-vco' })).toBeTruthy();
+        expect(allFields.legalContactDob.shouldShow({ 'organisation-type': 'school' })).toBeFalsy();
+    });
+});
+
+describe('legalContactAddress', () => {
+    test('valid', () => {
+        const { error } = allFields.legalContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        });
+        expect(error).toBeNull();
+    });
+
+    test('missing', () => {
+        const { error } = allFields.legalContactAddress.schema.validate();
+        expect(error.message).toContain('is required');
+    });
+
+    test('partial address fields', () => {
+        const { error } = allFields.legalContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        });
+        expect(error.message).toEqual('child "town-city" fails because ["town-city" is required]');
+    });
+
+    test('invalid postcode', () => {
+        const { error } = allFields.legalContactAddress.schema.validate({
+            'building-street': '3 Embassy Drive',
+            'town-city': 'Edgbaston, Birmingham',
+            county: 'West Midlands',
+            postcode: 'not a postcode'
+        });
+        expect(error.message).toContain('fails to match the required pattern');
+    });
+
+    test('not required if organisation-type is a school', () => {
+        const schemaWithOrgType = {
+            'organisation-type': allFields.organisationType.schema,
+            'main-contact-dob': allFields.legalContactAddress.schema
+        };
+
+        const { error } = Joi.validate(
+            {
+                'organisation-type': 'school',
+                'main-contact-dob': null
+            },
+            schemaWithOrgType
+        );
+
+        expect(error).toBeNull();
+
+        expect(allFields.legalContactAddress.shouldShow()).toBeTruthy();
+        expect(allFields.legalContactAddress.shouldShow({ 'organisation-type': 'unregistered-vco' })).toBeTruthy();
+        expect(allFields.legalContactAddress.shouldShow({ 'organisation-type': 'school' })).toBeFalsy();
+    });
+});
+
+describe('legalContactEmail', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('legalContactPhone', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('legalContactCommunicationNeeds', () => {
+    test.todo('valid');
+    test.todo('optional');
+});
+
+describe('bankAccountName', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('bankSortCode', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('bankAccountNumber', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('bankBuildingSocietyNumber', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
+});
+
+describe('bankStatement', () => {
+    test.todo('valid');
+    test.todo('invalid');
+    test.todo('missing');
 });

--- a/controllers/apply-next/simple/fields.test.js
+++ b/controllers/apply-next/simple/fields.test.js
@@ -1,0 +1,88 @@
+'use strict';
+/* eslint-env jest */
+/* @TODO: It would be nice to also validate the messages from `normaliseErrors` here. */
+
+const faker = require('faker');
+const Joi = require('joi');
+const moment = require('moment');
+const { allFields } = require('./fields');
+const { applicationTitle, applicationCountry, projectStartDate, mainContactDob } = allFields;
+
+const toDateParts = dt => ({
+    day: dt.get('day'),
+    month: dt.get('month') + 1,
+    year: dt.get('year')
+});
+
+describe('applicationTitle', () => {
+    test('valid', () => {
+        const { error } = Joi.validate(faker.lorem.words(5), applicationTitle.schema);
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = Joi.validate('', applicationTitle.schema);
+        expect(error.message).toContain('not allowed to be empty');
+    });
+});
+
+describe('applicationCountry', () => {
+    test('valid', () => {
+        const { error } = Joi.validate(
+            faker.random.arrayElement(['england', 'northern-ireland', 'scotland', 'wales']),
+            applicationCountry.schema
+        );
+        expect(error).toBeNull();
+    });
+
+    test('invalid', () => {
+        const { error } = Joi.validate('not-a-country', applicationCountry.schema);
+        expect(error.message).toContain('must be one of [england, northern-ireland, scotland, wales]');
+    });
+});
+
+describe('projectStartDate', () => {
+    test('valid', () => {
+        const dt = moment().add(12, 'weeks');
+        const { error } = Joi.validate(toDateParts(dt), projectStartDate.schema);
+        expect(error).toBeNull();
+    });
+
+    test('missing', () => {
+        const { error } = Joi.validate(null, projectStartDate.schema);
+        expect(error.message).toContain('must be an object');
+    });
+
+    test('invalid', () => {
+        const { error } = Joi.validate({ day: 31, month: 2, year: 2030 }, projectStartDate.schema);
+        expect(error.message).toContain('contains an invalid value');
+    });
+
+    test('less than 12 weeks in the future', () => {
+        const dt = moment().add(6, 'weeks');
+        const { error } = Joi.validate(toDateParts(dt), projectStartDate.schema);
+        expect(error.message).toContain('Date must be at least');
+    });
+});
+
+describe('mainContactDob', () => {
+    test('valid', () => {
+        const dt = moment().subtract(18, 'years');
+        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema);
+        expect(error).toBeNull();
+    });
+
+    test('under 18', () => {
+        const dt = moment().subtract(16, 'years');
+        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema);
+        expect(error.message).toContain('Must be at least 18 years old');
+    });
+
+    test('not required if organisation-type is a school', () => {
+        const dt = moment().subtract(18, 'years');
+        const { error } = Joi.validate(toDateParts(dt), mainContactDob.schema, {
+            context: { 'organisation-type': 'school' }
+        });
+        expect(error).toBeNull();
+    });
+});

--- a/controllers/apply-next/simple/form-model.js
+++ b/controllers/apply-next/simple/form-model.js
@@ -1,7 +1,5 @@
 'use strict';
-const { get, includes } = require('lodash');
-
-const { schema, allFields, organisationTypes } = require('./fields');
+const { schema, allFields } = require('./fields');
 const processor = require('./processor');
 const validateModel = require('../lib/validate-model');
 
@@ -77,33 +75,11 @@ const sectionOrganisation = {
             ]
         },
         {
-            title: { en: 'Charity number', cy: '' },
-            matchesCondition: function(formData = {}) {
-                return get(formData, 'organisation-type') === organisationTypes.unincorporatedRegisteredCharity.value;
-            },
+            title: { en: 'Registration numbers', cy: '' },
             fieldsets: [
                 {
-                    legend: { en: 'Charity number', cy: '' },
-                    fields: [allFields.charityNumber]
-                }
-            ]
-        },
-        {
-            title: { en: 'Company number', cy: '' },
-            matchesCondition: function(formData = {}) {
-                return includes(
-                    [
-                        organisationTypes.charitableIncorporatedOrganisation.value,
-                        organisationTypes.notForProfitCompany.value,
-                        organisationTypes.communityInterestCompany.value
-                    ],
-                    get(formData, 'organisation-type')
-                );
-            },
-            fieldsets: [
-                {
-                    legend: { en: 'Company number', cy: '' },
-                    fields: [allFields.companyNumber]
+                    legend: { en: 'Registration numbers', cy: '' },
+                    fields: [allFields.companyNumber, allFields.charityNumber]
                 }
             ]
         },

--- a/controllers/apply-next/views/step.njk
+++ b/controllers/apply-next/views/step.njk
@@ -35,25 +35,26 @@
                 {{ formErrors(errors = errors) }}
 
                 {% for fieldset in step.fieldsets %}
-                    <fieldset class="form-fieldset u-constrained-wide">
-                        <legend class="form-fieldset__legend t2 t--underline">
-                            {{ fieldset.legend }}
-                        </legend>
+                    {% if fieldset.fields.length > 0 %}
+                        <fieldset class="form-fieldset u-constrained-wide">
+                            <legend class="form-fieldset__legend t2 t--underline">
+                                {{ fieldset.legend }}
+                            </legend>
 
-                        {% set introduction = fieldsetCopy.introduction or fieldset.introduction %}
-                        {% if introduction %}
-                            <div class="form-fieldset__intro s-prose">{{ introduction | safe }}</div>
-                        {% endif %}
+                            {% set introduction = fieldsetCopy.introduction or fieldset.introduction %}
+                            {% if introduction %}
+                                <div class="form-fieldset__intro s-prose">{{ introduction | safe }}</div>
+                            {% endif %}
 
-                        <div class="form-fieldset__fields">
-                            {% for field in fieldset.fields %}
-                                {% set fieldCopy = copy.fields[field.name] %}
-                                {{ formField(field, errors = errors) }}
-                            {% endfor %}
-                        </div>
-                    </fieldset>
+                            <div class="form-fieldset__fields">
+                                {% for field in fieldset.fields %}
+                                    {% set fieldCopy = copy.fields[field.name] %}
+                                    {{ formField(field, errors = errors) }}
+                                {% endfor %}
+                            </div>
+                        </fieldset>
+                    {% endif %}
                 {% endfor %}
-
 
                 {% if csrfToken %}
                     <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/controllers/apply-next/views/step.njk
+++ b/controllers/apply-next/views/step.njk
@@ -35,25 +35,23 @@
                 {{ formErrors(errors = errors) }}
 
                 {% for fieldset in step.fieldsets %}
-                    {% if fieldset.fields.length > 0 %}
-                        <fieldset class="form-fieldset u-constrained-wide">
-                            <legend class="form-fieldset__legend t2 t--underline">
-                                {{ fieldset.legend }}
-                            </legend>
+                    <fieldset class="form-fieldset u-constrained-wide">
+                        <legend class="form-fieldset__legend t2 t--underline">
+                            {{ fieldset.legend }}
+                        </legend>
 
-                            {% set introduction = fieldsetCopy.introduction or fieldset.introduction %}
-                            {% if introduction %}
-                                <div class="form-fieldset__intro s-prose">{{ introduction | safe }}</div>
-                            {% endif %}
+                        {% set introduction = fieldsetCopy.introduction or fieldset.introduction %}
+                        {% if introduction %}
+                            <div class="form-fieldset__intro s-prose">{{ introduction | safe }}</div>
+                        {% endif %}
 
-                            <div class="form-fieldset__fields">
-                                {% for field in fieldset.fields %}
-                                    {% set fieldCopy = copy.fields[field.name] %}
-                                    {{ formField(field, errors = errors) }}
-                                {% endfor %}
-                            </div>
-                        </fieldset>
-                    {% endif %}
+                        <div class="form-fieldset__fields">
+                            {% for field in fieldset.fields %}
+                                {% set fieldCopy = copy.fields[field.name] %}
+                                {{ formField(field, errors = errors) }}
+                            {% endfor %}
+                        </div>
+                    </fieldset>
                 {% endfor %}
 
                 {% if csrfToken %}

--- a/controllers/apply-next/views/summary.njk
+++ b/controllers/apply-next/views/summary.njk
@@ -71,7 +71,7 @@
                                         Step {{ stepNumber }} of {{ section.steps.length }} &ndash; {{ step.title }}
                                     </h4>
 
-                                    {% if not step.notRequired %}
+                                    {% if step.isRequired %}
                                         {% for fieldset in step.fieldsets %}
                                             {% for field in fieldset.fields %}
                                                 <div class="application-summary__data">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8046,6 +8046,12 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "eslint-plugin-compat": "2.6.3",
     "eslint-plugin-no-only-tests": "2.1.0",
     "eslint-plugin-vue": "5.1.0",
+    "faker": "4.1.0",
     "husky": "1.3.1",
     "jest": "24.1.0",
     "node-mocks-http": "1.7.3",

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -204,7 +204,7 @@
                                 name="{{ field.name }}"
                                 value="{{ option.value }}"
                                 {% if field.isRequired %}required aria-required="true"{% endif %}
-                                {% if field.value[0] === option.value %}checked{% endif %}
+                                {% if field.value[0] === option.value or field.value === option.value %}checked{% endif %}
                             />
                         {% endif %}
                     </div>


### PR DESCRIPTION
This PR does some work to refactor how conditional steps and fields are handled.

The biggest change is to move the conditional logic from steps down to individual fields. This allows us to handle conditional fields within a step (e.g. not asking for date of birth and address for school contacts) as well as whole conditional steps (e.g. registration numbers).

Still a little work in progress, needs more unit tests to validate these changes.