### PR TITLE
Auto-run prettier on assets

### DIFF
--- a/assets/js/common/tabs.js
+++ b/assets/js/common/tabs.js
@@ -36,12 +36,16 @@ function showNewTabPane($tabClicked) {
         if ($paneSet.length > 0) {
             // toggle the active pane in this set
             let $oldActivePane = $paneSet.find(`> .${ACTIVE_CLASS}`);
-            $oldActivePane.removeClass(ACTIVE_CLASS).attr('aria-hidden', 'true');
+            $oldActivePane
+                .removeClass(ACTIVE_CLASS)
+                .attr('aria-hidden', 'true');
             $paneToShow.addClass(ACTIVE_CLASS).attr('aria-hidden', 'false');
 
             // toggle the active tab in this set
             let $oldActiveTab = $tabset.find(`.${ACTIVE_CLASS}`);
-            $oldActiveTab.removeClass(ACTIVE_CLASS).attr('aria-selected', 'false');
+            $oldActiveTab
+                .removeClass(ACTIVE_CLASS)
+                .attr('aria-selected', 'false');
             $tabClicked.addClass(ACTIVE_CLASS).attr('aria-selected', 'true');
 
             // pass this data back to the click handler
@@ -159,7 +163,9 @@ function openTabOnHashchange() {
             scrollIntoView(linkEl);
         } else {
             const idEl = $(hash).first();
-            const parentTabLinkEl = idEl.closest(SELECTORS.tabpane).find(SELECTORS.tab);
+            const parentTabLinkEl = idEl
+                .closest(SELECTORS.tabpane)
+                .find(SELECTORS.tab);
 
             if (idEl.length > 0 && parentTabLinkEl.length > 0) {
                 showNewTabPane(parentTabLinkEl);
@@ -174,7 +180,10 @@ function init() {
     const $tabs = $(SELECTORS.tab);
     const matchCriteria = $container.attr('data-breakpoint');
 
-    if ($tabs.length < 1 || (matchCriteria && window.matchMedia(matchCriteria).matches === false)) {
+    if (
+        $tabs.length < 1 ||
+        (matchCriteria && window.matchMedia(matchCriteria).matches === false)
+    ) {
         return;
     }
 

--- a/assets/js/vue-apps/components/cookie-consent.vue
+++ b/assets/js/vue-apps/components/cookie-consent.vue
@@ -8,7 +8,8 @@ const STORAGE_KEY = 'biglotteryfund:cookie-consent';
 export default {
     props: ['title', 'message', 'action'],
     data() {
-        const hasAccepted = canStore && window.localStorage.getItem(STORAGE_KEY) === 'true';
+        const hasAccepted =
+            canStore && window.localStorage.getItem(STORAGE_KEY) === 'true';
         return { isShown: hasAccepted === false };
     },
     methods: {
@@ -26,7 +27,9 @@ export default {
         <div class="cookie-consent__inner">
             <div class="cookie-consent__content" v-html="message"></div>
             <div class="cookie-consent__actions">
-                <button class="btn btn--small" @click="handleAccept">{{ action }}</button>
+                <button class="btn btn--small" @click="handleAccept">
+                    {{ action }}
+                </button>
             </div>
         </div>
     </aside>

--- a/assets/js/vue-apps/components/facet-choice.vue
+++ b/assets/js/vue-apps/components/facet-choice.vue
@@ -22,7 +22,9 @@ export default {
     computed: {
         optionsToDisplay() {
             if (this.shouldTruncate()) {
-                return this.isOpen ? this.options : take(this.options, this.optionLimit);
+                return this.isOpen
+                    ? this.options
+                    : take(this.options, this.optionLimit);
             } else {
                 return this.options;
             }
@@ -37,7 +39,9 @@ export default {
             });
         },
         shouldTruncate() {
-            return this.optionLimit && this.options.length >= this.optionLimit + 2;
+            return (
+                this.optionLimit && this.options.length >= this.optionLimit + 2
+            );
         },
         fieldId(index) {
             return `field-dynamic-${this.name}-${index}`;
@@ -68,22 +72,36 @@ export default {
                         :name="name"
                         :value="option.value"
                         :checked="option.value == value"
-                        @change="handleInput($event, option);"
+                        @change="handleInput($event, option)"
                     />
-                    <label class="ff-choice__label" :for="fieldId(index)"> {{ option.label }} </label>
+                    <label class="ff-choice__label" :for="fieldId(index)">
+                        {{ option.label }}
+                    </label>
 
                     <button
                         class="active-filter active-filter--mini u-margin-left-s"
-                        @click="$emit('clear-selection');"
+                        @click="$emit('clear-selection')"
                         v-if="option.value == value"
                     >
-                        <IconClose :id="'clear-' + fieldId(index)" :description="copy.filters.clearSelection" />
+                        <IconClose
+                            :id="'clear-' + fieldId(index)"
+                            :description="copy.filters.clearSelection"
+                        />
                     </button>
                 </li>
             </ul>
         </fieldset>
-        <button type="button" class="btn-link" v-if="shouldTruncate()" @click="toggle">
-            {{ isOpen ? copy.filters.options.truncate.seeFewer : copy.filters.options.truncate.seeMore }}
+        <button
+            type="button"
+            class="btn-link"
+            v-if="shouldTruncate()"
+            @click="toggle"
+        >
+            {{
+                isOpen
+                    ? copy.filters.options.truncate.seeFewer
+                    : copy.filters.options.truncate.seeMore
+            }}
         </button>
     </div>
 </template>

--- a/assets/js/vue-apps/components/facet-disclose.vue
+++ b/assets/js/vue-apps/components/facet-disclose.vue
@@ -24,7 +24,15 @@ export default {
 
 <template>
     <div :aria-expanded="isOpen ? 'true' : 'false'" :aria-controls="ariaId">
-        <div v-show="isOpen" :id="ariaId" :aria-hidden="isOpen ? 'false' : 'true'"><slot></slot></div>
-        <button class="btn-link" type="button" @click="toggle">{{ isOpen ? labelOpen : labelClosed }}</button>
+        <div
+            v-show="isOpen"
+            :id="ariaId"
+            :aria-hidden="isOpen ? 'false' : 'true'"
+        >
+            <slot></slot>
+        </div>
+        <button class="btn-link" type="button" @click="toggle">
+            {{ isOpen ? labelOpen : labelClosed }}
+        </button>
     </div>
 </template>

--- a/assets/js/vue-apps/components/facet-group.vue
+++ b/assets/js/vue-apps/components/facet-group.vue
@@ -53,11 +53,22 @@ export default {
     >
         <fieldset class="facet-group__fieldset">
             <button class="facet-group__toggle" type="button" @click="toggle">
-                <IconArrowDown :id="'facet-' + id" :description="toggleLabel + ' ' + legend" />
-                <span class="u-visually-hidden">{{ toggleLabel }} {{ legend }}</span>
+                <IconArrowDown
+                    :id="'facet-' + id"
+                    :description="toggleLabel + ' ' + legend"
+                />
+                <span class="u-visually-hidden"
+                    >{{ toggleLabel }} {{ legend }}</span
+                >
             </button>
             <legend class="facet-group__legend">{{ legend }}</legend>
-            <div class="facet-group__body" :id="ariaId" :aria-hidden="isOpen ? 'false' : 'true'"><slot></slot></div>
+            <div
+                class="facet-group__body"
+                :id="ariaId"
+                :aria-hidden="isOpen ? 'false' : 'true'"
+            >
+                <slot></slot>
+            </div>
         </fieldset>
     </div>
 </template>

--- a/assets/js/vue-apps/components/facet-select.vue
+++ b/assets/js/vue-apps/components/facet-select.vue
@@ -4,7 +4,15 @@ import IconClose from './icon-close.vue';
 
 export default {
     components: { IconClose },
-    props: ['value', 'name', 'label', 'labelAny', 'options', 'clearLabel', 'handleActiveFilter'],
+    props: [
+        'value',
+        'name',
+        'label',
+        'labelAny',
+        'options',
+        'clearLabel',
+        'handleActiveFilter'
+    ],
     computed: {
         isOptgroup() {
             return isPlainObject(this.options);
@@ -31,10 +39,20 @@ export default {
     <div class="ff-choice">
         <label class="ff-label" :for="id"> {{ label }} </label>
         <div class="ff-choice__option ff-choice__option--flex">
-            <select class="ff-select" :id="id" :name="name" :value="value" @change="handleInput">
+            <select
+                class="ff-select"
+                :id="id"
+                :name="name"
+                :value="value"
+                @change="handleInput"
+            >
                 <option value="" v-if="labelAny">{{ labelAny }}</option>
                 <template v-if="isOptgroup">
-                    <optgroup v-for="(group, groupLabel) in options" :label="groupLabel" :key="groupLabel">
+                    <optgroup
+                        v-for="(group, groupLabel) in options"
+                        :label="groupLabel"
+                        :key="groupLabel"
+                    >
                         <option
                             v-for="(option, index) in group"
                             :value="option.value"
@@ -46,7 +64,11 @@ export default {
                     </optgroup>
                 </template>
                 <template v-else>
-                    <option v-for="option in options" :value="option.value" :key="option.label">
+                    <option
+                        v-for="option in options"
+                        :value="option.value"
+                        :key="option.label"
+                    >
                         {{ option.label }}
                     </option>
                 </template>

--- a/assets/js/vue-apps/components/grants-back-to-search.vue
+++ b/assets/js/vue-apps/components/grants-back-to-search.vue
@@ -18,7 +18,10 @@ export default {
         }
     },
     mounted: function() {
-        const searchData = getWithExpiry({ type: 'localStorage', key: this.storageKey });
+        const searchData = getWithExpiry({
+            type: 'localStorage',
+            key: this.storageKey
+        });
         if (searchData) {
             this.returnLink = this.prefix + '?' + searchData;
         }

--- a/assets/js/vue-apps/components/grants-filter-summary.vue
+++ b/assets/js/vue-apps/components/grants-filter-summary.vue
@@ -8,14 +8,24 @@ export default {
 
 <template>
     <ul class="filter-list">
-        <li class="filter-list__item" v-for="item in filterSummary" :key="item.name">
-            <button class="active-filter" @click="$emit('clear-filters', item.name);" :title="item.name">
+        <li
+            class="filter-list__item"
+            v-for="item in filterSummary"
+            :key="item.name"
+        >
+            <button
+                class="active-filter"
+                @click="$emit('clear-filters', item.name)"
+                :title="item.name"
+            >
                 {{ item.label }}
                 <IconClose id="prompt-close" description="Remove this filter" />
             </button>
         </li>
         <li class="filter-list__item" v-if="filterSummary.length > 0">
-            <button type="button" class="btn-link" @click="$emit('clear-all');">{{ clearLabel }}</button>
+            <button type="button" class="btn-link" @click="$emit('clear-all')">
+                {{ clearLabel }}
+            </button>
         </li>
     </ul>
 </template>

--- a/assets/js/vue-apps/components/grants-filters.vue
+++ b/assets/js/vue-apps/components/grants-filters.vue
@@ -8,7 +8,14 @@ import $ from 'jquery';
 
 export default {
     components: { FacetGroup, FacetDisclose, FacetChoice, FacetSelect },
-    props: ['facets', 'filters', 'status', 'copy', 'handleActiveFilter', 'trackUi'],
+    props: [
+        'facets',
+        'filters',
+        'status',
+        'copy',
+        'handleActiveFilter',
+        'trackUi'
+    ],
     methods: {
         isActiveFacet(name) {
             return has(this.filters, name);
@@ -26,15 +33,28 @@ export default {
 </script>
 
 <template>
-    <fieldset class="search-filters" :class="{ 'search-filters--locked': status.state === 'Loading' }">
+    <fieldset
+        class="search-filters"
+        :class="{ 'search-filters--locked': status.state === 'Loading' }"
+    >
         <div class="search-filters__header">
-            <legend class="search-filters__title">{{ copy.filters.title }}</legend>
-            <button type="button" class="search-filters__clear-all btn-link" @click="$emit('clear-filters')">
+            <legend class="search-filters__title">
+                {{ copy.filters.title }}
+            </legend>
+            <button
+                type="button"
+                class="search-filters__clear-all btn-link"
+                @click="$emit('clear-filters')"
+            >
                 {{ copy.filters.reset }}
             </button>
         </div>
 
-        <FacetGroup :legend="copy.filters.grantLegend" :toggle-label="copy.filters.toggle" :track-ui="trackUi">
+        <FacetGroup
+            :legend="copy.filters.grantLegend"
+            :toggle-label="copy.filters.toggle"
+            :track-ui="trackUi"
+        >
             <FacetChoice
                 v-model="filters.amount"
                 type="radio"
@@ -74,7 +94,11 @@ export default {
             />
         </FacetGroup>
 
-        <FacetGroup :legend="copy.filters.organisationLegend" :toggle-label="copy.filters.toggle" :track-ui="trackUi">
+        <FacetGroup
+            :legend="copy.filters.organisationLegend"
+            :toggle-label="copy.filters.toggle"
+            :track-ui="trackUi"
+        >
             <FacetChoice
                 v-model="filters.country"
                 type="radio"
@@ -91,7 +115,10 @@ export default {
             <FacetDisclose
                 :label-open="copy.filters.options.country.labelOpen"
                 :label-closed="copy.filters.options.country.labelClosed"
-                :initial-open="isActiveFacet('localAuthority') || isActiveFacet('westminsterConstituency')"
+                :initial-open="
+                    isActiveFacet('localAuthority') ||
+                        isActiveFacet('westminsterConstituency')
+                "
                 :track-ui="trackUi"
                 :filter-name="'country'"
             >
@@ -112,10 +139,14 @@ export default {
                     name="westminsterConstituency"
                     class="facet-group__item"
                     :label="copy.filters.options.westminsterConstituency.label"
-                    :label-any="copy.filters.options.westminsterConstituency.any"
+                    :label-any="
+                        copy.filters.options.westminsterConstituency.any
+                    "
                     :clear-label="copy.filters.clearSelection"
                     :options="facets.westminsterConstituencies"
-                    @clear-selection="$emit('clear-filters', 'westminsterConstituency')"
+                    @clear-selection="
+                        $emit('clear-filters', 'westminsterConstituency')
+                    "
                     :handle-active-filter="handleActiveFilter"
                 />
             </FacetDisclose>
@@ -135,6 +166,9 @@ export default {
         <p class="u-margin-top-s u-margin-bottom-s">
             <strong>{{ copy.feedback.title }}</strong>
         </p>
-        <p v-html="copy.feedback.body" @click="triggerFeedbackPanel($event)"></p>
+        <p
+            v-html="copy.feedback.body"
+            @click="triggerFeedbackPanel($event)"
+        ></p>
     </fieldset>
 </template>

--- a/assets/js/vue-apps/components/grants-loading-status.vue
+++ b/assets/js/vue-apps/components/grants-loading-status.vue
@@ -4,8 +4,16 @@
             <i class="icon--loading-spinner"></i> {{ props.copy.pleaseWait }}
         </template>
 
-        <div class="message message--error" v-if="props.status.state === 'Failure'">
-            <span v-if="props.status.error && props.status.error.code === 'ERR-POSTCODE'">
+        <div
+            class="message message--error"
+            v-if="props.status.state === 'Failure'"
+        >
+            <span
+                v-if="
+                    props.status.error &&
+                        props.status.error.code === 'ERR-POSTCODE'
+                "
+            >
                 {{ props.copy.errors.postcode }}
             </span>
             <span v-else>{{ props.copy.errors.generic }}</span>

--- a/assets/js/vue-apps/components/grants-no-results.vue
+++ b/assets/js/vue-apps/components/grants-no-results.vue
@@ -12,28 +12,53 @@ export default {
 };
 </script>
 <template>
-    <div class="s-prose u-padded" v-if="totalResults === 0 && status.state !== 'Loading'">
+    <div
+        class="s-prose u-padded"
+        v-if="totalResults === 0 && status.state !== 'Loading'"
+    >
         <h3>{{ copy.errors.noResults.heading }}</h3>
 
-        <div v-if="searchSuggestions && searchSuggestions.suggestions.length > 0">
+        <div
+            v-if="searchSuggestions && searchSuggestions.suggestions.length > 0"
+        >
             <p v-html="copy.errors.noResults.didYouMean"></p>
             <ul>
-                <li v-for="suggestion in searchSuggestions.suggestions" :key="suggestion">
-                    <button class="btn-link" @click="$emit('update-query', suggestion)">{{ suggestion }}</button>
+                <li
+                    v-for="suggestion in searchSuggestions.suggestions"
+                    :key="suggestion"
+                >
+                    <button
+                        class="btn-link"
+                        @click="$emit('update-query', suggestion)"
+                    >
+                        {{ suggestion }}
+                    </button>
                 </li>
             </ul>
         </div>
 
         <p v-html="copy.errors.noResults.tryTheseTips"></p>
         <ul>
-            <li v-for="suggestion in copy.errors.noResults.suggestions" v-html="suggestion" :key="suggestion"></li>
+            <li
+                v-for="suggestion in copy.errors.noResults.suggestions"
+                v-html="suggestion"
+                :key="suggestion"
+            ></li>
         </ul>
 
         <p>
-            <button type="button" class="btn btn--medium" @click="$emit('clear-all')">{{ copy.filters.clear }}</button>
+            <button
+                type="button"
+                class="btn btn--medium"
+                @click="$emit('clear-all')"
+            >
+                {{ copy.filters.clear }}
+            </button>
             <span v-if="canGoBack()">
                 {{ copy.or }}
-                <button type="button" class="btn btn--medium" @click="goBack">{{ copy.goBackAStep }}</button>
+                <button type="button" class="btn btn--medium" @click="goBack">
+                    {{ copy.goBackAStep }}
+                </button>
             </span>
         </p>
 

--- a/assets/js/vue-apps/components/grants-related.vue
+++ b/assets/js/vue-apps/components/grants-related.vue
@@ -16,7 +16,10 @@ export default {
         getRelatedGrants() {
             let geocode;
             if (this.beneficiaryLocation) {
-                let loc = find(JSON.parse(this.beneficiaryLocation), location => location.geoCodeType === 'CMLAD');
+                let loc = find(
+                    JSON.parse(this.beneficiaryLocation),
+                    location => location.geoCodeType === 'CMLAD'
+                );
                 if (loc) {
                     geocode = loc.geoCode;
                 }

--- a/assets/js/vue-apps/components/grants-sort.vue
+++ b/assets/js/vue-apps/components/grants-sort.vue
@@ -12,9 +12,13 @@ export default {
             name="sort"
             id="field-sort"
             :value="sort.activeSort"
-            @change="$emit('change-sort', $event.target.value);"
+            @change="$emit('change-sort', $event.target.value)"
         >
-            <option v-for="option in sort.sortOptions" :key="option.label" :value="option.value">
+            <option
+                v-for="option in sort.sortOptions"
+                :key="option.label"
+                :value="option.value"
+            >
                 {{ option.label }}
             </option>
         </select>

--- a/assets/js/vue-apps/components/grants-total-summary.vue
+++ b/assets/js/vue-apps/components/grants-total-summary.vue
@@ -2,7 +2,9 @@
     <span>
         {{ props.totalResults.toLocaleString() }} {{ props.copy.resultsCount }}
         <template v-if="props.totalAwarded">
-            {{ props.copy.totalCount }} £{{ props.totalAwarded.toLocaleString() }}
+            {{ props.copy.totalCount }} £{{
+                props.totalAwarded.toLocaleString()
+            }}
         </template>
     </span>
 </template>

--- a/assets/js/vue-apps/components/icon-arrow-down.vue
+++ b/assets/js/vue-apps/components/icon-arrow-down.vue
@@ -8,7 +8,11 @@
         height="32"
         :aria-describedby="'aria-arrow-down-desc-' + props.id"
     >
-        <desc :id="'aria-arrow-down-desc-' + props.id">{{ props.description }}</desc>
-        <path d="M396.6 160l19.4 20.7L256 352 96 180.7l19.3-20.7L256 310.5"></path>
+        <desc :id="'aria-arrow-down-desc-' + props.id">
+            {{ props.description }}
+        </desc>
+        <path
+            d="M396.6 160l19.4 20.7L256 352 96 180.7l19.3-20.7L256 310.5"
+        ></path>
     </svg>
 </template>

--- a/assets/js/vue-apps/components/icon-arrow-left.vue
+++ b/assets/js/vue-apps/components/icon-arrow-left.vue
@@ -8,7 +8,9 @@
         height="32"
         :aria-describedby="'aria-arrow-left-desc-' + props.id"
     >
-        <desc :id="'aria-arrow-left-desc-' + props.id">{{ props.description }}</desc>
+        <desc :id="'aria-arrow-left-desc-' + props.id">
+            {{ props.description }}
+        </desc>
         <path
             d="M327.3 98.9l-2.1 1.8-156.5 136c-5.3 4.6-8.6 11.5-8.6 19.2 0 7.7 3.4 14.6 8.6 19.2L324.9 411l2.6 2.3c2.5 1.7 5.5 2.7 8.7 2.7 8.7 0 15.8-7.4 15.8-16.6V112.6c0-9.2-7.1-16.6-15.8-16.6-3.3 0-6.4 1.1-8.9 2.9z"
         ></path>

--- a/assets/js/vue-apps/components/icon-bin.vue
+++ b/assets/js/vue-apps/components/icon-bin.vue
@@ -9,6 +9,8 @@
         :aria-describedby="'aria-bin-desc-' + props.id"
     >
         <desc :id="'aria-bin-desc-' + props.id">{{ props.description }}</desc>
-        <path d="M3 16h10l1-11h-12zM10 2v-2h-4v2h-5v3l1-1h12l1 1v-3h-5zM9 2h-2v-1h2v1z"></path>
+        <path
+            d="M3 16h10l1-11h-12zM10 2v-2h-4v2h-5v3l1-1h12l1 1v-3h-5zM9 2h-2v-1h2v1z"
+        ></path>
     </svg>
 </template>

--- a/assets/js/vue-apps/components/survey.vue
+++ b/assets/js/vue-apps/components/survey.vue
@@ -9,7 +9,18 @@ const statuses = {
 };
 
 export default {
-    props: ['question', 'prompt', 'yes', 'yesExtended', 'no', 'noExtended', 'submit', 'cancel', 'success', 'error'],
+    props: [
+        'question',
+        'prompt',
+        'yes',
+        'yesExtended',
+        'no',
+        'noExtended',
+        'submit',
+        'cancel',
+        'success',
+        'error'
+    ],
     data() {
         return {
             statuses: statuses,
@@ -69,28 +80,70 @@ export default {
             <div class="survey__choices" v-if="status === statuses.NOT_ASKED">
                 <p class="survey__choices-question">{{ question }}</p>
                 <div class="survey__choices-actions">
-                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('yes')">
-                        {{ yes }} <span class="u-visually-hidden">{{ yesExtended }}</span>
+                    <button
+                        class="btn btn--small survey__choice"
+                        type="button"
+                        @click="selectChoice('yes')"
+                    >
+                        {{ yes }}
+                        <span class="u-visually-hidden">{{ yesExtended }}</span>
                     </button>
-                    <button class="btn btn--small survey__choice" type="button" @click="selectChoice('no')">
-                        {{ no }} <span class="u-visually-hidden">{{ noExtended }}</span>
+                    <button
+                        class="btn btn--small survey__choice"
+                        type="button"
+                        @click="selectChoice('no')"
+                    >
+                        {{ no }}
+                        <span class="u-visually-hidden">{{ noExtended }}</span>
                     </button>
                 </div>
             </div>
 
-            <p class="survey__response" v-if="status === statuses.SUBMISSION_SUCCESS">{{ success }}</p>
+            <p
+                class="survey__response"
+                v-if="status === statuses.SUBMISSION_SUCCESS"
+            >
+                {{ success }}
+            </p>
 
-            <p class="survey__response" v-if="status === statuses.SUBMISSION_ERROR">{{ error }}</p>
+            <p
+                class="survey__response"
+                v-if="status === statuses.SUBMISSION_ERROR"
+            >
+                {{ error }}
+            </p>
 
-            <div class="survey__extra" v-if="status === statuses.MESSAGE_BOX_SHOWN">
-                <form class="survey__form" @submit.prevent="storeResponse('no')">
+            <div
+                class="survey__extra"
+                v-if="status === statuses.MESSAGE_BOX_SHOWN"
+            >
+                <form
+                    class="survey__form"
+                    @submit.prevent="storeResponse('no')"
+                >
                     <div class="survey__form-fields">
-                        <label class="ff-label" for="survey-extra-msg">{{ prompt }}</label>
-                        <textarea class="ff-textarea" id="survey-extra-msg" v-model="response.message"></textarea>
+                        <label class="ff-label" for="survey-extra-msg">{{
+                            prompt
+                        }}</label>
+                        <textarea
+                            class="ff-textarea"
+                            id="survey-extra-msg"
+                            v-model="response.message"
+                        ></textarea>
                     </div>
                     <div class="survey__form-actions">
-                        <input type="submit" class="btn btn--small" :value="submit" />
-                        <button type="reset" class="btn-link" @click="resetChoice">{{ cancel }}</button>
+                        <input
+                            type="submit"
+                            class="btn btn--small"
+                            :value="submit"
+                        />
+                        <button
+                            type="reset"
+                            class="btn-link"
+                            @click="resetChoice"
+                        >
+                            {{ cancel }}
+                        </button>
                     </div>
                 </form>
             </div>

--- a/assets/js/vue-apps/form-components/address-line.vue
+++ b/assets/js/vue-apps/form-components/address-line.vue
@@ -11,8 +11,7 @@ export default {
 
 <template>
     <div class="ff-address__field">
-        <label class="ff-label"
-               :for="'field-' + name">
+        <label class="ff-label" :for="'field-' + name">
             <span v-html="label"></span>
             <!-- @TODO i18n -->
             <span v-if="!required" class="ff-label-note">(Optional)</span>

--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -47,7 +47,7 @@ export default {
         };
     },
     mounted() {
-        this.$root.$on('update:conditionalRadio', (value) => {
+        this.$root.$on('update:conditionalRadio', value => {
             if (value === 'yes') {
                 this.currentState = states.NotRequired;
             } else if (this.fullAddress) {
@@ -75,13 +75,25 @@ export default {
             } catch (e) {} // eslint-disable-line no-empty
         }
 
-        const $form = $(this.$el).parents('form').find('input[type="submit"]');
+        const $form = $(this.$el)
+            .parents('form')
+            .find('input[type="submit"]');
         const that = this;
         $form.on('click', function() {
-            if (that.candidates.length === 0 && !that.showFallbackFields && that.postcode) {
+            if (
+                that.candidates.length === 0 &&
+                !that.showFallbackFields &&
+                that.postcode
+            ) {
                 // @TODO i18n
-                alert(`Please click "Find address" and choose an address from the list.`);
-                trackEvent('Form warning', 'Postcode lookup', 'Typed but not submitted');
+                alert(
+                    `Please click "Find address" and choose an address from the list.`
+                );
+                trackEvent(
+                    'Form warning',
+                    'Postcode lookup',
+                    'Typed but not submitted'
+                );
                 document.querySelector('.address-lookup').scrollIntoView();
                 // Prevent form submission (for nested)
                 return false;
@@ -158,13 +170,13 @@ export default {
             this.showFallbackFields = false;
         },
         clearAddress() {
-           this.fullAddress = {
-               line1: null,
-               line2: null,
-               townCity: null,
-               county: null,
-               postcode: null
-           };
+            this.fullAddress = {
+                line1: null,
+                line2: null,
+                townCity: null,
+                county: null,
+                postcode: null
+            };
         },
         removeAddress() {
             this.currentState = this.states.Asking;
@@ -205,11 +217,11 @@ export default {
             handler() {
                 this.fullAddressPreview = this.fullAddress
                     ? compact([
-                        this.fullAddress.line1,
-                        this.fullAddress.line2,
-                        this.fullAddress.townCity,
-                        this.fullAddress.postcode
-                    ]).join('<br />')
+                          this.fullAddress.line1,
+                          this.fullAddress.line2,
+                          this.fullAddress.townCity,
+                          this.fullAddress.postcode
+                      ]).join('<br />')
                     : '';
             },
             deep: true
@@ -217,10 +229,7 @@ export default {
     },
     computed: {
         fieldsAreRequired() {
-            return (
-                !this.showFallbackFields &&
-                this.shouldShowPostcodeLookup
-            );
+            return !this.showFallbackFields && this.shouldShowPostcodeLookup;
         },
         shouldShowPostcodeLookup() {
             return (
@@ -257,14 +266,14 @@ export default {
 </script>
 
 <template>
-    <div
-        v-if="currentState !== states.NotRequired">
+    <div v-if="currentState !== states.NotRequired">
+        <legend class="ff-label ff-address__legend" v-html="label"></legend>
 
-        <legend class="ff-label ff-address__legend"
-                v-html="label">
-        </legend>
-
-        <div class="ff-help s-prose" v-if="explanation" v-html="explanation"></div>
+        <div
+            class="ff-help s-prose"
+            v-if="explanation"
+            v-html="explanation"
+        ></div>
 
         <!-- @TODO i18n -->
         <div v-if="shouldShowPostcodeLookup" class="address-lookup">
@@ -354,12 +363,16 @@ export default {
         </div>
 
         <!-- fallback fields -->
-        <details class="o-details u-margin-top"
-                 :open="showFallbackFields"
-                 v-if="currentState !== states.NotRequired">
-            <summary class="js-only o-details__summary"
-                     @click="showFallbackFields = !showFallbackFields"
-                     data-testid="manual-address">
+        <details
+            class="o-details u-margin-top"
+            :open="showFallbackFields"
+            v-if="currentState !== states.NotRequired"
+        >
+            <summary
+                class="js-only o-details__summary"
+                @click="showFallbackFields = !showFallbackFields"
+                data-testid="manual-address"
+            >
                 Enter address manually
             </summary>
 
@@ -368,14 +381,16 @@ export default {
                     :name="fieldName + '[line1]'"
                     label="Building and street"
                     :is-required="true"
-                    v-model="fullAddress.line1">
+                    v-model="fullAddress.line1"
+                >
                 </AddressLine>
 
                 <AddressLine
                     :name="fieldName + '[line2]'"
                     label="Address line 2"
                     is-required="false"
-                    v-model="fullAddress.line2">
+                    v-model="fullAddress.line2"
+                >
                 </AddressLine>
 
                 <AddressLine
@@ -383,7 +398,8 @@ export default {
                     label="Town or city"
                     :is-required="true"
                     v-model="fullAddress.townCity"
-                    size="30">
+                    size="30"
+                >
                 </AddressLine>
 
                 <AddressLine
@@ -391,7 +407,8 @@ export default {
                     label="County"
                     is-required="false"
                     v-model="fullAddress.county"
-                    size="30">
+                    size="30"
+                >
                 </AddressLine>
 
                 <AddressLine
@@ -399,14 +416,18 @@ export default {
                     label="Postcode"
                     :is-required="true"
                     v-model="fullAddress.postcode"
-                    size="10">
+                    size="10"
+                >
                 </AddressLine>
 
-                <button type="button" class="btn-link u-margin-top-s" @click="finishEditing">
+                <button
+                    type="button"
+                    class="btn-link u-margin-top-s"
+                    @click="finishEditing"
+                >
                     I'm done editing
                 </button>
             </div>
         </details>
-
     </div>
 </template>

--- a/assets/js/vue-apps/form-components/budget-input.vue
+++ b/assets/js/vue-apps/form-components/budget-input.vue
@@ -34,9 +34,14 @@ export default {
                 if (this.shouldAddNewRow()) {
                     this.addRow();
                 }
-                this.error.TOO_MANY_ITEMS = this.budgetRows.length === this.maxItems;
-                this.error.OVER_BUDGET = this.maxBudget && this.total > this.maxBudget;
-                this.error.UNDER_BUDGET = this.minBudget && this.total < this.minBudget && this.total > 0;
+                this.error.TOO_MANY_ITEMS =
+                    this.budgetRows.length === this.maxItems;
+                this.error.OVER_BUDGET =
+                    this.maxBudget && this.total > this.maxBudget;
+                this.error.UNDER_BUDGET =
+                    this.minBudget &&
+                    this.total < this.minBudget &&
+                    this.total > 0;
             },
             deep: true
         }
@@ -58,7 +63,10 @@ export default {
             this.budgetRows = this.budgetRows.filter(i => i !== item);
         },
         canDelete(index) {
-            return this.budgetRows.length > 1 && index !== this.budgetRows.length - 1;
+            return (
+                this.budgetRows.length > 1 &&
+                index !== this.budgetRows.length - 1
+            );
         }
     }
 };
@@ -68,9 +76,17 @@ export default {
 <template>
     <div class="ff-budget">
         <ol class="ff-budget__list">
-            <li class="ff-budget__row" v-for="(lineItem, index) in budgetRows" :key="index" data-testid="budget-row">
+            <li
+                class="ff-budget__row"
+                v-for="(lineItem, index) in budgetRows"
+                :key="index"
+                data-testid="budget-row"
+            >
                 <div class="ff-budget__row-item">
-                    <label class="ff-label" :for="getLineItemName(index, 'item')">
+                    <label
+                        class="ff-label"
+                        :for="getLineItemName(index, 'item')"
+                    >
                         Item or activity
                     </label>
                     <input
@@ -83,7 +99,10 @@ export default {
                     />
                 </div>
                 <div class="ff-budget__row-amount">
-                    <label class="ff-label" :for="getLineItemName(index, 'cost')">
+                    <label
+                        class="ff-label"
+                        :for="getLineItemName(index, 'cost')"
+                    >
                         Amount
                     </label>
                     <div class="ff-currency ff-currency--row">
@@ -108,7 +127,10 @@ export default {
                         v-if="canDelete(index)"
                     >
                         <span class="btn__icon btn__icon-left">
-                            <IconBin :id="'delete-icon-' + index" description="Delete this row" />
+                            <IconBin
+                                :id="'delete-icon-' + index"
+                                description="Delete this row"
+                            />
                         </span>
                         Delete row
                         <span class="u-visually-hidden">
@@ -119,22 +141,39 @@ export default {
             </li>
         </ol>
 
-        <div class="ff-budget__errors" aria-live="polite" aria-atomic="true" data-testid="budget-errors">
+        <div
+            class="ff-budget__errors"
+            aria-live="polite"
+            aria-atomic="true"
+            data-testid="budget-errors"
+        >
             <!-- @TODO localise -->
             <p v-if="error.TOO_MANY_ITEMS">
-                You must use {{ maxItems }} budget headings or fewer to tell us your costs
+                You must use {{ maxItems }} budget headings or fewer to tell us
+                your costs
             </p>
             <p v-if="error.OVER_BUDGET">
-                Project costs must be less than £{{ maxBudget.toLocaleString() }}.
+                Project costs must be less than £{{
+                    maxBudget.toLocaleString()
+                }}.
             </p>
             <p v-if="error.UNDER_BUDGET">
-                Project costs must be greater than £{{ minBudget.toLocaleString() }}.
+                Project costs must be greater than £{{
+                    minBudget.toLocaleString()
+                }}.
             </p>
         </div>
 
-        <dl class="ff-budget__total" aria-live="polite" aria-atomic="true" data-testid="budget-total">
+        <dl
+            class="ff-budget__total"
+            aria-live="polite"
+            aria-atomic="true"
+            data-testid="budget-total"
+        >
             <dt class="ff-budget__total-label">Total</dt>
-            <dd class="ff-budget__total-amount">£{{ total.toLocaleString() }}</dd>
+            <dd class="ff-budget__total-amount">
+                £{{ total.toLocaleString() }}
+            </dd>
         </dl>
     </div>
 </template>

--- a/assets/js/vue-apps/form-components/conditional-radios.vue
+++ b/assets/js/vue-apps/form-components/conditional-radios.vue
@@ -25,7 +25,7 @@ export default {
     },
     computed: {
         inputName() {
-            return `${ this.fieldName }[${ this.subFieldName }]`;
+            return `${this.fieldName}[${this.subFieldName}]`;
         }
     },
     watch: {
@@ -38,12 +38,13 @@ export default {
 
 <template>
     <div>
-        <legend class="ff-label ff-address__legend" v-html="label">
-        </legend>
+        <legend class="ff-label ff-address__legend" v-html="label"></legend>
         <ul class="ff-choice__list">
-            <li class="ff-choice__option"
+            <li
+                class="ff-choice__option"
                 v-for="option in radioOptions"
-                :key="option.value">
+                :key="option.value"
+            >
                 <div class="ff-choice__input">
                     <input
                         type="radio"
@@ -53,8 +54,7 @@ export default {
                         v-model="currentChoice"
                     />
                 </div>
-                <label class="ff-choice__label"
-                       :for="optionId(option)">
+                <label class="ff-choice__label" :for="optionId(option)">
                     {{ option.label }}
                 </label>
             </li>

--- a/assets/js/vue-apps/form-components/word-count.vue
+++ b/assets/js/vue-apps/form-components/word-count.vue
@@ -63,7 +63,14 @@ export default {
 </script>
 
 <template>
-    <div class="word-count" :class="{ 'word-count--over': isOverLimit }" role="region" aria-live="polite" aria-atomic="true" data-testid="word-count">
+    <div
+        class="word-count"
+        :class="{ 'word-count--over': isOverLimit }"
+        role="region"
+        aria-live="polite"
+        aria-atomic="true"
+        data-testid="word-count"
+    >
         <span class="word-count__counter" v-html="currentCountMessage"></span>
         <span class="word-count__message" v-html="helpMessage"></span>
     </div>

--- a/assets/js/vue-apps/materials.js
+++ b/assets/js/vue-apps/materials.js
@@ -9,7 +9,9 @@ function init() {
     $('body').on('click', `.js-has-radios input[type="radio"]`, function() {
         const $clickedRadio = $(this);
         // find the corresponding <input> field for this radio set
-        const $other = $('#' + $clickedRadio.parents(`.js-has-radios`).data('other-id'));
+        const $other = $(
+            '#' + $clickedRadio.parents(`.js-has-radios`).data('other-id')
+        );
         if ($other.length === 0) {
             return;
         }
@@ -30,10 +32,12 @@ function init() {
 
     let langParam = 'lang';
     // make sure we only allow valid language options
-    let isValidLangParam = param => ['monolingual', 'bilingual'].indexOf(param) !== -1;
+    let isValidLangParam = param =>
+        ['monolingual', 'bilingual'].indexOf(param) !== -1;
 
     // save the language preference in the form so we can redirect to it
-    let storeLangPrefInForm = newState => $('#js-language-choice').val(newState);
+    let storeLangPrefInForm = newState =>
+        $('#js-language-choice').val(newState);
 
     new Vue({
         el: mountEl,
@@ -65,14 +69,20 @@ function init() {
                     storeLangPrefInForm(newState);
                     // add this to the URL
                     if (history.replaceState) {
-                        history.replaceState(null, null, `?${langParam}=${newState}`);
+                        history.replaceState(
+                            null,
+                            null,
+                            `?${langParam}=${newState}`
+                        );
                     }
                 }
             },
             // look up the quantity of a given item, defaulting to its
             // value when the page was loaded (eg. from session cookie)
             getQuantity: function(productId) {
-                let product = this.orderData.find(o => o.productId === parseInt(productId));
+                let product = this.orderData.find(
+                    o => o.productId === parseInt(productId)
+                );
                 return product ? product.quantity : 0;
             },
             // work out if the user has anything in their "basket"


### PR DESCRIPTION
Runs prettier auto-formatting against client-side JS. Thes files have not been re-formatted since upgrading prettier with new formatting rules. This formatting fixes a couple of lint warnings from `eslint-plugin-vue`