### PR TITLE
Rework normalise errors

### DIFF
--- a/controllers/apply-next/lib/normalise-errors.js
+++ b/controllers/apply-next/lib/normalise-errors.js
@@ -1,0 +1,47 @@
+'use strict';
+const { concat, has, head, flatMap } = require('lodash');
+const { filter, getOr, uniqBy } = require('lodash/fp');
+
+/**
+ * Find suitable errors
+ * 1. Find messages which either have a key **and** type or **only** a type
+ *    Allows us to scope errors messages to specific keys in groups of fields (e.g. addresses, dates of birth)
+ * 2. If no matching messages are found then look for a type of 'base'
+ *    Allows us to show a generic message for any unmatched error type e.g. "Please enter your name"
+ */
+function messagesForError(detail, messages) {
+    const filterKeyAndType = filter(message => message.key === detail.context.key && message.type === detail.type);
+    const filterTypeOnly = filter(message => !has(message, 'key') && message.type === detail.type);
+    const filterBase = filter(message => !has(message, 'key') && message.type === 'base');
+
+    const matches = concat(filterKeyAndType(messages), filterTypeOnly(messages));
+
+    return matches.length ? matches : filterBase(messages);
+}
+
+/**
+ * Normalise errors for use in views
+ * - Maps raw joi error objects to a simplified format and
+ * - In order to avoid showing multiple validation errors per field we find the first error per field name
+ * - Determines the appropriate translated error message to use based on current error type.
+ *
+ * @param {Object} options
+ * @param {Object} options.errorDetails
+ * @param {Object} options.errorMessages
+ */
+module.exports = function normaliseErrors({ errorDetails, errorMessages }) {
+    const uniqueErrorsDetails = uniqBy(detail => head(detail.path))(errorDetails);
+
+    return flatMap(uniqueErrorsDetails, detail => {
+        const name = head(detail.path);
+        const fieldMessages = getOr([], name)(errorMessages);
+        const matchingMessages = messagesForError(detail, fieldMessages);
+
+        return matchingMessages.map(match => {
+            return {
+                param: name,
+                msg: match.message
+            };
+        });
+    });
+};

--- a/controllers/apply-next/lib/normalise-errors.test.js
+++ b/controllers/apply-next/lib/normalise-errors.test.js
@@ -1,0 +1,56 @@
+/* eslint-env jest */
+'use strict';
+
+const Joi = require('joi');
+const normaliseErrors = require('./normalise-errors');
+
+const mockSchema = Joi.object({
+    a: Joi.string()
+        .min(10)
+        .invalid(Joi.ref('b'))
+        .required(),
+    b: Joi.string()
+        .min(12)
+        .required(),
+    c: Joi.string().required()
+});
+
+const mockErrorMessages = {
+    a: [
+        { type: 'base', message: 'Please enter A' },
+        { type: 'string.min', message: 'A must be at least 10 characters' },
+        { type: 'any.invalid', message: 'A must not be the same as B' }
+    ],
+    b: [{ type: 'base', message: 'Please enter B' }]
+};
+
+describe('normaliseErrors', () => {
+    test('normalise errors', () => {
+        const { error } = mockSchema.validate({ a: 'tooshort', c: 'here' }, { abortEarly: false });
+
+        const normalised = normaliseErrors({
+            errorDetails: error.details,
+            errorMessages: mockErrorMessages
+        });
+
+        expect(normalised).toEqual([
+            { param: 'b', msg: 'Please enter B' },
+            { param: 'a', msg: 'A must be at least 10 characters' }
+        ]);
+    });
+
+    test('returns first error per field', () => {
+        const { error } = mockSchema.validate({ a: 'same', b: 'same', c: 'here' }, { abortEarly: false });
+
+        const normalised = normaliseErrors({
+            errorDetails: error.details,
+            errorMessages: mockErrorMessages
+        });
+
+        expect(error.details.length).toBe(3);
+        expect(normalised).toEqual([
+            { param: 'b', msg: 'Please enter B' },
+            { param: 'a', msg: 'A must not be the same as B' }
+        ]);
+    });
+});

