### PR TITLE
Fix issue with beneficiaries groups validations

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -686,17 +686,21 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     function conditionalBeneficiaryChoice({ match, schema }) {
         return Joi.when(Joi.ref('beneficiariesGroupsCheck'), {
             is: 'yes',
-            // Conditional based on array
-            // https://github.com/hapijs/joi/issues/622
-            then: Joi.when(Joi.ref('beneficiariesGroups'), {
-                is: Joi.array().items(
-                    Joi.string()
-                        .only(match)
-                        .required(),
-                    Joi.any()
-                ),
-                then: schema,
-                otherwise: Joi.any().strip()
+            then: Joi.when('beneficiariesGroupsOther', {
+                is: Joi.string().required(),
+                then: Joi.any().strip(),
+                // Conditional based on array
+                // https://github.com/hapijs/joi/issues/622
+                otherwise: Joi.when(Joi.ref('beneficiariesGroups'), {
+                    is: Joi.array().items(
+                        Joi.string()
+                            .only(match)
+                            .required(),
+                        Joi.any()
+                    ),
+                    then: schema,
+                    otherwise: Joi.any().strip()
+                })
             }),
             otherwise: Joi.any().strip()
         });
@@ -1361,7 +1365,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 return Joi.when('beneficiariesGroupsCheck', {
                     is: 'yes',
                     then: Joi.when('beneficiariesGroupsOther', {
-                        is: Joi.string(),
+                        is: Joi.string().required(),
                         then: Joi.any().strip(),
                         otherwise: multiChoice(this.options).required()
                     }),

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -197,7 +197,7 @@ module.exports = function({ locale, data = {} }) {
      * Used to conditionally render fields for age, gender etc.
      */
     function includeIfBeneficiaryType(type, fields) {
-        const groupChoices = getOr([], 'beneficiariesGroups')(data);
+        const groupChoices = get('beneficiariesGroups')(data) || [];
         return groupChoices.includes(type) ? fields : [];
     }
 

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -7,7 +7,6 @@ const random = require('lodash/random');
 const range = require('lodash/range');
 const sample = require('lodash/sample');
 const times = require('lodash/times');
-const values = require('lodash/values');
 const faker = require('faker');
 const moment = require('moment');
 
@@ -73,7 +72,7 @@ function mockFullForm({
         projectBudget: mockBudget(),
         projectTotalCosts: 20000,
         beneficiariesGroupsCheck: 'yes',
-        beneficiariesGroups: values(BENEFICIARY_GROUPS),
+        beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
         beneficiariesGroupsOther: undefined,
         beneficiariesGroupsEthnicBackground: ['african', 'caribbean'],
         beneficiariesGroupsGender: ['non-binary'],
@@ -351,6 +350,81 @@ describe('Form validations', () => {
                     label: 'Specific groups of people',
                     url: '/apply/awards-for-all/beneficiaries/1'
                 }
+            });
+        });
+
+        test('require beneficiaries groups if check question was yes', () => {
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'no',
+                beneficiariesGroups: null,
+                beneficiariesGroupsOther: null,
+                beneficiariesGroupsEthnicBackground: null,
+                beneficiariesGroupsGender: null,
+                beneficiariesGroupsAge: null,
+                beneficiariesGroupsDisabledPeople: null,
+                beneficiariesGroupsReligion: null,
+                beneficiariesGroupsReligionOther: null
+            });
+
+            assertMessagesByKey(
+                {
+                    beneficiariesGroupsCheck: 'yes',
+                    beneficiariesGroups: null,
+                    beneficiariesGroupsOther: null,
+                    beneficiariesGroupsEthnicBackground: null,
+                    beneficiariesGroupsGender: null,
+                    beneficiariesGroupsAge: null,
+                    beneficiariesGroupsDisabledPeople: null,
+                    beneficiariesGroupsReligion: null,
+                    beneficiariesGroupsReligionOther: null
+                },
+                [expect.stringContaining('Select the specific group')]
+            );
+
+            assertMessagesByKey(
+                {
+                    beneficiariesGroupsCheck: 'yes',
+                    beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
+                    beneficiariesGroupsOther: null,
+                    beneficiariesGroupsEthnicBackground: null,
+                    beneficiariesGroupsGender: null,
+                    beneficiariesGroupsAge: null,
+                    beneficiariesGroupsDisabledPeople: null,
+                    beneficiariesGroupsReligion: null,
+                    beneficiariesGroupsReligionOther: null
+                },
+                [
+                    expect.stringContaining('Select the age group'),
+                    expect.stringContaining('Select the disabled people'),
+                    expect.stringContaining('Select the ethnic background'),
+                    expect.stringContaining('Select the gender'),
+                    expect.stringContaining('Select the religion')
+                ]
+            );
+        });
+
+        test('ignore beneficiary groups if beneficiariesOther is present', () => {
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: ['lgbt'],
+                beneficiariesGroupsEthnicBackground: ['african', 'caribbean'],
+                beneficiariesGroupsGender: ['non-binary'],
+                beneficiariesGroupsAge: ['0-12', '13-24'],
+                beneficiariesGroupsDisabledPeople: ['sensory'],
+                beneficiariesGroupsReligion: ['sikh'],
+                beneficiariesGroupsReligionOther: undefined
+            });
+
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: null,
+                beneficiariesGroupsOther: 'example',
+                beneficiariesGroupsEthnicBackground: null,
+                beneficiariesGroupsGender: null,
+                beneficiariesGroupsAge: null,
+                beneficiariesGroupsDisabledPeople: null,
+                beneficiariesGroupsReligion: null,
+                beneficiariesGroupsReligionOther: null
             });
         });
 

--- a/controllers/apply/form-router-next/lib/form-model.js
+++ b/controllers/apply/form-router-next/lib/form-model.js
@@ -86,7 +86,7 @@ class FormModel {
 
             function sectionStatus() {
                 const fieldNames = fieldsForSection().map(f => f.name);
-                const fieldData = pick(validation.value, fieldNames);
+                const fieldData = pick(data, fieldNames);
                 const fieldErrors = validation.messages.filter(item =>
                     fieldNames.includes(item.param)
                 );


### PR DESCRIPTION
Spotted an issue where the beneficiary groups section was not showing the correct errors on the summary screen making it hard to tell what you had to complete. The submit button check works as expected, but the logic to determine the correct messages wasn't quite right.

Added a failing unit test to validate this and then updated the field schema. The source of the issue was the conditional validation for `beneficiariesGroupsOther`