### PR TITLE
Add content type "People Stories" to News section

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -370,15 +370,18 @@ news:
     press-releases:
       singular: Datganiad i’r wasg
       plural: Datganiadau i’r wasg
-    # @TODO decide on the name for this and get it translated
-    updates:
-      singular: Updates
-      plural: Updates
+    people-stories:
+      singular: Stori Pobl
+      plural: Straeon Pobl
+  aboutThisContent:
+    blog: Ynglŷn â’r blog postio hwn
+    people-stories: Ynglŷn â’r Stori Pobl hwn
   datePublished: Dyddiad cyhoeddi
   readMoreAboutProgramme: Darllen mwy am y rhaglen hon
   blogpost:
-    aboutThisBlogPost: Ynglŷn â’r blog postio hwn
     viewAllBlogPosts: Gweld yr holl bostiadau blog
+  peopleStories:
+    viewAllPeopleStories: Gweld holl Straeon Pobl
   pressRelease:
     region: Rhanbarth
     notesToEditors: Nodiadau i Olygyddion
@@ -402,6 +405,8 @@ news:
       Bydd ein datganiadau i’r wasg yn rhoi’r prif ffeithiau i chi am gyhoeddiadau ariannu, grantiau neu ymchwil newydd, digwyddiadau arbennig, digwyddiadau lansio, pa elusennau y gwobrwywyd arian iddynt, prosiectau dyfeisgar, arfer gorau yn y sector a mwy.
     blog: >
       Chwilio am liw, cyd-destun a phersbectif ar waith Cronfa Gymunedol y Loteri Genedlaethol, ei effaith ar gymunedau a’r pynciau sydd yn y newyddion ar hyn o bryd? Mae’r cyfan yma. Bydd y blog hwn yn esbonio, ymchwilio, arddangos ac archwilio ffyrdd y mae cymdeithas sifil, ac o ganlyniad i hynny, y sector, yn newid. Darllenwch am yr hyn yr oedd pobl mewn cymunedau led led y DU a’r sector yn ei feddwl yr oedd gan arweinyddion i’w ddweud a ffurfio eich barn eich hunan.
+    people-stories: >
+      Rydym o’r gred pan mae pobl yn arwain, mae cymunedau’n ffynnu. Yma, gallwch ddarllen straeon bywyd go iawn am bobl sydd wedi cael budd o arian y Loteri Genedlaethol; wedi cymryd rhan mewn prosiectau sydd wedi ehangu gorwelion, gwella eu cymunedau a newid eu bywydau am y gorau.
   filters:
     viewPostsTagged: Gweld yr holl byst sydd wedi’u tagio gyda
     viewPostsIn: Gweld yr holl byst o fewn

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -380,7 +380,7 @@ news:
   readMoreAboutProgramme: Darllen mwy am y rhaglen hon
   blogpost:
     viewAllBlogPosts: Gweld yr holl bostiadau blog
-  peopleStories:
+  people-stories:
     viewAllPeopleStories: Gweld holl Straeon Pobl
   pressRelease:
     region: Rhanbarth

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -480,7 +480,7 @@ news:
   readMoreAboutProgramme: Read more about this programme
   blogpost:
     viewAllBlogPosts: View all blog posts
-  peopleStories:
+  people-stories:
     viewAllPeopleStories: View all People Stories
   pressRelease:
     region: Region

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -506,7 +506,7 @@ news:
     blog: >
       Looking for colour, context and perspective about the work of The National Lottery Community Fund, its impact on communities and topics currently in the news? It’s all here. This blog will explain, explore, showcase and examine the ways in which civil society, and as a result the sector, is changing. Read about what people in communities across the UK and sector thought leaders have to say and form your own opinion.
     people-stories: >
-      TBD
+      We believe that when people are in the lead, communities thrive. Here you can read real-life stories about people who have benefited from National Lottery funding; taking part in projects that have broadened their horizons, improved their communities, and changed their lives for the better.
   filters:
     viewPostsTagged: Viewing all posts tagged
     viewPostsIn: Viewing all posts in

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -470,15 +470,18 @@ news:
     press-releases:
       singular: Press Release
       plural: Press Releases
-    # @TODO decide on the name for this and get it translated
-    updates:
-      singular: Updates
-      plural: Updates
+    people-stories:
+      singular: People Story
+      plural: People Stories
+  aboutThisContent:
+    blog: About this blog post
+    people-stories: About this People Story
   datePublished: Date published
   readMoreAboutProgramme: Read more about this programme
   blogpost:
-    aboutThisBlogPost: About this blog post
     viewAllBlogPosts: View all blog posts