--- a/controllers/apply-next/lib/validate-model.js
+++ b/controllers/apply-next/lib/validate-model.js
@@ -33,7 +33,7 @@ module.exports = function validateModel(formModel) {
             Joi.object({
                 type: Joi.string().required(),
                 key: Joi.string().optional(),
-                message: Joi.any().required()
+                message: Joi.string().required()
             })
         )
     });

--- a/controllers/apply-next/simple/form.js
+++ b/controllers/apply-next/simple/form.js
@@ -69,11 +69,14 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter an email address', cy: '' }
+                    message: localise({ en: 'Enter an email address', cy: '' })
                 },
                 {
                     type: 'string.email',
-                    message: { en: 'Email address must be in the correct format, like name@example.com', cy: '' }
+                    message: localise({
+                        en: 'Email address must be in the correct format, like name@example.com',
+                        cy: ''
+                    })
                 }
             ]
         };
@@ -95,11 +98,11 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter a UK telephone number', cy: '' }
+                    message: localise({ en: 'Enter a UK telephone number', cy: '' })
                 },
                 {
                     type: 'string.phonenumber',
-                    message: { en: 'Enter a real UK telephone number', cy: '' }
+                    message: localise({ en: 'Enter a real UK telephone number', cy: '' })
                 }
             ]
         };
@@ -115,32 +118,32 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter a full UK address', cy: '' }
+                    message: localise({ en: 'Enter a full UK address', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'building-street',
-                    message: { en: 'Enter a building and street', cy: '' }
+                    message: localise({ en: 'Enter a building and street', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'town-city',
-                    message: { en: 'Enter a town or city', cy: '' }
+                    message: localise({ en: 'Enter a town or city', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'county',
-                    message: { en: 'Enter a county', cy: '' }
+                    message: localise({ en: 'Enter a county', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'postcode',
-                    message: { en: 'Enter a postcode', cy: '' }
+                    message: localise({ en: 'Enter a postcode', cy: '' })
                 },
                 {
                     type: 'string.regex.base',
                     key: 'postcode',
-                    message: { en: 'Enter a real postcode', cy: '' }
+                    message: localise({ en: 'Enter a real postcode', cy: '' })
                 }
             ]
         };
@@ -168,37 +171,37 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter a full UK address', cy: '' }
+                    message: localise({ en: 'Enter a full UK address', cy: '' })
                 },
                 {
                     type: 'any.required',
                     key: 'current-address-meets-minimum',
-                    message: { en: 'Choose from one of the options provided', cy: '' }
+                    message: localise({ en: 'Choose from one of the options provided', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'building-street',
-                    message: { en: 'Enter a building and street', cy: '' }
+                    message: localise({ en: 'Enter a building and street', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'town-city',
-                    message: { en: 'Enter a town or city', cy: '' }
+                    message: localise({ en: 'Enter a town or city', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'county',
-                    message: { en: 'Enter a county', cy: '' }
+                    message: localise({ en: 'Enter a county', cy: '' })
                 },
                 {
                     type: 'any.empty',
                     key: 'postcode',
-                    message: { en: 'Enter a postcode', cy: '' }
+                    message: localise({ en: 'Enter a postcode', cy: '' })
                 },
                 {
                     type: 'string.regex.base',
                     key: 'postcode',
-                    message: { en: 'Enter a real postcode', cy: '' }
+                    message: localise({ en: 'Enter a real postcode', cy: '' })
                 }
             ]
         };
@@ -215,7 +218,7 @@ module.exports = function({ locale, data = {} }) {
             },
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter first name', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter first name', cy: '' }) }]
         };
 
         return { ...defaultProps, ...props };
@@ -230,7 +233,7 @@ module.exports = function({ locale, data = {} }) {
             },
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter last name', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter last name', cy: '' }) }]
         };
 
         return { ...defaultProps, ...props };
