### PR TITLE
Minor tweaks

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -638,10 +638,8 @@ $inputOutline: 3px solid get-color('border', 'outline');
     }
 
     &.has-errors {
-        .form-field__main {
-            border-left: 3px solid get-color('message', 'warning');
-            padding-left: $spacingUnit / 2;
-        }
+        border-left: 3px solid get-color('message', 'warning');
+        padding-left: $spacingUnit / 2;
     }
 }
 

--- a/controllers/apply/form-router-next/views/dashboard.njk
+++ b/controllers/apply/form-router-next/views/dashboard.njk
@@ -65,11 +65,11 @@
             <ol class="u-list-unstyled">
                 {% for section in application.progress.sections %}
                     <li class="section-progress-mini section-progress-mini--{{ section.status }}">
-                        <a class="section-progress-mini__title u-link-minimal" href="{{ formBaseUrl }}/{{ section.slug }}">
+                        <span class="section-progress-mini__title">
                             {{ loop.index }}: {{ section.label }}
-                        </a>
+                        </span>
 
-                        <a class="section-progress-mini__marker u-link-minimal" href="{{ formBaseUrl }}/{{ section.slug }}">
+                        <span class="section-progress-mini__marker">
                             {% if section.status === 'complete' %}
                                 {{ iconTick() }} {{ copy.statusComplete }}
                             {% elseif section.status === 'incomplete' %}
@@ -77,7 +77,7 @@
                             {% else %}
                                 {{ copy.statusNotStarted }}
                             {% endif %}
-                        </a>
+                        </span>
                     </li>
                 {% endfor %}
             </ol>

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -599,11 +599,17 @@
             {% endif %}
         </div>
         {% if fieldErrors.length > 0 %}
+            {% if field.settings.showWordCount %}
+                <noscript>
+            {% endif %}
             <ol class="form-field__errors">
                 {% for error in fieldErrors %}
                     <li>{{ error.msg }}</li>
                 {% endfor %}
             </ol>
+            {% if field.settings.showWordCount %}
+                </noscript>
+            {% endif %}
         {% endif %}
     </div>
 {% endmacro %}

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -565,47 +565,45 @@
     <div
         id="form-field-{{ field.name }}"
         class="form-field form-field--{{ field.name }} form-field--type-{{ field.type }}{% if fieldErrors | length > 0 %} has-errors{% endif %}">
-        <div class="form-field__main">
-            <div class="form-field__body">
-                {% if field.type === 'textarea' %}
-                    {{ inputTextarea(field) }}
-                {% elseif field.type === 'select' %}
-                    {{ inputSelect(field) }}
-                {% elseif field.type === 'checkbox' %}
-                    {{ inputCheckbox(field) }}
-                {% elseif field.type === 'radio' %}
-                    {{ inputRadio(field) }}
-                {% elseif field.type === 'date' %}
-                    {{ inputDate(field) }}
-                {% elseif field.type === 'date-range' %}
-                    {{ inputDateRange(field) }}
-                {% elseif field.type === 'day-month' %}
-                    {{ inputDate(field, includeYear = false) }}
-                {% elseif field.type === 'month-year' %}
-                    {{ inputDate(field, includeDay = false) }}
-                {% elseif field.type === 'currency' %}
-                    {{ inputCurrency(field) }}
-                {% elseif field.type === 'address' %}
-                    {{ inputAddress(field) }}
-                {% elseif field.type === 'address-history' %}
-                    {{ inputAddressHistory(field) }}
-                {% elseif field.type === 'budget' %}
-                    {{ inputBudget(field) }}
-                {% elseif field.type === 'file' %}
-                    {{ inputFile(field) }}
-                {% elseif field.type === 'full-name' %}
-                    {{ inputNames(field) }}
-                {% else %}
-                    {{ inputText(field) }}
-                {% endif %}
-            </div>
-            {% if fieldErrors.length > 0 %}
-                <ol class="form-field__errors">
-                    {% for error in fieldErrors %}
-                        <li>{{ error.msg }}</li>
-                    {% endfor %}
-                </ol>
+        <div class="form-field__body">
+            {% if field.type === 'textarea' %}
+                {{ inputTextarea(field) }}
+            {% elseif field.type === 'select' %}
+                {{ inputSelect(field) }}
+            {% elseif field.type === 'checkbox' %}
+                {{ inputCheckbox(field) }}
+            {% elseif field.type === 'radio' %}
+                {{ inputRadio(field) }}
+            {% elseif field.type === 'date' %}
+                {{ inputDate(field) }}
+            {% elseif field.type === 'date-range' %}
+                {{ inputDateRange(field) }}
+            {% elseif field.type === 'day-month' %}
+                {{ inputDate(field, includeYear = false) }}
+            {% elseif field.type === 'month-year' %}
+                {{ inputDate(field, includeDay = false) }}
+            {% elseif field.type === 'currency' %}
+                {{ inputCurrency(field) }}
+            {% elseif field.type === 'address' %}
+                {{ inputAddress(field) }}
+            {% elseif field.type === 'address-history' %}
+                {{ inputAddressHistory(field) }}
+            {% elseif field.type === 'budget' %}
+                {{ inputBudget(field) }}
+            {% elseif field.type === 'file' %}
+                {{ inputFile(field) }}
+            {% elseif field.type === 'full-name' %}
+                {{ inputNames(field) }}
+            {% else %}
+                {{ inputText(field) }}
             {% endif %}
         </div>
