### PR TITLE
Add user logging

### DIFF
--- a/controllers/user/lib/alert-message.js
+++ b/controllers/user/lib/alert-message.js
@@ -6,6 +6,18 @@ module.exports = function alertMessage({ locale, status }) {
 
     let result;
     switch (status) {
+        case 'activationSent':
+            result = localise({
+                en: `An email was sent to your registered address with instructions to activate your account.`,
+                cy: ``
+            });
+            break;
+        case 'activationComplete':
+            result = localise({
+                en: `Your account was successfully activated!`,
+                cy: ``
+            });
+            break;
         case 'passwordUpdated':
             result = localise({
                 en: `Your password was successfully updated!`,

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -13,6 +13,7 @@ const {
 } = require('../../middleware/authed');
 const { csrfProtection } = require('../../middleware/cached');
 
+const logger = require('../../common/logger');
 const alertMessage = require('./lib/alert-message');
 
 const router = express.Router();
@@ -41,14 +42,22 @@ router
         renderForm(req, res);
     })
     .post((req, res, next) => {
+        logger.info('User login: attempted');
         passport.authenticate('local', function(err, user) {
             if (err) {
+                logger.info('User login: failed', {
+                    error: err
+                });
                 next(err);
             } else if (user) {
                 req.logIn(user, function(loginErr) {
                     if (loginErr) {
+                        logger.info('User login: failed', {
+                            error: loginErr
+                        });
                         next(loginErr);
                     } else {
+                        logger.info('User login: succeeded');
                         redirectUrlWithFallback(req, res, '/user');
                     }
                 });
@@ -57,6 +66,9 @@ router
                  * User is invalid
                  * Show a generic error message here to avoid exposing account state
                  */
+                logger.info('User login: failed', {
+                    error: 'Invalid credentials'
+                });
                 return renderForm(req, res, req.body, [
                     { msg: `Your username and password combination is invalid` }
                 ]);

--- a/controllers/user/logout.js
+++ b/controllers/user/logout.js
@@ -3,7 +3,10 @@ const express = require('express');
 
 const router = express.Router();
 
-router.get('/', (req, res) => {
+const logger = require('../../common/logger');
+
+router.get('/', async (req, res) => {
+    logger.info('User logout');
     req.logout();
     req.session.save(() => {
         res.redirect('/user/login?s=loggedOut');

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -14,6 +14,8 @@ const {
     injectBreadcrumbs
 } = require('../../middleware/inject-content');
 
+const logger = require('../../common/logger');
+
 const {
     signTokenPasswordReset,
     verifyTokenPasswordReset
@@ -50,6 +52,7 @@ async function processResetRequest(req, user) {
 }
 
 function sendPasswordResetNotification(req, email) {
+    console.log(email);
     const template = path.resolve(
         __dirname,
         './views/emails/password-reset.njk'
@@ -113,11 +116,13 @@ router
 
                 if (user) {
                     await processResetRequest(req, user);
+                    logger.info('User password: reset request succeeded');
                     res.locals.passwordWasJustReset = true;
                 }
 
                 renderForgotForm(req, res);
             } catch (error) {
+                logger.info('User password: reset request failed');
                 Sentry.captureException(error);
                 renderForgotForm(req, res);
             }
@@ -155,6 +160,7 @@ router
                 res.locals.token = token();
                 renderResetForm(req, res);
             } catch (error) {
+                logger.info('User password: reset request token invalid');
                 renderResetFormExpired(req, res);
             }
         } else {
@@ -187,14 +193,19 @@ router
 
                 if (validationResult.isValid) {
                     try {
-                        const { username, password } = validationResult.value;
+                        const username = req.user.userData.username;
+                        const { password } = validationResult.value;
                         await Users.updateNewPassword({
                             id: sanitise(username),
                             newPassword: password
                         });
                         await sendPasswordResetNotification(req, username);
+                        logger.info('User password: change successful');
                         redirectForLocale(req, res, '/user?s=passwordUpdated');
                     } catch (error) {
+                        logger.info('User password: change failed', {
+                            error: error
+                        });
                         renderResetForm(req, res, validationResult.value, [
                             {
                                 msg: `There was a problem updating your password`
@@ -227,6 +238,9 @@ router
                     try {
                         decodedData = await verifyTokenPasswordReset(token);
                     } catch (jwtError) {
+                        logger.info(
+                            'User password: reset request token invalid'
+                        );
                         return renderResetFormExpired(req, res);
                     }
 
@@ -245,13 +259,20 @@ router
                                 req,
                                 user.username
                             );
+                            logger.info('User password: reset email sent');
                         } else {
+                            logger.info(
+                                'User password: reset not valid for user'
+                            );
                             redirectForLocale(req, res, '/user/login');
                         }
 
                         const urlPath = '/user/login?s=passwordUpdated';
                         redirectForLocale(req, res, urlPath);
                     } catch (error) {
+                        logger.info('User password: reset failed', {
+                            error: error
+                        });
                         Sentry.captureException(error);
                         res.locals.token = token;
                         const errors = [

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -52,7 +52,6 @@ async function processResetRequest(req, user) {
 }
 
 function sendPasswordResetNotification(req, email) {
-    console.log(email);
     const template = path.resolve(
         __dirname,
         './views/emails/password-reset.njk'


### PR DESCRIPTION
Adds some basic logging, building off https://github.com/biglotteryfund/blf-alpha/pull/2001

![image](https://user-images.githubusercontent.com/394376/59773289-48ca7e00-92a5-11e9-8a9a-c2414bb0dfcf.png)

Note that some of these don't seem to fire. Not sure if we need to make the `logger` calls async/await, though I tried this with the Logout endpoint and it still didn't output anything (possibly `req.logout()` returns immediately or something). Really it's worth just examining whether this format/style works for us.