### PR TITLE
Remove long line-length from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,6 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-max_line_length = 120
 
 [{*.yml,*.json}]
 indent_size = 2


### PR DESCRIPTION
This setting is used by prettier and regularly results in overly compact code. From the prettier docs:
https://prettier.io/docs/en/options.html

> **For readability we recommend against using more than 80 characters:**
>
> In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don't strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.
>
> Prettier, on the other hand, strives to fit the most code into every line. With the print width set to 120, prettier may produce overly compact, or otherwise undesirable code.

Removing this line uses the 80 character default setting. Our prettier formatting happens on a per-file basis as we edit them rather than as a batch job so this won't change anything right away but there will be some formatting churn as we edit files.