### PR TITLE
Enable logger with feature flag and silence in tests

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -40,14 +40,15 @@
   "features": {
     "enableAllowLocalhost": false,
     "enableAwardsForAllApplications": false,
+    "enableCloudWatchLogs": true,
     "enableDigitalFundApplications": false,
     "enableHotjar": false,
     "enableMailSendMetrics": false,
     "enableNameChangeMessage": true,
     "enableRelatedGrants": false,
+    "enableSalesforceConnector": false,
     "enableSeeders": false,
-    "enableSiteSurvey": true,
-    "enableSalesforceConnector": false
+    "enableSiteSurvey": true
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/config/development.json
+++ b/config/development.json
@@ -5,6 +5,7 @@
   "features": {
     "enableAllowLocalhost": false,
     "enableAwardsForAllApplications": true,
+    "enableCloudWatchLogs": false,
     "enableSeeders": true,
     "enableSalesforceConnector": true
   }


### PR DESCRIPTION
Update CloudWatch logger to be enabled using a feature flag and silence console logger when running in a test server.