### PR TITLE
Contact strip bug

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1859,7 +1859,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             name: 'mainContactAddress',
             label: localise({ en: 'Current address', cy: '' }),
             schema: Joi.ukAddress().when(Joi.ref('organisationType'), {
-                is: Joi.valid(
+                is: Joi.exist().valid(
                     ORGANISATION_TYPES.SCHOOL,
                     ORGANISATION_TYPES.STATUTORY_BODY
                 ),
@@ -1909,7 +1909,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             name: 'seniorContactAddress',
             label: localise({ en: 'Current address', cy: '' }),
             schema: Joi.ukAddress().when(Joi.ref('organisationType'), {
-                is: Joi.valid(
+                is: Joi.exist().valid(
                     ORGANISATION_TYPES.SCHOOL,
                     ORGANISATION_TYPES.STATUTORY_BODY
                 ),

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -254,7 +254,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             schema: Joi.dateParts()
                 .dob(minAge)
                 .when(Joi.ref('organisationType'), {
-                    is: Joi.valid(
+                    is: Joi.exist().valid(
                         ORGANISATION_TYPES.SCHOOL,
                         ORGANISATION_TYPES.STATUTORY_BODY
                     ),

--- a/controllers/apply/awards-for-all/fields.test.js
+++ b/controllers/apply/awards-for-all/fields.test.js
@@ -288,37 +288,6 @@ describe('fields', () => {
         });
     }
 
-    function testContactDateOfBirth(field, minAge) {
-        test(`must be at least ${minAge} years old`, () => {
-            assertValid(field, mockDateOfBirth(minAge));
-            assertErrorContains(
-                field,
-                mockDateOfBirth(0, minAge - 1),
-                `Must be at least ${minAge} years old`
-            );
-        });
-
-        test('optional if organisationType is a school or statutory-body', () => {
-            const schemaWithOrgType = {
-                'organisationType': fields.organisationType.schema,
-                [field.name]: field.schema
-            };
-
-            const optionalOrgTypes = [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ];
-            optionalOrgTypes.forEach(type => {
-                const { error } = Joi.validate(
-                    { organisationType: type },
-                    schemaWithOrgType
-                );
-
-                expect(error).toBeNull();
-            });
-        });
-    }
-
     function testContactAddress(field) {
         test('must be a full valid address', () => {
             assertValid(field, mockAddress());
@@ -457,10 +426,6 @@ describe('fields', () => {
         testContactNamePart(fields.mainContactLastName);
     });
 
-    describe('mainContactDob', () => {
-        testContactDateOfBirth(fields.mainContactDob, 16);
-    });
-
     describe('mainContactAddress', () => {
         testContactAddress(fields.mainContactAddress);
     });
@@ -571,10 +536,6 @@ describe('fields', () => {
                 'chief-executive'
             ]);
         });
-    });
-
-    describe('seniorContactDob', () => {
-        testContactDateOfBirth(fields.seniorContactDob, 18);
     });
 
     describe('seniorContactAddress', () => {

--- a/controllers/apply/awards-for-all/fields.test.js
+++ b/controllers/apply/awards-for-all/fields.test.js
@@ -288,48 +288,6 @@ describe('fields', () => {
         });
     }
 
-    function testContactAddress(field) {
-        test('must be a full valid address', () => {
-            assertValid(field, mockAddress());
-            assertErrorContains(field, null, 'must be an object');
-
-            assertErrorContains(
-                field,
-                {
-                    line1: '3 Embassy Drive',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR'
-                },
-                'child "townCity" fails because ["townCity" is required]'
-            );
-
-            assertErrorContains(
-                field,
-                { ...mockAddress(), ...{ postcode: 'not a postcode' } },
-                'did not seem to be a valid postcode'
-            );
-        });
-
-        test('optional if organisationType is a school or statutory-body', () => {
-            const schemaWithOrgType = {
-                'organisationType': fields.organisationType.schema,
-                [field.name]: field.schema
-            };
-
-            const optionalOrgTypes = [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ];
-            optionalOrgTypes.forEach(type => {
-                const { error } = Joi.validate(
-                    { organisationType: type },
-                    schemaWithOrgType
-                );
-                expect(error).toBeNull();
-            });
-        });
-    }
-
     function testContactAddressHistory(field) {
         test('require address history if less than three years at current address', () => {
             assertValid(field, {
@@ -424,10 +382,6 @@ describe('fields', () => {
     describe('mainContactName', () => {
         testContactNamePart(fields.mainContactFirstName);
         testContactNamePart(fields.mainContactLastName);
-    });
-
-    describe('mainContactAddress', () => {
-        testContactAddress(fields.mainContactAddress);
     });
 
     describe('mainContactAddressHistory', () => {
@@ -536,10 +490,6 @@ describe('fields', () => {
                 'chief-executive'
             ]);
         });
-    });
-
-    describe('seniorContactAddress', () => {
-        testContactAddress(fields.seniorContactAddress);
     });
 
     describe('seniorContactAddressHistory', () => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -243,6 +243,70 @@ describe('form model', () => {
         });
     });
 
+    function testAddressField(fieldName) {
+        test('address is valid', () => {
+            function value(val) {
+                return {
+                    [fieldName]: val
+                };
+            }
+
+            assertValidByKey(value(mockAddress()));
+            assertMessagesByKey(value(null), ['Enter a full UK address']);
+            assertMessagesByKey(
+                value({
+                    line1: '3 Embassy Drive',
+                    county: 'West Midlands',
+                    postcode: 'B15 1TR'
+                }),
+                ['Enter a full UK address']
+            );
+            assertMessagesByKey(
+                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
+                ['Enter a real postcode']
+            );
+        });
+
+        test('address is included when there is a required organisation type', () => {
+            const valueWithOrgType = {
+                organisationType: ORGANISATION_TYPES.CIO,
+                [fieldName]: mockAddress()
+            };
+            expect(testValidate(valueWithOrgType).value).toEqual(
+                valueWithOrgType
+            );
+        });
+
+        test('address is included when there is no organisation type', () => {
+            const valueWithoutOrgType = {
+                [fieldName]: mockAddress()
+            };
+            expect(testValidate(valueWithoutOrgType).value).toEqual(
+                valueWithoutOrgType
+            );
+        });
+
+        test('address value stripped for schools and statutory bodies', () => {
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                expect(
+                    testValidate({
+                        organisationType: orgType,
+                        [fieldName]: mockAddress()
+                    }).value
+                ).toEqual({
+                    organisationType: orgType
+                });
+
+                assertValidByKey({
+                    organisationType: orgType
+                });
+            });
+        });
+    }
+
     describe('senior contact', () => {
         test('date of birth must be at least 18', () => {
             function value(val) {
@@ -298,67 +362,7 @@ describe('form model', () => {
             });
         });
 
-        test('address is valid', () => {
-            function value(val) {
-                return {
-                    seniorContactAddress: val
-                };
-            }
-
-            assertValidByKey(value(mockAddress()));
-            assertMessagesByKey(value(null), ['Enter a full UK address']);
-            assertMessagesByKey(
-                value({
-                    line1: '3 Embassy Drive',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR'
-                }),
-                ['Enter a full UK address']
-            );
-            assertMessagesByKey(
-                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
-                ['Enter a real postcode']
-            );
-        });
-
-        test('address is included when there is a required organisation type', () => {
-            const valueWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                seniorContactAddress: mockAddress()
-            };
-            expect(testValidate(valueWithOrgType).value).toEqual(
-                valueWithOrgType
-            );
-        });
-
-        test('address is included when there is no organisation type', () => {
-            const valueWithoutOrgType = {
-                seniorContactAddress: mockAddress()
-            };
-            expect(testValidate(valueWithoutOrgType).value).toEqual(
-                valueWithoutOrgType
-            );
-        });
-
-        test('address value stripped for schools and statutory bodies', () => {
-            [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ].forEach(orgType => {
-                expect(
-                    testValidate({
-                        organisationType: orgType,
-                        seniorContactAddress: mockAddress()
-                    }).value
-                ).toEqual({
-                    organisationType: orgType
-                });
-
-                assertValidByKey({
-                    organisationType: orgType
-                });
-            });
-        });
+        testAddressField('seniorContactAddress');
 
         test('contact fields not included for schools and statutory bodies', () => {
             const seniorContactFn = fieldNamesFor(
@@ -449,67 +453,7 @@ describe('form model', () => {
             });
         });
 
-        test('address is valid', () => {
-            function value(val) {
-                return {
-                    mainContactAddress: val
-                };
-            }
-
-            assertValidByKey(value(mockAddress()));
-            assertMessagesByKey(value(null), ['Enter a full UK address']);
-            assertMessagesByKey(
-                value({
-                    line1: '3 Embassy Drive',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR'
-                }),
-                ['Enter a full UK address']
-            );
-            assertMessagesByKey(
-                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
-                ['Enter a real postcode']
-            );
-        });
-
-        test('address is included when there is a required organisation type', () => {
-            const valueWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                mainContactAddress: mockAddress()
-            };
-            expect(testValidate(valueWithOrgType).value).toEqual(
-                valueWithOrgType
-            );
-        });
-
-        test('address is included when there is no organisation type', () => {
-            const valueWithoutOrgType = {
-                mainContactAddress: mockAddress()
-            };
-            expect(testValidate(valueWithoutOrgType).value).toEqual(
-                valueWithoutOrgType
-            );
-        });
-
-        test('address value stripped for schools and statutory bodies', () => {
-            [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ].forEach(orgType => {
-                expect(
-                    testValidate({
-                        organisationType: orgType,
-                        mainContactAddress: mockAddress()
-                    }).value
-                ).toEqual({
-                    organisationType: orgType
-                });
-
-                assertValidByKey({
-                    organisationType: orgType
-                });
-            });
-        });
+        testAddressField('mainContactAddress');
 
         test('contact fields not included for schools and statutory bodies', () => {
             const mainContactFn = fieldNamesFor('main-contact', 'Main contact');

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -7,7 +7,12 @@ const faker = require('faker');
 const validateModel = require('../form-router-next/lib/validate-model');
 const validateForm = require('../form-router-next/lib/validate-form');
 
-const { mockDateOfBirth, mockStartDate, mockFullForm } = require('./mocks');
+const {
+    mockAddress,
+    mockDateOfBirth,
+    mockStartDate,
+    mockFullForm
+} = require('./mocks');
 const { ORGANISATION_TYPES } = require('./constants');
 const formBuilder = require('./form');
 
@@ -278,12 +283,12 @@ describe('form model', () => {
                 ORGANISATION_TYPES.SCHOOL,
                 ORGANISATION_TYPES.STATUTORY_BODY
             ].forEach(orgType => {
-                const dobWithSchool = {
-                    organisationType: orgType,
-                    seniorContactDateOfBirth: mockDateOfBirth(18, 90)
-                };
-
-                expect(testValidate(dobWithSchool).value).toEqual({
+                expect(
+                    testValidate({
+                        organisationType: orgType,
+                        seniorContactDateOfBirth: mockDateOfBirth(18, 90)
+                    }).value
+                ).toEqual({
                     organisationType: orgType
                 });
 
@@ -293,13 +298,75 @@ describe('form model', () => {
             });
         });
 
-        test('date of birth fields not included for schools and statutory bodies', () => {
+        test('address is valid', () => {
+            function value(val) {
+                return {
+                    seniorContactAddress: val
+                };
+            }
+
+            assertValidByKey(value(mockAddress()));
+            assertMessagesByKey(value(null), ['Enter a full UK address']);
+            assertMessagesByKey(
+                value({
+                    line1: '3 Embassy Drive',
+                    county: 'West Midlands',
+                    postcode: 'B15 1TR'
+                }),
+                ['Enter a full UK address']
+            );
+            assertMessagesByKey(
+                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
+                ['Enter a real postcode']
+            );
+        });
+
+        test('address is included when there is a required organisation type', () => {
+            const valueWithOrgType = {
+                organisationType: ORGANISATION_TYPES.CIO,
+                seniorContactAddress: mockAddress()
+            };
+            expect(testValidate(valueWithOrgType).value).toEqual(
+                valueWithOrgType
+            );
+        });
+
+        test('address is included when there is no organisation type', () => {
+            const valueWithoutOrgType = {
+                seniorContactAddress: mockAddress()
+            };
+            expect(testValidate(valueWithoutOrgType).value).toEqual(
+                valueWithoutOrgType
+            );
+        });
+
+        test('address value stripped for schools and statutory bodies', () => {
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                expect(
+                    testValidate({
+                        organisationType: orgType,
+                        seniorContactAddress: mockAddress()
+                    }).value
+                ).toEqual({
+                    organisationType: orgType
+                });
+
+                assertValidByKey({
+                    organisationType: orgType
+                });
+            });
+        });
+
+        test('contact fields not included for schools and statutory bodies', () => {
             const seniorContactFn = fieldNamesFor(
                 'senior-contact',
                 'Senior contact'
             );
 
-            const seniorContactDefaultFields = [
+            expect(seniorContactFn({})).toEqual([
                 'seniorContactFirstName',
                 'seniorContactLastName',
                 'seniorContactRole',
@@ -309,26 +376,21 @@ describe('form model', () => {
                 'seniorContactEmail',
                 'seniorContactPhone',
                 'seniorContactCommunicationNeeds'
-            ];
+            ]);
 
-            const seniorContactReducedFields = [
-                'seniorContactFirstName',
-                'seniorContactLastName',
-                'seniorContactRole',
-                'seniorContactEmail',
-                'seniorContactPhone',
-                'seniorContactCommunicationNeeds'
-            ];
-
-            expect(seniorContactFn({})).toEqual(seniorContactDefaultFields);
-            expect(
-                seniorContactFn({ organisationType: ORGANISATION_TYPES.SCHOOL })
-            ).toEqual(seniorContactReducedFields);
-            expect(
-                seniorContactFn({
-                    organisationType: ORGANISATION_TYPES.STATUTORY_BODY
-                })
-            ).toEqual(seniorContactReducedFields);
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                expect(seniorContactFn({ organisationType: orgType })).toEqual([
+                    'seniorContactFirstName',
+                    'seniorContactLastName',
+                    'seniorContactRole',
+                    'seniorContactEmail',
+                    'seniorContactPhone',
+                    'seniorContactCommunicationNeeds'
+                ]);
+            });
         });
     });
 
@@ -387,10 +449,72 @@ describe('form model', () => {
             });
         });
 
-        test('date of birth fields not included for schools and statutory bodies', () => {
+        test('address is valid', () => {
+            function value(val) {
+                return {
+                    mainContactAddress: val
+                };
+            }
+
+            assertValidByKey(value(mockAddress()));
+            assertMessagesByKey(value(null), ['Enter a full UK address']);
+            assertMessagesByKey(
+                value({
+                    line1: '3 Embassy Drive',
+                    county: 'West Midlands',
+                    postcode: 'B15 1TR'
+                }),
+                ['Enter a full UK address']
+            );
+            assertMessagesByKey(
+                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
+                ['Enter a real postcode']
+            );
+        });
+
+        test('address is included when there is a required organisation type', () => {
+            const valueWithOrgType = {
+                organisationType: ORGANISATION_TYPES.CIO,
+                mainContactAddress: mockAddress()
+            };
+            expect(testValidate(valueWithOrgType).value).toEqual(
+                valueWithOrgType
+            );
+        });
+
+        test('address is included when there is no organisation type', () => {
+            const valueWithoutOrgType = {
+                mainContactAddress: mockAddress()
+            };
+            expect(testValidate(valueWithoutOrgType).value).toEqual(
+                valueWithoutOrgType
+            );
+        });
+
+        test('address value stripped for schools and statutory bodies', () => {
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                expect(
+                    testValidate({
+                        organisationType: orgType,
+                        mainContactAddress: mockAddress()
+                    }).value
+                ).toEqual({
+                    organisationType: orgType
+                });
+
+                assertValidByKey({
+                    organisationType: orgType
+                });
+            });
+        });
+
+        test('contact fields not included for schools and statutory bodies', () => {
             const mainContactFn = fieldNamesFor('main-contact', 'Main contact');
 
-            const mainContactDefaultFields = [
+            expect(mainContactFn({})).toEqual([
                 'mainContactFirstName',
                 'mainContactLastName',
                 'mainContactDateOfBirth',
@@ -399,25 +523,20 @@ describe('form model', () => {
                 'mainContactEmail',
                 'mainContactPhone',
                 'mainContactCommunicationNeeds'
-            ];
+            ]);
 
-            const mainContactReducedFields = [
-                'mainContactFirstName',
-                'mainContactLastName',
-                'mainContactEmail',
-                'mainContactPhone',
-                'mainContactCommunicationNeeds'
-            ];
-
-            expect(mainContactFn({})).toEqual(mainContactDefaultFields);
-            expect(
-                mainContactFn({ organisationType: ORGANISATION_TYPES.SCHOOL })
-            ).toEqual(mainContactReducedFields);
-            expect(
-                mainContactFn({
-                    organisationType: ORGANISATION_TYPES.STATUTORY_BODY
-                })
-            ).toEqual(mainContactReducedFields);
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                expect(mainContactFn({ organisationType: orgType })).toEqual([
+                    'mainContactFirstName',
+                    'mainContactLastName',
+                    'mainContactEmail',
+                    'mainContactPhone',
+                    'mainContactCommunicationNeeds'
+                ]);
+            });
         });
     });
 });

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -243,6 +243,62 @@ describe('form model', () => {
         });
     });
 
+    function testDateOfBirthField(fieldName, minAge) {
+        test(`date of birth must be at least ${minAge}`, () => {
+            function value(val) {
+                return {
+                    [fieldName]: val
+                };
+            }
+
+            assertMessagesByKey(value(null), ['Enter a date of birth']);
+            assertMessagesByKey(value({ year: 2000, month: 2, day: 31 }), [
+                'Enter a real date'
+            ]);
+            assertMessagesByKey(value(mockDateOfBirth(0, minAge - 1)), [
+                `Must be at least ${minAge} years old`
+            ]);
+            assertValidByKey(value(mockDateOfBirth(minAge, 90)));
+        });
+
+        test('date of birth is included if there is no organisation type', () => {
+            const dobWithoutOrgType = {
+                [fieldName]: mockDateOfBirth(minAge, 90)
+            };
+            expect(testValidate(dobWithoutOrgType).value).toEqual(
+                dobWithoutOrgType
+            );
+        });
+
+        test('date of birth is included when there is a required organisation type', () => {
+            const dobWithOrgType = {
+                organisationType: ORGANISATION_TYPES.CIO,
+                [fieldName]: mockDateOfBirth(minAge, 90)
+            };
+            expect(testValidate(dobWithOrgType).value).toEqual(dobWithOrgType);
+        });
+
+        test('date of birth value stripped for schools and statutory bodies', () => {
+            [
+                ORGANISATION_TYPES.SCHOOL,
+                ORGANISATION_TYPES.STATUTORY_BODY
+            ].forEach(orgType => {
+                const dobWithSchool = {
+                    organisationType: orgType,
+                    [fieldName]: mockDateOfBirth(minAge, 90)
+                };
+
+                expect(testValidate(dobWithSchool).value).toEqual({
+                    organisationType: orgType
+                });
+
+                assertValidByKey({
+                    organisationType: orgType
+                });
+            });
+        });
+    }
+
     function testAddressField(fieldName) {
         test('address is valid', () => {
             function value(val) {
@@ -308,59 +364,7 @@ describe('form model', () => {
     }
 
     describe('senior contact', () => {
-        test('date of birth must be at least 18', () => {
-            function value(val) {
-                return {
-                    seniorContactDateOfBirth: val
-                };
-            }
-
-            assertMessagesByKey(value(null), ['Enter a date of birth']);
-            assertMessagesByKey(value({ year: 2000, month: 2, day: 31 }), [
-                'Enter a real date'
-            ]);
-            assertMessagesByKey(value(mockDateOfBirth(0, 17)), [
-                'Must be at least 18 years old'
-            ]);
-            assertValidByKey(value(mockDateOfBirth(18, 90)));
-        });
-
-        test('date of birth is included if there is no organisation type', () => {
-            const dobWithoutOrgType = {
-                seniorContactDateOfBirth: mockDateOfBirth(18, 90)
-            };
-            expect(testValidate(dobWithoutOrgType).value).toEqual(
-                dobWithoutOrgType
-            );
-        });
-
-        test('date of birth is included when there is a required organisation type', () => {
-            const dobWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                seniorContactDateOfBirth: mockDateOfBirth(18, 90)
-            };
-            expect(testValidate(dobWithOrgType).value).toEqual(dobWithOrgType);
-        });
-
-        test('date of birth value stripped for schools and statutory bodies', () => {
-            [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ].forEach(orgType => {
-                expect(
-                    testValidate({
-                        organisationType: orgType,
-                        seniorContactDateOfBirth: mockDateOfBirth(18, 90)
-                    }).value
-                ).toEqual({
-                    organisationType: orgType
-                });
-
-                assertValidByKey({
-                    organisationType: orgType
-                });
-            });
-        });
+        testDateOfBirthField('seniorContactDateOfBirth', 18);
 
         testAddressField('seniorContactAddress');
 
@@ -399,59 +403,7 @@ describe('form model', () => {
     });
 
     describe('main contact', () => {
-        test('date of birth must be at least 16', () => {
-            function value(val) {
-                return {
-                    mainContactDateOfBirth: val
-                };
-            }
-
-            assertMessagesByKey(value(null), ['Enter a date of birth']);
-            assertMessagesByKey(value({ year: 2000, month: 2, day: 31 }), [
-                'Enter a real date'
-            ]);
-            assertMessagesByKey(value(mockDateOfBirth(0, 15)), [
-                'Must be at least 16 years old'
-            ]);
-            assertValidByKey(value(mockDateOfBirth(16, 90)));
-        });
-
-        test('date of birth is included if there is no organisation type', () => {
-            const dobWithoutOrgType = {
-                mainContactDateOfBirth: mockDateOfBirth(16, 90)
-            };
-            expect(testValidate(dobWithoutOrgType).value).toEqual(
-                dobWithoutOrgType
-            );
-        });
-
-        test('date of birth is included when there is a required organisation type', () => {
-            const dobWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                mainContactDateOfBirth: mockDateOfBirth(16, 90)
-            };
-            expect(testValidate(dobWithOrgType).value).toEqual(dobWithOrgType);
-        });
-
-        test('date of birth value stripped for schools and statutory bodies', () => {
-            [
-                ORGANISATION_TYPES.SCHOOL,
-                ORGANISATION_TYPES.STATUTORY_BODY
-            ].forEach(orgType => {
-                const dobWithSchool = {
-                    organisationType: orgType,
-                    mainContactDateOfBirth: mockDateOfBirth(18, 90)
-                };
-
-                expect(testValidate(dobWithSchool).value).toEqual({
-                    organisationType: orgType
-                });
-
-                assertValidByKey({
-                    organisationType: orgType
-                });
-            });
-        });
+        testDateOfBirthField('mainContactDateOfBirth', 16);
 
         testAddressField('mainContactAddress');
 


### PR DESCRIPTION
Fixes a 🐛 excellently spotted by @mattandrews where contact details (date of birth and address) were getting stripped when the organisation type wasn't present. This information should only be stripped when an organisation type is explicitly school or statutory body.

After some debugging it turns out we were missing an `.exist` on the `joi` validation.

- Adds failing tests
- Addes `.exist` to `.when` clause