### PR TITLE
Travis merge jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ env:
 
 dist: xenial
 
-# Build stage conditions
-stages:
-  - test
-  # https://github.com/travis-ci/travis-ci/issues/9614#issuecomment-388798396
-  - name: build
-    if: (NOT type IN (pull_request)) AND (branch = master)
-
 # Defaults
 language: node_js
 node_js: '10'
@@ -30,53 +23,47 @@ cache:
   directories:
     - ~/.cache # Cypress installed into ~/.cache/Cypress
 
-# Build stages
-jobs:
-  include:
-    # Stage: Tests
-    - stage: test
-      script: npm run test-ci
-
-    # Stage: Build & deploy (only on master)
-    - stage: build
-      script: npm run build-production
-      after_success:
-        - npm prune --production > /dev/null 2>&1
-        - sh deploy/store_deploy_info.sh
-        - zip -qr latest * -x .\* -x "README.md" -x assets/\* -x "gulpfile.js"
-        - mkdir -p dpl_cd_upload
-        - mv latest.zip dpl_cd_upload/build-$TRAVIS_BUILD_NUMBER.zip
-      deploy:
-        - provider: s3
-          region: eu-west-1
-          bucket: blf-assets
-          access_key_id: $AWS_ACCESS_KEY_ID
-          secret_access_key: $AWS_SECRET_ACCESS_KEY
-          local_dir: public
-          upload-dir: assets
-          acl: public_read
-          cache_control: 'max-age=31536000'
-          skip_cleanup: true
-        - provider: s3
-          region: eu-west-2
-          bucket: blf-deployments
-          access_key_id: $AWS_ACCESS_KEY_ID
-          secret_access_key: $AWS_SECRET_ACCESS_KEY
-          local_dir: dpl_cd_upload
-          skip_cleanup: true
-          on:
-            repo: biglotteryfund/blf-alpha
-        - provider: codedeploy
-          region: eu-west-2
-          access_key_id: $AWS_ACCESS_KEY_ID
-          secret_access_key: $AWS_SECRET_ACCESS_KEY
-          bucket: blf-deployments
-          key: build-$TRAVIS_BUILD_NUMBER.zip
-          bundle_type: zip
-          application: BLF_WWW
-          deployment_group: Test_Fleet
-          on:
-            tags: false
+script:
+  - npm run-build production
+  - npm test
+  - npm run test-integration
+before_deploy:
+  - npm prune --production > /dev/null 2>&1
+  - sh deploy/store_deploy_info.sh
+  - zip -qr latest * -x .\* -x "README.md" -x assets/\* -x "gulpfile.js"
+  - mkdir -p dpl_cd_upload
+  - mv latest.zip dpl_cd_upload/build-$TRAVIS_BUILD_NUMBER.zip
+deploy:
+  - provider: s3
+    region: eu-west-1
+    bucket: blf-assets
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    local_dir: public
+    upload-dir: assets
+    acl: public_read
+    cache_control: 'max-age=31536000'
+    skip_cleanup: true
+  - provider: s3
+    region: eu-west-2
+    bucket: blf-deployments
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    local_dir: dpl_cd_upload
+    skip_cleanup: true
+    on:
+      repo: biglotteryfund/blf-alpha
+  - provider: codedeploy
+    region: eu-west-2
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: blf-deployments
+    key: build-$TRAVIS_BUILD_NUMBER.zip
+    bundle_type: zip
+    application: BLF_WWW
+    deployment_group: Test_Fleet
+    on:
+      tags: false
 
 # Notifications
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
     - ~/.cache # Cypress installed into ~/.cache/Cypress
 
 script:
-  - npm run-build production
+  - npm run build-production
   - npm test
   - npm run test-integration
 before_deploy:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test-watch": "jest --watch",
     "test": "npm audit || true && npm run lint && npm run test-unit",
     "test-integration": "./bin/start-test-server & wait-on http://localhost:8090 && percy exec -- cypress run",
-    "test-ci": "npm run build && concurrently --raw npm:test npm:test-integration",
     "clean": "del-cli $npm_package_config_dist_root/* ./config/assets.json",
     "build-sass": "node-sass assets/sass --output $npm_package_config_dist_css --source-map $npm_package_config_dist_css",
     "build-css": "npm run build-sass && postcss $npm_package_config_dist_css/*.css --replace --map",


### PR DESCRIPTION
Following on from https://github.com/biglotteryfund/blf-alpha/pull/1864 this PR explores (re)merging the separate build and deploy jobs back together.

I don't know if Travis have adjusted their build lifecycles or if it's something else but the deploy dependencies no longer seem to get installed if the build is not deployable (i.e. merge/PR build) so on first pass this looks like it will speed up the builds even further as we a) no longer have spin up two jobs for `master` builds and b) avoid double building and can do a single production build up front.

We'll need to merge and run a test build on `master` to confirm the speed improvements are real, but looks promising.