### PR TITLE
New field macros

### DIFF
--- a/controllers/apply-next/simple/form.js
+++ b/controllers/apply-next/simple/form.js
@@ -1221,17 +1221,17 @@ module.exports = function({ locale, data = {} }) {
             },
             {
                 name: 'terms-person-name',
-                autocompleteName: 'name',
-                type: 'text',
                 label: localise({ en: 'Full name of person completing this form', cy: '' }),
-                isRequired: true
+                type: 'text',
+                isRequired: true,
+                attributes: { autocomplete: 'name' }
             },
             {
                 name: 'terms-person-position',
-                autocompleteName: 'position',
-                type: 'text',
                 label: localise({ en: 'Position in organisation', cy: '' }),
-                isRequired: true
+                type: 'text',
+                isRequired: true,
+                attributes: { autocomplete: 'position' }
             }
         ],
         eligibilityQuestions: [

--- a/controllers/apply-next/views/eligibility.njk
+++ b/controllers/apply-next/views/eligibility.njk
@@ -1,5 +1,5 @@
 {% extends "layouts/main.njk" %}
-{% from "components/form-fields/macros.njk" import formField with context %}
+{% from "components/form-fields-next/macros.njk" import formField with context %}
 {% from "components/form-header/macro.njk" import formHeader with context %}
 
 {% block title %}Eligibility | {{ formTitle }} | {% endblock %}

--- a/controllers/apply-next/views/step.njk
+++ b/controllers/apply-next/views/step.njk
@@ -31,7 +31,7 @@
 
                 {# {{ languageServiceMessage(currentLocale = locale) }} #}
 
-                {{ formErrors(errors = errors) }}
+                {{ formErrors(__('global.misc.errorTitle'), errors) }}
 
                 {% for fieldset in step.fieldsets %}
                     <fieldset class="form-fieldset u-constrained-wide">

--- a/controllers/apply-next/views/step.njk
+++ b/controllers/apply-next/views/step.njk
@@ -2,7 +2,7 @@
 {% from "components/hero.njk" import hero with context %}
 {% from "components/icons.njk" import iconTick %}
 {% from "components/form-header/macro.njk" import formHeader with context %}
-{% from "components/form-fields/macros.njk" import formErrors, formField with context %}
+{% from "components/form-fields-next/macros.njk" import formErrors, formField with context %}
 {% from "components/language/macros.njk" import languageServiceMessage with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
@@ -11,7 +11,6 @@
         <div class="content-box u-inner-wide-only">
             <form action="" method="POST" class="js-form-warn-unsaved">
                 {{ breadcrumbTrail(breadcrumbs) }}
-
 
                 {% set formHeaderTitle = currentApplicationTitle if currentApplicationTitle else formTitle %}
                 {% set formHeaderSuffix = formTitle if currentApplicationTitle %}

--- a/controllers/apply-next/views/terms.njk
+++ b/controllers/apply-next/views/terms.njk
@@ -17,7 +17,7 @@
                 title = "Terms & Conditions"
             ) }}
 
-            {{ formErrors(errors = errors) }}
+            {{ formErrors( __('global.misc.errorTitle'), errors) }}
 
             <form method="post" action="" class="u-constrained-content-wide">
 

--- a/controllers/apply-next/views/terms.njk
+++ b/controllers/apply-next/views/terms.njk
@@ -3,7 +3,7 @@
 {% from "components/icons.njk" import iconArrowDown, iconTick, iconBin %}
 {% from "components/form-header/macro.njk" import formHeader with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-{% from "components/form-fields/macros.njk" import formErrors, formField with context %}
+{% from "components/form-fields-next/macros.njk" import formErrors, formField with context %}
 
 {% block title %}Terms & Conditions | {{ formTitle }} | {% endblock %}
 

--- a/modules/test-renderers.js
+++ b/modules/test-renderers.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const nunjucks = require('nunjucks');
+nunjucks.configure('views');
+
+function renderComponentMacro(componentPath, macroName, params) {
+    /**
+     * Mock any global translation strings.
+     * Wherever possible you should avoid requiring context for components
+     */
+    const context = {
+        __(key) {
+            return `[i18n:${key}]`;
+        }
+    };
+
+    const macroParams = JSON.stringify(params, null, 2);
+    const macroString = `{%- from "${componentPath}" import ${macroName} with context -%}{{- ${macroName}(${macroParams}) -}}`;
+    return new Promise((resolve, reject) => {
+        nunjucks.renderString(macroString, context, (err, res) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(res);
+            }
+        });
+    });
+}
+
+module.exports = {
+    renderComponentMacro
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -6580,6 +6580,15 @@
       "integrity": "sha512-46OkIuVGBBnrC0soO/4LHu5LHGHx0uhP65OVz8XOrAJpqiCB2aVIuESvjI1F9oqebuvY8lekS1pt6TN7vt7qsw==",
       "dev": true
     },
+    "diffable-html": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/diffable-html/-/diffable-html-4.0.0.tgz",
+      "integrity": "sha512-keJdgy2qBkdrrnwP1YE6e834d4Y+mV0aRFzk8w7WzyAJVbQVfcJltSmUWB3r/NOoO/0jt7RdJlvy5ioyqvmQcw==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.9.2"
+      }
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -12083,6 +12092,15 @@
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.0.0.tgz",
       "integrity": "sha512-9FKxQyrFgHtx3ozU+1a8v938ILBE7S8Ko3uiAVjT8Yfi2o91j/fj81jacCQZ/Ihjiff/VsUCXVgQ+iF1XdImOw==",
       "dev": true
