### PR TITLE
Update validation-rules.md

### DIFF
--- a/assets/js/vue-apps/form-components/budget-input.test.js
+++ b/assets/js/vue-apps/form-components/budget-input.test.js
@@ -40,13 +40,13 @@ describe('BudgetInput', () => {
         // Over-budget
         lastRow.find('input[type="number"]').setValue(10000);
         expect(wrapper.find('[data-testid="budget-errors"]').text()).toContain(
-            `Total project costs must be less than £${maxBudget}.`
+            `Project costs must be less than £${maxBudget}.`
         );
 
         // Under-budget
         lastRow.find('input[type="number"]').setValue(10);
         expect(wrapper.find('[data-testid="budget-errors"]').text()).toContain(
-            `Total project costs must be greater than £${minBudget}.`
+            `Project costs must be greater than £${minBudget}.`
         );
 
         // Reach limit

--- a/assets/js/vue-apps/form-components/budget-input.vue
+++ b/assets/js/vue-apps/form-components/budget-input.vue
@@ -122,10 +122,10 @@ export default {
                 You must use {{ maxItems }} budget headings or fewer to tell us your costs
             </p>
             <p v-if="error.OVER_BUDGET">
-                Total project costs must be less than £{{ maxBudget.toLocaleString() }}.
+                Project costs must be less than £{{ maxBudget.toLocaleString() }}.
             </p>
             <p v-if="error.UNDER_BUDGET">
-                Total project costs must be greater than £{{ minBudget.toLocaleString() }}.
+                Project costs must be greater than £{{ minBudget.toLocaleString() }}.
             </p>
         </div>
 

--- a/controllers/apply/awards-for-all/docs/validation-rules.md
+++ b/controllers/apply/awards-for-all/docs/validation-rules.md
@@ -12,15 +12,16 @@ This file documents validation rules, conditions, and error message text for all
 
 ### When would you like to start and end your project?
 
-| Rule                   | Message                                                          |
-| ---------------------- | ---------------------------------------------------------------- |
-| Required field         | Enter a date                                                     |
-| Both invalid           | Enter a valid project start and end date                         |
-| Start date invalid     | Enter a valid project start date                                 |
-| End date invalid       | Enter a valid project end date                                   |
-| Date too soon          | Date you start or end the project must be after [example date]   |
-| Ends before start date | Project end date must be after start date                        |
-| Outside limit          | Project end date must be within [max duration] of the start date |
+| Rule                                | Message                                                          |
+| ----------------------------------- | ---------------------------------------------------------------- |
+| Required field (start date)         | Enter a project start date                                       |
+| Required field (end date)           | Enter an project end date                                        |
+| Both invalid                        | Project start and end dates must be real dates                   |
+| Start date invalid                  | Date you start the project must be a real date                   |
+| End date invalid                    | Date you end the project must be a real date                     |
+| Date too soon                       | Date you start the project must be after [example date]          |
+| Ends before start date              | Date you end the project must be after the start date            |
+| Outside limit                       | Date you end the project must be within [max duration] of the start date |
 
 ## Project Country
 
@@ -28,7 +29,7 @@ This file documents validation rules, conditions, and error message text for all
 
 | Rule           | Message                |
 | -------------- | ---------------------- |
-| Required field | Choose a valid country |
+| Required field | Select a country       |
 
 ## Project Location
 
@@ -36,13 +37,13 @@ This file documents validation rules, conditions, and error message text for all
 
 | Rule           | Message           |
 | -------------- | ----------------- |
-| Required field | Choose a location |
+| Required field | Select a location |
 
 ### Tell us the towns, villages or wards where your beneficiaries live
 
-| Rule           | Message             |
-| -------------- | ------------------- |
-| Required field | Enter a description |
+| Rule           | Message                                                         |
+| -------------- | --------------------------------------------------------------- |
+| Required field | Tell us the towns, villages or wards your beneficiaries live in |
 
 ### What is the postcode of the location where your project will take place?
 
@@ -62,11 +63,11 @@ This file documents validation rules, conditions, and error message text for all
 
 ### How does your project meet at least one of our funding priorities?
 
-| Rule           | Message                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| Required field | Tell us how your project meet at least one of our funding priorities |
-| Min words      | Answer must be at least [min] words                                  |
-| Max words      | Answer must be no more than [max] words                              |
+| Rule           | Message                                                               |
+| -------------- | --------------------------------------------------------------------- |
+| Required field | Tell us how your project meets at least one of our funding priorities |
+| Min words      | Answer must be at least [min] words                                   |
+| Max words      | Answer must be no more than [max] words                               |
 
 ### How does your project involve your community?
 
@@ -105,8 +106,8 @@ Client-side warnings:
 
 | Rule                  | Message                                                        |
 | --------------------- | -------------------------------------------------------------- |
-| Amount is below limit | Total project costs must be greater than [min]                 |
-| Amount is over limit  | Total project costs must be less than [max]                    |
+| Amount is below limit | Project costs must be greater than [min]                       |
+| Amount is over limit  | Project costs must be less than [max]                          |
 | Too many rows         | You must use 10 budget headings or fewer to tell us your costs |
 
 ### Project total cost
@@ -123,23 +124,23 @@ Client-side warnings:
 
 | Rule           | Message          |
 | -------------- | ---------------- |
-| Required field | Answer yes or no |
+| Required field | Select yes or no |
 
 ### What specific groups of people is your project aimed at?
 
 Shown if answered "yes" to the question above.
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                         |
+| -------------- | --------------------------------------------------------------- |
+| Required field | Select the specific group(s) of people your project is aimed at |
 
 An additional "Other" field is provided for free text responses.
 
 ### Ethnic background
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| Required field | Select the ethnic background(s) of the people that will benefit from your project             |
 
 #### Conditions
 
@@ -147,9 +148,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Gender
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                         |
+| -------------- | ------------------------------------------------------------------------------- |
+| Required field | Select the gender(s) of the people that will benefit from your project          |
 
 #### Conditions
 
@@ -157,9 +158,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Age
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| Required field | Select the age group(s) of the people that will benefit from your project                     |
 
 #### Conditions
 
@@ -167,9 +168,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Disabled people
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                         |
+| -------------- | ------------------------------------------------------------------------------- |
+| Required field | Select the disabled people that will benefit from your project                  |
 
 #### Conditions
 
@@ -177,9 +178,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Religion
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Required field | Select the religion(s) or belief(s) of the people that will benefit from your project     |
 
 #### Conditions
 
@@ -189,9 +190,9 @@ An additional "Other" field is provided for free text responses.
 
 ### How many of the people who will benefit from your project speak Welsh?
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Required field | Select the amount of people who speak Welsh that will benefit from your project           |
 
 #### Conditions
 
@@ -199,9 +200,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Which community do the people who will benefit from your project belong to?
 
-| Rule           | Message                                 |
-| -------------- | --------------------------------------- |
-| Required field | Choose from one of the options provided |
+| Rule           | Message                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| Required field | Select the community that the people who will benefit from your project belong to         |
 
 #### Conditions
 
@@ -225,28 +226,28 @@ _Does your organisation use a different name in your day-to-day work?_
 
 ### When was your organisation set up?
 
-| Rule         | Message                    |
-| ------------ | -------------------------- |
-| Empty        | Enter a day and month      |
-| Invalid date | Enter a real day and month |
-| In future    | Enter a past date          |
+| Rule         | Message                     |
+| ------------ | --------------------------- |
+| Empty        | Enter a month and year      |
+| Invalid date | Enter a real month and year |
+| In future    | Date you enter must be in the past |
 
 ### Organisation address
 
-| Rule                   | Message                     |
-| ---------------------- | --------------------------- |
-| Required field         | Enter a full UK address     |
-| No building and street | Enter a building and street |
-| No town or city        | Enter a town or city        |
-| No county              | Enter a county              |
-| No postcode            | Enter a postcode            |
-| Valid postcode         | Enter a real postcode       |
+| Rule                       | Message                     |
+| -------------------------- | --------------------------- |
+| Required field             | Enter a full UK address     |
+| No building and street     | Enter a building and street |
+| No town or city            | Enter a town or city        |
+| No county (optional field) | n/a                         |
+| No postcode                | Enter a postcode            |
+| Valid postcode             | Enter a real postcode       |
 
 ### Organisation type
 
 | Rule           | Message                       |
 | -------------- | ----------------------------- |
-| Required field | Choose a type of organisation |
+| Required field | Select a type of organisation |
 
 ### Company number
 
@@ -297,12 +298,17 @@ _Does your organisation use a different name in your day-to-day work?_
 | -------------- | ---------------- |
 | Required field | Enter first name |
 
+### Senior contact last name
+
+| Rule           | Message          |
+| -------------- | ---------------- |
+| Required field | Enter last name |
+
 ### Senior contact name
 
 | Rule                   | Message                                                            |
 | ---------------------- | ------------------------------------------------------------------ |
-| Required field         | Enter a first and last name                                        |
-| Matches Senior Contact | Senior contact name must be different from the main contact's name |
+| Matches Senior Contact | Senior contact must be a different person from the main contact    |
 
 #### Mappings
 
@@ -338,28 +344,27 @@ The senior contact role shows the following choices depending on the organisatio
 
 ### Senior contact address
 
-| Rule                   | Message                     |
-| ---------------------- | --------------------------- |
-| Required field         | Enter a full UK address     |
-| No building and street | Enter a building and street |
-| No town or city        | Enter a town or city        |
-| No county              | Enter a county              |
-| No postcode            | Enter a postcode            |
-| Valid postcode         | Enter a real postcode       |
+| Rule                       | Message                     |
+| -------------------------- | --------------------------- |
+| Required field             | Enter a full UK address     |
+| No building and street     | Enter a building and street |
+| No town or city            | Enter a town or city        |
+| No county (optional field) | n/a                         |
+| No postcode                | Enter a postcode            |
+| Valid postcode             | Enter a real postcode       |
 
 ### Senior contact address history
 
 Address history field group, consists of:
 
-| Rule                   | Message                                 |
-| ---------------------- | --------------------------------------- |
-| Required field         | Enter a full UK address                 |
-| Invalid choice         | Choose from one of the options provided |
-| No building and street | Enter a building and street             |
-| No town or city        | Enter a town or city                    |
-| No county              | Enter a county                          |
-| No postcode            | Enter a postcode                        |
-| Valid postcode         | Enter a real postcode                   |
+| Rule                       | Message                     |
+| -------------------------- | --------------------------- |
+| Required field             | Enter a full UK address     |
+| No building and street     | Enter a building and street |
+| No town or city            | Enter a town or city        |
+| No county (optional field) | n/a                         |
+| No postcode                | Enter a postcode            |
+| Valid postcode             | Enter a real postcode       |
 
 #### Conditions
 
@@ -371,6 +376,7 @@ Address history field group, consists of:
 | -------------- | ------------------------------------------------------------------ |
 | Required field | Enter an email address                                             |
 | Invalid format | Email address must be in the correct format, like name@example.com |
+| Matches main contact | Senior contact email address must be different from the main contact's email address |
 
 ### Senior contact phone
 
@@ -387,12 +393,23 @@ Address history field group, consists of:
 
 ## Main contact
 
+### Main contact first name
+
+| Rule           | Message          |
+| -------------- | ---------------- |
+| Required field | Enter first name |
+
+### Main contact last name
+
+| Rule           | Message          |
+| -------------- | ---------------- |
+| Required field | Enter last name |
+
 ### Main contact name
 
 | Rule                   | Message                                                            |
 | ---------------------- | ------------------------------------------------------------------ |
-| Required field         | Enter a first and last name                                        |
-| Matches Senior Contact | Main contact name must be different from the senior contact's name |
+| Matches Senior Contact | Main contact must be a different person from the senior contact    |
 
 ### Main contact date of birth
 
@@ -408,14 +425,14 @@ Address history field group, consists of:
 
 ### Main contact address
 
-| Rule                   | Message                     |
-| ---------------------- | --------------------------- |
-| Required field         | Enter a full UK address     |
-| No building and street | Enter a building and street |
-| No town or city        | Enter a town or city        |
-| No county              | Enter a county              |
-| No postcode            | Enter a postcode            |
-| Valid postcode         | Enter a real postcode       |
+| Rule                       | Message                     |
+| -------------------------- | --------------------------- |
+| Required field             | Enter a full UK address     |
+| No building and street     | Enter a building and street |
+| No town or city            | Enter a town or city        |
+| No county (optional field) | n/a                         |
+| No postcode                | Enter a postcode            |
+| Valid postcode             | Enter a real postcode       |
 
 #### Conditions
 
@@ -423,15 +440,14 @@ Address history field group, consists of:
 
 ### Main contact address history
 
-| Rule                   | Message                                 |
-| ---------------------- | --------------------------------------- |
-| Required field         | Enter a full UK address                 |
-| Invalid choice         | Choose from one of the options provided |
-| No building and street | Enter a building and street             |
-| No town or city        | Enter a town or city                    |
-| No county              | Enter a county                          |
-| No postcode            | Enter a postcode                        |
-| Valid postcode         | Enter a real postcode                   |
+| Rule                       | Message                     |
+| -------------------------- | --------------------------- |
+| Required field             | Enter a full UK address     |
+| No building and street     | Enter a building and street |
+| No town or city            | Enter a town or city        |
+| No county (optional field) | n/a                         |
+| No postcode                | Enter a postcode            |
+| Valid postcode             | Enter a real postcode       |
 
 #### Conditions
 
@@ -462,23 +478,24 @@ Address history field group, consists of:
 
 ### Account name
 
-| Rule           | Message                  |
-| -------------- | ------------------------ |
-| Required field | Name on the bank account |
+| Rule           | Message                                                                   |
+| -------------- | ------------------------------------------------------------------------- |
+| Required field | Enter the name of your organisaiton, as it appears on your bank statement |
 
 ### Sort code
 
 | Rule           | Message                     |
 | -------------- | --------------------------- |
-| Required field | Enter a sort-code           |
-| Too short      | Enter a six digit sort code |
+| Required field | Enter a sort code           |
+| Too short      | Sort code must be six digits long |
+| Too long       | Sort code must be six digits long |
 
 ### Account number
 
 | Rule           | Message                             |
 | -------------- | ----------------------------------- |
 | Required field | Enter an account number             |
-| Too short      | Enter an eight digit account number |
+| Too short      | Is this correct? Account numbers are usually eight digits long |
 
 ### Building society number
 
@@ -500,34 +517,34 @@ Address history field group, consists of:
 
 | Rule     | Message                                           |
 | -------- | ------------------------------------------------- |
-| Required | You must agree to all of the terms and conditions |
+| Required | You must confirm that you're authorised to submit this application |
 
 ### Terms checkbox 2
 
 | Rule     | Message                                           |
 | -------- | ------------------------------------------------- |
-| Required | You must agree to all of the terms and conditions |
+| Required | You must confirm that the information you've provided in this application is accurate |
 
 ### Terms checkbox 3
 
 | Rule     | Message                                           |
 | -------- | ------------------------------------------------- |
-| Required | You must agree to all of the terms and conditions |
+| Required | You must confirm that you understand how we'll use any personal information you've provided |
 
 ### Terms checkbox 3
 
 | Rule     | Message                                           |
 | -------- | ------------------------------------------------- |
-| Required | You must agree to all of the terms and conditions |
+| Required | You must confirm that you understand your application is subject to our Freedom of Information policy  |
 
 ### Full name of person completing this form
 
 | Rule     | Message                                                      |
 | -------- | ------------------------------------------------------------ |
-| Required | You must provide the name of the person completing this form |
+| Required | Enter the full name of the person completing this form       |
 
 ### Position in organisation
 
 | Rule     | Message                                                          |
 | -------- | ---------------------------------------------------------------- |
-| Required | You must provide the position of the person completing this form |
+| Required | Enter the position of the person completing this form            |

--- a/controllers/apply/awards-for-all/docs/validation-rules.md
+++ b/controllers/apply/awards-for-all/docs/validation-rules.md
@@ -12,24 +12,23 @@ This file documents validation rules, conditions, and error message text for all
 
 ### When would you like to start and end your project?
 
-| Rule                                | Message                                                          |
-| ----------------------------------- | ---------------------------------------------------------------- |
-| Required field (start date)         | Enter a project start date                                       |
-| Required field (end date)           | Enter an project end date                                        |
-| Both invalid                        | Project start and end dates must be real dates                   |
-| Start date invalid                  | Date you start the project must be a real date                   |
-| End date invalid                    | Date you end the project must be a real date                     |
-| Date too soon                       | Date you start the project must be after [example date]          |
-| Ends before start date              | Date you end the project must be after the start date            |
-| Outside limit                       | Date you end the project must be within [max duration] of the start date |
+| Rule                   | Message                                                                  |
+| ---------------------- | ------------------------------------------------------------------------ |
+| Required field         | Enter a project start and end date                                       |
+| Both invalid           | Project start and end dates must be real dates                           |
+| Start date invalid     | Date you start the project must be a real date                           |
+| End date invalid       | Date you end the project must be a real date                             |
+| Date too soon          | Date you start the project must be after [example date]                  |
+| Ends before start date | Date you end the project must be after the start date                    |
+| Outside limit          | Date you end the project must be within [max duration] of the start date |
 
 ## Project Country
 
 ### What country will your project be based in?
 
-| Rule           | Message                |
-| -------------- | ---------------------- |
-| Required field | Select a country       |
+| Rule           | Message          |
+| -------------- | ---------------- |
+| Required field | Select a country |
 
 ## Project Location
 
@@ -93,14 +92,14 @@ All project idea questions have the following in-browser word-count messages.
 
 Server-side errors:
 
-| Rule                  | Message                                        |
-| --------------------- | ---------------------------------------------- |
-| Required field        | Enter a project budget                         |
-| Missing description   | Enter an item or activity                      |
-| Missing cost          | Enter an amount                                |
-| Cost is not a number  | Each cost must be a real number                |
-| Amount is below limit | Total project costs must be greater than [min] |
-| Amount is over limit  | Total project costs must be less than [max]    |
+| Rule                  | Message                                  |
+| --------------------- | ---------------------------------------- |
+| Required field        | Enter a project budget                   |
+| Missing description   | Enter an item or activity                |
+| Missing cost          | Enter an amount                          |
+| Cost is not a number  | Each cost must be a real number          |
+| Amount is below limit | Project costs must be greater than [min] |
+| Amount is over limit  | Project costs must be less than [max]    |
 
 Client-side warnings:
 
@@ -138,9 +137,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Ethnic background
 
-| Rule           | Message                                                                                       |
-| -------------- | --------------------------------------------------------------------------------------------- |
-| Required field | Select the ethnic background(s) of the people that will benefit from your project             |
+| Rule           | Message                                                                           |
+| -------------- | --------------------------------------------------------------------------------- |
+| Required field | Select the ethnic background(s) of the people that will benefit from your project |
 
 #### Conditions
 
@@ -148,9 +147,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Gender
 
-| Rule           | Message                                                                         |
-| -------------- | ------------------------------------------------------------------------------- |
-| Required field | Select the gender(s) of the people that will benefit from your project          |
+| Rule           | Message                                                                |
+| -------------- | ---------------------------------------------------------------------- |
+| Required field | Select the gender(s) of the people that will benefit from your project |
 
 #### Conditions
 
@@ -158,9 +157,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Age
 
-| Rule           | Message                                                                                       |
-| -------------- | --------------------------------------------------------------------------------------------- |
-| Required field | Select the age group(s) of the people that will benefit from your project                     |
+| Rule           | Message                                                                   |
+| -------------- | ------------------------------------------------------------------------- |
+| Required field | Select the age group(s) of the people that will benefit from your project |
 
 #### Conditions
 
@@ -168,9 +167,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Disabled people
 
-| Rule           | Message                                                                         |
-| -------------- | ------------------------------------------------------------------------------- |
-| Required field | Select the disabled people that will benefit from your project                  |
+| Rule           | Message                                                        |
+| -------------- | -------------------------------------------------------------- |
+| Required field | Select the disabled people that will benefit from your project |
 
 #### Conditions
 
@@ -178,9 +177,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Religion
 
-| Rule           | Message                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Required field | Select the religion(s) or belief(s) of the people that will benefit from your project     |
+| Rule           | Message                                                                               |
+| -------------- | ------------------------------------------------------------------------------------- |
+| Required field | Select the religion(s) or belief(s) of the people that will benefit from your project |
 
 #### Conditions
 
@@ -190,9 +189,9 @@ An additional "Other" field is provided for free text responses.
 
 ### How many of the people who will benefit from your project speak Welsh?
 
-| Rule           | Message                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Required field | Select the amount of people who speak Welsh that will benefit from your project           |
+| Rule           | Message                                                                         |
+| -------------- | ------------------------------------------------------------------------------- |
+| Required field | Select the amount of people who speak Welsh that will benefit from your project |
 
 #### Conditions
 
@@ -200,9 +199,9 @@ An additional "Other" field is provided for free text responses.
 
 ### Which community do the people who will benefit from your project belong to?
 
-| Rule           | Message                                                                                   |
-| -------------- | ----------------------------------------------------------------------------------------- |
-| Required field | Select the community that the people who will benefit from your project belong to         |
+| Rule           | Message                                                                           |
+| -------------- | --------------------------------------------------------------------------------- |
+| Required field | Select the community that the people who will benefit from your project belong to |
 
 #### Conditions
 
@@ -226,10 +225,10 @@ _Does your organisation use a different name in your day-to-day work?_
 
 ### When was your organisation set up?
 
-| Rule         | Message                     |
-| ------------ | --------------------------- |
-| Empty        | Enter a month and year      |
-| Invalid date | Enter a real month and year |
+| Rule         | Message                            |
+| ------------ | ---------------------------------- |
+| Empty        | Enter a month and year             |
+| Invalid date | Enter a real month and year        |
 | In future    | Date you enter must be in the past |
 
 ### Organisation address
@@ -294,21 +293,14 @@ _Does your organisation use a different name in your day-to-day work?_
 
 ### Senior contact first name
 
-| Rule           | Message          |
-| -------------- | ---------------- |
-| Required field | Enter first name |
-
-### Senior contact last name
-
-| Rule           | Message          |
-| -------------- | ---------------- |
-| Required field | Enter last name |
-
 ### Senior contact name
 
-| Rule                   | Message                                                            |
-| ---------------------- | ------------------------------------------------------------------ |
-| Matches Senior Contact | Senior contact must be a different person from the main contact    |
+| Rule                   | Message                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| Required field         | Enter a first and last name                                     |
+| First name missing     | Enter first name                                                |
+| Last name missing      | Enter last name                                                 |
+| Matches Senior Contact | Senior contact must be a different person from the main contact |
 
 #### Mappings
 
@@ -372,10 +364,10 @@ Address history field group, consists of:
 
 ### Senior contact email
 
-| Rule           | Message                                                            |
-| -------------- | ------------------------------------------------------------------ |
-| Required field | Enter an email address                                             |
-| Invalid format | Email address must be in the correct format, like name@example.com |
+| Rule                 | Message                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| Required field       | Enter an email address                                                               |
+| Invalid format       | Email address must be in the correct format, like name@example.com                   |
 | Matches main contact | Senior contact email address must be different from the main contact's email address |
 
 ### Senior contact phone
@@ -393,23 +385,14 @@ Address history field group, consists of:
 
 ## Main contact
 
-### Main contact first name
-
-| Rule           | Message          |
-| -------------- | ---------------- |
-| Required field | Enter first name |
-
-### Main contact last name
-
-| Rule           | Message          |
-| -------------- | ---------------- |
-| Required field | Enter last name |
-
 ### Main contact name
 
-| Rule                   | Message                                                            |
-| ---------------------- | ------------------------------------------------------------------ |
-| Matches Senior Contact | Main contact must be a different person from the senior contact    |
+| Rule                   | Message                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| Required field         | Enter a first and last name                                     |
+| First name missing     | Enter first name                                                |
+| Last name missing      | Enter last name                                                 |
+| Matches Senior Contact | Main contact must be a different person from the senior contact |
 
 ### Main contact date of birth
 
@@ -478,23 +461,22 @@ Address history field group, consists of:
 
 ### Account name
 
-| Rule           | Message                                                                   |
-| -------------- | ------------------------------------------------------------------------- |
-| Required field | Enter the name of your organisaiton, as it appears on your bank statement |
+| Rule           | Message                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| Required field | Enter the name of your organisation as it appears on your bank statement |
 
 ### Sort code
 
-| Rule           | Message                     |
-| -------------- | --------------------------- |
-| Required field | Enter a sort code           |
-| Too short      | Sort code must be six digits long |
-| Too long       | Sort code must be six digits long |
+| Rule           | Message                           |
+| -------------- | --------------------------------- |
+| Required field | Enter a sort code                 |
+| Invalid length | Sort code must be six digits long |
 
 ### Account number
 
-| Rule           | Message                             |
-| -------------- | ----------------------------------- |
-| Required field | Enter an account number             |
+| Rule           | Message                                                        |
+| -------------- | -------------------------------------------------------------- |
+| Required field | Enter an account number                                        |
 | Too short      | Is this correct? Account numbers are usually eight digits long |
 
 ### Building society number
@@ -515,36 +497,36 @@ Address history field group, consists of:
 
 ### Terms checkbox 1
 
-| Rule     | Message                                           |
-| -------- | ------------------------------------------------- |
+| Rule     | Message                                                            |
+| -------- | ------------------------------------------------------------------ |
 | Required | You must confirm that you're authorised to submit this application |
 
 ### Terms checkbox 2
 
-| Rule     | Message                                           |
-| -------- | ------------------------------------------------- |
+| Rule     | Message                                                                               |
+| -------- | ------------------------------------------------------------------------------------- |
 | Required | You must confirm that the information you've provided in this application is accurate |
 
 ### Terms checkbox 3
 
-| Rule     | Message                                           |
-| -------- | ------------------------------------------------- |
+| Rule     | Message                                                                                     |
+| -------- | ------------------------------------------------------------------------------------------- |
 | Required | You must confirm that you understand how we'll use any personal information you've provided |
 
 ### Terms checkbox 3
 
-| Rule     | Message                                           |
-| -------- | ------------------------------------------------- |
-| Required | You must confirm that you understand your application is subject to our Freedom of Information policy  |
+| Rule     | Message                                                                                               |
+| -------- | ----------------------------------------------------------------------------------------------------- |
+| Required | You must confirm that you understand your application is subject to our Freedom of Information policy |
 
 ### Full name of person completing this form
 
-| Rule     | Message                                                      |
-| -------- | ------------------------------------------------------------ |
-| Required | Enter the full name of the person completing this form       |
+| Rule     | Message                                                |
+| -------- | ------------------------------------------------------ |
+| Required | Enter the full name of the person completing this form |
 
 ### Position in organisation
 
-| Rule     | Message                                                          |
-| -------- | ---------------------------------------------------------------- |
-| Required | Enter the position of the person completing this form            |
+| Rule     | Message                                               |
+| -------- | ----------------------------------------------------- |
+| Required | Enter the position of the person completing this form |

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -127,13 +127,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     },
                     {
                         type: 'any.empty',
-                        key: 'county',
-                        message: localise({ en: 'Enter a county', cy: '' })
-                    },
-                    {
-                        type: 'any.empty',
                         key: 'postcode',
-                        message: localise({ en: 'Enter a postcode', cy: '' })
+                        message: localise({
+                            en: 'Enter a postcode',
+                            cy: ''
+                        })
                     },
                     {
                         type: 'string.postcode',
@@ -237,6 +235,22 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                         type: 'base',
                         message: localise({
                             en: 'Enter a first and last name',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'any.empty',
+                        key: 'firstName',
+                        message: localise({
+                            en: 'Enter first name',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'any.empty',
+                        key: 'lastName',
+                        message: localise({
+                            en: 'Enter last name',
                             cy: ''
                         })
                     }
@@ -388,7 +402,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose a type of organisation',
+                        en: 'Select a type of organisation',
                         cy: ''
                     })
                 }
@@ -543,14 +557,12 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
                 if (this.type === 'radio') {
                     text += localise({
-                        en:
-                            'The options given to you for selection are based on this.',
+                        en: `The options given to you for selection are based on this.`,
                         cy: ''
                     });
                 } else {
                     text += localise({
-                        en:
-                            'This should be someone in a position of authority in your organisation.',
+                        en: `This should be someone in a position of authority in your organisation.`,
                         cy: ''
                     });
                 }
@@ -663,7 +675,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         });
     }
 
