### PR TITLE
Fixes issue where JS-powered "Expand all" link on summary was in the wrong state

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -5,7 +5,11 @@ import { trackEvent } from '../helpers/metrics';
 function handleBeforeUnload(e) {
     // Message cannot be customised in Chrome 51+
     // https://developers.google.com/web/updates/2016/04/chrome-51-deprecations?hl=en
-    trackEvent('Apply', 'User warned before abandoning form changes', 'message shown');
+    trackEvent(
+        'Apply',
+        'User warned before abandoning form changes',
+        'message shown'
+    );
     const confirmationMessage = 'Are you sure you want to leave this page?';
     e.returnValue = confirmationMessage; // Gecko, Trident, Chrome 34-51
     return confirmationMessage; // Gecko, WebKit, Chrome <34
@@ -28,7 +32,12 @@ function handleAbandonmentMessage(formEl) {
     formEl.addEventListener('submit', removeBeforeUnload);
 
     window.addEventListener('unload', function() {
-        recordUnload && trackEvent('Apply', 'User warned before abandoning form changes', 'left page');
+        recordUnload &&
+            trackEvent(
+                'Apply',
+                'User warned before abandoning form changes',
+                'left page'
+            );
     });
 }
 
@@ -71,12 +80,20 @@ function toggleReviewAnswers() {
 }
 
 function handleExpandingDetails() {
-    let isClosed = true;
     const $toggleBtn = $('.js-toggle-all-details');
-    $toggleBtn.text($toggleBtn.data('label-closed')).show();
+    const isOpenInitially = $toggleBtn.data('is-open');
+    let isClosed = !isOpenInitially;
+    const btnText = isOpenInitially
+        ? $toggleBtn.data('label-open')
+        : $toggleBtn.data('label-closed');
+    $toggleBtn.text(btnText).show();
 
     $toggleBtn.on('click', function() {
-        $toggleBtn.text(isClosed ? $toggleBtn.data('label-open') : $toggleBtn.data('label-closed'));
+        $toggleBtn.text(
+            isClosed
+                ? $toggleBtn.data('label-open')
+                : $toggleBtn.data('label-closed')
+        );
         $('details.js-toggleable').attr('open', isClosed);
         isClosed = !isClosed;
     });
@@ -86,7 +103,9 @@ function handleConditionalRadios() {
     forEach(document.querySelectorAll('.js-conditional-radios'), el => {
         function setAttributes(radioEl) {
             var inputIsChecked = radioEl.checked;
-            var conditionalEl = el.querySelector(`#${radioEl.getAttribute('aria-controls')}`);
+            var conditionalEl = el.querySelector(
+                `#${radioEl.getAttribute('aria-controls')}`
+            );
             if (conditionalEl) {
                 conditionalEl.setAttribute('aria-expanded', inputIsChecked);
 

--- a/controllers/apply/form-router-next/views/summary.njk
+++ b/controllers/apply/form-router-next/views/summary.njk
@@ -107,6 +107,7 @@
             <p class="u-align-right">
                 <button type="button"
                     class="btn-link u-text-small js-toggle-all-details js-only"
+                    {% if form.progress.isComplete %}data-is-open="true"{% endif %}
                     data-label-open="{{ copy.summary.collapseAll }}"
                     data-label-closed="{{ copy.summary.expandAll }}">
                 </button>


### PR DESCRIPTION
Fixes an issue where visiting the summary page for a complete application showed a link to expand sections even though they're already expanded.

![image](https://user-images.githubusercontent.com/394376/59604904-5e08a680-9105-11e9-8785-60fd6ed430c8.png)