+    },
+    "jest-serializer-html": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer-html/-/jest-serializer-html-6.0.0.tgz",
+      "integrity": "sha512-S855oT9Yt1T07I45+uRaLsH22TR5lAvgqBxKreqDKs6QmcaxzapGgKamc4J2KxMrPc2uDdWcuOaprcjIuVUxvQ==",
+      "dev": true,
+      "requires": {
+        "diffable-html": "^4.0.0"
+      }
     },
     "jest-snapshot": {
       "version": "24.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "transform": {
       "^.+\\.js$": "babel-jest",
       ".*\\.vue$": "vue-jest"
-    }
+    },
+    "snapshotSerializers": ["jest-serializer-html"]
   },
   "prettier": {
     "singleQuote": true,
@@ -157,6 +158,7 @@
     "faker": "4.1.0",
     "husky": "1.3.1",
     "jest": "24.1.0",
+    "jest-serializer-html": "6.0.0",
     "node-mocks-http": "1.7.3",
     "node-sass": "4.11.0",
     "nodemon": "1.18.9",

--- a/services/__tests__/__snapshots__/mail.test.js.snap
+++ b/services/__tests__/__snapshots__/mail.test.js.snap
@@ -3,7 +3,11 @@
 exports[`buildMailOptions build mail options for a html email 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@tnlcommunityfund.org.uk>",
-  "html": "<p>This is a test</p>",
+  "html": 
+<p>
+  This is a test
+</p>
+,
   "subject": "Test",
   "text": "This is a test",
   "to": Array [
@@ -44,7 +48,11 @@ Object {
 exports[`buildMailOptions build mail options for an internal html email 1`] = `
 Object {
   "from": "The National Lottery Community Fund <noreply@blf.digital>",
-  "html": "<p>This is a test</p>",
+  "html": 
+<p>
+  This is a test
+</p>
+,
   "subject": "Test",
   "text": "This is a test",
   "to": Array [
@@ -72,9 +80,14 @@ Object {
 `;
 
 exports[`generateHtmlEmail generate html email content 1`] = `
-"<h1>Test email</h1>
-<p>Example data</p>
-"
+
+<h1>
+  Test email
+</h1>
+<p>
+  Example data
+</p>
+
 `;
 
 exports[`sendEmail create a html email response to be sent 1`] = `
@@ -83,7 +96,12 @@ Example data"
 `;
 
 exports[`sendEmail create a html email response to be sent 2`] = `
-"<h1>Test email</h1>
-<p>Example data</p>
-"
+
+<h1>
+  Test email
+</h1>
+<p>
+  Example data
+</p>
+
 `;

--- a/views/components/form-fields-next/__snapshots__/macros.test.js.snap
+++ b/views/components/form-fields-next/__snapshots__/macros.test.js.snap
@@ -15,7 +15,6 @@ exports[`form field macros inputCurrency 1`] = `
          type="number"
          id="field-example"
          name="example"
-         value
          required
          aria-required="true"
   >

--- a/views/components/form-fields-next/__snapshots__/macros.test.js.snap
+++ b/views/components/form-fields-next/__snapshots__/macros.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form field macros inputCurrency 1`] = `
+
+<label class="ff-label"
+       for="field-example"
+>
+  Amount
+</label>
+<div class="ff-currency ff-currency--constrained">
+  <div class="ff-currency__pre">
+    £
+  </div>
+  <input class="ff-currency__input"
+         type="number"
+         id="field-example"
+         name="example"
+         value
+         required
+         aria-required="true"
+  >
+</div>
+
+`;
+
+exports[`form field macros inputText 1`] = `
+
+<label class="ff-label"
+       for="field-example"
+>
+  First name
+</label>
+<input class="ff-text"
+       type="text"
+       id="field-example"
+       name="example"
+       required
+       aria-required="true"
+       size="40"
+>
+
+`;

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -110,7 +110,7 @@
             type="number"
             id="field-{{ field.name }}"
             name="{{ field.name }}"
-            value="{% if field.value %}{{ field.value }}{% endif %}"
+            {% if field.value %}value="{{ field.value }}"{% endif %}
             {% if field.isRequired %}required aria-required="true"{% endif %}
             {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
         />

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -39,9 +39,7 @@
 
 {% macro fieldLabelText(field, fieldCopy) -%}
     {{ fieldCopy.label or field.label }}
-    {% if field.isRequired %}
-        <span class="ff-label-note ff-label-note--required">* {{ __('global.misc.required') }}</span>
-    {% elseif not field.silentlyOptional %}
+    {% if not field.isRequired %}
         <span class="ff-label-note">{{ __('global.misc.optional') }}</span>
     {% endif %}
 {%- endmacro %}

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -1,0 +1,391 @@
+{% from "components/icons.njk" import iconBin %}
+
+{% macro formErrors(errors, title) %}
+    {% if errors | length > 0 %}
+        <div class="form-errors">
+            <h2 class="form-errors__title">
+                {% if title -%}{{ title }}{%- else -%}{{ __('global.misc.errorTitle') }}{%- endif %}
+            </h2>
+            {% if errors.length > 0 %}
+                <ol class="form-errors__list">
+                    {% for error in errors %}
+                        <li>
+                            {% if error.param %}<a href="#form-field-{{ error.param }}">{% endif %}
+                            {{ error.msg }}
+                            {% if error.param %}</a>{% endif %}
+                        </li>
+                    {% endfor %}
+                </ol>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+{% macro fieldHelpText(field, fieldCopy) %}
+    {% set lengthHint = fieldCopy.lengthHint or field.lengthHint %}
+    {% if lengthHint %}
+        <small class="ff-length-hint">{{ lengthHint }}</small>
+    {% endif %}
+    {# @TODO: Merge helpText and explanation #}
+    {% set explanation = fieldCopy.explanation or field.explanation %}
+    {% if explanation %}
+        <div class="ff-help s-prose">{{ explanation | safe }}</div>
+    {% endif %}
+    {% set helpText = fieldCopy.helpText or field.helpText %}
+    {% if helpText %}
+        <div class="ff-help s-prose">{{ helpText | safe }}</div>
+    {% endif %}
+{% endmacro %}
+
+{% macro fieldLabelText(field, fieldCopy) -%}
+    {{ fieldCopy.label or field.label }}
+    {% if field.isRequired %}
+        <span class="ff-label-note ff-label-note--required">* {{ __('global.misc.required') }}</span>
+    {% elseif not field.silentlyOptional %}
+        <span class="ff-label-note">{{ __('global.misc.optional') }}</span>
+    {% endif %}
+{%- endmacro %}
+
+{% macro inputText(field, fieldCopy) %}
+    <label class="ff-label" for="field-{{ field.name }}">
+        {{ fieldLabelText(field, fieldCopy) }}
+    </label>
+    {{ fieldHelpText(field, fieldCopy) }}
+    <input
+        class="ff-text"
+        type="{{ field.type }}"
+        id="field-{{ field.name }}"
+        name="{{ field.name }}"
+        {% if field.value %}value="{{ field.value }}"{% endif %}
+        {% if field.isRequired %}required aria-required="true"{% endif %}
+        {% if field.autocompleteName %}autocomplete="{{ field.autocompleteName }}"{% endif %}
+        {% if not field.attributes.size %}size="{{ field.size | default(40, true) }}"{% endif %}
+        {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+    />
+{% endmacro %}
+
+{% macro inputDate(field, includeYear = true) %}
+    <fieldset class="ff-date" id="field-{{ field.name }}">
+        <legend class="ff-label ff-date__legend">
+            {{ field.label }}
+        </legend>
+        {{ fieldHelpText(field, fieldCopy) }}
+
+        <label class="ff-date__field">
+            <span class="ff-label">{{ __('global.misc.day') }}</span>
+            <input
+                class="ff-text ff-width-2"
+                name="{{ field.name }}[day]"
+                type="number"
+                pattern="[0-9]*"  min="1"
+                autocomplete="off"
+                {% if field.isRequired %}required aria-required="true"{% endif %}
+                value="{{ field.value.day }}"
+            />
+        </label>
+        <label class="ff-date__field">
+            <span class="ff-label">{{ __('global.misc.month') }}</span>
+            <input
+                class="ff-text ff-width-2"
+                name="{{ field.name }}[month]"
+                type="number"
+                pattern="[0-9]*"  min="1"
+                autocomplete="off"
+                {% if field.isRequired %}required aria-required="true"{% endif %}
+                value="{{ field.value.month }}"
+            />
+        </label>
+        {% if includeYear %}
+            <label class="ff-date__field">
+                <span class="ff-label">{{ __('global.misc.year') }}</span>
+                <input
+                    class="ff-text ff-width-4"
+                    name="{{ field.name }}[year]"
+                    type="number"
+                    pattern="[0-9]*" min="{{ field.settings.minYear | default(1900) }}"
+                    autocomplete="off"
+                    size="20"
+                    {% if field.isRequired %}required aria-required="true"{% endif %}
+                    value="{{ field.value.year }}"
+                />
+            </label>
+        {% endif %}
+    </fieldset>
+{% endmacro %}
+
+{% macro inputCurrency(field, fieldCopy) %}
+    <label class="ff-label" for="field-{{ field.name }}">
+        {{ fieldLabelText(field, fieldCopy) }}
+    </label>
+    {{ fieldHelpText(field, fieldCopy) }}
+    <div class="ff-currency ff-currency--constrained">
+        <div class="ff-currency__pre">£</div>
+        <input class="ff-currency__input"
+            type="number"
+            id="field-{{ field.name }}"
+            name="{{ field.name }}"
+            value="{% if field.value %}{{ field.value }}{% endif %}"
+            {% if field.isRequired %}required aria-required="true"{% endif %}
+            {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+        />
+    </div>
+{% endmacro %}
+
+{% macro inputTextarea(field, fieldCopy) %}
+    {% set settings = field.settings %}
+    {% if settings.showWordCount %}<div class="js-word-count">{% endif %}
+    <label class="ff-label" for="field-{{ field.name }}">
+        {{ fieldLabelText(field, fieldCopy) }}
+    </label>
+    {{ fieldHelpText(field, fieldCopy) }}
+    <textarea class="ff-textarea"
+        id="field-{{ field.name }}"
+        name="{{ field.name }}"
+        {% if field.isRequired %}required aria-required="true"{% endif %}
+        {# @TODO: Remove field.rows in favour of field.attributes #}
+        {% if field.rows %}rows="{{ field.rows }}"{% endif %} 
+        {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+        {% if settings.showWordCount %} @input="onInput" ref="textarea"{% endif %}
+    >{{ field.value }}</textarea>
+    {% if settings.showWordCount %}
+        <word-count
+            :current-text="text"
+            locale="{{ locale }}"
+            field-id="field-{{ field.name }}"
+            :min-words={{ settings.minWords }}
+            :max-words={{ settings.maxWords }}
+            :recommended-words={{ settings.recommendedWords }}
+        ></word-count>
+    {% endif %}
+    {% if settings.showWordCount %}</div>{% endif %}
+{% endmacro %}
+
+{% macro inputSelect(field, fieldCopy) %}
+    <label class="ff-label" for="field-{{ field.name }}">
+        {{ fieldLabelText(field, fieldCopy) }}
+    </label>
+    {{ fieldHelpText(field) }}
+    <select
+        class="ff-select"
+        id="field-{{ field.name }}"
+        name="{{ field.name }}">
+        {% for option in field.options %}
+            {% set optionCopy = fieldCopy.options[loop.index0] %}
+            <option
+                value="{{ option.value }}"{% if option.selected === true or field.value === option.value %} selected{% endif %}>
+                {{ optionCopy.label or option.label }}
+            </option>
+        {% endfor %}
+    </select>
+{% endmacro %}
+
+{% macro inputChoice(field, fieldCopy) %}
+    <fieldset class="ff-choice">
+        <legend class="ff-label" for="field-{{ field.name }}">
+            {{ fieldLabelText(field, fieldCopy) }}
+        </legend>
+        {{ fieldHelpText(field, fieldCopy) }}
+        <ul class="ff-choice__list">
+            {% for option in field.options %}
+                {% set optionCopy = fieldCopy.options[loop.index0] %}
+                <li class="ff-choice__option">
+                    <div class="ff-choice__input">
+                        {% if field.type === 'checkbox' %}
+                            <input
+                                type="checkbox"
+                                id="field-{{ field.name }}-{{ loop.index }}"
+                                name="{{ field.name }}"
+                                value="{{ option.value }}"
+                                {% if field.value.length and field.value.indexOf(option.value) > -1 %}checked{% endif %}
+                            />
+                        {% else %}
+                            <input
+                                type="radio"
+                                id="field-{{ field.name }}-{{ loop.index }}"
+                                name="{{ field.name }}"
+                                value="{{ option.value }}"
+                                {% if field.isRequired %}required aria-required="true"{% endif %}
+                                {% if field.value[0] === option.value or field.value === option.value %}checked{% endif %}
+                            />
+                        {% endif %}
+                    </div>
+                    <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
+                        {{ optionCopy.label or option.label }}
+                        {% set explanation = optionCopy.explanation or option.explanation %}
+                        {% if explanation %}
+                            <small class="ff-choice__caption">{{ explanation }}</small>
+                        {% endif %}
+                    </label>
+                </li>
+            {% endfor %}
+        </ul>
+    </fieldset>
+{% endmacro %}
+
+{% macro inputAddress(field) %}
+    <fieldset class="ff-address" id="field-{{ field.name }}">
+        <legend class="ff-address__legend t2 t--underline">
+            {{ fieldLabelText(field) }}
+        </legend>
+
+        {{ fieldHelpText(field, fieldCopy) }}
+
+        <div class="ff-address__field">
+            {{ inputText({
+                label: 'Building and street',
+                name: field.name + '[building-street]',
+                value: field.value['building-street'],
+                type: 'text',
+                isRequired: field.isRequired,
+                attributes: { size: 40 }
+            }) }}
+        </div>
+        <div class="ff-address__field">
+            {{ inputText({
+                label: 'Town or city',
+                name: field.name + '[town-city]',
+                value: field.value['town-city'],
+                type: 'text',
+                isRequired: field.isRequired,
+                attributes: { size: 30 }
+            }) }}
+        </div>
+        <div class="ff-address__field">
+            {{ inputText({
+                label: 'County',
+                name: field.name + '[county]',
+                value: field.value['county'],
+                type: 'text',
+                isRequired: field.isRequired,
+                attributes: { size: 30 }
+            }) }}
+        </div>
+        <div class="ff-address__field">
+            {{ inputText({
+                label: 'Postcode',
+                name: field.name + '[postcode]',
+                value: field.value['postcode'],
+                type: 'text',
+                isRequired: field.isRequired,
+                attributes: { size: 10 }
+            }) }}
+        </div>
+    </fieldset>
+{% endmacro %}
+
+{% macro inputBudget(field, fieldCopy) %}
+    <fieldset>
+        <legend class="ff-label">
+            {{ fieldLabelText(field) }}
+        </legend>
+        {{ fieldHelpText(field, fieldCopy) }}
+
+        <div id="js-budget-input">
+            <budget-input
+                field-name="{{ field.name }}"
+                :max-budget="{{ field.attributes.max }}"
+                :max-items="{{ field.attributes.rowLimit }}"
+                {% if field.value %}:budget-data="{{ field.value | dump }}"{% endif %}>
+            </budget-input>
+
+            {# Non-JS version (*not* <noscript> because we still need it if JS fails #}
+            {# (this will be removed by our Vue component when mounted) #}
+            <div class="js-fallback-only ff-budget">
+                <ol class="ff-budget__list">
+                    {% for lineItem in field.value %}
+                        {{ budgetRow(field, loop.index0, lineItem) }}
+                    {% endfor %}
+                    {% for i in range(0 + field.value | length, field.attributes.rowLimit) %}
+                        {{ budgetRow(field, i) }}
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
+    </fieldset>
+{% endmacro %}
+
+{# If we update this we should change the Vue component too #}
+{% macro budgetRow(field, counter, lineItem = false) %}
+    <li class="ff-budget__row">
+        <div class="ff-budget__row-item">
+            <label class="ff-label" for="ff-{{ field.name }}-{{ counter }}-item">
+                Item or activity
+            </label>
+            <input type="text"
+                id="ff-{{ field.name }}-{{ counter }}-item"
+                autocomplete="off"
+                name="{{ field.name }}[{{ counter }}][item]"
+                {% if lineItem %}value="{{ lineItem.item }}"{% endif %}
+                class="ff-text u-block-full"
+            />
+        </div>
+        <div class="ff-budget__row-amount">
+            <label class="ff-label" for="ff-{{ field.name }}-{{ counter }}-cost">
+                Amount
+            </label>
+            <div class="ff-currency">
+                <div class="ff-currency__pre">£</div>
+                <input
+                    type="number"
+                    id="ff-{{ field.name }}-{{ counter }}-cost"
+                    name="{{ field.name }}[{{ counter }}][cost]"
+                    min="1" max="{{ field.attributes.max }}"
+                    {% if lineItem %}value="{{ lineItem.cost }}"{% endif %}
+                    class="ff-currency__input"
+                />
+            </div>
+        </div>
+    </li>
+{% endmacro %}
+
+
+{% macro formField(field, fieldCopy = {}, errors = []) %}
+    {% set fieldErrors = errors | filter('param', field.name) %}
+    <div
+        id="form-field-{{ field.name }}"
+        class="form-field form-field--{{ field.name }} form-field--type-{{ field.type }}{% if fieldErrors | length > 0 %} has-errors{% endif %}">
+        <div class="form-field__main">
+            <div class="form-field__body">
+                {% if field.type === 'textarea' %}
+                    {{ inputTextarea(field, fieldCopy) }}
+                {% elseif field.type === 'select' %}
+                    {{ inputSelect(field, fieldCopy) }}
+                {% elseif field.type === 'checkbox' or field.type === 'radio' %}
+                    {{ inputChoice(field, fieldCopy) }}
+                {% elseif field.type === 'date' %}
+                    {{ inputDate(field) }}
+                {% elseif field.type === 'day-month' %}
+                    {{ inputDate(field, includeYear = false) }}
+                {% elseif field.type === 'currency' %}
+                    {{ inputCurrency(field, fieldCopy) }}
+                {% elseif field.type === 'address' %}
+                    {{ inputAddress(field) }}
+                {% elseif field.type === 'budget' %}
+                    {{ inputBudget(field, fieldCopy) }}
+                {% else %}
+                    {{ inputText(field, fieldCopy) }}
+                {% endif %}
+            </div>
+            {% if fieldErrors.length > 0 %}
+                <ol class="form-field__errors">
+                    {% for error in fieldErrors %}
+                        <li>{{ error.msg }}</li>
+                    {% endfor %}
+                </ol>
+            {% endif %}
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro facetGroup(legend) %}
+    <div class="facet-group is-open">
+        <fieldset class="facet-group__fieldset">
+            <legend class="facet-group__legend">
+                {{ legend }}
+            </legend>
+            <div class="facet-group__body">
+                {{ caller() }}
+            </div>
+        </fieldset>
+    </div>
+{% endmacro %}

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -21,34 +21,24 @@
     {% endif %}
 {% endmacro %}
 
-{% macro fieldHelpText(field, fieldCopy) %}
-    {% set lengthHint = fieldCopy.lengthHint or field.lengthHint %}
-    {% if lengthHint %}
-        <small class="ff-length-hint">{{ lengthHint }}</small>
-    {% endif %}
-    {# @TODO: Merge helpText and explanation #}
-    {% set explanation = fieldCopy.explanation or field.explanation %}
-    {% if explanation %}
-        <div class="ff-help s-prose">{{ explanation | safe }}</div>
-    {% endif %}
-    {% set helpText = fieldCopy.helpText or field.helpText %}
-    {% if helpText %}
-        <div class="ff-help s-prose">{{ helpText | safe }}</div>
+{% macro explanationFor(field) %}
+    {% if field.explanation %}
+        <div class="ff-help s-prose">{{ field.explanation | safe }}</div>
     {% endif %}
 {% endmacro %}
 
-{% macro fieldLabelText(field, fieldCopy) -%}
-    {{ fieldCopy.label or field.label }}
-    {% if not field.isRequired %}
+{% macro labelFor(field) -%}
+    {{ field.label }}
+    {% if field.isRequired === false %}
         <span class="ff-label-note">{{ __('global.misc.optional') }}</span>
     {% endif %}
 {%- endmacro %}
 
-{% macro inputText(field, fieldCopy) %}
+{% macro inputText(field) %}
     <label class="ff-label" for="field-{{ field.name }}">
-        {{ fieldLabelText(field, fieldCopy) }}
+        {{ labelFor(field) }}
     </label>
-    {{ fieldHelpText(field, fieldCopy) }}
+    {{ explanationFor(field) }}
     <input
         class="ff-text"
         type="{{ field.type }}"
@@ -56,7 +46,7 @@
         name="{{ field.name }}"
         {% if field.value %}value="{{ field.value }}"{% endif %}
         {% if field.isRequired %}required aria-required="true"{% endif %}
-        {% if field.autocompleteName %}autocomplete="{{ field.autocompleteName }}"{% endif %}
+        {# @TODO: Remove in favour of always setting explicit size #}
         {% if not field.attributes.size %}size="{{ field.size | default(40, true) }}"{% endif %}
         {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
     />
@@ -67,7 +57,7 @@
         <legend class="ff-label ff-date__legend">
             {{ field.label }}
         </legend>
-        {{ fieldHelpText(field, fieldCopy) }}
+        {{ explanationFor(field) }}
 
         <label class="ff-date__field">
             <span class="ff-label">{{ __('global.misc.day') }}</span>
@@ -111,11 +101,11 @@
     </fieldset>
 {% endmacro %}
 
-{% macro inputCurrency(field, fieldCopy) %}
+{% macro inputCurrency(field) %}
     <label class="ff-label" for="field-{{ field.name }}">
-        {{ fieldLabelText(field, fieldCopy) }}
+        {{ labelFor(field) }}
     </label>
-    {{ fieldHelpText(field, fieldCopy) }}
+    {{ explanationFor(field) }}
     <div class="ff-currency ff-currency--constrained">
         <div class="ff-currency__pre">£</div>
         <input class="ff-currency__input"
@@ -129,19 +119,17 @@
     </div>
 {% endmacro %}
 
-{% macro inputTextarea(field, fieldCopy) %}
+{% macro inputTextarea(field) %}
     {% set settings = field.settings %}
     {% if settings.showWordCount %}<div class="js-word-count">{% endif %}
     <label class="ff-label" for="field-{{ field.name }}">
-        {{ fieldLabelText(field, fieldCopy) }}
+        {{ labelFor(field) }}
     </label>
-    {{ fieldHelpText(field, fieldCopy) }}
+    {{ explanationFor(field) }}
     <textarea class="ff-textarea"
         id="field-{{ field.name }}"
         name="{{ field.name }}"
         {% if field.isRequired %}required aria-required="true"{% endif %}
-        {# @TODO: Remove field.rows in favour of field.attributes #}
-        {% if field.rows %}rows="{{ field.rows }}"{% endif %} 
         {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
         {% if settings.showWordCount %} @input="onInput" ref="textarea"{% endif %}
     >{{ field.value }}</textarea>
@@ -158,34 +146,32 @@
     {% if settings.showWordCount %}</div>{% endif %}
 {% endmacro %}
 
-{% macro inputSelect(field, fieldCopy) %}
+{% macro inputSelect(field) %}
     <label class="ff-label" for="field-{{ field.name }}">
-        {{ fieldLabelText(field, fieldCopy) }}
+        {{ labelFor(field) }}
     </label>
-    {{ fieldHelpText(field) }}
+    {{ explanationFor(field) }}
     <select
         class="ff-select"
         id="field-{{ field.name }}"
         name="{{ field.name }}">
         {% for option in field.options %}
-            {% set optionCopy = fieldCopy.options[loop.index0] %}
             <option
                 value="{{ option.value }}"{% if option.selected === true or field.value === option.value %} selected{% endif %}>
-                {{ optionCopy.label or option.label }}
+                {{ option.label }}
             </option>
         {% endfor %}
     </select>
 {% endmacro %}
 
-{% macro inputChoice(field, fieldCopy) %}
+{% macro inputChoice(field) %}
     <fieldset class="ff-choice">
         <legend class="ff-label" for="field-{{ field.name }}">
-            {{ fieldLabelText(field, fieldCopy) }}
+            {{ labelFor(field) }}
         </legend>
-        {{ fieldHelpText(field, fieldCopy) }}
+        {{ explanationFor(field) }}
         <ul class="ff-choice__list">
             {% for option in field.options %}
-                {% set optionCopy = fieldCopy.options[loop.index0] %}
                 <li class="ff-choice__option">
                     <div class="ff-choice__input">
                         {% if field.type === 'checkbox' %}
@@ -208,10 +194,9 @@
                         {% endif %}
                     </div>
                     <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
-                        {{ optionCopy.label or option.label }}
-                        {% set explanation = optionCopy.explanation or option.explanation %}
-                        {% if explanation %}
-                            <small class="ff-choice__caption">{{ explanation }}</small>
+                        {{ option.label }}
+                        {% if option.explanation %}
+                            <small class="ff-choice__caption">{{ option.explanation }}</small>
                         {% endif %}
                     </label>
                 </li>
@@ -223,10 +208,10 @@
 {% macro inputAddress(field) %}
     <fieldset class="ff-address" id="field-{{ field.name }}">
         <legend class="ff-address__legend t2 t--underline">
-            {{ fieldLabelText(field) }}
+            {{ labelFor(field) }}
         </legend>
 
-        {{ fieldHelpText(field, fieldCopy) }}
+        {{ explanationFor(field) }}
 
         <div class="ff-address__field">
             {{ inputText({
@@ -271,12 +256,12 @@
     </fieldset>
 {% endmacro %}
 
-{% macro inputBudget(field, fieldCopy) %}
+{% macro inputBudget(field) %}
     <fieldset>
         <legend class="ff-label">
-            {{ fieldLabelText(field) }}
+            {{ labelFor(field) }}
         </legend>
-        {{ fieldHelpText(field, fieldCopy) }}
+        {{ explanationFor(field) }}
 
         <div id="js-budget-input">
             <budget-input
@@ -336,8 +321,7 @@
     </li>
 {% endmacro %}
 
-
-{% macro formField(field, fieldCopy = {}, errors = []) %}
+{% macro formField(field, errors = []) %}
     {% set fieldErrors = errors | filter('param', field.name) %}
     <div
         id="form-field-{{ field.name }}"
@@ -345,23 +329,23 @@
         <div class="form-field__main">
             <div class="form-field__body">
                 {% if field.type === 'textarea' %}
-                    {{ inputTextarea(field, fieldCopy) }}
+                    {{ inputTextarea(field) }}
                 {% elseif field.type === 'select' %}
-                    {{ inputSelect(field, fieldCopy) }}
+                    {{ inputSelect(field) }}
                 {% elseif field.type === 'checkbox' or field.type === 'radio' %}
-                    {{ inputChoice(field, fieldCopy) }}
+                    {{ inputChoice(field) }}
                 {% elseif field.type === 'date' %}
                     {{ inputDate(field) }}
                 {% elseif field.type === 'day-month' %}
                     {{ inputDate(field, includeYear = false) }}
                 {% elseif field.type === 'currency' %}
-                    {{ inputCurrency(field, fieldCopy) }}
+                    {{ inputCurrency(field) }}
                 {% elseif field.type === 'address' %}
                     {{ inputAddress(field) }}
                 {% elseif field.type === 'budget' %}
-                    {{ inputBudget(field, fieldCopy) }}
+                    {{ inputBudget(field) }}
                 {% else %}
-                    {{ inputText(field, fieldCopy) }}
+                    {{ inputText(field) }}
                 {% endif %}
             </div>
             {% if fieldErrors.length > 0 %}
@@ -372,18 +356,5 @@
                 </ol>
             {% endif %}
         </div>
-    </div>
-{% endmacro %}
-
-{% macro facetGroup(legend) %}
-    <div class="facet-group is-open">
-        <fieldset class="facet-group__fieldset">
-            <legend class="facet-group__legend">
-                {{ legend }}
-            </legend>
-            <div class="facet-group__body">
-                {{ caller() }}
-            </div>
-        </fieldset>
     </div>
 {% endmacro %}

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -1,11 +1,9 @@
 {% from "components/icons.njk" import iconBin %}
 
-{% macro formErrors(errors, title) %}
+{% macro formErrors(title, errors) %}
     {% if errors | length > 0 %}
         <div class="form-errors">
-            <h2 class="form-errors__title">
-                {% if title -%}{{ title }}{%- else -%}{{ __('global.misc.errorTitle') }}{%- endif %}
-            </h2>
+            <h2 class="form-errors__title">{{ title }}</h2>
             {% if errors.length > 0 %}
                 <ol class="form-errors__list">
                     {% for error in errors %}

--- a/views/components/form-fields-next/macros.test.js
+++ b/views/components/form-fields-next/macros.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+'use strict';
+const { renderComponentMacro } = require('../../../modules/test-renderers');
+
+describe.only('form field macros', () => {
+    test('inputText', async () => {
+        const result = await renderComponentMacro('components/form-fields-next/macros.njk', 'inputText', {
+            name: 'example',
+            type: 'text',
+            label: 'First name',
+            isRequired: true
+        });
+        expect(result).toMatchSnapshot();
+    });
+
+    test('inputCurrency', async () => {
+        const result = await renderComponentMacro('components/form-fields-next/macros.njk', 'inputCurrency', {
+            name: 'example',
+            label: 'Amount',
+            isRequired: true
+        });
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -377,6 +377,7 @@
     </div>
 {% endmacro %}
 
+{# @TODO: Move to a dedicated component #}
 {% macro facetGroup(legend) %}
     <div class="facet-group is-open">
         <fieldset class="facet-group__fieldset">

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -64,55 +64,6 @@
     />
 {% endmacro %}
 
-{% macro inputDate(field, includeYear = true) %}
-    <fieldset class="ff-date" id="field-{{ field.name }}">
-        <legend class="ff-label ff-date__legend">
-            {{ field.label }}
-        </legend>
-        {{ fieldHelpText(field, fieldCopy) }}
-
-        <label class="ff-date__field">
-            <span class="ff-label">{{ __('global.misc.day') }}</span>
-            <input
-                class="ff-text ff-width-2"
-                name="{{ field.name }}[day]"
-                type="number"
-                pattern="[0-9]*"  min="1"
-                autocomplete="off"
-                {% if field.isRequired %}required aria-required="true"{% endif %}
-                value="{{ field.value.day }}"
-            />
-        </label>
-        <label class="ff-date__field">
-            <span class="ff-label">{{ __('global.misc.month') }}</span>
-            <input
-                class="ff-text ff-width-2"
-                name="{{ field.name }}[month]"
-                type="number"
-                pattern="[0-9]*"  min="1"
-                autocomplete="off"
-                {% if field.isRequired %}required aria-required="true"{% endif %}
-                value="{{ field.value.month }}"
-            />
-        </label>
-        {% if includeYear %}
-            <label class="ff-date__field">
-                <span class="ff-label">{{ __('global.misc.year') }}</span>
-                <input
-                    class="ff-text ff-width-4"
-                    name="{{ field.name }}[year]"
-                    type="number"
-                    pattern="[0-9]*" min="{{ field.settings.minYear | default(1900) }}"
-                    autocomplete="off"
-                    size="20"
-                    {% if field.isRequired %}required aria-required="true"{% endif %}
-                    value="{{ field.value.year }}"
-                />
-            </label>
-        {% endif %}
-    </fieldset>
-{% endmacro %}
-
 {% macro inputCurrency(field, fieldCopy) %}
     <label class="ff-label" for="field-{{ field.name }}">
         {{ fieldLabelText(field, fieldCopy) }}
@@ -132,8 +83,6 @@
 {% endmacro %}
 
 {% macro inputTextarea(field, fieldCopy) %}
-    {% set settings = field.settings %}
-    {% if settings.showWordCount %}<div class="js-word-count">{% endif %}
     <label class="ff-label" for="field-{{ field.name }}">
         {{ fieldLabelText(field, fieldCopy) }}
     </label>
@@ -145,19 +94,7 @@
         {# @TODO: Remove field.rows in favour of field.attributes #}
         {% if field.rows %}rows="{{ field.rows }}"{% endif %} 
         {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
-        {% if settings.showWordCount %} @input="onInput" ref="textarea"{% endif %}
     >{{ field.value }}</textarea>
-    {% if settings.showWordCount %}
-        <word-count
-            :current-text="text"
-            locale="{{ locale }}"
-            field-id="field-{{ field.name }}"
-            :min-words={{ settings.minWords }}
-            :max-words={{ settings.maxWords }}
-            :recommended-words={{ settings.recommendedWords }}
-        ></word-count>
-    {% endif %}
-    {% if settings.showWordCount %}</div>{% endif %}
 {% endmacro %}
 
 {% macro inputSelect(field, fieldCopy) %}
@@ -222,123 +159,6 @@
     </fieldset>
 {% endmacro %}
 
-{% macro inputAddress(field) %}
-    <fieldset class="ff-address" id="field-{{ field.name }}">
-        <legend class="ff-address__legend t2 t--underline">
-            {{ fieldLabelText(field) }}
-        </legend>
-
-        {{ fieldHelpText(field, fieldCopy) }}
-
-        <div class="ff-address__field">
-            {{ inputText({
-                label: 'Building and street',
-                name: field.name + '[building-street]',
-                value: field.value['building-street'],
-                type: 'text',
-                isRequired: field.isRequired,
-                attributes: { size: 40 }
-            }) }}
-        </div>
-        <div class="ff-address__field">
-            {{ inputText({
-                label: 'Town or city',
-                name: field.name + '[town-city]',
-                value: field.value['town-city'],
-                type: 'text',
-                isRequired: field.isRequired,
-                attributes: { size: 30 }
-            }) }}
-        </div>
-        <div class="ff-address__field">
-            {{ inputText({
-                label: 'County',
-                name: field.name + '[county]',
-                value: field.value['county'],
-                type: 'text',
-                isRequired: field.isRequired,
-                attributes: { size: 30 }
-            }) }}
-        </div>
-        <div class="ff-address__field">
-            {{ inputText({
-                label: 'Postcode',
-                name: field.name + '[postcode]',
-                value: field.value['postcode'],
-                type: 'text',
-                isRequired: field.isRequired,
-                attributes: { size: 10 }
-            }) }}
-        </div>
-    </fieldset>
-{% endmacro %}
-
-{% macro inputBudget(field, fieldCopy) %}
-    <fieldset>
-        <legend class="ff-label">
-            {{ fieldLabelText(field) }}
-        </legend>
-        {{ fieldHelpText(field, fieldCopy) }}
-
-        <div id="js-budget-input">
-            <budget-input
-                field-name="{{ field.name }}"
-                :max-budget="{{ field.attributes.max }}"
-                :max-items="{{ field.attributes.rowLimit }}"
-                {% if field.value %}:budget-data="{{ field.value | dump }}"{% endif %}>
-            </budget-input>
-
-            {# Non-JS version (*not* <noscript> because we still need it if JS fails #}
-            {# (this will be removed by our Vue component when mounted) #}
-            <div class="js-fallback-only ff-budget">
-                <ol class="ff-budget__list">
-                    {% for lineItem in field.value %}
-                        {{ budgetRow(field, loop.index0, lineItem) }}
-                    {% endfor %}
-                    {% for i in range(0 + field.value | length, field.attributes.rowLimit) %}
-                        {{ budgetRow(field, i) }}
-                    {% endfor %}
-                </ol>
-            </div>
-        </div>
-    </fieldset>
-{% endmacro %}
-
-{# If we update this we should change the Vue component too #}
-{% macro budgetRow(field, counter, lineItem = false) %}
-    <li class="ff-budget__row">
-        <div class="ff-budget__row-item">
-            <label class="ff-label" for="ff-{{ field.name }}-{{ counter }}-item">
-                Item or activity
-            </label>
-            <input type="text"
-                id="ff-{{ field.name }}-{{ counter }}-item"
-                autocomplete="off"
-                name="{{ field.name }}[{{ counter }}][item]"
-                {% if lineItem %}value="{{ lineItem.item }}"{% endif %}
-                class="ff-text u-block-full"
-            />
-        </div>
-        <div class="ff-budget__row-amount">
-            <label class="ff-label" for="ff-{{ field.name }}-{{ counter }}-cost">
-                Amount
-            </label>
-            <div class="ff-currency">
-                <div class="ff-currency__pre">£</div>
-                <input
-                    type="number"
-                    id="ff-{{ field.name }}-{{ counter }}-cost"
-                    name="{{ field.name }}[{{ counter }}][cost]"
-                    min="1" max="{{ field.attributes.max }}"
-                    {% if lineItem %}value="{{ lineItem.cost }}"{% endif %}
-                    class="ff-currency__input"
-                />
-            </div>
-        </div>
-    </li>
-{% endmacro %}
-
-
 {% macro formField(field, fieldCopy = {}, errors = []) %}
     {% set fieldErrors = errors | filter('param', field.name) %}
     <div
@@ -352,16 +172,8 @@
                     {{ inputSelect(field, fieldCopy) }}
                 {% elseif field.type === 'checkbox' or field.type === 'radio' %}
                     {{ inputChoice(field, fieldCopy) }}
-                {% elseif field.type === 'date' %}
-                    {{ inputDate(field) }}
-                {% elseif field.type === 'day-month' %}
-                    {{ inputDate(field, includeYear = false) }}
                 {% elseif field.type === 'currency' %}
                     {{ inputCurrency(field, fieldCopy) }}
-                {% elseif field.type === 'address' %}
-                    {{ inputAddress(field) }}
-                {% elseif field.type === 'budget' %}
-                    {{ inputBudget(field, fieldCopy) }}
                 {% else %}
                     {{ inputText(field, fieldCopy) }}
                 {% endif %}


### PR DESCRIPTION
This PR creates a new version of the field macros focussed on the fields we are using for new forms. This enables us to iterate more freely on new form fields without the risk of introducing changes to current fields. I've left granular commits to show the stages to this process:

- Wholesale clone the form-fields file to form-fields-next and update the new forms to use this new file.
- Make some simplifications to the new macros to remove the requirement for `fieldCopy` and to make some desired changes like not showing * required for all fields (only marking when fields are optional)
- Adds some experimental tests for the new field macros
- Remove any work-in-progress or new field types from the original macros file. Stripping it back to only what is used on in-production forms.