### PR TITLE
Update formatters for radio and checkboxes

### DIFF
--- a/controllers/apply-next/lib/formatters.js
+++ b/controllers/apply-next/lib/formatters.js
@@ -1,16 +1,44 @@
 'use strict';
 const moment = require('moment');
-const { get, castArray, filter, includes, isArray, sumBy } = require('lodash');
+const {
+    castArray,
+    filter,
+    flatMap,
+    get,
+    includes,
+    isArray,
+    sumBy
+} = require('lodash');
 
-function formatOptions(options) {
+function formatRadio(field) {
     return function(value) {
         const choices = castArray(value);
+
+        const matches = filter(field.options, option =>
+            includes(choices, option.value)
+        );
+
+        return matches.length > 0
+            ? matches.map(match => match.label).join(',\n')
+            : choices.join(', ');
+    };
+}
+
+function formatCheckbox(field) {
+    const options = field.optgroups
+        ? flatMap(field.optgroups, o => o.options)
+        : field.options;
+
+    return function(value) {
+        const choices = castArray(value);
+
         const matches = filter(options, option =>
             includes(choices, option.value)
         );
+
         return matches.length > 0
-            ? matches.map(match => match.label).join(', ')
-            : choices.join(', ');
+            ? matches.map(match => match.label).join(',\n')
+            : choices.join(',\n');
     };
 }
 
@@ -80,8 +108,10 @@ function formatterFor(field) {
     let formatter;
     switch (field.type) {
         case 'radio':
+            formatter = formatRadio(field);
+            break;
         case 'checkbox':
-            formatter = formatOptions(field.options);
+            formatter = formatCheckbox(field);
             break;
         case 'address':
             formatter = formatAddress;
@@ -111,7 +141,8 @@ function formatterFor(field) {
 
 module.exports = {
     formatterFor,
-    formatOptions,
+    formatCheckbox,
+    formatRadio,
     formatAddress,
     formatDate,
     formatDayMonth,

--- a/controllers/apply-next/lib/formatters.test.js
+++ b/controllers/apply-next/lib/formatters.test.js
@@ -26,7 +26,7 @@ describe('formatters', () => {
             }
         });
 
-        expect(formatter(['b', 'c'])).toBe('B, C');
+        expect(formatter(['b', 'c'])).toBe('B,\nC');
     });
 
     test('address', () => {


### PR DESCRIPTION
Update formatters for radio and checkboxes. Accounts for long options and opt groups by formatting multiple choices with a newline rather than a single line list.