### PR TITLE
prettier autoformat

### DIFF
--- a/controllers/apply-next/eligibility-router.js
+++ b/controllers/apply-next/eligibility-router.js
@@ -34,7 +34,10 @@ module.exports = function(eligibilityBuilder) {
             res.render(templatePath, {
                 csrfToken: req.csrfToken(),
                 eligibilityStatus: 'pending',
-                backUrl: currentStepNumber === 1 ? formBaseUrl : `${req.baseUrl}/${currentStepNumber - 1}`
+                backUrl:
+                    currentStepNumber === 1
+                        ? formBaseUrl
+                        : `${req.baseUrl}/${currentStepNumber - 1}`
             });
         })
         .post(async (req, res) => {

--- a/controllers/apply-next/lib/joi-extensions.js
+++ b/controllers/apply-next/lib/joi-extensions.js
@@ -48,7 +48,12 @@ const wordCount = joi => {
                 },
                 validate(params, value, state, options) {
                     if (countWords(value) > params.max) {
-                        return this.createError('string.maxWords', { max: params.max }, state, options);
+                        return this.createError(
+                            'string.maxWords',
+                            { max: params.max },
+                            state,
+                            options
+                        );
                     } else {
                         return value;
                     }
@@ -65,7 +70,12 @@ const wordCount = joi => {
                 },
                 validate(params, value, state, options) {
                     if (countWords(value) < params.min) {
-                        return this.createError('string.minWords', { min: params.min }, state, options);
+                        return this.createError(
+                            'string.minWords',
+                            { min: params.min },
+                            state,
+                            options
+                        );
                     } else {
                         return value;
                     }
@@ -101,7 +111,12 @@ const dateParts = joi => {
             if (date.isValid()) {
                 return value;
             } else {
-                return this.createError('any.invalid', { v: value }, state, options);
+                return this.createError(
+                    'any.invalid',
+                    { v: value },
+                    state,
+                    options
+                );
             }
         },
         rules: [
@@ -115,7 +130,12 @@ const dateParts = joi => {
                     if (date.isValid() && date.isSameOrAfter(params.min)) {
                         return value;
                     } else {
-                        return this.createError('dateParts.futureDate', { v: value, min: params.min }, state, options);
+                        return this.createError(
+                            'dateParts.futureDate',
+                            { v: value, min: params.min },
+                            state,
+                            options
+                        );
                     }
                 }
             },
@@ -130,7 +150,12 @@ const dateParts = joi => {
                     if (date.isValid() && date.isSameOrBefore(maxDate)) {
                         return value;
                     } else {
-                        return this.createError('dateParts.dob', { v: value, minAge: params.minAge }, state, options);
+                        return this.createError(
+                            'dateParts.dob',
+                            { v: value, minAge: params.minAge },
+                            state,
+                            options
+                        );
                     }
                 }
             }
@@ -161,7 +186,12 @@ const dayMonth = joi => {
             if (date.isValid()) {
                 return value;
             } else {
-                return this.createError('any.invalid', { v: value }, state, options);
+                return this.createError(
+                    'any.invalid',
+                    { v: value },
+                    state,
+                    options
+                );
             }
         }
     };
@@ -194,7 +224,10 @@ const budgetItems = joi => {
             if (isArray(value)) {
                 // Strip out anything that doesn't have an item name and a cost
                 // (eg. validate things that are half-supplied, but not empty)
-                return reject(value, line => isEmpty(line.item) && isEmpty(line.cost));
+                return reject(
+                    value,
+                    line => isEmpty(line.item) && isEmpty(line.cost)
+                );
             } else {
                 return value;
             }
@@ -236,7 +269,12 @@ const budgetTotalCosts = joi => {
             if (projectBudget) {
                 const total = sumBy(projectBudget, item => item.cost);
                 if (value < total) {
-                    return this.createError('budgetTotalCosts.underBudget', { v: value }, state, options);
+                    return this.createError(
+                        'budgetTotalCosts.underBudget',
+                        { v: value },
+                        state,
+                        options
+                    );
                 }
             }
             return value;
@@ -244,4 +282,11 @@ const budgetTotalCosts = joi => {
     };
 };
 
-module.exports = baseJoi.extend([phoneNumber, wordCount, dateParts, dayMonth, budgetItems, budgetTotalCosts]);
+module.exports = baseJoi.extend([
+    phoneNumber,
+    wordCount,
+    dateParts,
+    dayMonth,
+    budgetItems,
+    budgetTotalCosts
+]);

--- a/controllers/apply-next/lib/normalise-errors.js
+++ b/controllers/apply-next/lib/normalise-errors.js
@@ -10,11 +10,21 @@ const { filter, getOr, uniqBy } = require('lodash/fp');
  *    Allows us to show a generic message for any unmatched error type e.g. "Please enter your name"
  */
 function messagesForError(detail, messages) {
-    const filterKeyAndType = filter(message => message.key === detail.context.key && message.type === detail.type);
-    const filterTypeOnly = filter(message => !has(message, 'key') && message.type === detail.type);
-    const filterBase = filter(message => !has(message, 'key') && message.type === 'base');
+    const filterKeyAndType = filter(
+        message =>
+            message.key === detail.context.key && message.type === detail.type
+    );
+    const filterTypeOnly = filter(
+        message => !has(message, 'key') && message.type === detail.type
+    );
+    const filterBase = filter(
+        message => !has(message, 'key') && message.type === 'base'
+    );
 
-    const matches = concat(filterKeyAndType(messages), filterTypeOnly(messages));
+    const matches = concat(
+        filterKeyAndType(messages),
+        filterTypeOnly(messages)
+    );
 
     return matches.length ? matches : filterBase(messages);
 }
@@ -30,7 +40,9 @@ function messagesForError(detail, messages) {
  * @param {Object} options.errorMessages
  */
 module.exports = function normaliseErrors({ errorDetails, errorMessages }) {
-    const uniqueErrorsDetails = uniqBy(detail => head(detail.path))(errorDetails);
+    const uniqueErrorsDetails = uniqBy(detail => head(detail.path))(
+        errorDetails
+    );
 
     return flatMap(uniqueErrorsDetails, detail => {
         const name = head(detail.path);

--- a/controllers/apply-next/lib/normalise-errors.test.js
+++ b/controllers/apply-next/lib/normalise-errors.test.js
@@ -26,7 +26,10 @@ const mockErrorMessages = {
 
 describe('normaliseErrors', () => {
     test('normalise errors', () => {
-        const { error } = mockSchema.validate({ a: 'tooshort', c: 'here' }, { abortEarly: false });
+        const { error } = mockSchema.validate(
+            { a: 'tooshort', c: 'here' },
+            { abortEarly: false }
+        );
 
         const normalised = normaliseErrors({
             errorDetails: error.details,
@@ -40,7 +43,10 @@ describe('normaliseErrors', () => {
     });
 
     test('returns first error per field', () => {
-        const { error } = mockSchema.validate({ a: 'same', b: 'same', c: 'here' }, { abortEarly: false });
+        const { error } = mockSchema.validate(
+            { a: 'same', b: 'same', c: 'here' },
+            { abortEarly: false }
+        );
 
         const normalised = normaliseErrors({
             errorDetails: error.details,

--- a/controllers/apply-next/lib/pagination.test.js
+++ b/controllers/apply-next/lib/pagination.test.js
@@ -23,7 +23,10 @@ describe('nextAndPrevious', () => {
         },
         {
             slug: 'section-c',
-            steps: [{ title: 'Step 1', isRequired: true }, { title: 'Step 2', isRequired: true }]
+            steps: [
+                { title: 'Step 1', isRequired: true },
+                { title: 'Step 2', isRequired: true }
+            ]
         }
     ];
 

--- a/controllers/apply-next/lib/validators.js
+++ b/controllers/apply-next/lib/validators.js
@@ -19,7 +19,8 @@ function budgetField(maxBudget) {
 
 function postcode() {
     // via https://github.com/chriso/validator.js/blob/master/lib/isPostalCode.js#L54
-    const POSTCODE_PATTERN = '(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)';
+    const POSTCODE_PATTERN =
+        '(gir\\s?0aa|[a-zA-Z]{1,2}\\d[\\da-zA-Z]?\\s?(\\d[a-zA-Z]{2})?)';
 
     return Joi.string()
         .trim()

--- a/controllers/apply-next/lib/validators.test.js
+++ b/controllers/apply-next/lib/validators.test.js
@@ -35,7 +35,9 @@ describe('postcode', () => {
         invalid.forEach(example => {
             const schema = postcode();
             const invalidPostcode = schema.validate(example);
-            expect(invalidPostcode.error.message).toContain('fails to match the required pattern');
+            expect(invalidPostcode.error.message).toContain(
+                'fails to match the required pattern'
+            );
         });
     });
 });
@@ -44,17 +46,29 @@ describe('dateParts', () => {
     test('valid date', () => {
         const schema = Joi.dateParts();
 
-        expect(Joi.attempt({ day: '1', month: '2', year: '2100' }, schema)).toEqual({ day: 1, month: 2, year: 2100 });
-        expect(Joi.attempt({ day: 1, month: 2, year: 2100 }, schema)).toEqual({ day: 1, month: 2, year: 2100 });
+        expect(
+            Joi.attempt({ day: '1', month: '2', year: '2100' }, schema)
+        ).toEqual({ day: 1, month: 2, year: 2100 });
+        expect(Joi.attempt({ day: 1, month: 2, year: 2100 }, schema)).toEqual({
+            day: 1,
+            month: 2,
+            year: 2100
+        });
 
         const missingDay = schema.validate({ month: 2, year: 2100 });
-        expect(missingDay.error.message).toBe('child "day" fails because ["day" is required]');
+        expect(missingDay.error.message).toBe(
+            'child "day" fails because ["day" is required]'
+        );
 
         const missingMonth = schema.validate({ day: 1, year: 2100 });
-        expect(missingMonth.error.message).toBe('child "month" fails because ["month" is required]');
+        expect(missingMonth.error.message).toBe(
+            'child "month" fails because ["month" is required]'
+        );
 
         const missingYear = schema.validate({ day: 1, month: 2 });
-        expect(missingYear.error.message).toBe('child "year" fails because ["year" is required]');
+        expect(missingYear.error.message).toBe(
+            'child "year" fails because ["year" is required]'
+        );
 
         const invalidDate = schema.validate({ day: 31, month: 2, year: 2100 });
         expect(invalidDate.error.details[0].type).toBe('any.invalid');

--- a/controllers/apply-next/simple/eligibility.js
+++ b/controllers/apply-next/simple/eligibility.js
@@ -54,7 +54,8 @@ module.exports = function({ locale }) {
 
     const question3 = {
         question: localise({
-            en: 'Does your project start at least 12 weeks from when you plan to submit your application?',
+            en:
+                'Does your project start at least 12 weeks from when you plan to submit your application?',
             cy: ``
         }),
         explanation: localise({

--- a/controllers/apply-next/simple/fields.js
+++ b/controllers/apply-next/simple/fields.js
@@ -36,8 +36,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'string.email',
                     message: localise({
-                        en: 'Email address must be in the correct format, like name@example.com',
-                        cy: ''
+                        en: `Email address must be in the correct format, like name@example.com`,
+                        cy: ``
                     })
                 }
             ]
@@ -130,13 +130,19 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 'current-address-meets-minimum': Joi.string()
                     .valid(['yes', 'no'])
                     .required(),
-                'previous-address': Joi.when(Joi.ref('current-address-meets-minimum'), {
-                    is: 'no',
-                    then: commonValidators.ukAddress().required(),
-                    otherwise: Joi.any()
-                })
+                'previous-address': Joi.when(
+                    Joi.ref('current-address-meets-minimum'),
+                    {
+                        is: 'no',
+                        then: commonValidators.ukAddress().required(),
+                        otherwise: Joi.any()
+                    }
+                )
             }).when(Joi.ref('organisation-type'), {
-                is: Joi.valid(ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY),
+                is: Joi.valid(
+                    ORGANISATION_TYPES.SCHOOL,
+                    ORGANISATION_TYPES.STATUTORY_BODY
+                ),
                 then: Joi.any().optional()
             }),
             messages: [
@@ -243,7 +249,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 .dateOfBirth(minAge)
                 .required()
                 .when(Joi.ref('organisation-type'), {
-                    is: Joi.valid(ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY),
+                    is: Joi.valid(
+                        ORGANISATION_TYPES.SCHOOL,
+                        ORGANISATION_TYPES.STATUTORY_BODY
+                    ),
                     then: Joi.any().optional()
                 }),
             messages: [
@@ -280,12 +289,18 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     value: 'braille',
                     label: localise({ en: 'Braille', cy: '' })
                 },
-                { value: 'disk', label: localise({ en: 'Disk', cy: '' }) },
+                {
+                    value: 'disk',
+                    label: localise({ en: 'Disk', cy: '' })
+                },
                 {
                     value: 'large-print',
                     label: localise({ en: 'Large print', cy: '' })
                 },
-                { value: 'letter', label: localise({ en: 'Letter', cy: '' }) },
+                {
+                    value: 'letter',
+                    label: localise({ en: 'Letter', cy: '' })
+                },
                 {
                     value: 'sign-language',
                     label: localise({ en: 'Sign language', cy: '' })
@@ -297,7 +312,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             ],
             get schema() {
                 return Joi.array()
-                    .items(Joi.string().valid(this.options.map(option => option.value)))
+                    .items(
+                        Joi.string().valid(
+                            this.options.map(option => option.value)
+                        )
+                    )
                     .single()
                     .optional();
             },
@@ -463,10 +482,20 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             let options = [];
             switch (organisationType) {
                 case ORGANISATION_TYPES.UNREGISTERED_VCO:
-                    options = [ROLES.CHAIR, ROLES.VICE_CHAIR, ROLES.SECRETARY, ROLES.TREASURER];
+                    options = [
+                        ROLES.CHAIR,
+                        ROLES.VICE_CHAIR,
+                        ROLES.SECRETARY,
+                        ROLES.TREASURER
+                    ];
                     break;
                 case ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY:
-                    options = [ROLES.TRUSTEE, ROLES.CHAIR, ROLES.VICE_CHAIR, ROLES.TREASURER];
+                    options = [
+                        ROLES.TRUSTEE,
+                        ROLES.CHAIR,
+                        ROLES.VICE_CHAIR,
+                        ROLES.TREASURER
+                    ];
                     break;
                 case ORGANISATION_TYPES.CIO:
                     options = [
@@ -481,7 +510,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     options = [ROLES.COMPANY_DIRECTOR, ROLES.COMPANY_SECRETARY];
                     break;
                 case ORGANISATION_TYPES.SCHOOL:
-                    options = [ROLES.HEAD_TEACHER, ROLES.CHANCELLOR, ROLES.VICE_CHANCELLOR];
+                    options = [
+                        ROLES.HEAD_TEACHER,
+                        ROLES.CHANCELLOR,
+                        ROLES.VICE_CHANCELLOR
+                    ];
                     break;
                 case ORGANISATION_TYPES.STATUTORY_BODY:
                     options = [ROLES.PARISH_CLERK, ROLES.CHIEF_EXECUTIVE];
@@ -503,7 +536,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     cy: ''
                 });
 
-                if (matchesOrganisationType(ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY)) {
+                if (
+                    matchesOrganisationType(
+                        ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY
+                    )
+                ) {
                     text += localise({
                         en: `<p><strong>
                             As a registered charity, your senior contact must be one of your organisation's trustees. This can include trustees taking on the role of Chair, Vice Chair or Treasurer.
@@ -596,21 +633,25 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         projectStartDate: {
             name: 'project-start-date',
             label: localise({
-                en: 'When is the planned (or estimated) start date of your project?',
-                cy: '(WELSH) When is the planned (or estimated) start date of your project?'
+                en: `When is the planned (or estimated) start date of your project?`,
+                cy: ``
             }),
             get settings() {
                 const dt = moment().add(12, 'weeks');
                 return {
                     minDateExample: dt.format('DD MM YYYY'),
-                    fromDateExample: dt.subtract(1, 'days').format('D MMMM YYYY'),
+                    fromDateExample: dt
+                        .subtract(1, 'days')
+                        .format('D MMMM YYYY'),
                     minYear: dt.format('YYYY')
                 };
             },
             get explanation() {
                 return localise({
                     en: `<p>This date needs to be at least 12 weeks from when you plan to submit your application. If your project is a one-off event, please tell us the date of the event.</p>
-                <p><strong>For example: ${this.settings.minDateExample}</strong></p>`,
+                <p><strong>For example: ${
+                    this.settings.minDateExample
+                }</strong></p>`,
                     cy: ''
                 });
             },
@@ -633,7 +674,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'dateParts.futureDate',
                         message: localise({
-                            en: `Date you start the project must be after ${this.settings.fromDateExample}`,
+                            en: `Date you start the project must be after ${
+                                this.settings.fromDateExample
+                            }`,
                             cy: ''
                         })
                     }
@@ -643,12 +686,12 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         projectPostcode: {
             name: 'project-postcode',
             label: localise({
-                en: 'What is the postcode of the location where your project will take place?',
-                cy: ''
+                en: `What is the postcode of the location where your project will take place?`,
+                cy: ``
             }),
             explanation: localise({
                 en: `If your project will take place across different locations, please use the postcode where most of the project will take place.`,
-                cy: ''
+                cy: ``
             }),
             type: 'text',
             attributes: {
@@ -671,18 +714,17 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: ''
             }),
             explanation: localise({
-                en: `
-            <p><strong>Here are some ideas of what to tell us about your project:</strong></p>
-            <ul>
-                <li>What you would like to do</li>
-                <li>What difference your project will make</li>
-                <li>Who will benefit from it</li>
-                <li>How long you expect to run it for. This can be an estimate</li>
-                <li>How you will make sure people know about it and will benefit from it</li>
-                <li>How you plan to learn from it and use this learning to shape future projects</li>
-                <li>Is it something new, or are you continuing something that has worked well previously? We want to fund both types of projects</li>
-            </ul>`,
-                cy: 'TODO'
+                en: `<p><strong>Here are some ideas of what to tell us about your project:</strong></p>
+                <ul>
+                    <li>What you would like to do</li>
+                    <li>What difference your project will make</li>
+                    <li>Who will benefit from it</li>
+                    <li>How long you expect to run it for. This can be an estimate</li>
+                    <li>How you will make sure people know about it and will benefit from it</li>
+                    <li>How you plan to learn from it and use this learning to shape future projects</li>
+                    <li>Is it something new, or are you continuing something that has worked well previously? We want to fund both types of projects</li>
+                </ul>`,
+                cy: ''
             }),
             type: 'textarea',
             settings: {
@@ -711,14 +753,18 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'string.minWords',
                         message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            en: `Answer must be at least ${
+                                this.settings.minWords
+                            } words`,
                             cy: ''
                         })
                     },
                     {
                         type: 'string.maxWords',
                         message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            en: `Answer must be no more than ${
+                                this.settings.maxWords
+                            } words`,
                             cy: ''
                         })
                     }
@@ -728,19 +774,18 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         yourIdeaPriorities: {
             name: 'your-idea-priorities',
             label: localise({
-                en: 'How does your project meet at least one of our funding priorities?',
-                cy: ''
+                en: `How does your project meet at least one of our funding priorities?`,
+                cy: ``
             }),
             explanation: localise({
-                en: `
-            <p>National Lottery Awards for All has three funding priorities, please tell us how your project will <strong>meet at least one of these:</strong></p>
-            <ol>
-                <li>bring people together and build strong relationships in and across communities</li>
-                <li>improve the places and spaces that matter to communities</li>
-                <li>help more people to reach their potential, by supporting them at the earliest possible stage</li>
-            </ol>
-            <p>You can tell us if your project meets more than one priority, but don't worry if it doesn't.</p>`,
-                cy: ''
+                en: `<p>National Lottery Awards for All has three funding priorities, please tell us how your project will <strong>meet at least one of these:</strong></p>
+                <ol>
+                    <li>bring people together and build strong relationships in and across communities</li>
+                    <li>improve the places and spaces that matter to communities</li>
+                    <li>help more people to reach their potential, by supporting them at the earliest possible stage</li>
+                </ol>
+                <p>You can tell us if your project meets more than one priority, but don't worry if it doesn't.</p>`,
+                cy: ``
             }),
             type: 'textarea',
             settings: {
@@ -764,21 +809,25 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'base',
                         message: localise({
-                            en: 'Tell us how your project meet at least one of our funding priorities',
-                            cy: ''
+                            en: `Tell us how your project meet at least one of our funding priorities`,
+                            cy: ``
                         })
                     },
                     {
                         type: 'string.minWords',
                         message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            en: `Answer must be at least ${
+                                this.settings.minWords
+                            } words`,
                             cy: ''
                         })
                     },
                     {
                         type: 'string.maxWords',
                         message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            en: `Answer must be no more than ${
+                                this.settings.maxWords
+                            } words`,
                             cy: ''
                         })
                     }
@@ -792,25 +841,22 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: ''
             }),
             explanation: localise({
-                en: `
-            <details>
-                <summary>What do we mean by 'community'?</summary>
+                en: `<p><strong>What do we mean by 'community'?</strong></p>
                 <ol>
                     <li>People living in the same area</li>
                     <li>People who have similar interests or life experiences, but might not live in the same area</li>
                     <li>We don't think of a school or club as a community, but will fund a project run by one of these organisations that also benefits the communities around it</li>
                 </ol>
-            </details>
 
-            <p>We believe that people understand what's needed in their communities better than anyone. Tell us how your community came up with the idea for your project, and how they will be involved in the development and delivery of the project you're planning.</p>
-            <p><strong>Here are some examples of how you could be involving your community:</strong></p>
-            <ul>
-                <li>Having regular chats with community members, in person or on social media</li>
-                <li>Including community members on your board or committee</li>
-                <li>Regular surveys</li>
-                <li>Setting up steering groups</li>
-                <li>Running open days</li>
-            </ul>`,
+                <p>We believe that people understand what's needed in their communities better than anyone. Tell us how your community came up with the idea for your project, and how they will be involved in the development and delivery of the project you're planning.</p>
+                <p><strong>Here are some examples of how you could be involving your community:</strong></p>
+                <ul>
+                    <li>Having regular chats with community members, in person or on social media</li>
+                    <li>Including community members on your board or committee</li>
+                    <li>Regular surveys</li>
+                    <li>Setting up steering groups</li>
+                    <li>Running open days</li>
+                </ul>`,
                 cy: ''
             }),
             type: 'textarea',
@@ -833,21 +879,25 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'base',
                         message: localise({
-                            en: 'Tell us how your project involves your community',
-                            cy: ''
+                            en: `Tell us how your project involves your community`,
+                            cy: ``
                         })
                     },
                     {
                         type: 'string.minWords',
                         message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            en: `Answer must be at least ${
+                                this.settings.minWords
+                            } words`,
                             cy: ''
                         })
                     },
                     {
                         type: 'string.maxWords',
                         message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            en: `Answer must be no more than ${
+                                this.settings.maxWords
+                            } words`,
                             cy: ''
                         })
                     }
@@ -906,12 +956,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: '(WELSH) Tell us the total cost of your project.'
             }),
             explanation: localise({
-                en: `
-            <p>This is the cost of everything related to your project, even things you aren't asking us to fund.</p>
+                en: `<p>This is the cost of everything related to your project, even things you aren't asking us to fund.</p>
 
-            <p>For example, if you are asking us for £8,000 and you are getting £10,000 from another funder to cover additional costs, then your total project cost is £18,000. If you are asking us for £8,000 and there are no other costs then your total project cost is £8,000.</p>
-            `,
-                cy: 'TODO'
+                <p>For example, if you are asking us for £8,000 and you are getting £10,000 from another funder to cover additional costs, then your total project cost is £18,000. If you are asking us for £8,000 and there are no other costs then your total project cost is £8,000.</p>`,
+                cy: ``
             }),
             type: 'currency',
             isRequired: true,
@@ -934,8 +982,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'budgetTotalCosts.underBudget',
                     message: localise({
-                        en: 'Total cost must be the same as or higher than the amount you’re asking us to fund',
-                        cy: ''
+                        en: `Total cost must be the same as or higher than the amount you’re asking us to fund`,
+                        cy: ``
                     })
                 }
             ]
@@ -943,14 +991,12 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         organisationLegalName: {
             name: 'organisation-legal-name',
             label: localise({
-                en: 'What is the full legal name of your organisation?',
-                cy: '(WELSH) What is the full legal name of your organisation, as shown on your governing document?'
+                en: `What is the full legal name of your organisation?`,
+                cy: ``
             }),
             explanation: localise({
-                en: `
-            <p>This must be as shown on your <strong>governing document</strong>. Your governing document could be called one of several things, depending on the type of organisation you're applying on behalf of. It may be called a constitution, trust deed, memorandum and articles of association, or something else entirely.</p>
-            `,
-                cy: ''
+                en: `<p>This must be as shown on your <strong>governing document</strong>. Your governing document could be called one of several things, depending on the type of organisation you're applying on behalf of. It may be called a constitution, trust deed, memorandum and articles of association, or something else entirely.</p>`,
+                cy: ``
             }),
             type: 'text',
             isRequired: true,
@@ -968,8 +1014,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         organisationAlias: {
             name: 'organisation-alias',
             label: localise({
-                en: 'Does your organisation use a different name in your day-to-day work?',
-                cy: ''
+                en: `Does your organisation use a different name in your day-to-day work?`,
+                cy: ``
             }),
             type: 'text',
             isRequired: false,
@@ -981,8 +1027,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         organisationAddress: addressField({
             name: 'organisation-address',
             label: localise({
-                en: 'What is the main or registered address of your organisation?',
-                cy: ''
+                en: `What is the main or registered address of your organisation?`,
+                cy: ``
             })
         }),
         organisationType: organisationTypeField(),
@@ -1015,7 +1061,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             type: 'text',
             attributes: { size: 20 },
             isRequired: includes(
-                [ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY, ORGANISATION_TYPES.CIO],
+                [
+                    ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+                    ORGANISATION_TYPES.CIO
+                ],
                 currentOrganisationType
             ),
             schema: Joi.when('organisation-type', {
@@ -1049,7 +1098,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Enter your organisation’s Department for Education number',
+                        en: `Enter your organisation’s Department for Education number`,
                         cy: ''
                     })
                 }
@@ -1123,10 +1172,15 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         mainContactAddress: addressField({
             name: 'main-contact-address',
             label: localise({ en: 'Current address', cy: '' }),
-            schema: commonValidators.ukAddress().when(Joi.ref('organisation-type'), {
-                is: Joi.valid(ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY),
-                then: Joi.any().optional()
-            })
+            schema: commonValidators
+                .ukAddress()
+                .when(Joi.ref('organisation-type'), {
+                    is: Joi.valid(
+                        ORGANISATION_TYPES.SCHOOL,
+                        ORGANISATION_TYPES.STATUTORY_BODY
+                    ),
+                    then: Joi.any().optional()
+                })
         }),
         mainContactAddressHistory: addressHistoryField({
             name: 'main-contact-address-history',
@@ -1150,8 +1204,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         mainContactCommunicationNeeds: communicationNeedsField({
             name: 'main-contact-communication-needs',
             label: localise({
-                en: 'Please tell us about any particular communication needs this contact has.',
-                cy: ''
+                en: `Please tell us about any particular communication needs this contact has.`,
+                cy: ``
             })
         }),
         seniorContactFirstName: firstNameField({
@@ -1170,16 +1224,21 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         seniorContactAddress: addressField({
             name: 'senior-contact-address',
             label: localise({ en: 'Current address', cy: '' }),
-            schema: commonValidators.ukAddress().when(Joi.ref('organisation-type'), {
-                is: Joi.valid(ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY),
-                then: Joi.any().optional()
-            })
+            schema: commonValidators
+                .ukAddress()
+                .when(Joi.ref('organisation-type'), {
+                    is: Joi.valid(
+                        ORGANISATION_TYPES.SCHOOL,
+                        ORGANISATION_TYPES.STATUTORY_BODY
+                    ),
+                    then: Joi.any().optional()
+                })
         }),
         seniorContactAddressHistory: addressHistoryField({
             name: 'senior-contact-address-history',
             label: localise({
-                en: 'Have you lived at your last address for at least three years?',
-                cy: ''
+                en: `Have you lived at your last address for at least three years?`,
+                cy: ``
             })
         }),
         seniorContactEmail: emailField({
@@ -1197,16 +1256,16 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         seniorContactCommunicationNeeds: communicationNeedsField({
             name: 'senior-contact-communication-needs',
             label: localise({
-                en: 'Please tell us about any particular communication needs this contact has.',
-                cy: ''
+                en: `Please tell us about any particular communication needs this contact has.`,
+                cy: ``
             })
         }),
         bankAccountName: {
             name: 'bank-account-name',
             label: localise({ en: 'Name on the bank account', cy: '' }),
             explanation: localise({
-                en: 'Name of your organisation as it appears on your bank statement',
-                cy: ''
+                en: `Name of your organisation as it appears on your bank statement`,
+                cy: ``
             }),
             type: 'text',
             isRequired: true,
@@ -1256,8 +1315,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             type: 'text',
             explanation: localise({
-                en: 'This is only applicable if your organisation’s account is with a building society.',
-                cy: ''
+                en: `This is only applicable if your organisation’s account is with a building society.`,
+                cy: ``
             }),
             isRequired: false,
             schema: Joi.string()

--- a/controllers/apply-next/simple/fields.test.js
+++ b/controllers/apply-next/simple/fields.test.js
@@ -5,7 +5,12 @@ const faker = require('faker');
 const Joi = require('joi');
 
 const { ORGANISATION_TYPES } = require('./constants');
-const { mockStartDate, mockDateOfBirth, mockAddress, mockBudget } = require('./mocks');
+const {
+    mockStartDate,
+    mockDateOfBirth,
+    mockAddress,
+    mockBudget
+} = require('./mocks');
 
 const fieldsFor = require('./fields');
 const fields = fieldsFor({ locale: 'en' });
@@ -24,7 +29,11 @@ describe('fields', () => {
     describe('projectName', () => {
         test('valididate project name', () => {
             assertValid(fields.projectName, faker.lorem.words(5));
-            assertErrorContains(fields.projectName, '', 'not allowed to be empty');
+            assertErrorContains(
+                fields.projectName,
+                '',
+                'not allowed to be empty'
+            );
         });
     });
 
@@ -32,7 +41,12 @@ describe('fields', () => {
         test('valididate project country', () => {
             assertValid(
                 fields.projectCountry,
-                faker.random.arrayElement(['england', 'northern-ireland', 'scotland', 'wales'])
+                faker.random.arrayElement([
+                    'england',
+                    'northern-ireland',
+                    'scotland',
+                    'wales'
+                ])
             );
             assertErrorContains(
                 fields.projectCountry,
@@ -45,7 +59,11 @@ describe('fields', () => {
     describe('projectStartDate', () => {
         test('must be a valid date', () => {
             assertValid(fields.projectStartDate, mockStartDate(12));
-            assertErrorContains(fields.projectStartDate, null, 'must be an object');
+            assertErrorContains(
+                fields.projectStartDate,
+                null,
+                'must be an object'
+            );
             assertErrorContains(
                 fields.projectStartDate,
                 { day: 31, month: 2, year: 2030 },
@@ -54,7 +72,9 @@ describe('fields', () => {
         });
 
         test('must be at least 12 weeks in the future', () => {
-            const { error } = fields.projectStartDate.schema.validate(mockStartDate(6));
+            const { error } = fields.projectStartDate.schema.validate(
+                mockStartDate(6)
+            );
             expect(error.message).toContain('Date must be at least');
         });
     });
@@ -62,8 +82,16 @@ describe('fields', () => {
     describe('projectPostcode', () => {
         test('must be a valid UK postcode', () => {
             assertValid(fields.projectPostcode, 'B15 1TR');
-            assertErrorContains(fields.projectPostcode, null, 'must be a string');
-            assertErrorContains(fields.projectPostcode, 'not a postcode', 'fails to match the required pattern');
+            assertErrorContains(
+                fields.projectPostcode,
+                null,
+                'must be a string'
+            );
+            assertErrorContains(
+                fields.projectPostcode,
+                'not a postcode',
+                'fails to match the required pattern'
+            );
         });
     });
 
@@ -75,8 +103,16 @@ describe('fields', () => {
             assertValid(field, faker.lorem.words(wordCount));
         });
 
-        assertErrorContains(field, faker.lorem.words(49), `must have at least ${min} words`);
-        assertErrorContains(field, faker.lorem.words(301), `must have less than ${max} words`);
+        assertErrorContains(
+            field,
+            faker.lorem.words(49),
+            `must have at least ${min} words`
+        );
+        assertErrorContains(
+            field,
+            faker.lorem.words(301),
+            `must have less than ${max} words`
+        );
     }
 
     describe('yourIdeaProject', () => {
@@ -103,7 +139,11 @@ describe('fields', () => {
         });
 
         test('must have at least one budget item', () => {
-            assertErrorContains(fields.projectBudget, [], 'must contain at least 1 items');
+            assertErrorContains(
+                fields.projectBudget,
+                [],
+                'must contain at least 1 items'
+            );
         });
 
         test('total amount requested must not exceed £10,000', () => {
@@ -111,20 +151,36 @@ describe('fields', () => {
                 item: faker.lorem.words(5),
                 cost: 1100
             }));
-            assertErrorContains(fields.projectBudget, budget, 'over maximum budget');
+            assertErrorContains(
+                fields.projectBudget,
+                budget,
+                'over maximum budget'
+            );
         });
 
         test('all items must contain both a description and a cost', () => {
             const budget = times(5, () => ({ item: faker.lorem.words(5) }));
-            assertErrorContains(fields.projectBudget, budget, '"cost" is required');
+            assertErrorContains(
+                fields.projectBudget,
+                budget,
+                '"cost" is required'
+            );
         });
     });
 
     describe('projectTotalCosts', () => {
         test('validate project total costs', () => {
             assertValid(fields.projectTotalCosts, 1000);
-            assertErrorContains(fields.projectTotalCosts, undefined, 'is required');
-            assertErrorContains(fields.projectTotalCosts, Infinity, 'contains an invalid value');
+            assertErrorContains(
+                fields.projectTotalCosts,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.projectTotalCosts,
+                Infinity,
+                'contains an invalid value'
+            );
         });
 
         test('must be at least value of project budget', () => {
@@ -148,15 +204,28 @@ describe('fields', () => {
                 { 'project-budget': budget, 'project-total-costs': 1000 },
                 schemaWithProjectBudget
             );
-            expect(validationResultInvalid.error.message).toContain('under project budget total');
+            expect(validationResultInvalid.error.message).toContain(
+                'under project budget total'
+            );
         });
     });
 
     describe('organisationLegalName', () => {
         test('validate organisation legal name', () => {
-            assertValid(fields.organisationLegalName, faker.company.companyName());
-            assertErrorContains(fields.organisationLegalName, undefined, 'is required');
-            assertErrorContains(fields.organisationLegalName, Infinity, 'must be a string');
+            assertValid(
+                fields.organisationLegalName,
+                faker.company.companyName()
+            );
+            assertErrorContains(
+                fields.organisationLegalName,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.organisationLegalName,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 
@@ -164,14 +233,22 @@ describe('fields', () => {
         test('optional field', () => {
             assertValid(fields.organisationAlias, undefined);
             assertValid(fields.organisationAlias, faker.company.companyName());
-            assertErrorContains(fields.organisationAlias, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.organisationAlias,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 
     describe('organisationAddress', () => {
         test('must be a full valid address', () => {
             assertValid(fields.organisationAddress, mockAddress());
-            assertErrorContains(fields.organisationAddress, undefined, 'is required');
+            assertErrorContains(
+                fields.organisationAddress,
+                undefined,
+                'is required'
+            );
 
             assertErrorContains(
                 fields.organisationAddress,
@@ -194,7 +271,11 @@ describe('fields', () => {
     describe('organisationType', () => {
         test('must be a valid organisation type', () => {
             assertValid(fields.organisationType, 'unregistered-vco');
-            assertErrorContains(fields.organisationType, undefined, 'is required');
+            assertErrorContains(
+                fields.organisationType,
+                undefined,
+                'is required'
+            );
             assertErrorContains(
                 fields.organisationType,
                 'not-an-option',
@@ -211,7 +292,10 @@ describe('fields', () => {
 
         const requiredOrgTypes = requiredTypes;
         requiredOrgTypes.forEach(type => {
-            const { error } = Joi.validate({ 'organisation-type': type }, schemaWithOrgType);
+            const { error } = Joi.validate(
+                { 'organisation-type': type },
+                schemaWithOrgType
+            );
             expect(error.message).toContain('is required');
         });
     }
@@ -221,7 +305,9 @@ describe('fields', () => {
             assertValid(fields.companyNumber, 'CE002712');
             assertValid(fields.companyNumber, undefined);
 
-            assertRequiredForOrganistionTypes(fields.companyNumber, [ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY]);
+            assertRequiredForOrganistionTypes(fields.companyNumber, [
+                ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY
+            ]);
         });
     });
 
@@ -242,23 +328,41 @@ describe('fields', () => {
             assertValid(fields.educationNumber, '1160580');
             assertValid(fields.educationNumber, undefined);
 
-            assertRequiredForOrganistionTypes(fields.educationNumber, [ORGANISATION_TYPES.SCHOOL]);
+            assertRequiredForOrganistionTypes(fields.educationNumber, [
+                ORGANISATION_TYPES.SCHOOL
+            ]);
         });
     });
 
     describe('accountingYearDate', () => {
         test('must be a valid day and month', () => {
             assertValid(fields.accountingYearDate, { day: 12, month: 2 });
-            assertErrorContains(fields.accountingYearDate, null, 'must be an object');
-            assertErrorContains(fields.accountingYearDate, { day: 31, month: 2 }, 'contains an invalid value');
+            assertErrorContains(
+                fields.accountingYearDate,
+                null,
+                'must be an object'
+            );
+            assertErrorContains(
+                fields.accountingYearDate,
+                { day: 31, month: 2 },
+                'contains an invalid value'
+            );
         });
     });
 
     describe('totalIncomeYear', () => {
         test('must be a valid number', () => {
             assertValid(fields.totalIncomeYear, 1000);
-            assertErrorContains(fields.totalIncomeYear, undefined, 'is required');
-            assertErrorContains(fields.totalIncomeYear, Infinity, 'contains an invalid value');
+            assertErrorContains(
+                fields.totalIncomeYear,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.totalIncomeYear,
+                Infinity,
+                'contains an invalid value'
+            );
         });
     });
 
@@ -273,7 +377,11 @@ describe('fields', () => {
     function testContactDateOfBirth(field, minAge) {
         test(`must be at least ${minAge} years old`, () => {
             assertValid(field, mockDateOfBirth(minAge));
-            assertErrorContains(field, mockDateOfBirth(0, minAge - 1), `Must be at least ${minAge} years old`);
+            assertErrorContains(
+                field,
+                mockDateOfBirth(0, minAge - 1),
+                `Must be at least ${minAge} years old`
+            );
         });
 
         test('optional if organisation-type is a school or statutory-body', () => {
@@ -282,9 +390,15 @@ describe('fields', () => {
                 [field.name]: field.schema
             };
 
-            const optionalOrgTypes = [ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY];
+            const optionalOrgTypes = [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ];
             optionalOrgTypes.forEach(type => {
-                const { error } = Joi.validate({ 'organisation-type': type }, schemaWithOrgType);
+                const { error } = Joi.validate(
+                    { 'organisation-type': type },
+                    schemaWithOrgType
+                );
 
                 expect(error).toBeNull();
             });
@@ -319,9 +433,15 @@ describe('fields', () => {
                 [field.name]: field.schema
             };
 
-            const optionalOrgTypes = [ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY];
+            const optionalOrgTypes = [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ];
             optionalOrgTypes.forEach(type => {
-                const { error } = Joi.validate({ 'organisation-type': type }, schemaWithOrgType);
+                const { error } = Joi.validate(
+                    { 'organisation-type': type },
+                    schemaWithOrgType
+                );
                 expect(error).toBeNull();
             });
         });
@@ -371,9 +491,15 @@ describe('fields', () => {
                 [field.name]: field.schema
             };
 
-            const optionalOrgTypes = [ORGANISATION_TYPES.SCHOOL, ORGANISATION_TYPES.STATUTORY_BODY];
+            const optionalOrgTypes = [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ];
             optionalOrgTypes.forEach(type => {
-                const validationResultA = Joi.validate({ 'organisation-type': type }, schemaWithOrgType);
+                const validationResultA = Joi.validate(
+                    { 'organisation-type': type },
+                    schemaWithOrgType
+                );
                 expect(validationResultA.error).toBeNull();
             });
         });
@@ -392,7 +518,11 @@ describe('fields', () => {
             assertValid(field, '0345 4 10 20 30');
             assertErrorContains(field, undefined, 'is required');
             assertErrorContains(field, NaN, 'must be a string');
-            assertErrorContains(field, 'not a phone number', 'did not seem to be a phone number');
+            assertErrorContains(
+                field,
+                'not a phone number',
+                'did not seem to be a phone number'
+            );
         });
     }
 
@@ -445,14 +575,24 @@ describe('fields', () => {
     describe('seniorContactRole', () => {
         test('must be a valid role', () => {
             assertValid(fields.seniorContactRole, 'chair');
-            assertErrorContains(fields.seniorContactRole, undefined, 'is required');
-            assertErrorContains(fields.seniorContactRole, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.seniorContactRole,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.seniorContactRole,
+                Infinity,
+                'must be a string'
+            );
         });
 
         test('include all roles if no organisation type is provided', () => {
             const { seniorContactRole } = fieldsFor({ locale: 'en' });
 
-            expect(seniorContactRole.options.map(option => option.value)).toEqual([
+            expect(
+                seniorContactRole.options.map(option => option.value)
+            ).toEqual([
                 'trustee',
                 'chair',
                 'vice-chair',
@@ -476,17 +616,22 @@ describe('fields', () => {
                     data: { 'organisation-type': type }
                 });
 
-                expect(seniorContactRole.options.map(option => option.value)).toEqual(expected);
+                expect(
+                    seniorContactRole.options.map(option => option.value)
+                ).toEqual(expected);
             }
 
-            assertRolesForType(ORGANISATION_TYPES.UNREGISTERED_VCO, ['chair', 'vice-chair', 'secretary', 'treasurer']);
-
-            assertRolesForType(ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY, [
-                'trustee',
+            assertRolesForType(ORGANISATION_TYPES.UNREGISTERED_VCO, [
                 'chair',
                 'vice-chair',
+                'secretary',
                 'treasurer'
             ]);
+
+            assertRolesForType(
+                ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+                ['trustee', 'chair', 'vice-chair', 'treasurer']
+            );
 
             assertRolesForType(ORGANISATION_TYPES.CIO, [
                 'trustee',
@@ -496,11 +641,21 @@ describe('fields', () => {
                 'chief-executive-officer'
             ]);
 
-            assertRolesForType(ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY, ['company-director', 'company-secretary']);
+            assertRolesForType(ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY, [
+                'company-director',
+                'company-secretary'
+            ]);
 
-            assertRolesForType(ORGANISATION_TYPES.SCHOOL, ['head-teacher', 'chancellor', 'vice-chancellor']);
+            assertRolesForType(ORGANISATION_TYPES.SCHOOL, [
+                'head-teacher',
+                'chancellor',
+                'vice-chancellor'
+            ]);
 
-            assertRolesForType(ORGANISATION_TYPES.STATUTORY_BODY, ['parish-clerk', 'chief-executive']);
+            assertRolesForType(ORGANISATION_TYPES.STATUTORY_BODY, [
+                'parish-clerk',
+                'chief-executive'
+            ]);
         });
     });
 
@@ -531,8 +686,16 @@ describe('fields', () => {
     describe('bankAccountName', () => {
         test('valid account name', () => {
             assertValid(fields.bankAccountName, faker.company.companyName());
-            assertErrorContains(fields.bankAccountName, undefined, 'is required');
-            assertErrorContains(fields.bankAccountName, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.bankAccountName,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.bankAccountName,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 
@@ -540,22 +703,38 @@ describe('fields', () => {
         test('valid sort code', () => {
             assertValid(fields.bankSortCode, '108800');
             assertErrorContains(fields.bankSortCode, undefined, 'is required');
-            assertErrorContains(fields.bankSortCode, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.bankSortCode,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 
     describe('bankAccountNumber', () => {
         test('valid account number', () => {
             assertValid(fields.bankAccountNumber, '00012345');
-            assertErrorContains(fields.bankAccountNumber, undefined, 'is required');
-            assertErrorContains(fields.bankAccountNumber, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.bankAccountNumber,
+                undefined,
+                'is required'
+            );
+            assertErrorContains(
+                fields.bankAccountNumber,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 
     describe('bankBuildingSocietyNumber', () => {
         test('optional field', () => {
             assertValid(fields.bankBuildingSocietyNumber);
-            assertErrorContains(fields.bankBuildingSocietyNumber, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.bankBuildingSocietyNumber,
+                Infinity,
+                'must be a string'
+            );
             assertValid(fields.bankBuildingSocietyNumber, '1234566');
         });
     });
@@ -564,7 +743,11 @@ describe('fields', () => {
         test('valid bank statement upload', () => {
             assertValid(fields.bankStatement, 'example.pdf');
             assertErrorContains(fields.bankStatement, undefined, 'is required');
-            assertErrorContains(fields.bankStatement, Infinity, 'must be a string');
+            assertErrorContains(
+                fields.bankStatement,
+                Infinity,
+                'must be a string'
+            );
         });
     });
 });

--- a/controllers/apply-next/simple/form.js
+++ b/controllers/apply-next/simple/form.js
@@ -59,7 +59,11 @@ module.exports = function({ locale, data = {} }) {
                             en: 'Your idea',
                             cy: '(WELSH) Your idea'
                         }),
-                        fields: [allFields.yourIdeaProject, allFields.yourIdeaPriorities, allFields.yourIdeaCommunity]
+                        fields: [
+                            allFields.yourIdeaProject,
+                            allFields.yourIdeaPriorities,
+                            allFields.yourIdeaCommunity
+                        ]
                     }
                 ]
             },
@@ -74,7 +78,10 @@ module.exports = function({ locale, data = {} }) {
                             en: 'Project costs',
                             cy: '(WELSH) Project costs'
                         }),
-                        fields: [allFields.projectBudget, allFields.projectTotalCosts]
+                        fields: [
+                            allFields.projectBudget,
+                            allFields.projectTotalCosts
+                        ]
                     }
                 ]
             }
@@ -124,7 +131,11 @@ module.exports = function({ locale, data = {} }) {
                         }),
                         get fields() {
                             const fields = [];
-                            if (matchesOrganisationType(ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY)) {
+                            if (
+                                matchesOrganisationType(
+                                    ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY
+                                )
+                            ) {
                                 fields.push(allFields.companyNumber);
                             }
 
@@ -138,7 +149,11 @@ module.exports = function({ locale, data = {} }) {
                                 fields.push(allFields.charityNumber);
                             }
 
-                            if (matchesOrganisationType(ORGANISATION_TYPES.SCHOOL)) {
+                            if (
+                                matchesOrganisationType(
+                                    ORGANISATION_TYPES.SCHOOL
+                                )
+                            ) {
                                 fields.push(allFields.educationNumber);
                             }
 
@@ -155,7 +170,10 @@ module.exports = function({ locale, data = {} }) {
                             en: 'Organisation finances',
                             cy: ''
                         }),
-                        fields: [allFields.accountingYearDate, allFields.totalIncomeYear]
+                        fields: [
+                            allFields.accountingYearDate,
+                            allFields.totalIncomeYear
+                        ]
                     }
                 ]
             }
@@ -341,7 +359,9 @@ module.exports = function({ locale, data = {} }) {
                     'You have been authorised by the governing body of your organisation (the board or committee that runs your organisation) to submit this application and to accept the Terms and Conditions set out above on their behalf.',
                 cy: ''
             }),
-            options: [{ value: 'yes', label: localise({ en: 'I agree', cy: '' }) }],
+            options: [
+                { value: 'yes', label: localise({ en: 'I agree', cy: '' }) }
+            ],
             isRequired: true
         },
         {
@@ -352,7 +372,9 @@ module.exports = function({ locale, data = {} }) {
                     'All the information you have provided in your application is accurate and complete; and you will notify us of any changes.',
                 cy: ''
             }),
-            options: [{ value: 'yes', label: localise({ en: 'I agree', cy: '' }) }],
+            options: [
+                { value: 'yes', label: localise({ en: 'I agree', cy: '' }) }
+            ],
             isRequired: true
         },
         {
@@ -363,7 +385,9 @@ module.exports = function({ locale, data = {} }) {
                     'You understand that we will use any personal information you have provided for the purposes described under the Data Protection Statement.',
                 cy: ''
             }),
-            options: [{ value: 'yes', label: localise({ en: 'I agree', cy: '' }) }],
+            options: [
+                { value: 'yes', label: localise({ en: 'I agree', cy: '' }) }
+            ],
             isRequired: true
         },
         {
@@ -374,7 +398,9 @@ module.exports = function({ locale, data = {} }) {
                     'If information about this application is requested under the Freedom of Information Act, we will release it in line with our Freedom of Information policy.',
                 cy: ''
             }),
-            options: [{ value: 'yes', label: localise({ en: 'I agree', cy: '' }) }],
+            options: [
+                { value: 'yes', label: localise({ en: 'I agree', cy: '' }) }
+            ],
             isRequired: true
         },
         {
@@ -413,7 +439,13 @@ module.exports = function({ locale, data = {} }) {
         isBilingual: true,
         schema: schema,
         allFields: allFields,
-        sections: [sectionProject, sectionOrganisation, sectionMainContact, sectionSeniorContact, sectionBankDetails],
+        sections: [
+            sectionProject,
+            sectionOrganisation,
+            sectionMainContact,
+            sectionSeniorContact,
+            sectionBankDetails
+        ],
         termsFields: termsFields
     };
 

--- a/controllers/apply-next/simple/form.test.js
+++ b/controllers/apply-next/simple/form.test.js
@@ -58,7 +58,8 @@ describe('form model', () => {
             validate(
                 mockFullForm({
                     country: 'england',
-                    organisationType: ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+                    organisationType:
+                        ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
                     charityNumber: '123456789'
                 })
             ).error
@@ -103,14 +104,22 @@ describe('form model', () => {
     }
 
     test('registration numbers shown based on organisation type', () => {
-        const fieldNamesFn = fieldNamesFor('organisation', 'Registration numbers');
+        const fieldNamesFn = fieldNamesFor(
+            'organisation',
+            'Registration numbers'
+        );
 
         expect(fieldNamesFn({})).toEqual([]);
 
         const mappings = {
-            [ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY]: ['charity-number'],
+            [ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY]: [
+                'charity-number'
+            ],
             [ORGANISATION_TYPES.CIO]: ['charity-number'],
-            [ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY]: ['company-number', 'charity-number'],
+            [ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY]: [
+                'company-number',
+                'charity-number'
+            ],
             [ORGANISATION_TYPES.SCHOOL]: ['education-number']
         };
 
@@ -143,14 +152,19 @@ describe('form model', () => {
         ];
 
         expect(mainContactFn({})).toEqual(mainContactDefaultFields);
-        expect(mainContactFn({ 'organisation-type': ORGANISATION_TYPES.SCHOOL })).toEqual(mainContactReducedFields);
+        expect(
+            mainContactFn({ 'organisation-type': ORGANISATION_TYPES.SCHOOL })
+        ).toEqual(mainContactReducedFields);
         expect(
             mainContactFn({
                 'organisation-type': ORGANISATION_TYPES.STATUTORY_BODY
             })
         ).toEqual(mainContactReducedFields);
 
-        const seniorContactFn = fieldNamesFor('senior-contact', 'Senior contact');
+        const seniorContactFn = fieldNamesFor(
+            'senior-contact',
+            'Senior contact'
+        );
 
         const seniorContactDefaultFields = [
             'senior-contact-first-name',
@@ -174,7 +188,9 @@ describe('form model', () => {
         ];
 
         expect(seniorContactFn({})).toEqual(seniorContactDefaultFields);
-        expect(seniorContactFn({ 'organisation-type': ORGANISATION_TYPES.SCHOOL })).toEqual(seniorContactReducedFields);
+        expect(
+            seniorContactFn({ 'organisation-type': ORGANISATION_TYPES.SCHOOL })
+        ).toEqual(seniorContactReducedFields);
         expect(
             seniorContactFn({
                 'organisation-type': ORGANISATION_TYPES.STATUTORY_BODY

--- a/controllers/apply-next/simple/mocks.js
+++ b/controllers/apply-next/simple/mocks.js
@@ -15,7 +15,10 @@ function mockStartDate(weeks) {
 }
 
 function mockDateOfBirth(minAge, maxAge = 75) {
-    const dt = moment().subtract(faker.random.number({ min: minAge, max: maxAge }), 'years');
+    const dt = moment().subtract(
+        faker.random.number({ min: minAge, max: maxAge }),
+        'years'
+    );
     return toDateParts(dt);
 }
 

--- a/controllers/apply-next/simple/processor.js
+++ b/controllers/apply-next/simple/processor.js
@@ -10,9 +10,14 @@ const { generateHtmlEmail, sendEmail } = require('../../../services/mail');
  * @param {object} options.data
  * @param {any} mailTransport
  */
-module.exports = async function processor({ form, data }, mailTransport = null) {
+module.exports = async function processor(
+    { form, data },
+    mailTransport = null
+) {
     const customerSendTo = {
-        name: `${data['main-contact-first-name']} ${data['main-contact-last-name']}`,
+        name: `${data['main-contact-first-name']} ${
+            data['main-contact-last-name']
+        }`,
         address: data['main-contact-email']
     };
 
@@ -30,7 +35,8 @@ module.exports = async function processor({ form, data }, mailTransport = null) 
             name: 'simple_prototype_customer',
             mailConfig: {
                 sendTo: customerSendTo,
-                subject: 'Thank you for getting in touch with The National Lottery Community Fund!',
+                subject:
+                    'Thank you for getting in touch with The National Lottery Community Fund!',
                 type: 'html',
                 content: customerHtml
             },


### PR DESCRIPTION
Re-runs `prettier` auto-formatting over the `apply-next` code to avoid piecemeal formatting churn in future PRs.