### PR TITLE
Fix an issue with video rendering in non-default tab panes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 .env
 .idea
+*.iml
 .map
 .vscode/
 always_restart.txt

--- a/assets/js/common/tabs.js
+++ b/assets/js/common/tabs.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import fitvids from 'fitvids';
 
 const SELECTORS = {
     container: '.js-tab-container',
@@ -43,6 +44,17 @@ function showNewTabPane($tabClicked) {
             let $oldActiveTab = $tabset.find(`.${ACTIVE_CLASS}`);
             $oldActiveTab.removeClass(ACTIVE_CLASS).attr('aria-selected', 'false');
             $tabClicked.addClass(ACTIVE_CLASS).attr('aria-selected', 'true');
+
+            // Re-render any videos embedded in the pane
+            // which aren't picked up on pageload by fitvids
+            // eg. https://github.com/davatron5000/FitVids.js/issues/8
+            const fitVidsClass = 'fluid-width-video-wrapper';
+            $paneToShow
+                .find(`.${fitVidsClass}`)
+                .removeClass(fitVidsClass)
+                .unwrap('div')
+                .removeAttr('style');
+            fitvids();
 
             // pass this data back to the click handler
             tabData = {


### PR DESCRIPTION
Videos embedded in tabs that aren't initially visible don't render properly as they have `height: 0` when `fitvids` does its thang: https://www.tnlcommunityfund.org.uk/funding/programmes/national-lottery-awards-for-all-scotland?draft=247#section-3

This slightly ugly change re-renders them when the tab is active.