@@ -259,15 +262,15 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter a date of birth', cy: '' }
+                    message: localise({ en: 'Enter a date of birth', cy: '' })
                 },
                 {
                     type: 'any.invalid',
-                    message: { en: 'Enter a real date', cy: '' }
+                    message: localise({ en: 'Enter a real date', cy: '' })
                 },
                 {
                     type: 'dateParts.dob',
-                    message: { en: `Must be at least ${minAge} years old`, cy: '' }
+                    message: localise({ en: `Must be at least ${minAge} years old`, cy: '' })
                 }
             ]
         };
@@ -296,7 +299,7 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'any.allowOnly',
-                    message: { en: 'Choose from one of the options provided', cy: '' }
+                    message: localise({ en: 'Choose from one of the options provided', cy: '' })
                 }
             ]
         };
@@ -312,7 +315,7 @@ module.exports = function({ locale, data = {} }) {
             type: 'text',
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter a project name', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter a project name', cy: '' }) }]
         },
         projectCountry: {
             name: 'project-country',
@@ -334,7 +337,7 @@ module.exports = function({ locale, data = {} }) {
                     .valid(this.options.map(option => option.value))
                     .required();
             },
-            messages: [{ type: 'base', message: { en: 'Choose a country', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Choose a country', cy: '' }) }]
         },
         projectStartDate: {
             name: 'project-start-date',
@@ -367,18 +370,18 @@ module.exports = function({ locale, data = {} }) {
                 return [
                     {
                         type: 'base',
-                        message: { en: 'Enter a date', cy: '' }
+                        message: localise({ en: 'Enter a date', cy: '' })
                     },
                     {
                         type: 'any.invalid',
-                        message: { en: 'Enter a real date', cy: '' }
+                        message: localise({ en: 'Enter a real date', cy: '' })
                     },
                     {
                         type: 'dateParts.futureDate',
-                        message: {
+                        message: localise({
                             en: `Date you start the project must be after ${this.settings.fromDateExample}`,
                             cy: ''
-                        }
+                        })
                     }
                 ];
             }
@@ -400,7 +403,7 @@ module.exports = function({ locale, data = {} }) {
             },
             isRequired: true,
             schema: commonValidators.postcode().required(),
-            messages: [{ type: 'base', message: { en: 'Enter a real postcode', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter a real postcode', cy: '' }) }]
         },
         yourIdeaProject: {
             name: 'your-idea-project',
@@ -441,15 +444,15 @@ module.exports = function({ locale, data = {} }) {
                 return [
                     {
                         type: 'base',
-                        message: { en: 'Tell us about your project', cy: '' }
+                        message: localise({ en: 'Tell us about your project', cy: '' })
                     },
                     {
                         type: 'string.minWords',
-                        message: { en: `Answer must be at least ${this.settings.minWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be at least ${this.settings.minWords} words`, cy: '' })
                     },
                     {
                         type: 'string.maxWords',
-                        message: { en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' })
                     }
                 ];
             }
@@ -492,15 +495,18 @@ module.exports = function({ locale, data = {} }) {
                 return [
                     {
                         type: 'base',
-                        message: { en: 'Tell us how your project meet at least one of our funding priorities', cy: '' }
+                        message: localise({
+                            en: 'Tell us how your project meet at least one of our funding priorities',
+                            cy: ''
+                        })
                     },
                     {
                         type: 'string.minWords',
-                        message: { en: `Answer must be at least ${this.settings.minWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be at least ${this.settings.minWords} words`, cy: '' })
                     },
                     {
                         type: 'string.maxWords',
-                        message: { en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' })
                     }
                 ];
             }
@@ -552,15 +558,15 @@ module.exports = function({ locale, data = {} }) {
                 return [
                     {
                         type: 'base',
-                        message: { en: 'Tell us how your project involves your community', cy: '' }
+                        message: localise({ en: 'Tell us how your project involves your community', cy: '' })
                     },
                     {
                         type: 'string.minWords',
-                        message: { en: `Answer must be at least ${this.settings.minWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be at least ${this.settings.minWords} words`, cy: '' })
                     },
                     {
                         type: 'string.maxWords',
-                        message: { en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' }
+                        message: localise({ en: `Answer must be no more than ${this.settings.maxWords} words`, cy: '' })
                     }
                 ];
             }
@@ -584,15 +590,15 @@ module.exports = function({ locale, data = {} }) {
             isRequired: true,
             schema: commonValidators.budgetField(MAX_BUDGET_TOTAL_GBP),
             messages: [
-                { type: 'base', message: { en: 'Enter a project budget', cy: '' } },
-                { type: 'any.empty', key: 'item', message: { en: 'Enter an item or activity', cy: '' } },
-                { type: 'number.base', key: 'cost', message: { en: 'Enter an amount', cy: '' } },
+                { type: 'base', message: localise({ en: 'Enter a project budget', cy: '' }) },
+                { type: 'any.empty', key: 'item', message: localise({ en: 'Enter an item or activity', cy: '' }) },
+                { type: 'number.base', key: 'cost', message: localise({ en: 'Enter an amount', cy: '' }) },
                 {
                     type: 'budgetItems.overBudget',
-                    message: {
+                    message: localise({
                         en: `Total project costs must be less than £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}`,
                         cy: ``
-                    }
+                    })
                 }
             ]
         },
@@ -616,18 +622,18 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter a total cost for your project', cy: '' }
+                    message: localise({ en: 'Enter a total cost for your project', cy: '' })
                 },
                 {
                     type: 'number.base',
-                    message: { en: 'Total cost must be a real number', cy: '' }
+                    message: localise({ en: 'Total cost must be a real number', cy: '' })
                 },
                 {
                     type: 'budgetTotalCosts.underBudget',
-                    message: {
+                    message: localise({
                         en: 'Total cost must be the same as or higher than the amount you’re asking us to fund',
                         cy: ''
-                    }
+                    })
                 }
             ]
         },
@@ -646,7 +652,9 @@ module.exports = function({ locale, data = {} }) {
             type: 'text',
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter the full legal name of the organisation', cy: '' } }]
+            messages: [
+                { type: 'base', message: localise({ en: 'Enter the full legal name of the organisation', cy: '' }) }
+            ]
         },
         organisationAlias: {
             name: 'organisation-alias',
@@ -721,7 +729,7 @@ module.exports = function({ locale, data = {} }) {
                     .valid(this.options.map(option => option.value))
                     .required();
             },
-            messages: [{ type: 'base', message: { en: 'Choose a type of organisation', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Choose a type of organisation', cy: '' }) }]
         },
         companyNumber: {
             name: 'company-number',
@@ -732,7 +740,9 @@ module.exports = function({ locale, data = {} }) {
                 is: ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY,
                 then: Joi.string().required()
             }),
-            messages: [{ type: 'base', message: { en: 'Enter your organisation’s Companies House number', cy: '' } }]
+            messages: [
+                { type: 'base', message: localise({ en: 'Enter your organisation’s Companies House number', cy: '' }) }
+            ]
         },
         charityNumber: {
             name: 'charity-number',
@@ -757,7 +767,7 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter your organisation’s charity number', cy: '' }
+                    message: localise({ en: 'Enter your organisation’s charity number', cy: '' })
                 }
             ]
         },
@@ -774,7 +784,7 @@ module.exports = function({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: { en: 'Enter your organisation’s Department for Education number', cy: '' }
+                    message: localise({ en: 'Enter your organisation’s Department for Education number', cy: '' })
                 }
             ]
         },
@@ -789,8 +799,8 @@ module.exports = function({ locale, data = {} }) {
             isRequired: true,
             schema: Joi.dayMonth().required(),
             messages: [
-                { type: 'base', message: { en: 'Enter a day and month', cy: '' } },
-                { type: 'any.invalid', message: { en: 'Enter a real day and month', cy: '' } }
+                { type: 'base', message: localise({ en: 'Enter a day and month', cy: '' }) },
+                { type: 'any.invalid', message: localise({ en: 'Enter a real day and month', cy: '' }) }
             ]
         },
         totalIncomeYear: {
@@ -800,8 +810,8 @@ module.exports = function({ locale, data = {} }) {
             isRequired: true,
             schema: Joi.number().required(),
             messages: [
-                { type: 'base', message: { en: 'Enter a total income for the year', cy: '' } },
-                { type: 'any.invalid', message: { en: 'Total income must be a real number', cy: '' } }
+                { type: 'base', message: localise({ en: 'Enter a total income for the year', cy: '' }) },
+                { type: 'any.invalid', message: localise({ en: 'Total income must be a real number', cy: '' }) }
             ]
         },
         mainContactFirstName: firstNameField({
@@ -860,7 +870,7 @@ module.exports = function({ locale, data = {} }) {
             options: seniorContactRolesFor(orgTypeFor(data)),
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Choose a role', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Choose a role', cy: '' }) }]
         },
         seniorContactDob: dateOfBirthField(MIN_AGE_SENIOR_CONTACT, {
             name: 'senior-contact-dob',
@@ -898,7 +908,7 @@ module.exports = function({ locale, data = {} }) {
             type: 'text',
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter the name on the bank account', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter the name on the bank account', cy: '' }) }]
         },
         bankSortCode: {
             name: 'bank-sort-code',
@@ -907,7 +917,7 @@ module.exports = function({ locale, data = {} }) {
             attributes: { size: 20 },
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter a sort-code', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter a sort-code', cy: '' }) }]
         },
         bankAccountNumber: {
             name: 'bank-account-number',
@@ -915,7 +925,7 @@ module.exports = function({ locale, data = {} }) {
             type: 'text',
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Enter an account number', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Enter an account number', cy: '' }) }]
         },
         bankBuildingSocietyNumber: {
             name: 'bank-building-society-number',
@@ -937,7 +947,7 @@ module.exports = function({ locale, data = {} }) {
             type: 'file',
             isRequired: true,
             schema: Joi.string().required(),
-            messages: [{ type: 'base', message: { en: 'Provide a bank statement', cy: '' } }]
+            messages: [{ type: 'base', message: localise({ en: 'Provide a bank statement', cy: '' }) }]
         }
     };
 

