### PR TITLE
Warnings and messages

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -564,109 +564,117 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             return options;
         }
 
+        /**
+         * Statutory bodies require a sub-type,
+         * some of which allow free text input for roles.
+         */
+        function isFreeText() {
+            return (
+                currentOrganisationType === ORGANISATION_TYPES.STATUTORY_BODY &&
+                [
+                    STATUTORY_BODY_TYPES.PRISON_SERVICE,
+                    STATUTORY_BODY_TYPES.FIRE_SERVICE,
+                    STATUTORY_BODY_TYPES.POLICE_AUTHORITY
+                ].includes(currentOrganisationSubType)
+            );
+        }
+
         return {
             name: 'seniorContactRole',
             label: localise({ en: 'Role', cy: '' }),
-            get explanation() {
+            explanation: localise({
+                en: `<p>
+                    You told us what sort of organisation you are earlier.
+                    So the senior contact role options we're giving you now,
+                    are based on your organisation type.
+                    ${
+                        isFreeText()
+                            ? `This should be someone in a position of authority in your organisation.`
+                            : `The options given to you for selection are based on this.`
+                    }
+                </p>`,
+                cy: ''
+            }),
+            get warnings() {
+                let result = [];
+
                 const projectCountry = get('projectCountry')(data);
-                const organisationType = get('organisationType')(data);
 
-                let text = localise({
-                    en: `<p>You told us what sort of organisation you are earlier. So the senior contact role options we're giving you now, are based on your organisation type. `,
-                    cy: ''
-                });
+                const isCharityOrCompany = [
+                    ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+                    ORGANISATION_TYPES.CIO,
+                    ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY
+                ].includes(currentOrganisationType);
 
-                if (this.type === 'radio') {
-                    text += localise({
-                        en:
-                            'The options given to you for selection are based on this.',
-                        cy: ''
-                    });
-                } else {
-                    text += localise({
-                        en:
-                            'This should be someone in a position of authority in your organisation.',
-                        cy: ''
-                    });
-                }
-
-                text += localise({
-                    en: '</p>',
-                    cy: '</p>'
-                });
-
-                const isCharityOrCompany = includes(
-                    [
-                        ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                        ORGANISATION_TYPES.CIO,
-                        ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY
-                    ],
-                    organisationType
-                );
-
+                /**
+                 * Scotland doesn't include trustees in their charity commission
+                 * data, so don't show this message in Scotland.
+                 */
                 if (isCharityOrCompany && projectCountry !== 'scotland') {
-                    text += localise({
-                        en: `<p><strong>Your senior contact must be listed as a member of your organisation's board or committee with the Charity Commission/Companies House.</strong></p>`
-                    });
-                } else if (
-                    matchesOrganisationType(
-                        ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY
-                    )
-                ) {
-                    text += localise({
-                        en: `<p><strong>
-                            As a registered charity, your senior contact must be one of your organisation's trustees. This can include trustees taking on the role of Chair, Vice Chair or Treasurer.
-                        </strong></p>`
-                    });
-                } else if (matchesOrganisationType(ORGANISATION_TYPES.CIO)) {
-                    text += localise({
-                        en: `<p><strong>
-                            As a charity, your senior contact can be one of your organisation's trustees.
-                            This can include trustees taking on the role of Chair, Vice Chair or Treasurer.
-                        </strong></p>`
-                    });
+                    result.push(
+                        localise({
+                            en: `Your senior contact must be listed as a member of your organisation's
+                                 board or committee with the Charity Commission/Companies House.`,
+                            cy: ``
+                        })
+                    );
                 }
 
-                return text;
-            },
-            get type() {
-                // Statutory bodies require a sub-type, some of which allow
-                // free text input for roles.
+                if (currentOrganisationType === ORGANISATION_TYPES.CIO) {
+                    result.push(
+                        localise({
+                            en: `As a charity, your senior contact can be one of your organisation's trustees.
+                         This can include trustees taking on the role of Chair, Vice Chair or Treasurer.`,
+                            cy: ``
+                        })
+                    );
+                }
+
                 if (
                     currentOrganisationType ===
-                        ORGANISATION_TYPES.STATUTORY_BODY &&
-                    includes(
-                        [
-                            STATUTORY_BODY_TYPES.PRISON_SERVICE,
-                            STATUTORY_BODY_TYPES.FIRE_SERVICE,
-                            STATUTORY_BODY_TYPES.POLICE_AUTHORITY
-                        ],
-                        currentOrganisationSubType
-                    )
+                    ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY
                 ) {
-                    return 'text';
+                    result.push(
+                        localise({
+                            en: `As a registered charity, your senior contact must be one of your organisation's trustees. 
+                                 This can include trustees taking on the role of Chair, Vice Chair or Treasurer.`,
+                            cy: ``
+                        })
+                    );
                 }
 
-                return 'radio';
+                if (currentOrganisationType === ORGANISATION_TYPES.SCHOOL) {
+                    result.push(
+                        localise({
+                            en: `As a school, your senior contact must be the headteacher`,
+                            cy: ``
+                        })
+                    );
+                }
+
+                return result;
             },
+            type: isFreeText() ? 'text' : 'radio',
             options: rolesFor(
                 currentOrganisationType,
                 currentOrganisationSubType
             ),
             isRequired: true,
             get schema() {
-                if (this.type === 'radio') {
+                if (isFreeText()) {
+                    return Joi.string().required();
+                } else {
                     return Joi.string()
                         .valid(this.options.map(option => option.value))
                         .required();
-                } else {
-                    return Joi.string().required();
                 }
             },
             messages: [
                 {
                     type: 'base',
-                    message: localise({ en: 'Choose a role', cy: '' })
+                    message: isFreeText()
+                        ? localise({ en: 'Enter a role', cy: '' })
+                        : localise({ en: 'Choose a role', cy: '' })
                 },
                 {
                     type: 'any.allowOnly',

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,6 +1,6 @@
 'use strict';
 const moment = require('moment/moment');
-const { get } = require('lodash/fp');
+const get = require('lodash/fp/get');
 const { flatMap, includes, values, concat, has } = require('lodash');
 
 const Joi = require('../form-router-next/joi-extensions');
@@ -22,10 +22,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
     const currentOrganisationType = get('organisationType')(data);
     const currentOrganisationSubType = get('organisationSubType')(data);
-
-    function matchesOrganisationType(type) {
-        return currentOrganisationType === type;
-    }
 
     function multiChoice(options) {
         return Joi.array()
@@ -2124,6 +2120,30 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     en: 'This person has to live in the UK.',
                     cy: ''
                 }),
+                get warnings() {
+                    let result = [];
+
+                    const seniorSurname = get('seniorContactName.lastName')(
+                        data
+                    );
+
+                    const lastNamesMatch =
+                        seniorSurname &&
+                        seniorSurname === get('mainContactName.lastName')(data);
+
+                    if (lastNamesMatch) {
+                        result.push(
+                            localise({
+                                en: `We've noticed that your main and senior contact
+                                     have the same surname. Remember we can't fund projects
+                                     where the two contacts are married or related by blood.`,
+                                cy: ``
+                            })
+                        );
+                    }
+
+                    return result;
+                },
                 schema: Joi.fullName()
                     .mainContact()
                     .required()

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -854,7 +854,8 @@ module.exports = function({ locale, data = {} }) {
                 en: 'National Lottery Awards for All',
                 cy: ''
             }),
-            isBilingual: true,
+            // @TODO: Re-enable when welsh translation has been added
+            isBilingual: false,
             allFields: fields,
             featuredErrorsAllowList: [
                 { param: 'projectDateRange', includeBaseError: false },

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -532,14 +532,6 @@ module.exports = function({ locale, data = {} }) {
                                 seniorFirstName && seniorSurname
                                     ? `, ${seniorFirstName} ${seniorSurname}`
                                     : '';
-                            const mainSurname = get('mainContactName.lastName')(
-                                data
-                            );
-
-                            let contactSameNameWarning = '';
-                            if (seniorSurname === mainSurname) {
-                                contactSameNameWarning = `<p><strong>We've noticed that your main and senior contact have the same surname. Remember we can't fund projects where the two contacts are married or related by blood.</strong></p>`;
-                            }
 
                             return localise({
                                 en: `<p>
@@ -549,7 +541,7 @@ module.exports = function({ locale, data = {} }) {
                                         The main contact must be a different person from the senior contact${seniorName}. 
                                         The two contacts also can't be married or in a long-term relationship with each 
                                         other, living together at the same address, or related by blood.
-                                    </p>${contactSameNameWarning}`,
+                                    </p>`,
                                 cy: ''
                             });
                         },

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -821,11 +821,11 @@ module.exports = function({ locale, data = {} }) {
             isBilingual: false,
             allFields: fields,
             featuredErrorsAllowList: [
-                { param: 'projectDateRange', includeBaseError: false },
-                { param: 'seniorContactRole', includeBaseError: false },
-                { param: 'mainContactName', includeBaseError: false },
-                { param: 'mainContactEmail', includeBaseError: false },
-                { param: 'mainContactPhone', includeBaseError: false }
+                'projectDateRange',
+                'seniorContactRole',
+                'mainContactName',
+                'mainContactEmail',
+                'mainContactPhone'
             ],
             summary: summary(),
             forSalesforce: forSalesforce,

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -474,47 +474,18 @@ module.exports = function({ locale, data = {} }) {
                             en: 'Who is your senior contact?',
                             cy: ''
                         }),
-                        get introduction() {
-                            function roleText() {
-                                let result;
-                                switch (currentOrganisationType) {
-                                    case ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY:
-                                    case ORGANISATION_TYPES.CIO:
-                                    case ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY:
-                                        result = localise({
-                                            en: `<p>This person must be a member of your board or committee.</p>`,
-                                            cy: ''
-                                        });
-                                        break;
-                                    case ORGANISATION_TYPES.SCHOOL:
-                                        result = localise({
-                                            en: `<p>If you are a school, this person must be the headteacher.</p>`,
-                                            cy: ''
-                                        });
-                                        break;
-                                    default:
-                                        result = localise({
-                                            en: `<p>This person is usually a senior leader, or a member of your board or committee.</p>`,
-                                            cy: ''
-                                        });
-                                        break;
-                                }
-
-                                return result;
-                            }
-
-                            return [
-                                localise({
-                                    en: `<p>Please give us the contact details of a senior member of your organisation.</p>`,
-                                    cy: ``
-                                }),
-                                roleText(),
-                                localise({
-                                    en: `<p>Your senior contact must be at least 18 years old and is legally responsible for ensuring that this application is supported by the organisation applying, any funding is delivered as set out in the application form, and that the funded organisation meets our monitoring requirements.</p>`,
-                                    cy: ''
-                                })
-                            ].join('\n');
-                        },
+                        introduction: localise({
+                            en: `<p>
+                                Please give us the contact details of a senior member of your organisation.
+                            </p>
+                            <p>
+                                Your senior contact must be at least 18 years old and is legally responsible
+                                for ensuring that this application is supported by the organisation applying,
+                                any funding is delivered as set out in the application form, and that the
+                                funded organisation meets our monitoring requirements.
+                            </p>`,
+                            cy: ``
+                        }),
                         fields: compact([
                             fields.seniorContactRole,
                             fields.seniorContactName,

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -1110,24 +1110,20 @@ describe('form shape', () => {
             }
         });
 
-        expect(
-            form.validation.messages.filter(message => message.isFeatured)
-        ).toEqual([
+        expect(form.validation.featuredMessages).toEqual([
             {
                 msg: expect.stringMatching(
                     /Date you start the project must be after/
                 ),
                 param: 'projectDateRange',
                 type: 'dateRange.minDate.invalid',
-                field: expect.any(Object),
-                isFeatured: expect.any(Boolean)
+                field: expect.any(Object)
             },
             {
                 msg: 'Senior contact role is not valid',
                 param: 'seniorContactRole',
                 type: 'any.allowOnly',
-                field: expect.any(Object),
-                isFeatured: expect.any(Boolean)
+                field: expect.any(Object)
             }
         ]);
     });

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -1026,6 +1026,24 @@ describe('Form validations', () => {
                 ]);
             });
         });
+
+        test('include warning if contact last names match', () => {
+            expect(fieldFor('mainContactName', null).warnings).toEqual([]);
+
+            const lastName = faker.name.lastName();
+            expect(
+                fieldFor('mainContactName', {
+                    seniorContactName: {
+                        firstName: faker.name.firstName(),
+                        lastName: lastName
+                    },
+                    mainContactName: {
+                        firstName: faker.name.firstName(),
+                        lastName: lastName
+                    }
+                }).warnings
+            ).toEqual([expect.stringContaining('have the same surname')]);
+        });
     });
 
     describe('Bank details', () => {

--- a/controllers/apply/form-router-next/summary.js
+++ b/controllers/apply/form-router-next/summary.js
@@ -34,9 +34,6 @@ module.exports = function(formBuilder) {
 
         const title = copy.summary.title;
         const showErrors = !!req.query['show-errors'] === true;
-        const featuredErrors = form.validation.messages.filter(
-            message => message.isFeatured
-        );
 
         res.render(path.resolve(__dirname, './views/summary'), {
             form: form,
@@ -47,7 +44,7 @@ module.exports = function(formBuilder) {
             showErrors: showErrors,
             errors: form.validation.messages,
             errorsByStep: errorsByStep(),
-            featuredErrors: featuredErrors,
+            featuredErrors: form.validation.featuredMessages,
             expandSections: form.progress.isComplete || showErrors
         });
     });

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -24,6 +24,15 @@
     {% if field.explanation %}
         <div class="ff-help s-prose">{{ field.explanation | safe }}</div>
     {% endif %}
+
+    {# Include soft warnings provided by the field #}
+    {% if field.warnings %}
+        <div class="ff-help s-prose">
+            {% for warning in field.warnings %}
+                <p><strong>{{ warning }}</strong></p>
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endmacro %}
 
 {% macro labelFor(field) -%}


### PR DESCRIPTION
This PR does some work to improve how we handle messages and warnings in the form model.

**Merge role type messages**

Some warning text for the senior contact role was handled in the step introduction and the rest was handled in the field explanation.

<img width="962" alt="duplication-conditions" src="https://user-images.githubusercontent.com/123386/61039174-2ddfbb00-a3c6-11e9-8a79-3d702115e358.png">

Added the concept of `warnings` on fields. Rationalised the logic for these messages into a single list of warnings and added tests.

**Move contact surname warning to field**

Also, moves the contact surname to the new `warnings` property and adds tests.

**Simplify featured errors logic**


All errors in the current allow list have `includeBaseError` set to `false`. This means that for now we can make the assumption that all errors in this allow-list will exclude the base error. Keen to avoid having a code path that is not being executed.

I also spotted that we can avoid the mutation and regular filtering required by setting an isFeatured flag on the message by returning a dedicated featuredMessages property from the validation function.