### PR TITLE
Rework mail tests to use jsonTransport

### DIFF
--- a/services/__tests__/__snapshots__/mail.test.js.snap
+++ b/services/__tests__/__snapshots__/mail.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`buildMailOptions should build mail options for a html email 1`] = `
+exports[`buildMailOptions build mail options for a html email 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "html": "<p>This is a test</p>",
@@ -14,7 +14,7 @@ Object {
 }
 `;
 
-exports[`buildMailOptions should build mail options for a text email 1`] = `
+exports[`buildMailOptions build mail options for a text email 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "subject": "Test",
@@ -27,7 +27,7 @@ Object {
 }
 `;
 
-exports[`buildMailOptions should build mail options for a text email with a name 1`] = `
+exports[`buildMailOptions build mail options for a text email with a name 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
   "subject": "Test",
@@ -41,7 +41,7 @@ Object {
 }
 `;
 
-exports[`buildMailOptions should build mail options for an internal html email 1`] = `
+exports[`buildMailOptions build mail options for an internal html email 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@blf.digital>",
   "html": "<p>This is a test</p>",
@@ -55,7 +55,7 @@ Object {
 }
 `;
 
-exports[`buildMailOptions should handle multiple send to addresses 1`] = `
+exports[`buildMailOptions handle multiple send to addresses 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@blf.digital>",
   "subject": "Test",
@@ -71,59 +71,19 @@ Object {
 }
 `;
 
-exports[`generateHtmlEmail should generate html email content 1`] = `
+exports[`generateHtmlEmail generate html email content 1`] = `
 "<h1>Test email</h1>
 <p>Example data</p>
 "
 `;
 
-exports[`sendEmail should create a html email response to be sent 1`] = `
-Object {
-  "from": "noreply@tnlcommunityfund.org.uk",
-  "to": Array [
-    "example@example.com",
-  ],
-}
+exports[`sendEmail create a html email response to be sent 1`] = `
+"TEST EMAIL
+Example data"
 `;
 
-exports[`sendEmail should create a html email response to be sent 2`] = `
-"Content-Type: multipart/alternative;
-From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
-To: example@example.com
-Subject: Mock email
-MIME-Version: 1.0
-
-Content-Type: text/plain
-Content-Transfer-Encoding: 7bit
-
-TEST EMAIL
-Example data
-Content-Type: text/html
-Content-Transfer-Encoding: 7bit
-
-<h1>Test email</h1>
+exports[`sendEmail create a html email response to be sent 2`] = `
+"<h1>Test email</h1>
 <p>Example data</p>
-
-"
-`;
-
-exports[`sendEmail should create a text email response to be sent 1`] = `
-Object {
-  "from": "noreply@tnlcommunityfund.org.uk",
-  "to": Array [
-    "example@example.com",
-  ],
-}
-`;
-
-exports[`sendEmail should create a text email response to be sent 2`] = `
-"Content-Type: text/plain
-From: The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>
-To: example@example.com
-Subject: Mock email
-Content-Transfer-Encoding: 7bit
-MIME-Version: 1.0
-
-This is a test email
 "
 `;


### PR DESCRIPTION
Similar to https://github.com/biglotteryfund/blf-alpha/pull/1867 this PR updates the common mail tests to use `jsonTransport` and only snapshot the parts we are interested in rather than shapshotting the whole thing and having to strip out Message-ID / date / boundary etc.