### PR TITLE
Rewrite parameter store fetching to account for pagination

### DIFF
--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 'use strict';
+/* eslint-disable no-console */
 const fs = require('fs');
 const assert = require('assert');
 const AWS = require('aws-sdk');
-const { chunk, flatten, partition, unionBy } = require('lodash');
+const unionBy = require('lodash/unionBy');
 
 AWS.config.update({ region: 'eu-west-2' });
 
@@ -17,97 +18,66 @@ const argv = require('yargs').option('environment', {
     default: 'development'
 }).argv;
 
-/**
- * Get Secrets
- * `describeParameters` returns up to **50** items but `getParameters`
- * will only return **10** items at a time so to get everything we
- * need we must chunk up our list of parameters and fetch them
- * in batches of 10 parameters at a time.
- */
-function getParametersInChunks(parameterNames) {
-    // https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html#API_GetParameters_RequestSyntax
-    const parameterChunks = chunk(parameterNames, 10);
-    return parameterChunks.map(names => {
-        return new Promise((resolve, reject) => {
-            ssm.getParameters(
-                {
-                    Names: names,
-                    WithDecryption: true
-                },
-                function(err, data) {
-                    if (err) {
-                        reject(err);
-                    }
-                    resolve(data.Parameters);
-                }
-            );
-        });
-    });
-}
-
 function normaliseParameterName(parameter) {
     parameter.OriginalName = parameter.Name;
     parameter.Name = parameter.Name.replace(/\/Web\/(Global|Test|Prod)\//, '');
     return parameter;
 }
 
-function getParametersForEnvironment(environment) {
-    return new Promise((resolve, reject) => {
-        const describeParametersOpts = {
-            // https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_DescribeParameters.html#EC2-DescribeParameters-request-MaxResults
-            MaxResults: 50,
-            ParameterFilters: [
-                {
-                    Key: 'Path',
-                    Option: 'Recursive',
-                    Values: ['/Web/Global', environment === 'production' ? '/Web/Prod' : '/Web/Test']
-                }
-            ]
-        };
+async function getParametersForPath(path) {
+    console.log(`Fetching ${path} parameters`);
+    let nextToken = null;
+    let parameters = [];
+    do {
+        const result = await ssm
+            .getParametersByPath({
+                NextToken: nextToken,
+                Path: path,
+                Recursive: true,
+                WithDecryption: true
+            })
+            .promise();
 
-        ssm.describeParameters(describeParametersOpts, function(err, data) {
-            if (err) {
-                reject(err);
-            }
+        parameters = parameters.concat(result.Parameters);
 
-            const parameterNames = data.Parameters.map(_ => _.Name);
-            Promise.all(getParametersInChunks(parameterNames))
-                .then(results => flatten(results))
-                .then(allParameters => {
-                    if (parameterNames.length !== allParameters.length) {
-                        throw new Error("Number of results doesn't match the amount requested");
-                    }
+        if (result.NextToken) {
+            nextToken = result.NextToken;
+        } else {
+            nextToken = null;
+        }
+    } while (nextToken);
 
-                    const [rawGlobalParameters, rawEnvironmentParameters] = partition(allParameters, parameter => {
-                        return /^\/Web\/Global/.test(parameter.Name);
-                    });
-
-                    const globalParameters = rawGlobalParameters.map(normaliseParameterName);
-                    const environmentParameters = rawEnvironmentParameters.map(normaliseParameterName);
-
-                    /**
-                     * Take union of /Web/Global and /Web/$Environment parameters
-                     * Favour environment specific parameters over global ones
-                     */
-                    const combinedParameters = unionBy(environmentParameters, globalParameters, 'Name');
-                    resolve(combinedParameters);
-                });
-        });
-    });
+    return parameters.map(normaliseParameterName);
 }
 
-console.log('\n', `Fetching parameters for: ${argv.environment}`, '\n');
-getParametersForEnvironment(argv.environment)
+async function getParameters(environment) {
+    const [globalParameters, environmentParameters] = await Promise.all([
+        getParametersForPath('/Web/Global'),
+        getParametersForPath(
+            environment === 'production' ? '/Web/Prod' : '/Web/Test'
+        )
+    ]);
+
+    /**
+     * Take union of /Web/Global and /Web/$Environment parameters
+     * Favour environment specific parameters over global ones
+     */
+    return unionBy(environmentParameters, globalParameters, 'Name');
+}
+
+console.log(`\nFetching for ${argv.environment} environment`);
+getParameters(argv.environment)
     .then(parameters => {
         if (!fs.existsSync(etcDir)) {
             fs.mkdirSync(etcDir);
         }
 
-        fs.writeFileSync(parametersDest, JSON.stringify(parameters, null, 4));
+        fs.writeFileSync(parametersDest, JSON.stringify(parameters, null, 2));
         assert(fs.existsSync(parametersDest));
 
-        console.log('Finished fetching parameters.');
-        console.log(`Written to ${parametersDest}`);
+        console.log(
+            `${parameters.length} parameters written to ${parametersDest}`
+        );
     })
     .catch(err => {
         console.log(err, err.stack);


### PR DESCRIPTION
Ran into an issue where parameter store get calls are paginated up to 50 entries. This PR reworks `get-secrets` to account for pagination.