### PR TITLE
Update API endpoints to use joi schema

### DIFF
--- a/assets/js/vue-apps/components/survey.vue
+++ b/assets/js/vue-apps/components/survey.vue
@@ -16,8 +16,7 @@ export default {
             status: statuses.NOT_ASKED,
             response: {
                 choice: null,
-                message: null,
-                path: window.location.pathname
+                message: null
             }
         };
     },
@@ -25,11 +24,20 @@ export default {
         storeResponse(choice) {
             this.response.choice = choice;
 
+            const data = {
+                choice: choice,
+                path: window.location.pathname
+            };
+
+            if (this.response.message) {
+                data.message = this.response.message;
+            }
+
             $.ajax({
                 url: `/api/survey`,
                 type: 'POST',
                 dataType: 'json',
-                data: this.response
+                data: data
             }).then(
                 response => {
                     if (response.status === 'success') {
@@ -61,10 +69,10 @@ export default {
             <div class="survey__choices" v-if="status === statuses.NOT_ASKED">
                 <p class="survey__choices-question">{{ question }}</p>
                 <div class="survey__choices-actions">
-                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('yes');">
+                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('yes')">
                         {{ yes }}
                     </button>
-                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('no');">
+                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('no')">
                         {{ no }}
                     </button>
                 </div>
@@ -75,7 +83,7 @@ export default {
             <p class="survey__response" v-if="status === statuses.SUBMISSION_ERROR">{{ error }}</p>
 
             <div class="survey__extra" v-if="status === statuses.MESSAGE_BOX_SHOWN">
-                <form class="survey__form" @submit.prevent="storeResponse('no');">
+                <form class="survey__form" @submit.prevent="storeResponse('no')">
                     <div class="survey__form-fields">
                         <label class="ff-label" for="survey-extra-msg">{{ prompt }}</label>
                         <textarea class="ff-textarea" id="survey-extra-msg" v-model="response.message"></textarea>

--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -1,106 +1,98 @@
 'use strict';
 const express = require('express');
+const Joi = require('joi');
 
 const router = express.Router();
 
-const { pick } = require('lodash');
-const { body, validationResult } = require('express-validator/check');
-const { matchedData } = require('express-validator/filter');
-
-const { purifyUserInput } = require('../../modules/validators');
-const surveyService = require('../../services/surveys');
 const feedbackService = require('../../services/feedback');
+const surveyService = require('../../services/surveys');
 
 /**
  * API: Feedback endpoint
  */
-router.post(
-    '/feedback',
-    [
-        body('description')
-            .exists()
-            .not()
-            .isEmpty(),
-        body('message')
-            .exists()
-            .not()
-            .isEmpty()
-    ],
-    (req, res) => {
-        const formErrors = validationResult(req);
-        const formData = matchedData(req);
-        const messageSuccess = req.i18n.__('global.feedback.success');
-        const messageError = req.i18n.__('global.feedback.error');
+router.post('/feedback', async (req, res) => {
+    const schema = Joi.object({
+        description: Joi.string().required(),
+        message: Joi.string().required()
+    });
 
-        if (formErrors.isEmpty()) {
-            feedbackService
-                .storeFeedback({
-                    description: formData['description'],
-                    message: formData['message']
-                })
-                .then(() => {
-                    res.json({
-                        message: messageSuccess,
-                        data: formData
-                    });
-                })
-                .catch(err => {
-                    res.status(400).json({
-                        message: messageError,
-                        err: err
-                    });
-                });
-        } else {
+    const validationResult = schema.validate(req.body, {
+        abortEarly: false,
+        stripUnknown: true
+    });
+
+    const messageSuccess = req.i18n.__('global.feedback.success');
+    const messageError = req.i18n.__('global.feedback.error');
+
+    if (validationResult.error) {
+        res.status(400).json({
+            status: 'error',
+            message: messageError,
+            err: validationResult.error.message
+        });
+    } else {
+        try {
+            const result = await feedbackService.storeFeedback({
+                description: validationResult.value.description,
+                message: validationResult.value.message
+            });
+
+            res.json({
+                status: 'success',
+                message: messageSuccess,
+                result: result
+            });
+        } catch (storeError) {
             res.status(400).json({
+                status: 'error',
                 message: messageError,
-                err: 'Please supply all fields'
+                err: storeError.message
             });
         }
     }
-);
+});
 
 /**
  * API: Survey endpoint
  */
-router.post(
-    '/survey',
-    [
-        body('choice')
-            .exists()
-            .not()
-            .isEmpty()
-            .isIn(['yes', 'no'])
-            .withMessage('Please supply a valid choice'),
-        body('path').exists()
-    ],
-    async (req, res) => {
-        const errors = validationResult(req);
+router.post('/survey', async (req, res) => {
+    const schema = Joi.object({
+        choice: Joi.string()
+            .valid(['yes', 'no'])
+            .required(),
+        path: Joi.string().required(),
+        message: Joi.string().optional()
+    });
 
-        if (errors.isEmpty()) {
-            for (let key in req.body) {
-                req.body[key] = purifyUserInput(req.body[key]);
-            }
+    const validationResult = schema.validate(req.body, {
+        abortEarly: false,
+        stripUnknown: true
+    });
 
-            try {
-                const responseData = pick(req.body, ['choice', 'path', 'message']);
-                const result = await surveyService.createResponse(responseData);
-                res.send({
-                    status: 'success',
-                    result: result
-                });
-            } catch (err) {
-                res.status(400).send({
-                    status: 'error',
-                    err: err
-                });
-            }
-        } else {
-            res.status(400).send({
+    if (validationResult.error) {
+        res.status(400).json({
+            status: 'error',
+            err: validationResult.error.message
+        });
+    } else {
+        try {
+            const result = await surveyService.createResponse({
+                choice: validationResult.value.choice,
+                path: validationResult.value.path,
+                message: validationResult.value.message
+            });
+
+            res.json({
+                status: 'success',
+                result: result
+            });
+        } catch (storeError) {
+            res.status(400).json({
                 status: 'error',
-                err: errors.array()
+                err: storeError.message
             });
         }
     }
-);
+});
 
 module.exports = router;

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -82,6 +82,48 @@ describe('common', function() {
         });
     });
 
+    it('should allow survey API responses', () => {
+        const dataYes = {
+            choice: 'yes',
+            path: '/'
+        };
+
+        cy.request('POST', '/api/survey', dataYes).then(response => {
+            expect(response.body.result).to.have.property('id');
+            expect(response.body.status).to.equal('success');
+            expect(response.body.result.choice).to.equal(dataYes.choice);
+            expect(response.body.result.path).to.equal(dataYes.path);
+        });
+
+        const dataNo = {
+            choice: 'no',
+            path: '/',
+            message: 'this is an example message'
+        };
+
+        cy.request('POST', '/api/survey', dataNo).then(response => {
+            expect(response.body.result).to.have.property('id');
+            expect(response.body.status).to.equal('success');
+            expect(response.body.result.choice).to.equal(dataNo.choice);
+            expect(response.body.result.path).to.equal(dataNo.path);
+            expect(response.body.result.message).to.equal(dataNo.message);
+        });
+    });
+
+    it('should allow feedback API responses', () => {
+        const data = {
+            description: 'example',
+            message: 'this is an example message'
+        };
+
+        cy.request('POST', '/api/feedback', data).then(response => {
+            expect(response.body.result).to.have.property('id');
+            expect(response.body.status).to.equal('success');
+            expect(response.body.result.description).to.equal(data.description);
+            expect(response.body.result.message).to.equal(data.message);
+        });
+    });
+
     it('should perform common interactions', () => {
         cy.visit('/');
         cy.checkA11y();

--- a/services/feedback.js
+++ b/services/feedback.js
@@ -3,19 +3,7 @@ const moment = require('moment');
 const { Op } = require('sequelize');
 const { groupBy } = require('lodash/fp');
 const { Feedback } = require('../models');
-
-function findAll() {
-    return Feedback.findAll({
-        order: [['description', 'ASC'], ['updatedAt', 'DESC']]
-    }).then(results => {
-        return groupBy(result => result.description.toLowerCase())(results);
-    });
-}
-
-function storeFeedback(response) {
-    cleanupOldData();
-    return Feedback.create(response);
-}
+const { purifyUserInput } = require('../modules/validators');
 
 function cleanupOldData() {
     return Feedback.destroy({
@@ -26,6 +14,22 @@ function cleanupOldData() {
                     .toDate()
             }
         }
+    });
+}
+
+function storeFeedback({ description, message }) {
+    cleanupOldData();
+    return Feedback.create({
+        description: purifyUserInput(description),
+        message: purifyUserInput(message)
+    });
+}
+
+function findAll() {
+    return Feedback.findAll({
+        order: [['description', 'ASC'], ['updatedAt', 'DESC']]
+    }).then(results => {
+        return groupBy(result => result.description.toLowerCase())(results);
     });
 }
 

--- a/services/surveys.js
+++ b/services/surveys.js
@@ -88,9 +88,13 @@ async function getAllResponses({ path = null } = {}) {
     }
 }
 
-function createResponse(response) {
+function createResponse({ choice, path, message }) {
     cleanupOldData();
-    return SurveyAnswer.create(response);
+    return SurveyAnswer.create({
+        choice: purifyUserInput(choice),
+        path: purifyUserInput(path),
+        message: purifyUserInput(message)
+    });
 }
 
 function cleanupOldData() {


### PR DESCRIPTION
This PR reworks the API endpoints for surveys and feedback forms to use `joi` for validation instead of `express-validator`. Gives a low-impact opportunity to use this validation in production.