-    const fields = {
+    return {
         projectName: {
             name: 'projectName',
             label: localise({
@@ -741,47 +753,52 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 return [
                     {
                         type: 'base',
-                        message: localise({ en: 'Enter a date', cy: '' })
+                        message: localise({
+                            en: 'Enter a project start and end date',
+                            cy: ''
+                        })
                     },
                     {
                         type: 'dateRange.both.invalid',
                         message: localise({
-                            en: 'Enter a valid project start and end date',
+                            en:
+                                'Project start and end dates must be real dates',
                             cy: ''
                         })
                     },
                     {
                         type: 'datesRange.startDate.invalid',
                         message: localise({
-                            en: 'Enter a valid project start date',
+                            en:
+                                'Date you start the project must be a real date',
                             cy: ''
                         })
                     },
                     {
                         type: 'dateRange.endDate.invalid',
                         message: localise({
-                            en: 'Enter a valid project end date',
+                            en: 'Date you end the project must be a real date',
                             cy: ''
                         })
                     },
                     {
                         type: 'dateRange.minDate.invalid',
                         message: localise({
-                            en: `Date you start or end the project must be after ${this.settings.fromDateExample}`,
+                            en: `Date you start the project must be after ${this.settings.fromDateExample}`,
                             cy: ''
                         })
                     },
                     {
                         type: 'dateRange.endDate.beforeStartDate',
                         message: localise({
-                            en: `Project end date must be after start date`,
+                            en: `Date you end the project must be after the start date`,
                             cy: ''
                         })
                     },
                     {
                         type: 'dateRange.endDate.outsideLimit',
                         message: localise({
-                            en: `Project end date must be within ${this.settings.maxDurationFromStart.label} of the start date.`,
+                            en: `Date you end the project must be within ${this.settings.maxDurationFromStart.label} of the start date.`,
                             cy: ''
                         })
                     }
@@ -845,7 +862,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Choose a valid country', cy: '' })
+                    message: localise({ en: 'Select a country', cy: '' })
                 }
             ]
         },
@@ -875,7 +892,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Choose a location', cy: '' })
+                    message: localise({ en: 'Select a location', cy: '' })
                 }
             ]
         },