+        {% if fieldErrors.length > 0 %}
+            <ol class="form-field__errors">
+                {% for error in fieldErrors %}
+                    <li>{{ error.msg }}</li>
+                {% endfor %}
+            </ol>
+        {% endif %}
     </div>
 {% endmacro %}

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -164,28 +164,26 @@
     <div
         id="form-field-{{ field.name }}"
         class="form-field form-field--{{ field.name }} form-field--type-{{ field.type }}{% if fieldErrors | length > 0 %} has-errors{% endif %}">
-        <div class="form-field__main">
-            <div class="form-field__body">
-                {% if field.type === 'textarea' %}
-                    {{ inputTextarea(field, fieldCopy) }}
-                {% elseif field.type === 'select' %}
-                    {{ inputSelect(field, fieldCopy) }}
-                {% elseif field.type === 'checkbox' or field.type === 'radio' %}
-                    {{ inputChoice(field, fieldCopy) }}
-                {% elseif field.type === 'currency' %}
-                    {{ inputCurrency(field, fieldCopy) }}
-                {% else %}
-                    {{ inputText(field, fieldCopy) }}
-                {% endif %}
-            </div>
-            {% if fieldErrors.length > 0 %}
-                <ol class="form-field__errors">
-                    {% for error in fieldErrors %}
-                        <li>{{ error.msg }}</li>
-                    {% endfor %}
-                </ol>
+        <div class="form-field__body">
+            {% if field.type === 'textarea' %}
+                {{ inputTextarea(field, fieldCopy) }}
+            {% elseif field.type === 'select' %}
+                {{ inputSelect(field, fieldCopy) }}
+            {% elseif field.type === 'checkbox' or field.type === 'radio' %}
+                {{ inputChoice(field, fieldCopy) }}
+            {% elseif field.type === 'currency' %}
+                {{ inputCurrency(field, fieldCopy) }}
+            {% else %}
+                {{ inputText(field, fieldCopy) }}
             {% endif %}
         </div>
+        {% if fieldErrors.length > 0 %}
+            <ol class="form-field__errors">
+                {% for error in fieldErrors %}
+                    <li>{{ error.msg }}</li>
+                {% endfor %}
+            </ol>
+        {% endif %}
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
**Remove section links from dashboard**
Noticed that these don't work as expected as the link is stateful based on the application being currently edited. It might be possible to get these working by (re)setting the active application when clicking one of these links but for now it's safer to remove the links

**Simplify field markup**
There were too many wrapping divs around all our fields, removing `form-field__main` streamlines things a big

**Suppress error warnings for fields with a word count**
Avoids server rendered error messages competing with client-side message by wrapping server error in a `<noscript>`