### PR TITLE
Sort applications by createdAt not updatedAt

### DIFF
--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -70,7 +70,7 @@ class PendingApplication extends Model {
                 userId: { [Op.eq]: userId },
                 formId: { [Op.eq]: formId }
             },
-            order: [['updatedAt', 'DESC']]
+            order: [['createdAt', 'DESC']]
         });
     }
     static findApplicationForForm({ formId, applicationId, userId }) {
@@ -210,7 +210,7 @@ class SubmittedApplication extends Model {
                 userId: { [Op.eq]: userId },
                 formId: { [Op.eq]: formId }
             },
-            order: [['updatedAt', 'DESC']]
+            order: [['createdAt', 'DESC']]
         });
     }
     static createFromPendingApplication({


### PR DESCRIPTION
Sort applications by createdAt not updatedAt. Current sort order causes list of applications to jump around when editing which is confusing.