### PR TITLE
Don't bother looking for URL aliases in the CMS if we know the path isn't valid

### DIFF
--- a/server.js
+++ b/server.js
@@ -315,6 +315,13 @@ app.route('*').get(
             alias => alias.from.toLowerCase() === req.path.toLowerCase()
         );
         try {
+            // Is this request a single-level path (eg. /foo, /bar)?
+            const pathCouldBeAlias = (req.path[0] === '/' ? req.path.substring(1) : req.path).split('/').length === 1;
+
+            if (!pathCouldBeAlias) {
+                return next();
+            }
+
             const enAliases = await contentApi.getAliases({ locale: 'en' });
             const enMatch = findAlias(enAliases);
             if (enMatch) {


### PR DESCRIPTION
This shaves a few seconds off the 404 page and will hopefully reduce CMS server load for pen tests etc.

Fixes https://github.com/biglotteryfund/blf-alpha/issues/2064