### PR TITLE
Don't hard code merchandise lookup to English

### DIFF
--- a/controllers/materials/index.js
+++ b/controllers/materials/index.js
@@ -170,7 +170,7 @@ router
         renderForm(req, res, FORM_STATES.NOT_SUBMITTED);
     })
     .post(
-        injectMerchandise({ locale: 'en' }),
+        injectMerchandise({}),
         map(materialFields, field => field.validator(field)),
         (req, res) => {
             req.body = mapValues(req.body, sanitise);


### PR DESCRIPTION
This is a weird one because it's probably been present forever.

If someone submits an order in Welsh, we fetch all the products from the API, and then look up the exact items they requested from the site. This was hardcoded to always lookup the English versions when `POST`ing the form, I think to ensure that the email that gets sent to PSL contains the English product names (for readability). This email also contains the item codes, though, so this is probably unnecessary. 

This had the side effect, though, of breaking orders, as the item IDs wouldn't match (eg. the Welsh bunting has a different database ID to the English, so it would never find it in the product list). This change fixes that.