+  peopleStories:
+    viewAllPeopleStories: View all People Stories
   pressRelease:
     region: Region
     notesToEditors: Notes to Editors
@@ -502,6 +505,8 @@ news:
       Our press releases will give you the key facts about funding announcements, new grants or research, special events, launches, which charities have been awarded funding, innovative projects, best practice in the sector and more.
     blog: >
       Looking for colour, context and perspective about the work of The National Lottery Community Fund, its impact on communities and topics currently in the news? It’s all here. This blog will explain, explore, showcase and examine the ways in which civil society, and as a result the sector, is changing. Read about what people in communities across the UK and sector thought leaders have to say and form your own opinion.
+    people-stories: >
+      TBD
   filters:
     viewPostsTagged: Viewing all posts tagged
     viewPostsIn: Viewing all posts in

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -60,26 +60,28 @@
                 </footer>
             </section>
 
-            {# Blog posts #}
-            <section class="latest-updates u-inner u-margin-bottom">
-                <header class="latest-updates__header">
-                    <h2 class="t--underline">{{ copy.types['people-stories'].plural }}</h2>
-                </header>
-                <div class="latest-updates__content">
-                    <ul class="flex-grid flex-grid--3up">
-                        {% for entry in peopleStories | take(3) %}
-                            <li class="flex-grid__item">
-                                {{ blogTrail(entry, updateType = 'people-stories') }}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                <footer class="latest-updates__footer">
-                    <a class="latest-updates__more" href="{{ localify('/news/people-stories') }}">
-                        {{ copy.peopleStories.viewAllPeopleStories }} &rarr;
-                    </a>
-                </footer>
-            </section>
+            {# People stories #}
+            {% if peopleStories.length > 0 %}
+                <section class="latest-updates u-inner u-margin-bottom">
+                    <header class="latest-updates__header">
+                        <h2 class="t--underline">{{ copy.types['people-stories'].plural }}</h2>
+                    </header>
+                    <div class="latest-updates__content">
+                        <ul class="flex-grid flex-grid--3up">
+                            {% for entry in peopleStories | take(3) %}
+                                <li class="flex-grid__item">
+                                    {{ blogTrail(entry, updateType = 'people-stories') }}
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    <footer class="latest-updates__footer">
+                        <a class="latest-updates__more" href="{{ localify('/news/people-stories') }}">
+                            {{ copy.peopleStories.viewAllPeopleStories }} &rarr;
+                        </a>
+                    </footer>
+                </section>
+            {% endif %}
 
             {# Press releases #}
             {% call contentBox() %}

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -60,6 +60,27 @@
                 </footer>
             </section>
 
+            {# Blog posts #}
+            <section class="latest-updates u-inner u-margin-bottom">
+                <header class="latest-updates__header">
+                    <h2 class="t--underline">{{ copy.types['people-stories'].plural }}</h2>
+                </header>
+                <div class="latest-updates__content">
+                    <ul class="flex-grid flex-grid--3up">
+                        {% for entry in peopleStories | take(3) %}
+                            <li class="flex-grid__item">
+                                {{ blogTrail(entry, updateType = 'people-stories') }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                <footer class="latest-updates__footer">
+                    <a class="latest-updates__more" href="{{ localify('/news/people-stories') }}">
+                        {{ copy.peopleStories.viewAllPeopleStories }} &rarr;
+                    </a>
+                </footer>
+            </section>
+
             {# Press releases #}
             {% call contentBox() %}
                 <h2>{{ copy.types['press-releases'].plural }}</h2>

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -77,7 +77,7 @@
                     </div>
                     <footer class="latest-updates__footer">
                         <a class="latest-updates__more" href="{{ localify('/news/people-stories') }}">
-                            {{ copy.peopleStories.viewAllPeopleStories }} &rarr;
+                            {{ copy['people-stories'].viewAllPeopleStories }} &rarr;
                         </a>
                     </footer>
                 </section>

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -43,7 +43,7 @@
                     {% set activeCategory = entriesMeta.activeCategory %}
                     <h1>{{ copy.filters.viewPostsIn }} {{ activeCategory.title }}</h1>
                 {% else %}
-                    <p>{{ copy.introductions.blog }}</p>
+                    <p>{{ copy.introductions[updateType] }}</p>
                 {% endif %}
             </div>
         </div>
@@ -67,7 +67,8 @@
                         {{ blogTrail(
                             entry = entry,
                             promoted = shouldPromote,
-                            showAuthor = entriesMeta.pageType !== 'author'
+                            showAuthor = entriesMeta.pageType !== 'author',
+                            updateType = updateType
                         ) }}
                     </li>
                 {% endfor %}

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -14,7 +14,7 @@
 
 {% macro articleMeta(entry) %}
 
-    {% set aboutTitle = copy.author.plural  if entry.authors.length > 1  else copy.author.singular %}
+    {% set aboutTitle = copy.author.plural if entry.authors.length > 1  else copy.author.singular %}
     {% call card(aboutTitle) %}
         {% for author in entry.authors -%}
             <aside class="o-media">
@@ -37,11 +37,11 @@
                     {% endif %}
                 </div>
             </aside>
-            <p class="u-margin-top-s"><a href="{{ localify('/news/blog?author=' + author.slug) }}">{{ copy.author.seeAllPosts }}</a></p>
+            <p class="u-margin-top-s"><a href="{{ localify('/news/' + updateType + '?author=' + author.slug) }}">{{ copy.author.seeAllPosts }}</a></p>
         {% endfor %}
     {% endcall %}
 
-    {% call card(copy.blogpost.aboutThisBlogPost) %}
+    {% call card(copy.aboutThisContent[updateType]) %}
         {% if entry.postDate %}
             <p class="u-margin-bottom-s">
                 <strong>{{ copy.datePublished }}:</strong>
@@ -58,14 +58,16 @@
         {% endif %}
 
         <ul class="tags-list">
-            <li class="tag">
-                <a href="{{ localify('/news/blog/?category=' + entry.category.slug) }}">
-                    {{ entry.category.title }}
-                </a>
-            </li>
+            {% if entry.category %}
+                <li class="tag">
+                    <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
+                        {{ entry.category.title }}
+                    </a>
+                </li>
+            {% endif %}
             {% for tag in entry.tags %}
                 <li class="tag tag--secondary">
-                    <a href="{{ localify('/news/blog?tag=' + tag.slug) }}">
+                    <a href="{{ localify('/news/' + updateType + '?tag=' + tag.slug) }}">
                         {{ tag.title }}
                     </a>
                 </li>
@@ -103,7 +105,7 @@
                 <aside class="article__topics" role="aside">
                     {% set links = [] %}
                     {% for tag in entry.tags %}
-                        {% set links = (links.push({ "label": tag.title, "url": localify('/news/blog?tag=' + tag.slug) }), links) %}
+                        {% set links = (links.push({ "label": tag.title, "url": localify('/news/' + updateType + '?tag=' + tag.slug) }), links) %}
                     {% endfor %}
                     {{ inlineLinks(prefix = __('global.misc.topics') | title, links = links) }}
                 </aside>
@@ -114,7 +116,7 @@
                     href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
                     data-ga-on="click"
                     data-ga-event-category="Facebook"
-                    data-ga-event-action="Share blogpost">
+                    data-ga-event-action="Share {{ updateType }}">
                     <span class="btn__icon">{{ iconFacebook() }}</span>
                     {{ __('global.misc.share.facebook') }}
                 </a>
@@ -122,7 +124,7 @@
                     href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ entry.title }}&via={{ globalCopy.brand.twitter }}"
                     data-ga-on="click"
                     data-ga-event-category="Twitter"
-                    data-ga-event-action="Share blogpost">
+                    data-ga-event-action="Share {{ updateType }}">
                     <span class="btn__icon">{{ iconTwitter() }}</span>
                     {{ __('global.misc.share.twitter')  }}
                 </a>

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -11,7 +11,7 @@
     {%- endfor %}
 {% endmacro %}
 
-{% macro blogTrail(entry, promoted = false, showAuthor = true) %}
+{% macro blogTrail(entry, promoted = false, showAuthor = true, updateType = 'blog') %}
     {% call promoCard({
         "title": entry.trailText or entry.title,
         subtitle: formatDate(entry.postDate.date, DATE_FORMATS.short),
@@ -57,14 +57,16 @@
 
             <div class="blogpost-attribution__tags">
                 <ul class="tags-list">
-                    <li class="tag">
-                        <a href="{{ localify('/news/blog?category=' + entry.category.slug) }}">
-                            {{ entry.category.title }}
-                        </a>
-                    </li>
+                    {% if entry.category %}
+                        <li class="tag">
+                            <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
+                                {{ entry.category.title }}
+                            </a>
+                        </li>
+                    {% endif %}
                     {% for tag in entry.tags %}
                         <li class="tag tag--secondary">
-                            <a href="{{ localify('/news/blog?tag=' + tag.slug) }}">
+                            <a href="{{ localify('/news/' + updateType + '?tag=' + tag.slug) }}">
                                 {{ tag.title }}
                             </a>
                         </li>


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/176

This shares the blogpost logic to expand into the Updates content type formerly known as "News", now renamed People Stories. They display the same as blogposts (minus the category field).