### PR TITLE
Use a absolute path to our logo for emails

### DIFF
--- a/common/mail.js
+++ b/common/mail.js
@@ -49,7 +49,10 @@ function generateHtmlEmail({ template, templateData }) {
                     html,
                     {
                         removeStyleTags: false,
-                        webResources: { relativeTo: publicRoot, images: 10 }
+                        webResources: {
+                            relativeTo: publicRoot,
+                            images: false // add `data-inline-ignore` to images to force them to be base64 inlined
+                        }
                     },
                     function(juiceErr, newHtml) {
                         /* istanbul ignore if */

--- a/views/layouts/emails.njk
+++ b/views/layouts/emails.njk
@@ -9,7 +9,7 @@
     </head>
     <body>
         <div class="logo">
-            <img src="/images/site-logo-email.jpg" alt="The National Lottery Community Fund logo" />
+            <img src="https://www.tnlcommunityfund.org.uk/assets/images/site-logo-email.jpg" alt="The National Lottery Community Fund logo" />
         </div>
 
         {% block content %}{% endblock %}


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/1973

This makes our logo hard-coded to the external file path. The base64 encoded (local) version didn't work in Gmail (see attached ticket). This version does (and Outlook too!):

![image](https://user-images.githubusercontent.com/394376/59601376-b0dd6080-90fb-11e9-8cb8-87e0428bce71.png)


![image](https://user-images.githubusercontent.com/394376/59601353-a753f880-90fb-11e9-9d5b-e77c059207f8.png)