@@ -891,7 +908,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Enter a description', cy: '' })
+                    message: localise({
+                        en: `Tell us the towns, villages or wards your beneficiaries live in`,
+                        cy: ''
+                    })
                 }
             ]
         },
@@ -1021,7 +1041,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'base',
                         message: localise({
-                            en: `Tell us how your project meet at least one of our funding priorities`,
+                            en: `Tell us how your project meets at least one of our funding priorities`,
                             cy: ``
                         })
                     },
@@ -1147,14 +1167,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'budgetItems.overBudget',
                     message: localise({
-                        en: `Total project costs must be less than £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}`,
+                        en: `Project costs must be less than £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}`,
                         cy: ``
                     })
                 },
                 {
                     type: 'budgetItems.underBudget',
                     message: localise({
-                        en: `Total project costs must be greater than £${MIN_BUDGET_TOTAL_GBP.toLocaleString()}`,
+                        en: `Project costs must be greater than £${MIN_BUDGET_TOTAL_GBP.toLocaleString()}`,
                         cy: ``
                     })
                 }
@@ -1233,7 +1253,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Answer yes or no', cy: '' })
+                    message: localise({ en: 'Select yes or no', cy: '' })
                 }
             ]
         },
@@ -1307,7 +1327,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the specific group(s) of people your project is aimed at`,
                         cy: ''
                     })
                 }
@@ -1468,7 +1488,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the ethnic background(s) of the people that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1508,7 +1528,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the gender(s) of the people that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1541,7 +1561,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the age group(s) of the people that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1602,7 +1622,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the disabled people that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1646,7 +1666,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the religion(s) or belief(s) of the people that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1701,7 +1721,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the amount of people who speak Welsh that will benefit from your project`,
                         cy: ''
                     })
                 }