--- a/controllers/user/forgotten-password.js
+++ b/controllers/user/forgotten-password.js
@@ -7,10 +7,10 @@ const Joi = require('joi');
 
 const { getAbsoluteUrl } = require('../../modules/urls');
 const { JWT_SIGNING_TOKEN } = require('../../modules/secrets');
-const { normaliseErrors } = require('../../modules/errors');
 const { requireUnauthed } = require('../../middleware/authed');
 const { sendEmail } = require('../../services/mail');
 const userService = require('../../services/user');
+const normaliseErrors = require('./lib/normalise-errors');
 const schema = require('./schema');
 
 const router = express.Router();

--- a/controllers/user/lib/normalise-errors.js
+++ b/controllers/user/lib/normalise-errors.js
@@ -1,5 +1,5 @@
 'use strict';
-const { concat, has, head, flatMap, includes } = require('lodash');
+const { concat, has, head, flatMap } = require('lodash');
 const { filter, get, getOr, uniqBy } = require('lodash/fp');
 
 /**
@@ -26,20 +26,15 @@ function messagesForError(detail, messages) {
  * - Determines the appropriate translated error message to use based on current error type.
  *
  * @param {Object} options
+ * @param {String} options.locale
  * @param {Object} options.validationError
  * @param {Object} options.errorMessages
- * @param {String} options.locale
- * @param {Array<String>} [options.fieldNames]
  */
