### PR TITLE
Add GA tracking for various Insights Document links

### DIFF
--- a/controllers/insights/views/insights-detail.njk
+++ b/controllers/insights/views/insights-detail.njk
@@ -56,7 +56,9 @@
                     {% if entry.documents %}
                         {{ documentsCard(
                             title = extraCopy.documents,
-                            documents = entry.documents
+                            documents = entry.documents,
+                            gaCategory = 'Insight Documents',
+                            gaAction = 'Downloaded a document'
                         ) }}
                     {% endif %}
 

--- a/controllers/insights/views/insights-documents.njk
+++ b/controllers/insights/views/insights-documents.njk
@@ -171,7 +171,12 @@
                                                 </a>
                                             {% endif %}
                                             {% if entry.document %}
-                                                <a class="btn btn--outline btn--small" href="{{ entry.document.url }}">
+                                                <a class="btn btn--outline btn--small"
+                                                   href="{{ entry.document.url }}"
+                                                   data-ga-on="click"
+                                                   data-ga-event-category="Insight Documents"
+                                                   data-ga-event-action="Downloaded a document"
+                                                   data-ga-event-label="{{ entry.document.url }}">
                                                     {{ iconDownload() }}
                                                     {{ docTitle }}
                                                 </a>

--- a/views/components/documents-card/macro.njk
+++ b/views/components/documents-card/macro.njk
@@ -1,4 +1,4 @@
-{% macro documentsCard(title, documents) %}
+{% macro documentsCard(title, documents, gaCategory = false, gaAction = false) %}
     <aside class="card">
         <header class="card__header">
             <h3 class="card__title">{{ title }}</h3>
@@ -6,7 +6,15 @@
         <div class="card__body">
             {% for document in documents %}
                 <div class="document-summary">
-                    <a class="document-summary__link u-document-link" href="{{ document.url }}">
+                    <a class="document-summary__link u-document-link"
+                       href="{{ document.url }}"
+                        {% if gaCategory and gaAction %}
+                            data-ga-on="click"
+                            data-ga-event-category="{{ gaCategory }}"
+                            data-ga-event-action="{{ gaAction }}"
+                            data-ga-event-label="{{ document.url }}"
+                       {% endif %}
+                    >
                         {{ document.title }}
                         {% if document.filetype or document.filesize %}
                             <small>({{ document.filetype | upper }} {{ document.filesize }})</small>
@@ -21,7 +29,15 @@
                     {% endif %}
 
                     <div class="document-summary__download u-align-center">
-                        <a href="{{ document.url }}" class="btn btn--medium">
+                        <a href="{{ document.url }}"
+                           class="btn btn--medium"
+                            {% if gaCategory and gaAction %}
+                                data-ga-on="click"
+                                data-ga-event-category="{{ gaCategory }}"
+                                data-ga-event-action="{{ gaAction }}"
+                                data-ga-event-label="{{ document.url }}"
+                            {% endif %}
+                        >
                             {{ __('global.misc.download') | title }}
                         </a>
                     </div>


### PR DESCRIPTION
We've had some requests for an analytics dashboard about Insights Documents so this adds some specific tracking for document downloads (as opposed to the generic document tracker which is harder to isolate to a specific section).

I also tried adding site search tracking via the `q` parameter in GA to try to work out what searches people use, otherwise we have to use a gnarly regex (`/insights/documents\?(.*)q=[\w\d%]+`) to find pageviews with populated querystrings (and even then it's still part of a URL) – will leave this a few days to see if it picks anything up.