@@ -1758,7 +1778,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Choose from one of the options provided',
+                        en: `Select the community that the people who will benefit from your project belong to`,
                         cy: ''
                     })
                 }
@@ -1820,19 +1840,19 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Enter a day and month', cy: '' })
+                    message: localise({ en: 'Enter a month and year', cy: '' })
                 },
                 {
                     type: 'any.invalid',
                     message: localise({
-                        en: 'Enter a real day and month',
+                        en: 'Enter a real month and year',
                         cy: ''
                     })
                 },
                 {
                     type: 'monthYear.pastDate',
                     message: localise({
-                        en: 'Enter a past date',
+                        en: 'Date you enter must be in the past',
                         cy: ''
                     })
                 }
@@ -2266,7 +2286,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'string.length',
                     message: localise({
-                        en: 'Enter a six digit sort code',
+                        en: 'Sort code must be six digits long',
                         cy: ''
                     })
                 }
@@ -2290,7 +2310,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'string.length',
                     message: localise({
-                        en: 'Enter an eight digit account number',
+                        en: `Is this correct? Account numbers are usually eight digits long`,
                         cy: ''
                     })
                 }
@@ -2373,7 +2393,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'You must agree to all of the terms and conditions',
+                        en: `You must confirm that you're authorised to submit this application`,
                         cy: ''
                     })
                 }
