### PR TITLE
File upload cleanup

### DIFF
--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -25,7 +25,7 @@ const { injectCopy } = require('../../../middleware/inject-content');
 
 const validateForm = require('./lib/validate-form');
 const salesforceService = require('./lib/salesforce');
-const s3 = require('./lib/s3');
+const s3Uploads = require('./lib/s3-uploads');
 
 function initFormRouter({
     formId,
@@ -345,44 +345,27 @@ function initFormRouter({
                     /**
                      * Upload each file in the submission to salesforce
                      */
-                    const fileFields = fields.filter(function(field) {
-                        return field.type === 'file';
-                    });
-
-                    await Promise.all(
-                        fileFields.map(function(field) {
-                            const attachmentName = `${field.name}${path.extname(
-                                field.value.filename
-                            )}`;
-
-                            const s3PathConfig = {
-                                formId: formId,
-                                applicationId: currentApplication.id,
-                                filename: field.value.filename
-                            };
-
-                            return s3
-                                .headObject(s3PathConfig)
-                                .then(function(headers) {
+                    const contentVersionPromises = fields
+                        .filter(field => field.type === 'file')
+                        .map(field => {
+                            return s3Uploads
+                                .buildMultipartData({
+                                    formId: formId,
+                                    applicationId: currentApplication.id,
+                                    filename: field.value.filename
+                                })
+                                .then(versionData => {
                                     return salesforce.contentVersion({
                                         recordId: salesforceRecordId,
-                                        attachmentName: attachmentName,
-                                        versionData: {
-                                            value: s3
-                                                .getObject(s3PathConfig)
-                                                .createReadStream(),
-                                            options: {
-                                                filename: s3PathConfig.filename,
-                                                contentType:
-                                                    headers.ContentType,
-                                                knownLength:
-                                                    headers.ContentLength
-                                            }
-                                        }
+                                        attachmentName: `${
+                                            field.name
+                                        }${path.extname(field.value.filename)}`,
+                                        versionData: versionData
                                     });
                                 });
-                        })
-                    );
+                        });
+
+                    await Promise.all(contentVersionPromises);
                 } else {
                     debug(`skipped salesforce submission for ${formId}`);
                 }
@@ -440,7 +423,7 @@ function initFormRouter({
     });
 
     /**
-     * Routes: Download a proxied file from S3 (if authorised)
+     * Routes: Stream file from S3 if authorised
      */
     router.route('/download/:fieldName/:filename').get((req, res, next) => {
         const { currentlyEditingId, currentApplicationData } = res.locals;
@@ -453,11 +436,12 @@ function initFormRouter({
             // Retrieve this file from S3
             // Stream the file's headers and serve it directly as a response
             // (via https://stackoverflow.com/a/43356401)
-            s3.getObject({
-                formId: formId,
-                applicationId: currentlyEditingId,
-                filename: req.params.filename
-            })
+            s3Uploads
+                .getObject({
+                    formId: formId,
+                    applicationId: currentlyEditingId,
+                    filename: req.params.filename
+                })
                 .on('httpHeaders', (code, headers) => {
                     res.status(code);
                     if (code < 300) {

--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -13,7 +13,7 @@ const { PendingApplication } = require('../../../db/models');
 
 const pagination = require('./lib/pagination');
 const validateForm = require('./lib/validate-form');
-const s3 = require('./lib/s3');
+const s3Uploads = require('./lib/s3-uploads');
 
 module.exports = function(formId, formBuilder) {
     const router = express.Router();
@@ -219,7 +219,7 @@ module.exports = function(formId, formBuilder) {
             } else {
                 try {
                     const uploadPromises = filesToUpload.map(file =>
-                        s3.uploadFile({
+                        s3Uploads.uploadFile({
                             formId: formId,
                             applicationId: currentlyEditingId,
                             fileMetadata: file


### PR DESCRIPTION
Makes a couple of adjustments to file upload code.

- Nests try/catch blocks in submission code to avoid needing the early `return`
- Extracts `buildMultipartData` method from submission code, that structure isn't specific to salesforce, it's just the metadata object required by `request` so makes sense to have it live with the s3 code.