### PR TITLE
Add a function to alert when the form data has changed but is not saved

### DIFF
--- a/assets/js/modules/forms.js
+++ b/assets/js/modules/forms.js
@@ -37,8 +37,8 @@ function handleAbandonmentMessage(formEl) {
  * Caveats: form must have the class below and the field must lose focus to trigger the change() event.
  * */
 function warnOnUnsavedChanges() {
-    let formHasChanged = false;
     $('.js-form-warn-unsaved').each(function() {
+        let formHasChanged = false;
         const $form = $(this);
         const initialState = $form.serialize();
         $(':input', $form).change(function() {

--- a/controllers/apply-next/views/step.njk
+++ b/controllers/apply-next/views/step.njk
@@ -9,7 +9,7 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
-            <form action="" method="POST">
+            <form action="" method="POST" class="js-form-warn-unsaved">
                 {{ breadcrumbTrail(breadcrumbs) }}
 
 


### PR DESCRIPTION
This change reuses some of the `beforeunload` functionality to warn the user if they attempt to navigate away from a form page when they've made changes to the data.

![warning](https://user-images.githubusercontent.com/394376/56347969-6142ed00-61bd-11e9-9d93-c9d9e3d3b3e9.gif)
