### PR TITLE
Add documentation test for schema.md

### DIFF
--- a/controllers/apply/awards-for-all/docs/schema.md
+++ b/controllers/apply/awards-for-all/docs/schema.md
@@ -139,6 +139,7 @@ Each submission has two top-level keys: `meta` which contains metadata about the
             "size": "123",
             "type": "application/pdf"
         },
+        "buildingSocietyNumber": null,
         "termsAgreement1": "yes",
         "termsAgreement2": "yes",
         "termsAgreement3": "yes",
@@ -560,6 +561,12 @@ type: `string`
 ### bankAccountNumber
 
 type: `string`
+
+### buildingSocietyNumber
+
+type: `string` or `null`
+
+Optional field
 
 ### bankStatement
 

--- a/controllers/apply/awards-for-all/docs/schema.test.js
+++ b/controllers/apply/awards-for-all/docs/schema.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+// @ts-nocheck
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const map = require('lodash/map');
+
+const formBuilder = require('../form');
+
+const docContents = fs.readFileSync(
+    path.resolve(__dirname, './schema.md'),
+    'utf8'
+);
+
+const form = formBuilder({ locale: 'en' });
+
+test.each(map(form.allFields, 'name'))(
+    '%s has documentation entry',
+    fieldName => {
+        const fieldNameRegexp = new RegExp(`### ${fieldName}`);
+        const match = fieldNameRegexp.test(docContents);
+        expect(match).toBeTruthy();
+    }
+);


### PR DESCRIPTION
Inspired by https://simonwillison.net/2018/Jul/28/documentation-unit-tests/ adds a basic documentation unit test which checks there is a section heading for every field in the form schema. Caught that the optional `buildingSocietyNumber` wasn't included.