### PR TITLE
Validate project total against budget

### DIFF
--- a/controllers/apply-next/simple/fields.js
+++ b/controllers/apply-next/simple/fields.js
@@ -467,11 +467,15 @@ const allFields = {
         },
         type: 'currency',
         isRequired: true,
-        schema: Joi.number().required(),
+        schema: Joi.budgetTotalCosts().required(),
         messages: [
             {
                 type: 'base',
                 message: { en: 'Enter a total cost for your project, must be a number', cy: '' }
+            },
+            {
+                type: 'budgetTotalCosts.underBudget',
+                message: { en: 'Must be at least equal to the requested project costs', cy: '' }
             }
         ]
     },

--- a/controllers/apply-next/simple/fields.test.js
+++ b/controllers/apply-next/simple/fields.test.js
@@ -176,6 +176,46 @@ describe('projectTotalCosts', () => {
         const { error } = allFields.projectTotalCosts.schema.validate(Infinity);
         expect(error.message).toContain('contains an invalid value');
     });
+
+    test('under project budget', () => {
+        const schemaWithProjectBudget = Joi.object({
+            'project-budget': allFields.projectBudget.schema,
+            'project-total-costs': allFields.projectTotalCosts.schema
+        });
+
+        const { error } = Joi.validate(
+            {
+                'project-budget': [
+                    { item: faker.lorem.words(5), cost: 1100 },
+                    { item: faker.lorem.words(5), cost: 1100 }
+                ],
+                'project-total-costs': 1000
+            },
+            schemaWithProjectBudget
+        );
+
+        expect(error.message).toContain('under project budget total');
+    });
+
+    test('minimum of project budget', () => {
+        const schemaWithProjectBudget = Joi.object({
+            'project-budget': allFields.projectBudget.schema,
+            'project-total-costs': allFields.projectTotalCosts.schema
+        });
+
+        const { error } = Joi.validate(
+            {
+                'project-budget': [
+                    { item: faker.lorem.words(5), cost: 1100 },
+                    { item: faker.lorem.words(5), cost: 1100 }
+                ],
+                'project-total-costs': 2200
+            },
+            schemaWithProjectBudget
+        );
+
+        expect(error).toBeNull();
+    });
 });
 
 describe('organisationLegalName', () => {


### PR DESCRIPTION
This PR adds validation to the project total costs to check that the value is at least the amount asked for in the project budget.

This uses a `joi` extension and checks against `state.parent` which feels like an anti pattern as it's asking for a field by name. I think the better approach would be to group the budget and total together as a larger field group given the are validated as one set, but form now this does the job.

I've added a ticket to revisit this.