### PR TITLE
Salesforce status

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -6,17 +6,22 @@ const appData = require('./appData');
 
 const skipLogs = !!process.env.TEST_SERVER === true;
 
-if (!skipLogs) {
-    // Push logs to Cloudwatch
-    winston.add(
-        new WinstonCloudWatch({
-            awsRegion: 'eu-west-2',
-            logGroupName: `/tnlcf/${appData.environment}/app`,
-            logStreamName: appData.buildNumber,
-            jsonMessage: true,
-            retentionInDays: 30
-        })
-    );
-}
+const transport = skipLogs
+    ? new winston.transports.Console({
+          format: winston.format.simple()
+      })
+    : new WinstonCloudWatch({
+          awsRegion: 'eu-west-2',
+          logGroupName: `/tnlcf/${appData.environment}/app`,
+          logStreamName: appData.buildNumber,
+          jsonMessage: true,
+          retentionInDays: 30
+      });
 
-module.exports = winston;
+const logger = winston.createLogger({
+    level: 'info',
+    format: winston.format.json(),
+    transports: [transport]
+});
+
+module.exports = logger;

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -58,18 +58,20 @@ const AZURE_AUTH = {
  * Salesforce authentication
  */
 const SALESFORCE_AUTH = {
-    API_URL: process.env.SALESFORCE_API_URL || getSecret('salesforce.apiUrl'),
-    CONSUMER_KEY:
+    apiUrl: process.env.SALESFORCE_API_URL || getSecret('salesforce.apiUrl'),
+    consumerKey:
         process.env.SALESFORCE_CONSUMER_KEY ||
         getSecret('salesforce.consumerKey'),
-    CONSUMER_SECRET:
+    consumerSecret:
         process.env.SALESFORCE_CONSUMER_SECRET ||
         getSecret('salesforce.consumerSecret'),
-    USERNAME:
+    username:
         process.env.SALESFORCE_USERNAME || getSecret('salesforce.username'),
-    PASSWORD:
+    password:
         process.env.SALESFORCE_PASSWORD || getSecret('salesforce.password'),
-    TOKEN: process.env.SALESFORCE_TOKEN || getSecret('salesforce.token')
+    token: process.env.SALESFORCE_TOKEN || getSecret('salesforce.token'),
+    instanceId:
+        process.env.SALESFORCE_INSTANCE_ID || getSecret('salesforce.instanceId')
 };
 
 /**

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -17,6 +17,7 @@ const {
     SubmittedApplication
 } = require('../../../db/models');
 
+const commonLogger = require('../../../common/logger');
 const appData = require('../../../common/appData');
 const { localify } = require('../../../common/urls');
 const { csrfProtection } = require('../../../middleware/cached');
@@ -262,6 +263,10 @@ function initFormRouter({
     router.post('/submission', async (req, res, next) => {
         const { currentApplication, currentApplicationData } = res.locals;
 
+        const logger = commonLogger.child({
+            service: 'salesforce'
+        });
+
         function canSubmit() {
             return isEmpty(currentApplication) === false;
         }
@@ -285,6 +290,8 @@ function initFormRouter({
             const fields = flatMap(fieldsets, 'fields');
 
             try {
+                logger.info('Submission started');
+
                 /**
                  * Increment submission attempts
                  * Allows us to report on failed submission attempts.
@@ -317,6 +324,8 @@ function initFormRouter({
                         salesforceFormData
                     );
 
+                    logger.info('FormData record created');
+
                     /**
                      * Upload each file in the submission to salesforce
                      */
@@ -341,6 +350,7 @@ function initFormRouter({
                         });
 
                     await Promise.all(contentVersionPromises);
+                    logger.info('File uploads attached to FormData record');
                 } else {
                     debug(`skipped salesforce submission for ${formId}`);
                 }
@@ -379,6 +389,7 @@ function initFormRouter({
                         data: currentApplicationData
                     });
 
+                    logger.info('Submission successful');
                     res.render(
                         path.resolve(__dirname, './views/confirmation'),
                         {
@@ -389,8 +400,25 @@ function initFormRouter({
                     );
                 });
             } catch (error) {
-                // @TODO: Redirect to custom /error rather than passing to default handler?
-                next(error);
+                logger.error('Submission failed');
+
+                /**
+                 * Salesforce submission failed,
+                 * Check the instance status and log if not OK,
+                 * allows us to monitor how many applications get submitted during
+                 * maintenance windows to determine if we need some visible messaging.
+                 */
+                try {
+                    const response = await salesforceService.checkStatus();
+
+                    if (response.status !== 'OK') {
+                        logger.info(`Salesforce status ${response.status}`);
+                    }
+
+                    next(error);
+                } catch (statusError) {
+                    next(error);
+                }
             }
         } else {
             res.redirect(req.baseUrl);

--- a/controllers/apply/form-router-next/lib/salesforce.js
+++ b/controllers/apply/form-router-next/lib/salesforce.js
@@ -31,9 +31,7 @@ class Salesforce {
     }
     async contentVersion({ recordId, attachmentName, versionData }) {
         return request.post({
-            url: `${this.apiUrl}/services/data/${
-                this.apiVersion
-            }/sobjects/ContentVersion`,
+            url: `${this.apiUrl}/services/data/${this.apiVersion}/sobjects/ContentVersion`,
             headers: this.headers,
             formData: {
                 entity_content: {
@@ -53,22 +51,31 @@ class Salesforce {
 }
 
 async function authorise() {
-    const AUTH_URL = `https://${SALESFORCE_AUTH.API_URL}/services/oauth2/token`;
+    const AUTH_URL = `https://${SALESFORCE_AUTH.apiUrl}/services/oauth2/token`;
     const resultJson = await request.post({
         url: AUTH_URL,
         json: true,
         form: {
             grant_type: 'password',
-            client_id: SALESFORCE_AUTH.CONSUMER_KEY,
-            client_secret: SALESFORCE_AUTH.CONSUMER_SECRET,
-            username: SALESFORCE_AUTH.USERNAME,
-            password: `${SALESFORCE_AUTH.PASSWORD}${SALESFORCE_AUTH.TOKEN}`
+            client_id: SALESFORCE_AUTH.consumerKey,
+            client_secret: SALESFORCE_AUTH.consumerSecret,
+            username: SALESFORCE_AUTH.username,
+            password: `${SALESFORCE_AUTH.password}${SALESFORCE_AUTH.token}`
         }
     });
 
     return new Salesforce(resultJson.instance_url, resultJson.access_token);
 }
 
+function checkStatus() {
+    return request({
+        url: `https://api.status.salesforce.com/v1/instances/${SALESFORCE_AUTH.instanceId}/status`,
+        json: true,
+        timeout: 3000
+    });
+}
+
 module.exports = {
-    authorise
+    authorise,
+    checkStatus
 };


### PR DESCRIPTION
Adds a `checkStatus` method to the salesforce lib code which is called if there is an error submitting to check the instance status. If the status is reported as anything other than `OK` then we log this. 

This doesn't block the application submission, simply acting as logging to see if anyone _does_ submit an application during a maintenance window. If we see more a reasonable number of these events logged then we'll know we need to do something more full-featured here.