### PR TITLE
Ensure we redirect logged-in users to their original destination

### DIFF
--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -64,7 +64,7 @@ function requireActiveUser(req, res, next) {
             redirectWithReturnUrl(req, res, '/user/activate');
         }
     } else {
-        redirectWithReturnUrl(req, res, '/user');
+        redirectWithReturnUrl(req, res, '/user/login');
     }
 }
 


### PR DESCRIPTION
We were sending non-logged-in users to `/user`, which in turn redirected them to `/user/login`, meaning their last-requested URL was `/user` rather than wherever they came from (eg. `/apply/awards-for-all`). This change fixes things so users get redirected to the place that required authentication.