### PR TITLE
Apply common body classes separately to fonts-loaded

### DIFF
--- a/assets/js/head.js
+++ b/assets/js/head.js
@@ -3,40 +3,26 @@
 import 'details-element-polyfill';
 import FontFaceObserver from 'fontfaceobserver/fontfaceobserver.js';
 
-function getCommonBodyClasses() {
-    const classes = ['js-on'];
-
-    if (AppConfig.isModernBrowser) {
-        classes.push('is-modern');
-    }
+(function() {
+    const docEl = document.documentElement;
+    docEl.className = docEl.className.replace('no-js', 'js-on');
 
     if (AppConfig.isOldIE) {
-        classes.push('is-ie');
+        docEl.className += ' ' + 'is-ie';
     }
 
-    return classes;
-}
-
-function addBodyClasses(classes) {
-    const docEl = document.documentElement;
-    const docClass = docEl.className;
-    docEl.className = docClass.replace('no-js', '') + ' ' + classes.join(' ');
-}
-
-(function() {
     const LOADED_CLASS = 'fonts-loaded';
-    const classes = getCommonBodyClasses();
-
     if (sessionStorage.fontsLoaded) {
-        classes.push(LOADED_CLASS);
-        addBodyClasses(classes);
+        docEl.className += ' ' + LOADED_CLASS;
     } else {
-        Promise.all([new FontFaceObserver('caecilia').load(), new FontFaceObserver('caecilia-sans-text').load()]).then(
-            function() {
-                classes.push(LOADED_CLASS);
-                addBodyClasses(classes);
-                sessionStorage.fontsLoaded = true;
-            }
-        );
+        const webFontObservers = [
+            new FontFaceObserver('caecilia').load(),
+            new FontFaceObserver('caecilia-sans-text').load()
+        ];
+
+        Promise.all(webFontObservers).then(function() {
+            docEl.className += ' ' + LOADED_CLASS;
+            sessionStorage.fontsLoaded = true;
+        });
     }
 })();

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -9,11 +9,6 @@
         isNotProduction: {{ appData.isNotProduction }},
         locale: '{{ locale }}',
         localePrefix: '{{ localePrefix }}',
-        isModernBrowser:
-            'querySelector' in document &&
-            'addEventListener' in window &&
-            'localStorage' in window &&
-            'bind' in Function,
         isOldIE:
             navigator.userAgent.indexOf('MSIE') !== -1 ||
             navigator.appVersion.indexOf('Trident/') > 0,


### PR DESCRIPTION
Noticed yesterday that if fonts fail to load we don't replace the `no-js` class with `js-on` class. We don't use this class in many places (we largely use `v-cloak` instead) but it effectively couples font-loading with the display of some javascript functionality.

I've reworked the `head.js` file to handle this class separately to the `fonts-loading` class.