### PR TITLE
Add nested Strategic Programme pages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -797,6 +797,8 @@ funding:
     under10k: Awards under £10,000
     over10k: Awards over £10,000
     allProgrammes: View all funding programmes
+  strategics:
+    title: Strategic investments in England
   archivedProgramme:
     archivedMessage: This programme is no longer available and has been archived
     archivedDetail: >

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -136,7 +136,12 @@ function flexibleContent() {
         injectBreadcrumbs,
         (req, res, next) => {
             if (res.locals.content) {
-                res.render(path.resolve(__dirname, './views/flexible-content'));
+                res.render(
+                    path.resolve(__dirname, './views/flexible-content'),
+                    {
+                        flexibleContent: res.locals.content.flexibleContent
+                    }
+                );
             } else {
                 next();
             }

--- a/controllers/common/views/flexible-content.njk
+++ b/controllers/common/views/flexible-content.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/main.njk" %}
 {% from "components/hero.njk" import hero with context %}
-{% from "components/flexible-content/macro.njk" import flexibleContent %}
+{% from "components/flexible-content/macro.njk" import flexibleContent as flexibleContentArea %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% block content %}
@@ -10,7 +10,7 @@
         <div class="nudge-up">
             <section class="content-box u-inner-wide-only">
                 {{ breadcrumbTrail(breadcrumbs) }}
-                {{ flexibleContent(content.flexibleContent) }}
+                {{ flexibleContentArea(flexibleContent) }}
             </section>
         </div>
     </main>

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -243,7 +243,8 @@ router.get(
                 res.render(
                     path.resolve(__dirname, '../common/views/flexible-content'),
                     {
-                        breadcrumbs: breadcrumbs
+                        breadcrumbs: breadcrumbs,
+                        flexibleContent: fundingProgramme.content
                     }
                 );
             } else if (

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -1,28 +1,84 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const { concat, startsWith } = require('lodash');
+const { concat, get, set, startsWith } = require('lodash');
 
 const {
     injectBreadcrumbs,
     injectListingContent,
     injectStrategicProgramme,
-    injectStrategicProgrammes
+    injectStrategicProgrammes,
+    setCommonLocals
 } = require('../../middleware/inject-content');
 
 const router = express.Router();
 
-router.get('/', injectListingContent, injectBreadcrumbs, injectStrategicProgrammes, function(req, res) {
+router.use(injectBreadcrumbs, (req, res, next) => {
+    const routerCrumb = {
+        label: req.i18n.__('funding.strategics.title'),
+        url: req.baseUrl
+    };
+    res.locals.breadcrumbs = concat(res.locals.breadcrumbs, [routerCrumb]);
+    next();
+});
+
+router.get('/', injectListingContent, injectStrategicProgrammes, function(
+    req,
+    res
+) {
     res.render(path.resolve(__dirname, './views/strategic-investments'));
 });
 
-router.get('/:slug', injectBreadcrumbs, injectStrategicProgramme, function(req, res, next) {
+router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
+    req,
+    res,
+    next
+) {
     const { currentPath, strategicProgramme } = res.locals;
     /* Only render if not using an external path */
-    if (strategicProgramme && startsWith(currentPath, strategicProgramme.linkUrl)) {
-        res.render(path.resolve(__dirname, './views/strategic-programme'), {
-            breadcrumbs: concat(res.locals.breadcrumbs, strategicProgramme.sectionBreadcrumbs)
-        });
+    if (
+        strategicProgramme &&
+        startsWith(currentPath, strategicProgramme.linkUrl)
+    ) {
+        // Render a plain content page if specified
+        if (get(strategicProgramme, 'entryType') === 'contentPage') {
+            setCommonLocals({ res, entry: strategicProgramme });
+            set(
+                res.locals,
+                'content.flexibleContent',
+                strategicProgramme.content
+            );
+            let breadcrumbs;
+
+            if (strategicProgramme.parent) {
+                const parentProgrammeCrumb = {
+                    label: strategicProgramme.parent.title,
+                    url: strategicProgramme.parent.linkUrl
+                };
+                breadcrumbs = concat(res.locals.breadcrumbs, [
+                    parentProgrammeCrumb,
+                    { label: res.locals.title }
+                ]);
+            } else {
+                breadcrumbs = concat(res.locals.breadcrumbs, [
+                    { label: res.locals.title }
+                ]);
+            }
+
+            res.render(
+                path.resolve(__dirname, '../common/views/flexible-content'),
+                {
+                    breadcrumbs: breadcrumbs
+                }
+            );
+        } else {
+            // Render a standard Strategic page
+            res.render(path.resolve(__dirname, './views/strategic-programme'), {
+                breadcrumbs: concat(res.locals.breadcrumbs, {
+                    label: res.locals.title
+                })
+            });
+        }
     } else {
         next();
     }

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -68,7 +68,8 @@ router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
             res.render(
                 path.resolve(__dirname, '../common/views/flexible-content'),
                 {
-                    breadcrumbs: breadcrumbs
+                    breadcrumbs: breadcrumbs,
+                    flexibleContent: strategicProgramme.content
                 }
             );
         } else {

--- a/middleware/inject-content.js
+++ b/middleware/inject-content.js
@@ -40,8 +40,11 @@ function setCommonLocals({ res, entry }) {
     res.locals.openGraph = get('openGraph')(entry);
 
     res.locals.previewStatus = {
-        isDraftOrVersion: entry.status === 'draft' || entry.status === 'version',
-        lastUpdated: moment(entry.dateUpdated.date).format('Do MMM YYYY [at] h:mma')
+        isDraftOrVersion:
+            entry.status === 'draft' || entry.status === 'version',
+        lastUpdated: moment(entry.dateUpdated.date).format(
+            'Do MMM YYYY [at] h:mma'
+        )
     };
 
     setHeroLocals({ res, entry });
@@ -97,7 +100,9 @@ function injectBreadcrumbs(req, res, next) {
             url: res.locals.sectionUrl
         };
 
-        const ancestors = res.locals.customAncestors || getOr([], 'ancestors')(res.locals.content);
+        const ancestors =
+            res.locals.customAncestors ||
+            getOr([], 'ancestors')(res.locals.content);
         const ancestorCrumbs = ancestors.map(ancestor => {
             return {
                 label: ancestor.title,
@@ -207,15 +212,17 @@ async function injectFundingProgramme(req, res, next) {
 
 async function injectStrategicProgramme(req, res, next) {
     try {
-        // Assumes a parameter of :slug in the request
-        const { slug } = req.params;
+        // Assumes a parameter of :slug and :childPageSlug? in the request
+        const { slug, childPageSlug } = req.params;
         let query = {};
         if (req.query.social) {
             query.social = req.query.social;
         }
         if (slug) {
+            const querySlug = childPageSlug ? `${slug}/${childPageSlug}` : slug;
+
             const entry = await contentApi.getStrategicProgrammes({
-                slug: slug,
+                slug: querySlug,
                 locale: req.i18n.getLocale(),
                 previewMode: res.locals.PREVIEW_MODE || false,
                 query: query
@@ -236,9 +243,11 @@ async function injectStrategicProgramme(req, res, next) {
 
 async function injectStrategicProgrammes(req, res, next) {
     try {
-        res.locals.strategicProgrammes = await contentApi.getStrategicProgrammes({
-            locale: req.i18n.getLocale()
-        });
+        res.locals.strategicProgrammes = await contentApi.getStrategicProgrammes(
+            {
+                locale: req.i18n.getLocale()
+            }
+        );
         next();
     } catch (error) {
         if (error.statusCode >= 500) {
@@ -318,7 +327,10 @@ function injectMerchandise({ locale = null, showAll = false }) {
     return async (req, res, next) => {
         try {
             const localeToUse = locale ? locale : req.i18n.getLocale();
-            res.locals.availableItems = await contentApi.getMerchandise(localeToUse, showAll);
+            res.locals.availableItems = await contentApi.getMerchandise(
+                localeToUse,
+                showAll
+            );
             next();
         } catch (error) {
             next(error);


### PR DESCRIPTION
This pairs with https://github.com/biglotteryfund/craft-dev/pull/177 and allows the rendering of child pages within Strategics, similar to Funding Programmes.

It also makes a tweak to Funding Programmes to avoid URL spoofing, eg. currently it's possible to rewrite this:

https://www.tnlcommunityfund.org.uk/funding/programmes/empowering-young-people/meet-our-young-people

to this:

https://www.tnlcommunityfund.org.uk/funding/programmes/any-old-slug/meet-our-young-people

because it's not possible to filter on parent slugs in Craft (without looking up the parent entry directly). 

The changes here mean we can make top-level funding/strategic programme pages which are plain "Content Pages", as well as making them children of strategics.