### PR TITLE
Fix budget component issue in Firefox

### DIFF
--- a/assets/js/vue-apps/form-components/budget-input.vue
+++ b/assets/js/vue-apps/form-components/budget-input.vue
@@ -86,7 +86,7 @@ export default {
                     <label class="ff-label" :for="getLineItemName(index, 'cost')">
                         Amount
                     </label>
-                    <div class="ff-currency">
+                    <div class="ff-currency ff-currency--row">
                         <div class="ff-currency__pre">£</div>
                         <input
                             type="number"

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -414,6 +414,12 @@ $inputOutline: 3px solid get-color('border', 'outline');
         max-width: 10em;
     }
 
+    &.ff-currency--row {
+        .ff-currency__input {
+            flex: auto;
+        }
+    }
+
     .ff-currency__pre,
     .ff-currency__input {
         padding: $inputPadding;
@@ -478,17 +484,19 @@ $inputOutline: 3px solid get-color('border', 'outline');
             display: flex;
             align-items: flex-end;
 
-            .ff-budget__row-item {
-                flex: 0 0 48%;
+            > * {
                 margin-right: 2%;
+                &:last-child {
+                    margin-right: 0;
+                }
             }
 
-            .ff-budget__row-amount,
-            .ff-budget-row__action {
-                flex: 1 1 100%;
+            .ff-budget__row-item {
+                flex-grow: 2;
             }
 
             .ff-budget-row__action {
+                min-width: 190px;
                 text-align: right;
             }
         }


### PR DESCRIPTION
Before:
![Screenshot 2019-06-25 10 44 04](https://user-images.githubusercontent.com/394376/60088211-36819180-9736-11e9-99e6-4ef779148fd9.png)

After:
![Screenshot 2019-06-25 10 43 13](https://user-images.githubusercontent.com/394376/60088222-3bdedc00-9736-11e9-8914-0e373fc9aefd.png)

Confirmed this works as expected in Chrome, Edge and IE11 too.