@@ -2396,7 +2416,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'You must agree to all of the terms and conditions',
+                        en: `You must confirm that the information you've provided in this application is accurate`,
                         cy: ''
                     })
                 }
@@ -2419,7 +2439,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'You must agree to all of the terms and conditions',
+                        en: `You must confirm that you understand how we'll use any personal information you've provided`,
                         cy: ''
                     })
                 }
@@ -2442,7 +2462,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'You must agree to all of the terms and conditions',
+                        en: `You must confirm that you understand your application is subject to our Freedom of Information policy`,
                         cy: ''
                     })
                 }
@@ -2461,7 +2481,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: `You must provide the name of the person completing this form`,
+                        en: `Enter the full name of the person completing this form`,
                         cy: ''
                     })
                 }
@@ -2477,7 +2497,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: `You must provide the position of the person completing this form`,
+                        en: `Enter the position of the person completing this form`,
                         cy: ''
                     })
                 }
@@ -2485,6 +2505,4 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true
         }
     };
-
-    return fields;
 };

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -180,20 +180,26 @@ describe('Form validations', () => {
             }
 
             assertValidByKey(value(mockStartDate(12), mockStartDate(30)));
-            assertMessagesByKey(value(null, null), ['Enter a date']);
+            assertMessagesByKey(value(null, null), [
+                'Enter a project start and end date'
+            ]);
             assertMessagesByKey(
                 value(
                     { day: 31, month: 2, year: 2030 },
                     { day: 31, month: 24, year: 2030 }
                 ),
-                ['Enter a valid project start and end date']
+                ['Project start and end dates must be real dates']
             );
             assertMessagesByKey(
                 value(
                     { day: 1, month: 1, year: 2020 },
                     { day: 1, month: 1, year: 2030 }
                 ),
-                [expect.stringMatching(/Project end date must be within/)]
+                [
+                    expect.stringMatching(
+                        /Date you end the project must be within/
+                    )
+                ]
             );
         });
 
