### PR TITLE
Alias cleanup

### DIFF
--- a/common/urls.js
+++ b/common/urls.js
@@ -47,6 +47,16 @@ function localify(locale) {
     };
 }
 
+/**
+ * Test if a path could be an alias
+ * i.e. more than one level deep
+ * @param path
+ * @returns {boolean}
+ */
+function pathCouldBeAlias(path) {
+    return (path[0] === '/' ? path.substring(1) : path).split('/').length === 1;
+}
+
 function getBaseUrl(req) {
     const headerProtocol = req.get('X-Forwarded-Proto');
     const protocol = headerProtocol ? headerProtocol : req.protocol;
@@ -146,8 +156,9 @@ module.exports = {
     isWelsh,
     localify,
     makeWelsh,
+    pathCouldBeAlias,
+    redirectForLocale,
     removeWelsh,
     sanitiseUrlPath,
-    stripTrailingSlashes,
-    redirectForLocale
+    stripTrailingSlashes
 };

--- a/common/urls.test.js
+++ b/common/urls.test.js
@@ -7,6 +7,7 @@ const {
     hasTrailingSlash,
     isWelsh,
     localify,
+    pathCouldBeAlias,
     sanitiseUrlPath,
     stripTrailingSlashes
 } = require('./urls');
@@ -144,6 +145,15 @@ describe('URL Helpers', () => {
 
         it('should not consider homepage as having a trailing slash', () => {
             expect(hasTrailingSlash('/')).toBe(false);
+        });
+    });
+
+    describe('#pathCouldBeAlias', () => {
+        it('should test if path could be an alias', () => {
+            expect(pathCouldBeAlias('/hello')).toBeTruthy();
+            expect(pathCouldBeAlias('/hyphenated-alias')).toBeTruthy();
+            expect(pathCouldBeAlias('/two/levels')).toBeFalsy();
+            expect(pathCouldBeAlias('/multi/level/path')).toBeFalsy();
         });
     });
 

--- a/cypress/integration/common.js
+++ b/cypress/integration/common.js
@@ -29,6 +29,14 @@ describe('server smoke tests', function() {
             expect(response.status).to.eq(404);
             expect(response.body).to.include('Error 404');
         });
+
+        cy.request({
+            url: '/not/a/page',
+            failOnStatusCode: false
+        }).then(response => {
+            expect(response.status).to.eq(404);
+            expect(response.body).to.include('Error 404');
+        });
     });
 
     it('should redirect search queries to a google site search', () => {

--- a/server.js
+++ b/server.js
@@ -26,7 +26,13 @@ if (appData.isDev) {
     require('dotenv').config();
 }
 
-const { isWelsh, makeWelsh, removeWelsh, localify } = require('./common/urls');
+const {
+    isWelsh,
+    localify,
+    makeWelsh,
+    pathCouldBeAlias,
+    removeWelsh
+} = require('./common/urls');
 const { SENTRY_DSN } = require('./common/secrets');
 const aliases = require('./controllers/aliases');
 const routes = require('./controllers/routes');
@@ -308,13 +314,8 @@ app.get('/error-unauthorised', renderUnauthorised);
  * - If all else fails, pass through to the 404 handler.
  */
 app.route('*').get(
-    async function vanityLookup(req, res, next) {
-        // Is this request a single-level path (eg. /foo, /bar)?
-        const pathCouldBeAlias =
-            (req.path[0] === '/' ? req.path.substring(1) : req.path).split('/')
-                .length === 1;
-
-        if (pathCouldBeAlias) {
+    async function(req, res, next) {
+        if (pathCouldBeAlias(req.path)) {
             try {
                 const urlMatch = await contentApi.getAlias(req.path);
                 if (urlMatch) {


### PR DESCRIPTION
Tiny bit of alias cleanup. Lifts the alias query logic up into `content-api`. Adds a unit test for `pathCouldBeAlias`