-function normaliseErrors({ validationError, errorMessages, locale, fieldNames = [] }) {
-    const errors = getOr([], 'details')(validationError);
-
-    const errorDetails =
-        fieldNames.length > 0 ? errors.filter(detail => includes(fieldNames, head(detail.path))) : errors;
-
+module.exports = function normaliseErrors({ locale, validationError, errorMessages }) {
+    const errorDetails = getOr([], 'details')(validationError);
     const uniqueErrorsDetails = uniqBy(detail => head(detail.path))(errorDetails);
 
-    const suitableErrors = flatMap(uniqueErrorsDetails, detail => {
+    return flatMap(uniqueErrorsDetails, detail => {
         const name = head(detail.path);
         const fieldMessages = getOr([], name)(errorMessages);
         const matchingMessages = messagesForError(detail, fieldMessages);
@@ -51,10 +46,4 @@ function normaliseErrors({ validationError, errorMessages, locale, fieldNames = 
             };
         });
     });
-
-    return suitableErrors;
-}
-
-module.exports = {
-    normaliseErrors
 };

--- a/controllers/user/lib/normalise-errors.test.js
+++ b/controllers/user/lib/normalise-errors.test.js
@@ -1,8 +1,7 @@
 /* eslint-env jest */
 'use strict';
-
 const Joi = require('joi');
-const { normaliseErrors } = require('../errors');
+const normaliseErrors = require('./normalise-errors');
 
 const mockSchema = Joi.object({
     a: Joi.string()
@@ -68,25 +67,5 @@ describe('normaliseErrors', () => {
             { param: 'b', msg: 'Please enter B' },
             { param: 'a', msg: 'A must not be the same as B' }
         ]);
-    });
-
-    test('can filter errors by name', () => {
-        const validationResult = mockSchema.validate({ c: 'here' }, { abortEarly: false });
-
-        const normalised = normaliseErrors({
-            validationError: validationResult.error,
-            errorMessages: mockErrorMessages,
-            locale: 'en'
-        });
-
-        const normalisedFiltered = normaliseErrors({
-            validationError: validationResult.error,
-            errorMessages: mockErrorMessages,
-            locale: 'en',
-            fieldNames: ['a']
-        });
-
-        expect(normalised).toEqual([{ param: 'b', msg: 'Please enter B' }, { param: 'a', msg: 'Please enter A' }]);
-        expect(normalisedFiltered).toEqual([{ param: 'a', msg: 'Please enter A' }]);
     });
 });

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -8,7 +8,7 @@ const userService = require('../../services/user');
 const { csrfProtection } = require('../../middleware/cached');
 const { requireUnauthed, redirectUrlWithFallback } = require('../../middleware/authed');
 const { localify } = require('../../modules/urls');
-const { normaliseErrors } = require('../../modules/errors');
+const normaliseErrors = require('./lib/normalise-errors');
 
 const { sendActivationEmail } = require('./helpers');
 const { accountSchema, errorMessages } = require('./schema');

--- a/controllers/user/reset-password.js
+++ b/controllers/user/reset-password.js
@@ -8,7 +8,7 @@ const { requireUnauthed } = require('../../middleware/authed');
 const userService = require('../../services/user');
 
 const { localify } = require('../../modules/urls');
-const { normaliseErrors } = require('../../modules/errors');
+const normaliseErrors = require('./lib/normalise-errors');
 const { accountSchema, errorMessages } = require('./schema');
 
 const router = express.Router();


### PR DESCRIPTION
- Duplicate normalise-errors for user code to allow better exploration of current abstraction.
- Simplify normalise-errors in apply-next to filter fields in controller upfront, and localise error messages up front.

This results in a duplication of  the `normalise-errors`, one for users, another for the new apply forms. The abstraction was a little premature with the apply code passing in a `fieldNames` parameter that wasn't needed in the user code at all. There was also translation happing within this function which could/should happen earlier. Separating the use cases out for now allows us to iterate a little more on the approach until we find the appropriate abstraction.