@@ -210,9 +216,7 @@ describe('Form validations', () => {
             ]);
 
             assertValidByKey(value(randomCountry));
-            assertMessagesByKey(value('not-a-country'), [
-                'Choose a valid country'
-            ]);
+            assertMessagesByKey(value('not-a-country'), ['Select a country']);
         });
 
         test('project postcode must be a valid UK postcode', () => {
@@ -279,7 +283,7 @@ describe('Form validations', () => {
             }));
 
             assertMessagesByKey(value(budget), [
-                'Total project costs must be less than £10,000'
+                'Project costs must be less than £10,000'
             ]);
         });
 
@@ -438,7 +442,7 @@ describe('Form validations', () => {
             }
 
             assertValidByKey(value({ month: 3, year: 2000 }));
-            assertMessagesByKey(value(null), ['Enter a day and month']);
+            assertMessagesByKey(value(null), ['Enter a month and year']);
         });
 
         test('organisation address must be provided', () => {
@@ -468,7 +472,7 @@ describe('Form validations', () => {
             }
 
             assertValidByKey(value(sample(Object.values(ORGANISATION_TYPES))));
-            const defaultMessages = ['Choose a type of organisation'];
+            const defaultMessages = ['Select a type of organisation'];
             assertMessagesByKey(value(null), defaultMessages);
             assertMessagesByKey(value('not-an-option'), defaultMessages);
         });
@@ -1045,7 +1049,7 @@ describe('form shape', () => {
         ).toEqual([
             {
                 msg: expect.stringMatching(
-                    /Date you start or end the project must be after/
+                    /Date you start the project must be after/
                 ),
                 param: 'projectDateRange',
                 type: 'dateRange.minDate.invalid',


### PR DESCRIPTION
According to this link, some bank account numbers (even with Lloyds TSB) can only be seven digits long: https://www.business.hsbc.co.uk/1/2/!ut/p/c5/04_SB8K8xLLM9MSSzPy8xBz9CP0os3gDC-NASzc3b38LA3_PYD9Lg0AjAwgAykeaxTu7O3qYmPsA-WGergaeJk4mBqa-boYGnsYEdPt55Oem6oeDbMVU5-0OV1eQG1Hh6aioCAAZFG7T/dl3/d3/L2dJQSEvUUt3QS9ZQnZ3LzZfMDgzUTlGRktPODBPSVNOOVBQMDAwMDAwMDA!/

I've seen other less reputable articles saying UK bank account numbers can be six to 11 digits long (https://blog.antoine-augusti.fr/2015/11/go-challenge-validating-uk-bank-account-numbers/)

So perhaps the error message about bank account numbers being too short should be a soft warning - was discussing this with Tim.