### PR TITLE
Redundant settings

### DIFF
--- a/assets/js/vue-apps/form-components/word-count.test.js
+++ b/assets/js/vue-apps/form-components/word-count.test.js
@@ -13,7 +13,6 @@ describe('WordCount', () => {
                 currentText: null,
                 minWords: 10,
                 maxWords: 150,
-                recommendedWords: 100,
                 locale: 'en'
             }
         });
@@ -29,7 +28,6 @@ describe('WordCount', () => {
                 currentText: null,
                 minWords: 50,
                 maxWords: 150,
-                recommendedWords: 100,
                 locale: 'en'
             }
         });

--- a/assets/js/vue-apps/form-components/word-count.vue
+++ b/assets/js/vue-apps/form-components/word-count.vue
@@ -4,7 +4,6 @@ export default {
         currentText: { type: String, default: '' },
         maxWords: { type: Number, required: true },
         minWords: { type: Number, required: true },
-        recommendedWords: { type: Number, required: true },
         locale: { type: String, required: true }
     },
     methods: {

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,7 +1,8 @@
 'use strict';
 const moment = require('moment/moment');
+const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
-const { flatMap, includes, values, concat, has } = require('lodash');
+const has = require('lodash/has');
 
 const Joi = require('../form-router-next/joi-extensions');
 const locationsFor = require('./locations');
@@ -38,25 +39,22 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             schema: Joi.string()
                 .email()
                 .required(),
-            messages: concat(
-                [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Enter an email address',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.email',
-                        message: localise({
-                            en: `Email address must be in the correct format, like name@example.com`,
-                            cy: ``
-                        })
-                    }
-                ],
-                additionalMessages
-            )
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter an email address',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'string.email',
+                    message: localise({
+                        en: `Email address must be in the correct format, like name@example.com`,
+                        cy: ``
+                    })
+                }
+            ].concat(additionalMessages)
         };
 
         return { ...defaultProps, ...props };
@@ -96,47 +94,44 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             type: 'address',
             isRequired: true,
             schema: Joi.ukAddress().required(),
-            messages: concat(
-                [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Enter a full UK address',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'any.empty',
-                        key: 'line1',
-                        message: localise({
-                            en: 'Enter a building and street',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'any.empty',
-                        key: 'townCity',
-                        message: localise({
-                            en: 'Enter a town or city',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'any.empty',
-                        key: 'postcode',
-                        message: localise({ en: 'Enter a postcode', cy: '' })
-                    },
-                    {
-                        type: 'string.postcode',
-                        key: 'postcode',
-                        message: localise({
-                            en: 'Enter a real postcode',
-                            cy: ''
-                        })
-                    }
-                ],
-                additionalMessages
-            )
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter a full UK address',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'any.empty',
+                    key: 'line1',
+                    message: localise({
+                        en: 'Enter a building and street',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'any.empty',
+                    key: 'townCity',
+                    message: localise({
+                        en: 'Enter a town or city',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'any.empty',
+                    key: 'postcode',
+                    message: localise({ en: 'Enter a postcode', cy: '' })
+                },
+                {
+                    type: 'string.postcode',
+                    key: 'postcode',
+                    message: localise({
+                        en: 'Enter a real postcode',
+                        cy: ''
+                    })
+                }
+            ].concat(additionalMessages)
         };
 
         return { ...defaultProps, ...props };
@@ -222,34 +217,31 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             type: 'full-name',
             isRequired: true,
             schema: Joi.fullName().required(),
-            messages: concat(
-                [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Enter first and last name',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'any.empty',
-                        key: 'firstName',
-                        message: localise({
-                            en: 'Enter first name',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'any.empty',
-                        key: 'lastName',
-                        message: localise({
-                            en: 'Enter last name',
-                            cy: ''
-                        })
-                    }
-                ],
-                additionalMessages
-            )
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter first and last name',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'any.empty',
+                    key: 'firstName',
+                    message: localise({
+                        en: 'Enter first name',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'any.empty',
+                    key: 'lastName',
+                    message: localise({
+                        en: 'Enter last name',
+                        cy: ''
+                    })
+                }
+            ].concat(additionalMessages)
         };
 
         return { ...defaultProps, ...props };
@@ -522,7 +514,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     ];
                     break;
                 default:
-                    options = values(ROLES);
+                    options = Object.values(ROLES);
                     break;
             }
 
@@ -552,7 +544,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                         options = [ROLES.CHIEF_EXECUTIVE, ROLES.DIRECTOR];
                         break;
                     default:
-                        options = values(ROLES);
+                        options = Object.values(ROLES);
                         break;
                 }
             }
@@ -2005,13 +1997,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             type: 'text',
             attributes: { size: 20 },
-            isRequired: includes(
-                [
-                    ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                    ORGANISATION_TYPES.CIO
-                ],
-                currentOrganisationType
-            ),
+            isRequired: [
+                ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+                ORGANISATION_TYPES.CIO
+            ].includes(currentOrganisationType),
             schema: Joi.when('organisationType', {
                 is: ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
                 then: Joi.number().required()

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -391,6 +391,205 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         };
     }
 
+    function fieldYourIdeaProject() {
+        return {
+            name: 'yourIdeaProject',
+            label: localise({
+                en: 'What would you like to do?',
+                cy: ''
+            }),
+            get explanation() {
+                return localise({
+                    en: `<p><strong>Here are some ideas of what to tell us about your project:</strong></p>
+                    <ul>
+                        <li>What you would like to do</li>
+                        <li>What difference your project will make</li>
+                        <li>Who will benefit from it</li>
+                        <li>How long you expect to run it for. This can be an estimate</li>
+                        <li>How you'll make sure people know about it</li>
+                        <li>How you plan to learn from it and use this learning to shape future projects</li>
+                        <li>Is it something new, or are you continuing something that has worked well previously? We want to fund both types of projects</li>
+                    </ul>
+                    <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
+                    cy: ''
+                });
+            },
+            type: 'textarea',
+            settings: {
+                stackedSummary: true,
+                showWordCount: true,
+                minWords: 50,
+                maxWords: 300
+            },
+            attributes: { rows: 20 },
+            isRequired: true,
+            get schema() {
+                return Joi.string()
+                    .minWords(this.settings.minWords)
+                    .maxWords(this.settings.maxWords)
+                    .required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: 'Tell us about your project',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'string.minWords',
+                        message: localise({
+                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'string.maxWords',
+                        message: localise({
+                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        };
+    }
+
+    function fieldYourIdeaPriorities() {
+        return {
+            name: 'yourIdeaPriorities',
+            label: localise({
+                en: `How does your project meet at least one of our funding priorities?`,
+                cy: ``
+            }),
+            get explanation() {
+                return localise({
+                    en: `<p>National Lottery Awards for All has three funding priorities, please tell us how your project will <strong>meet at least one of these:</strong></p>
+                        <ol>
+                            <li>Bring people together and build strong relationships in and across communities</li>
+                            <li>Improve the places and spaces that matter to communities</li>
+                            <li>Help more people to reach their potential, by supporting them at the earliest possible stage</li>
+                        </ol>
+                        <p>You can tell us if your project meets more than one priority, but don't worry if it doesn't.</p>
+                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
+                    cy: ``
+                });
+            },
+            type: 'textarea',
+            settings: {
+                stackedSummary: true,
+                showWordCount: true,
+                minWords: 50,
+                maxWords: 150
+            },
+            attributes: {
+                rows: 12
+            },
+            isRequired: true,
+            get schema() {
+                return Joi.string()
+                    .minWords(this.settings.minWords)
+                    .maxWords(this.settings.maxWords)
+                    .required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: `Tell us how your project meets at least one of our funding priorities`,
+                            cy: ``
+                        })
+                    },
+                    {
+                        type: 'string.minWords',
+                        message: localise({
+                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'string.maxWords',
+                        message: localise({
+                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        };
+    }
+
+    function fieldYourIdeaCommunity() {
+        return {
+            name: 'yourIdeaCommunity',
+            label: localise({
+                en: 'How does your project involve your community?',
+                cy: ''
+            }),
+            get explanation() {
+                return localise({
+                    en: `
+                        <details class="o-details u-margin-bottom-s">
+                            <summary class="o-details__summary">What do we mean by community?</summary>
+                            <div class="o-details__content">
+                                <ol>
+                                    <li>People living in the same area</li>
+                                    <li>People who have similar interests or life experiences, but might not live in the same area</li>
+                                    <li>Even though schools can be at the heart of a community - we'll only fund schools that also benefit the communities around them.</li>
+                                </ol>
+                            <div>
+                        </details>
+                        <p>We believe that people understand what's needed in their communities better than anyone. Tell us how your community came up with the idea for your project. We want to know how many people you've spoken to, and how they'll be involved in the development and delivery of the project.</p>
+                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
+                    cy: ''
+                });
+            },
+            type: 'textarea',
+            settings: {
+                stackedSummary: true,
+                showWordCount: true,
+                minWords: 50,
+                maxWords: 200
+            },
+            attributes: { rows: 15 },
+            isRequired: true,
+            get schema() {
+                return Joi.string()
+                    .minWords(this.settings.minWords)
+                    .maxWords(this.settings.maxWords)
+                    .required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: `Tell us how your project involves your community`,
+                            cy: ``
+                        })
+                    },
+                    {
+                        type: 'string.minWords',
+                        message: localise({
+                            en: `Answer must be at least ${this.settings.minWords} words`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'string.maxWords',
+                        message: localise({
+                            en: `Answer must be no more than ${this.settings.maxWords} words`,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        };
+    }
+
     function fieldOrganisationType() {
         const options = [
             {
@@ -955,196 +1154,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        yourIdeaProject: {
-            name: 'yourIdeaProject',
-            label: localise({
-                en: 'What would you like to do?',
-                cy: ''
-            }),
-            get explanation() {
-                return localise({
-                    en: `<p><strong>Here are some ideas of what to tell us about your project:</strong></p>
-                    <ul>
-                        <li>What you would like to do</li>
-                        <li>What difference your project will make</li>
-                        <li>Who will benefit from it</li>
-                        <li>How long you expect to run it for. This can be an estimate</li>
-                        <li>How you'll make sure people know about it</li>
-                        <li>How you plan to learn from it and use this learning to shape future projects</li>
-                        <li>Is it something new, or are you continuing something that has worked well previously? We want to fund both types of projects</li>
-                    </ul>
-                    <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ''
-                });
-            },
-            type: 'textarea',
-            settings: {
-                stackedSummary: true,
-                showWordCount: true,
-                minWords: 50,
-                maxWords: 300
-            },
-            attributes: { rows: 20 },
-            isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Tell us about your project',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        },
-        yourIdeaPriorities: {
-            name: 'yourIdeaPriorities',
-            label: localise({
-                en: `How does your project meet at least one of our funding priorities?`,
-                cy: ``
-            }),
-            get explanation() {
-                return localise({
-                    en: `<p>National Lottery Awards for All has three funding priorities, please tell us how your project will <strong>meet at least one of these:</strong></p>
-                        <ol>
-                            <li>Bring people together and build strong relationships in and across communities</li>
-                            <li>Improve the places and spaces that matter to communities</li>
-                            <li>Help more people to reach their potential, by supporting them at the earliest possible stage</li>
-                        </ol>
-                        <p>You can tell us if your project meets more than one priority, but don't worry if it doesn't.</p>
-                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ``
-                });
-            },
-            type: 'textarea',
-            settings: {
-                stackedSummary: true,
-                showWordCount: true,
-                minWords: 50,
-                maxWords: 150
-            },
-            attributes: {
-                rows: 12
-            },
-            isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Tell us how your project meets at least one of our funding priorities`,
-                            cy: ``
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        },
-        yourIdeaCommunity: {
-            name: 'yourIdeaCommunity',
-            label: localise({
-                en: 'How does your project involve your community?',
-                cy: ''
-            }),
-            get explanation() {
-                return localise({
-                    en: `
-                        <details class="o-details u-margin-bottom-s">
-                            <summary class="o-details__summary">What do we mean by community?</summary>
-                            <div class="o-details__content">
-                                <ol>
-                                    <li>People living in the same area</li>
-                                    <li>People who have similar interests or life experiences, but might not live in the same area</li>
-                                    <li>Even though schools can be at the heart of a community - we'll only fund schools that also benefit the communities around them.</li>
-                                </ol>
-                            <div>
-                        </details>
-                        <p>We believe that people understand what's needed in their communities better than anyone. Tell us how your community came up with the idea for your project. We want to know how many people you've spoken to, and how they'll be involved in the development and delivery of the project.</p>
-                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ''
-                });
-            },
-            type: 'textarea',
-            settings: {
-                stackedSummary: true,
-                showWordCount: true,
-                minWords: 50,
-                maxWords: 200
-            },
-            attributes: { rows: 15 },
-            isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Tell us how your project involves your community`,
-                            cy: ``
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        },
+        yourIdeaProject: fieldYourIdeaProject(),
+        yourIdeaPriorities: fieldYourIdeaPriorities(),
+        yourIdeaCommunity: fieldYourIdeaCommunity(),
         projectBudget: {
             name: 'projectBudget',
             label: localise({

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -3,6 +3,7 @@ const moment = require('moment/moment');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 const has = require('lodash/has');
+const { oneLine } = require('common-tags');
 
 const Joi = require('../form-router-next/joi-extensions');
 const locationsFor = require('./locations');
@@ -303,9 +304,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             get settings() {
                 return {
-                    fromDateExample: minStartDate
-                        .subtract(1, 'days')
-                        .format('D MMMM YYYY'),
                     minYear: minStartDate.format('YYYY'),
                     maxDurationFromStart: {
                         amount: 1,
@@ -377,7 +375,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'dateRange.minDate.invalid',
                         message: localise({
-                            en: `Date you start the project must be after ${this.settings.fromDateExample}`,
+                            en: oneLine`Date you start the project must be after
+                                ${minStartDate
+                                    .subtract(1, 'days')
+                                    .format('D MMMM YYYY')}`,
                             cy: ''
                         })
                     },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -334,8 +334,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true,
             schema: Joi.dateRange()
                 .minDate(minDate.format('YYYY-MM-DD'))
-                .maxDate(maxDate.format('YYYY-MM-DD'))
-                .futureEndDate(),
+                .maxDate(maxDate.format('YYYY-MM-DD')),
             messages: [
                 {
                     type: 'base',

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -997,8 +997,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 stackedSummary: true,
                 showWordCount: true,
                 minWords: 50,
-                maxWords: 300,
-                recommendedWords: 250
+                maxWords: 300
             },
             attributes: { rows: 20 },
             isRequired: true,
@@ -1058,8 +1057,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 stackedSummary: true,
                 showWordCount: true,
                 minWords: 50,
-                maxWords: 150,
-                recommendedWords: 100
+                maxWords: 150
             },
             attributes: {
                 rows: 12
@@ -1126,8 +1124,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 stackedSummary: true,
                 showWordCount: true,
                 minWords: 50,
-                maxWords: 200,
-                recommendedWords: 150
+                maxWords: 200
             },
             attributes: { rows: 15 },
             isRequired: true,

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -293,6 +293,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     }
 
     function fieldProjectDateRange() {
+        const minStartDate = moment().add(12, 'weeks');
+
         return {
             name: 'projectDateRange',
             label: localise({
@@ -300,16 +302,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: ``
             }),
             get settings() {
-                const minStart = {
-                    amount: 12,
-                    units: 'weeks'
-                };
-                const minStartDate = moment().add(
-                    minStart.amount,
-                    minStart.units
-                );
                 return {
-                    minStart: minStart,
                     minDateExample: minStartDate.format('DD/MM/YYYY'),
                     fromDateExample: minStartDate
                         .subtract(1, 'days')

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -303,7 +303,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             get settings() {
                 return {
-                    minDateExample: minStartDate.format('DD/MM/YYYY'),
                     fromDateExample: minStartDate
                         .subtract(1, 'days')
                         .format('D MMMM YYYY'),
@@ -320,8 +319,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             },
             get explanation() {
                 return localise({
-                    en: `<p>If you don't know exactly, your dates can be estimates. But you need to start your project after ${this.settings.minDateExample}.</p>
-                      <p>We usually only fund projects that last ${this.settings.maxDurationFromStart.label} or less. So, the end date can't be more than ${this.settings.maxDurationFromStart.label} after the start date.</p>
+                    en: `<p>If you don't know exactly, your dates can be estimates. But you need to start your project after ${minStartDate.format(
+                        'DD/MM/YYYY'
+                    )}.</p>
+                      <p>We usually only fund projects that last ${
+                          this.settings.maxDurationFromStart.label
+                      } or less. So, the end date can't be more than ${
+                        this.settings.maxDurationFromStart.label
+                    } after the start date.</p>
                       <p><strong>If your project is a one-off event</strong></p>
                       <p>Just let us know the date you plan to hold the event in the start and end date boxes below.</p>`,
                     cy: ''

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -294,7 +294,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     }
 
     function fieldProjectDateRange() {
-        const minStartDate = moment().add(12, 'weeks');
+        const minDate = moment().add(12, 'weeks');
+        const minDateAfter = minDate.subtract(1, 'days');
         const maxDurationFromStart = {
             amount: 1,
             units: 'years',
@@ -311,13 +312,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: ``
             }),
             settings: {
-                minYear: minStartDate.format('YYYY')
+                minYear: minDate.format('YYYY')
             },
             explanation: localise({
                 en: `<p>
                     If you don't know exactly, your dates can be estimates.
                     But you need to start your project after
-                    ${minStartDate.format('DD/MM/YYYY')}.
+                    ${minDate.format('DD/MM/YYYY')}.
                 </p>
                 <p>
                     We usually only fund projects that last
@@ -335,7 +336,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             type: 'date-range',
             isRequired: true,
             schema: Joi.dateRange()
-                .minDate(minStartDate.format('YYYY-MM-DD'))
+                .minDate(minDate.format('YYYY-MM-DD'))
                 .futureEndDate()
                 .endDateLimit(
                     maxDurationFromStart.amount,
@@ -374,9 +375,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     type: 'dateRange.minDate.invalid',
                     message: localise({
                         en: oneLine`Date you start the project must be after
-                            ${minStartDate
-                                .subtract(1, 'days')
-                                .format('D MMMM YYYY')}`,
+                            ${minDateAfter.format('D MMMM YYYY')}`,
                         cy: ''
                     })
                 },
@@ -390,7 +389,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'dateRange.endDate.outsideLimit',
                     message: localise({
-                        en: `Date you end the project must be within ${maxDurationFromStart.label} of the start date.`,
+                        en: oneLine`Date you end the project must be within
+                            ${maxDurationFromStart.label} of the start date.`,
                         cy: ''
                     })
                 }

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -296,14 +296,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     function fieldProjectDateRange() {
         const minDate = moment().add(12, 'weeks');
         const minDateAfter = minDate.subtract(1, 'days');
-        const maxDurationFromStart = {
-            amount: 1,
-            units: 'years',
-            label: localise({
-                en: `twelve months`,
-                cy: ``
-            })
-        };
+        const maxDate = moment().add(1, 'years');
+        const maxDateLabel = localise({
+            en: `twelve months`,
+            cy: ``
+        });
 
         return {
             name: 'projectDateRange',
@@ -322,9 +319,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 </p>
                 <p>
                     We usually only fund projects that last
-                    ${maxDurationFromStart.label} or less.
+                    ${maxDateLabel} or less.
                     So, the end date can't be more than
-                    ${maxDurationFromStart.label} after the start date.    
+                    ${maxDateLabel} after the start date.    
                 </p>
                 <p><strong>If your project is a one-off event</strong></p>
                 <p>
@@ -337,11 +334,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true,
             schema: Joi.dateRange()
                 .minDate(minDate.format('YYYY-MM-DD'))
-                .futureEndDate()
-                .endDateLimit(
-                    maxDurationFromStart.amount,
-                    maxDurationFromStart.units
-                ),
+                .maxDate(maxDate.format('YYYY-MM-DD'))
+                .futureEndDate(),
             messages: [
                 {
                     type: 'base',
@@ -380,17 +374,17 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     })
                 },
                 {
-                    type: 'dateRange.endDate.beforeStartDate',
+                    type: 'dateRange.maxDate.invalid',
                     message: localise({
-                        en: `Date you end the project must be after the start date`,
+                        en: oneLine`Date you end the project must be within
+                            ${maxDateLabel} of the start date.`,
                         cy: ''
                     })
                 },
                 {
-                    type: 'dateRange.endDate.outsideLimit',
+                    type: 'dateRange.endDate.beforeStartDate',
                     message: localise({
-                        en: oneLine`Date you end the project must be within
-                            ${maxDurationFromStart.label} of the start date.`,
+                        en: `Date you end the project must be after the start date`,
                         cy: ''
                     })
                 }

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -295,6 +295,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
     function fieldProjectDateRange() {
         const minStartDate = moment().add(12, 'weeks');
+        const maxDurationFromStart = {
+            amount: 1,
+            units: 'years',
+            label: localise({
+                en: `twelve months`,
+                cy: ``
+            })
+        };
 
         return {
             name: 'projectDateRange',
@@ -304,15 +312,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             get settings() {
                 return {
-                    minYear: minStartDate.format('YYYY'),
-                    maxDurationFromStart: {
-                        amount: 1,
-                        units: 'years',
-                        label: localise({
-                            en: `twelve months`,
-                            cy: ``
-                        })
-                    }
+                    minYear: minStartDate.format('YYYY')
                 };
             },
             get explanation() {
@@ -321,9 +321,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                         'DD/MM/YYYY'
                     )}.</p>
                       <p>We usually only fund projects that last ${
-                          this.settings.maxDurationFromStart.label
+                          maxDurationFromStart.label
                       } or less. So, the end date can't be more than ${
-                        this.settings.maxDurationFromStart.label
+                        maxDurationFromStart.label
                     } after the start date.</p>
                       <p><strong>If your project is a one-off event</strong></p>
                       <p>Just let us know the date you plan to hold the event in the start and end date boxes below.</p>`,
@@ -338,8 +338,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     .minDate(minDate.format('YYYY-MM-DD'))
                     .futureEndDate()
                     .endDateLimit(
-                        this.settings.maxDurationFromStart.amount,
-                        this.settings.maxDurationFromStart.units
+                        maxDurationFromStart.amount,
+                        maxDurationFromStart.units
                     );
             },
             get messages() {
@@ -392,7 +392,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     {
                         type: 'dateRange.endDate.outsideLimit',
                         message: localise({
-                            en: `Date you end the project must be within ${this.settings.maxDurationFromStart.label} of the start date.`,
+                            en: `Date you end the project must be within ${maxDurationFromStart.label} of the start date.`,
                             cy: ''
                         })
                     }

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -292,7 +292,117 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         return { ...defaultProps, ...props };
     }
 
-    function organisationTypeField() {
+    function fieldProjectDateRange() {
+        return {
+            name: 'projectDateRange',
+            label: localise({
+                en: `When would you like to start and end your project?`,
+                cy: ``
+            }),
+            get settings() {
+                const minStart = {
+                    amount: 12,
+                    units: 'weeks'
+                };
+                const minStartDate = moment().add(
+                    minStart.amount,
+                    minStart.units
+                );
+                return {
+                    minStart: minStart,
+                    minDateExample: minStartDate.format('DD/MM/YYYY'),
+                    fromDateExample: minStartDate
+                        .subtract(1, 'days')
+                        .format('D MMMM YYYY'),
+                    minYear: minStartDate.format('YYYY'),
+                    maxDurationFromStart: {
+                        amount: 1,
+                        units: 'years',
+                        label: localise({
+                            en: `twelve months`,
+                            cy: ``
+                        })
+                    }
+                };
+            },
+            get explanation() {
+                return localise({
+                    en: `<p>If you don't know exactly, your dates can be estimates. But you need to start your project after ${this.settings.minDateExample}.</p>
+                      <p>We usually only fund projects that last ${this.settings.maxDurationFromStart.label} or less. So, the end date can't be more than ${this.settings.maxDurationFromStart.label} after the start date.</p>
+                      <p><strong>If your project is a one-off event</strong></p>
+                      <p>Just let us know the date you plan to hold the event in the start and end date boxes below.</p>`,
+                    cy: ''
+                });
+            },
+            type: 'date-range',
+            isRequired: true,
+            get schema() {
+                const minDate = moment().add('12', 'weeks');
+                return Joi.dateRange()
+                    .minDate(minDate.format('YYYY-MM-DD'))
+                    .futureEndDate()
+                    .endDateLimit(
+                        this.settings.maxDurationFromStart.amount,
+                        this.settings.maxDurationFromStart.units
+                    );
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: 'Enter a project start and end date',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'dateRange.both.invalid',
+                        message: localise({
+                            en: `Project start and end dates must be real dates`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'datesRange.startDate.invalid',
+                        message: localise({
+                            en: `Date you start the project must be a real date`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'dateRange.endDate.invalid',
+                        message: localise({
+                            en: 'Date you end the project must be a real date',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'dateRange.minDate.invalid',
+                        message: localise({
+                            en: `Date you start the project must be after ${this.settings.fromDateExample}`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'dateRange.endDate.beforeStartDate',
+                        message: localise({
+                            en: `Date you end the project must be after the start date`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'dateRange.endDate.outsideLimit',
+                        message: localise({
+                            en: `Date you end the project must be within ${this.settings.maxDurationFromStart.label} of the start date.`,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        };
+    }
+
+    function fieldOrganisationType() {
         const options = [
             {
                 value: ORGANISATION_TYPES.UNREGISTERED_VCO,
@@ -403,7 +513,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         };
     }
 
-    function seniorContactRoleField() {
+    function fieldSeniorContactRole() {
         function rolesFor(organisationType, organisationSubType) {
             const ROLES = {
                 CHAIR: {
@@ -698,7 +808,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         });
     }
 
-    const fields = {
+    return {
         projectName: {
             name: 'projectName',
             label: localise({
@@ -719,113 +829,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        projectDateRange: {
-            name: 'projectDateRange',
-            label: localise({
-                en: `When would you like to start and end your project?`,
-                cy: ``
-            }),
-            get settings() {
-                const minStart = {
-                    amount: 12,
-                    units: 'weeks'
-                };
-                const minStartDate = moment().add(
-                    minStart.amount,
-                    minStart.units
-                );
-                return {
-                    minStart: minStart,
-                    minDateExample: minStartDate.format('DD/MM/YYYY'),
-                    fromDateExample: minStartDate
-                        .subtract(1, 'days')
-                        .format('D MMMM YYYY'),
-                    minYear: minStartDate.format('YYYY'),
-                    maxDurationFromStart: {
-                        amount: 1,
-                        units: 'years',
-                        label: localise({
-                            en: `twelve months`,
-                            cy: ``
-                        })
-                    }
-                };
-            },
-            get explanation() {
-                return localise({
-                    en: `<p>If you don't know exactly, your dates can be estimates. But you need to start your project after ${this.settings.minDateExample}.</p>
-                      <p>We usually only fund projects that last ${this.settings.maxDurationFromStart.label} or less. So, the end date can't be more than ${this.settings.maxDurationFromStart.label} after the start date.</p>
-                      <p><strong>If your project is a one-off event</strong></p>
-                      <p>Just let us know the date you plan to hold the event in the start and end date boxes below.</p>`,
-                    cy: ''
-                });
-            },
-            type: 'date-range',
-            isRequired: true,
-            get schema() {
-                const minDate = moment().add('12', 'weeks');
-                return Joi.dateRange()
-                    .minDate(minDate.format('YYYY-MM-DD'))
-                    .futureEndDate()
-                    .endDateLimit(
-                        this.settings.maxDurationFromStart.amount,
-                        this.settings.maxDurationFromStart.units
-                    );
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Enter a project start and end date',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.both.invalid',
-                        message: localise({
-                            en: `Project start and end dates must be real dates`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'datesRange.startDate.invalid',
-                        message: localise({
-                            en: `Date you start the project must be a real date`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.invalid',
-                        message: localise({
-                            en: 'Date you end the project must be a real date',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.minDate.invalid',
-                        message: localise({
-                            en: `Date you start the project must be after ${this.settings.fromDateExample}`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.beforeStartDate',
-                        message: localise({
-                            en: `Date you end the project must be after the start date`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.outsideLimit',
-                        message: localise({
-                            en: `Date you end the project must be within ${this.settings.maxDurationFromStart.label} of the start date.`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        },
+        projectDateRange: fieldProjectDateRange(),
         projectCountry: {
             name: 'projectCountry',
             label: localise({
@@ -1911,7 +1915,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: ``
             })
         }),
-        organisationType: organisationTypeField(),
+        organisationType: fieldOrganisationType(),
         organisationSubTypeStatutoryBody: {
             name: 'organisationSubType',
             label: localise({
@@ -2227,7 +2231,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 .optional(),
             messages: []
         },
-        seniorContactRole: seniorContactRoleField(),
+        seniorContactRole: fieldSeniorContactRole(),
         seniorContactName: nameField(
             {
                 name: 'seniorContactName',
@@ -2583,6 +2587,4 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true
         }
     };
-
-    return fields;
 };

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -392,201 +392,221 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     }
 
     function fieldYourIdeaProject() {
+        const minWords = 50;
+        const maxWords = 300;
+
         return {
             name: 'yourIdeaProject',
             label: localise({
                 en: 'What would you like to do?',
                 cy: ''
             }),
-            get explanation() {
-                return localise({
-                    en: `<p><strong>Here are some ideas of what to tell us about your project:</strong></p>
-                    <ul>
-                        <li>What you would like to do</li>
-                        <li>What difference your project will make</li>
-                        <li>Who will benefit from it</li>
-                        <li>How long you expect to run it for. This can be an estimate</li>
-                        <li>How you'll make sure people know about it</li>
-                        <li>How you plan to learn from it and use this learning to shape future projects</li>
-                        <li>Is it something new, or are you continuing something that has worked well previously? We want to fund both types of projects</li>
-                    </ul>
-                    <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ''
-                });
-            },
+            explanation: localise({
+                en: `<p><strong>
+                    Here are some ideas of what to tell us about your project:
+                </strong></p>
+                <ul>
+                    <li>What you would like to do</li>
+                    <li>What difference your project will make</li>
+                    <li>Who will benefit from it</li>
+                    <li>How long you expect to run it for. This can be an estimate</li>
+                    <li>How you'll make sure people know about it</li>
+                    <li>How you plan to learn from it and use this
+                        learning to shape future projects</li>
+                    <li>Is it something new, or are you continuing something that
+                        has worked well previously? We want to fund both types of projects</li>
+                </ul>
+                <p><strong>
+                    You can write up to ${maxWords} words for this section,
+                    but don't worry if you use less.
+                </strong></p>`,
+                cy: ''
+            }),
             type: 'textarea',
             settings: {
                 stackedSummary: true,
                 showWordCount: true,
-                minWords: 50,
-                maxWords: 300
+                minWords: minWords,
+                maxWords: maxWords
             },
             attributes: { rows: 20 },
             isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Tell us about your project',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
+            schema: Joi.string()
+                .minWords(minWords)
+                .maxWords(maxWords)
+                .required(),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Tell us about your project',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'string.minWords',
+                    message: localise({
+                        en: `Answer must be at least ${minWords} words`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'string.maxWords',
+                    message: localise({
+                        en: `Answer must be no more than ${maxWords} words`,
+                        cy: ''
+                    })
+                }
+            ]
         };
     }
 
     function fieldYourIdeaPriorities() {
+        const minWords = 50;
+        const maxWords = 150;
+
         return {
             name: 'yourIdeaPriorities',
             label: localise({
                 en: `How does your project meet at least one of our funding priorities?`,
                 cy: ``
             }),
-            get explanation() {
-                return localise({
-                    en: `<p>National Lottery Awards for All has three funding priorities, please tell us how your project will <strong>meet at least one of these:</strong></p>
-                        <ol>
-                            <li>Bring people together and build strong relationships in and across communities</li>
-                            <li>Improve the places and spaces that matter to communities</li>
-                            <li>Help more people to reach their potential, by supporting them at the earliest possible stage</li>
-                        </ol>
-                        <p>You can tell us if your project meets more than one priority, but don't worry if it doesn't.</p>
-                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ``
-                });
-            },
+            explanation: localise({
+                en: `<p>
+                    National Lottery Awards for All has three funding priorities, 
+                    please tell us how your project will
+                    <strong>meet at least one of these:</strong>
+                </p>
+                <ol>
+                    <li>Bring people together and build strong
+                        relationships in and across communities</li>
+                    <li>Improve the places and spaces that matter to communities</li>
+                    <li>Help more people to reach their potential,
+                        by supporting them at the earliest possible stage</li>
+                </ol>
+                <p>You can tell us if your project meets more than one priority,
+                   but don't worry if it doesn't.</p>
+                <p><strong>
+                    You can write up to ${maxWords} words for this section,
+                    but don't worry if you use less.
+                </strong></p>`,
+                cy: ``
+            }),
             type: 'textarea',
             settings: {
                 stackedSummary: true,
                 showWordCount: true,
-                minWords: 50,
-                maxWords: 150
+                minWords: minWords,
+                maxWords: maxWords
             },
             attributes: {
                 rows: 12
             },
             isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Tell us how your project meets at least one of our funding priorities`,
-                            cy: ``
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
+            schema: Joi.string()
+                .minWords(minWords)
+                .maxWords(maxWords)
+                .required(),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: `Tell us how your project meets at least one of our funding priorities`,
+                        cy: ``
+                    })
+                },
+                {
+                    type: 'string.minWords',
+                    message: localise({
+                        en: `Answer must be at least ${minWords} words`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'string.maxWords',
+                    message: localise({
+                        en: `Answer must be no more than ${maxWords} words`,
+                        cy: ''
+                    })
+                }
+            ]
         };
     }
 
     function fieldYourIdeaCommunity() {
+        const minWords = 50;
+        const maxWords = 200;
+
         return {
             name: 'yourIdeaCommunity',
             label: localise({
                 en: 'How does your project involve your community?',
                 cy: ''
             }),
-            get explanation() {
-                return localise({
-                    en: `
-                        <details class="o-details u-margin-bottom-s">
-                            <summary class="o-details__summary">What do we mean by community?</summary>
-                            <div class="o-details__content">
-                                <ol>
-                                    <li>People living in the same area</li>
-                                    <li>People who have similar interests or life experiences, but might not live in the same area</li>
-                                    <li>Even though schools can be at the heart of a community - we'll only fund schools that also benefit the communities around them.</li>
-                                </ol>
-                            <div>
-                        </details>
-                        <p>We believe that people understand what's needed in their communities better than anyone. Tell us how your community came up with the idea for your project. We want to know how many people you've spoken to, and how they'll be involved in the development and delivery of the project.</p>
-                        <p><strong>You can write up to ${this.settings.maxWords} words for this section, but don't worry if you use less.</strong></p>`,
-                    cy: ''
-                });
-            },
+            explanation: localise({
+                en: `
+                <details class="o-details u-margin-bottom-s">
+                    <summary class="o-details__summary">What do we mean by community?</summary>
+                    <div class="o-details__content">
+                        <ol>
+                            <li>People living in the same area</li>
+                            <li>People who have similar interests or life experiences,
+                                but might not live in the same area</li>
+                            <li>Even though schools can be at the heart of a
+                                community—we'll only fund schools that also
+                                benefit the communities around them.</li>
+                        </ol>
+                    <div>
+                </details>
+                <p>
+                    We believe that people understand what's needed in their
+                    communities better than anyone. Tell us how your community 
+                    came up with the idea for your project. We want to know how
+                    many people you've spoken to, and how they'll be involved
+                    in the development and delivery of the project.
+                </p>
+                <p><strong>
+                    You can write up to ${maxWords} words for this section,
+                    but don't worry if you use less.
+                </strong></p>`,
+                cy: ''
+            }),
             type: 'textarea',
             settings: {
                 stackedSummary: true,
                 showWordCount: true,
-                minWords: 50,
-                maxWords: 200
+                minWords: minWords,
+                maxWords: maxWords
             },
             attributes: { rows: 15 },
             isRequired: true,
-            get schema() {
-                return Joi.string()
-                    .minWords(this.settings.minWords)
-                    .maxWords(this.settings.maxWords)
-                    .required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Tell us how your project involves your community`,
-                            cy: ``
-                        })
-                    },
-                    {
-                        type: 'string.minWords',
-                        message: localise({
-                            en: `Answer must be at least ${this.settings.minWords} words`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'string.maxWords',
-                        message: localise({
-                            en: `Answer must be no more than ${this.settings.maxWords} words`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
+            schema: Joi.string()
+                .minWords(minWords)
+                .maxWords(maxWords)
+                .required(),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: `Tell us how your project involves your community`,
+                        cy: ``
+                    })
+                },
+                {
+                    type: 'string.minWords',
+                    message: localise({
+                        en: `Answer must be at least ${minWords} words`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'string.maxWords',
+                    message: localise({
+                        en: `Answer must be no more than ${maxWords} words`,
+                        cy: ''
+                    })
+                }
+            ]
         };
     }
 

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -310,94 +310,91 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 en: `When would you like to start and end your project?`,
                 cy: ``
             }),
-            get settings() {
-                return {
-                    minYear: minStartDate.format('YYYY')
-                };
+            settings: {
+                minYear: minStartDate.format('YYYY')
             },
-            get explanation() {
-                return localise({
-                    en: `<p>If you don't know exactly, your dates can be estimates. But you need to start your project after ${minStartDate.format(
-                        'DD/MM/YYYY'
-                    )}.</p>
-                      <p>We usually only fund projects that last ${
-                          maxDurationFromStart.label
-                      } or less. So, the end date can't be more than ${
-                        maxDurationFromStart.label
-                    } after the start date.</p>
-                      <p><strong>If your project is a one-off event</strong></p>
-                      <p>Just let us know the date you plan to hold the event in the start and end date boxes below.</p>`,
-                    cy: ''
-                });
-            },
+            explanation: localise({
+                en: `<p>
+                    If you don't know exactly, your dates can be estimates.
+                    But you need to start your project after
+                    ${minStartDate.format('DD/MM/YYYY')}.
+                </p>
+                <p>
+                    We usually only fund projects that last
+                    ${maxDurationFromStart.label} or less.
+                    So, the end date can't be more than
+                    ${maxDurationFromStart.label} after the start date.    
+                </p>
+                <p><strong>If your project is a one-off event</strong></p>
+                <p>
+                    Just let us know the date you plan to hold the event
+                    in the start and end date boxes below.
+                </p>`,
+                cy: ''
+            }),
             type: 'date-range',
             isRequired: true,
-            get schema() {
-                const minDate = moment().add('12', 'weeks');
-                return Joi.dateRange()
-                    .minDate(minDate.format('YYYY-MM-DD'))
-                    .futureEndDate()
-                    .endDateLimit(
-                        maxDurationFromStart.amount,
-                        maxDurationFromStart.units
-                    );
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: 'Enter a project start and end date',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.both.invalid',
-                        message: localise({
-                            en: `Project start and end dates must be real dates`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'datesRange.startDate.invalid',
-                        message: localise({
-                            en: `Date you start the project must be a real date`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.invalid',
-                        message: localise({
-                            en: 'Date you end the project must be a real date',
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.minDate.invalid',
-                        message: localise({
-                            en: oneLine`Date you start the project must be after
-                                ${minStartDate
-                                    .subtract(1, 'days')
-                                    .format('D MMMM YYYY')}`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.beforeStartDate',
-                        message: localise({
-                            en: `Date you end the project must be after the start date`,
-                            cy: ''
-                        })
-                    },
-                    {
-                        type: 'dateRange.endDate.outsideLimit',
-                        message: localise({
-                            en: `Date you end the project must be within ${maxDurationFromStart.label} of the start date.`,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
+            schema: Joi.dateRange()
+                .minDate(minStartDate.format('YYYY-MM-DD'))
+                .futureEndDate()
+                .endDateLimit(
+                    maxDurationFromStart.amount,
+                    maxDurationFromStart.units
+                ),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter a project start and end date',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'dateRange.both.invalid',
+                    message: localise({
+                        en: `Project start and end dates must be real dates`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'datesRange.startDate.invalid',
+                    message: localise({
+                        en: `Date you start the project must be a real date`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'dateRange.endDate.invalid',
+                    message: localise({
+                        en: 'Date you end the project must be a real date',
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'dateRange.minDate.invalid',
+                    message: localise({
+                        en: oneLine`Date you start the project must be after
+                            ${minStartDate
+                                .subtract(1, 'days')
+                                .format('D MMMM YYYY')}`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'dateRange.endDate.beforeStartDate',
+                    message: localise({
+                        en: `Date you end the project must be after the start date`,
+                        cy: ''
+                    })
+                },
+                {
+                    type: 'dateRange.endDate.outsideLimit',
+                    message: localise({
+                        en: `Date you end the project must be within ${maxDurationFromStart.label} of the start date.`,
+                        cy: ''
+                    })
+                }
+            ]
         };
     }
 

--- a/controllers/apply/form-router-next/joi-extensions/date-range.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.js
@@ -132,27 +132,6 @@ module.exports = function dateParts(joi) {
                         );
                     }
                 }
-            },
-            {
-                name: 'futureEndDate',
-                validate(params, value, state, options) {
-                    const dates = toRange(value);
-
-                    if (
-                        dates.startDate.isValid() &&
-                        dates.endDate.isValid() &&
-                        dates.endDate.isSameOrAfter(dates.startDate)
-                    ) {
-                        return value;
-                    } else {
-                        return this.createError(
-                            'dateRange.endDate.beforeStartDate',
-                            { v: value, min: params.min },
-                            state,
-                            options
-                        );
-                    }
-                }
             }
         ]
     };

--- a/controllers/apply/form-router-next/joi-extensions/date-range.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.js
@@ -72,6 +72,13 @@ module.exports = function dateParts(joi) {
                     state,
                     options
                 );
+            } else if (dates.endDate.isSameOrAfter(dates.startDate) === false) {
+                return this.createError(
+                    'dateRange.endDate.beforeStartDate',
+                    { v: value },
+                    state,
+                    options
+                );
             } else {
                 return value;
             }

--- a/controllers/apply/form-router-next/joi-extensions/date-range.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.js
@@ -38,7 +38,8 @@ module.exports = function dateParts(joi) {
                 invalid: 'Invalid startDate'
             },
             endDate: {
-                invalid: 'Invalid endDate'
+                invalid: 'Invalid endDate',
+                beforeStartDate: 'endDate must not be before startDate'
             },
             minDate: {
                 invalid: 'Date must be at least {{min}}'

--- a/controllers/apply/form-router-next/joi-extensions/date-range.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.js
@@ -30,6 +30,21 @@ module.exports = function dateParts(joi) {
             startDate: datePartsConfig,
             endDate: datePartsConfig
         }),
+        language: {
+            both: {
+                invalid: 'Both startDate and endDate are invalid'
+            },
+            startDate: {
+                invalid: 'Invalid startDate'
+            },
+            endDate: {
+                invalid: 'Invalid endDate',
+                outsideLimit: 'Date is outside limit'
+            },
+            minDate: {
+                invalid: 'Date must be at least {{min}}'
+            }
+        },
         pre(value, state, options) {
             const dates = toRange(value);
 

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -1,0 +1,78 @@
+/* eslint-env jest */
+// @ts-nocheck
+'use strict';
+const baseJoi = require('@hapi/joi');
+const Joi = baseJoi.extend(require('./date-range'));
+
+describe('dateRange', () => {
+    test('valid date range', () => {
+        const schema = Joi.dateRange();
+
+        expect(
+            schema.validate({
+                startDate: { day: 1, month: 2, year: 2100 },
+                endDate: { day: 1, month: 2, year: 2100 }
+            }).error
+        ).toBeNull();
+
+        const bothInvalid = schema.validate({
+            startDate: { day: 31, month: 2, year: 2100 },
+            endDate: { day: 31, month: 2, year: 2100 }
+        });
+
+        expect(bothInvalid.error.message).toContain(
+            'Both startDate and endDate are invalid'
+        );
+
+        const startDateInvalid = schema.validate({
+            startDate: { day: 31, month: 2, year: 2100 },
+            endDate: { day: 1, month: 2, year: 2100 }
+        });
+
+        expect(startDateInvalid.error.message).toContain('Invalid startDate');
+
+        const endDateInvalid = schema.validate({
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 31, month: 2, year: 2100 }
+        });
+
+        expect(endDateInvalid.error.message).toContain('Invalid endDate');
+    });
+
+    test('minDate', () => {
+        const schema = Joi.dateRange().minDate('2100-01-01');
+        const valid = schema.validate({
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 1, month: 2, year: 2100 }
+        });
+
+        expect(valid.error).toBeNull();
+
+        const invalid = schema.validate({
+            startDate: { day: 1, month: 2, year: 2099 },
+            endDate: { day: 1, month: 2, year: 2099 }
+        });
+
+        expect(invalid.error.message).toContain(
+            'Date must be at least 2100-01-01'
+        );
+    });
+
+    test('endDateLimit', () => {
+        const schema = Joi.dateRange().endDateLimit(7, 'days');
+
+        const valid = schema.validate({
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 7, month: 2, year: 2100 }
+        });
+
+        expect(valid.error).toBeNull();
+
+        const invalid = schema.validate({
+            startDate: { day: 1, month: 2, year: 2099 },
+            endDate: { day: 1, month: 3, year: 2099 }
+        });
+
+        expect(invalid.error.message).toContain('Date is outside limit');
+    });
+});

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -75,4 +75,23 @@ describe('dateRange', () => {
 
         expect(invalid.error.message).toContain('Date is outside limit');
     });
+
+    test('futureEndDate', () => {
+        const schema = Joi.dateRange().futureEndDate();
+
+        const valid = {
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 1, month: 2, year: 2100 }
+        };
+
+        expect(schema.validate(valid).error).toBeNull();
+
+        const invalid = {
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 1, month: 1, year: 2100 }
+        };
+        expect(schema.validate(invalid).error.message).toContain(
+            'endDate must not be before startDate'
+        );
+    });
 });

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -58,8 +58,8 @@ describe('dateRange', () => {
         );
     });
 
-    test('endDateLimit', () => {
-        const schema = Joi.dateRange().endDateLimit(7, 'days');
+    test('maxDate', () => {
+        const schema = Joi.dateRange().maxDate('2100-02-28');
 
         const valid = schema.validate({
             startDate: { day: 1, month: 2, year: 2100 },
@@ -69,8 +69,8 @@ describe('dateRange', () => {
         expect(valid.error).toBeNull();
 
         const invalid = schema.validate({
-            startDate: { day: 1, month: 2, year: 2099 },
-            endDate: { day: 1, month: 3, year: 2099 }
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 1, month: 3, year: 2100 }
         });
 
         expect(invalid.error.message).toContain('Date is outside limit');

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -84,23 +84,4 @@ describe('dateRange', () => {
 
         expect(invalid.error.message).toContain('Date is outside limit');
     });
-
-    test('futureEndDate', () => {
-        const schema = Joi.dateRange().futureEndDate();
-
-        const valid = {
-            startDate: { day: 1, month: 2, year: 2100 },
-            endDate: { day: 1, month: 2, year: 2100 }
-        };
-
-        expect(schema.validate(valid).error).toBeNull();
-
-        const invalid = {
-            startDate: { day: 1, month: 2, year: 2100 },
-            endDate: { day: 1, month: 1, year: 2100 }
-        };
-        expect(schema.validate(invalid).error.message).toContain(
-            'endDate must not be before startDate'
-        );
-    });
 });

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -37,6 +37,15 @@ describe('dateRange', () => {
         });
 
         expect(endDateInvalid.error.message).toContain('Invalid endDate');
+
+        const endDateBeforeStart = schema.validate({
+            startDate: { day: 1, month: 2, year: 2100 },
+            endDate: { day: 1, month: 1, year: 2100 }
+        });
+
+        expect(endDateBeforeStart.error.message).toContain(
+            'endDate must not be before startDate'
+        );
     });
 
     test('minDate', () => {

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -215,7 +215,6 @@
             field-id="field-{{ field.name }}"
             :min-words={{ settings.minWords }}
             :max-words={{ settings.maxWords }}
-            :recommended-words={{ settings.recommendedWords }}
         ></word-count>
     {% endif %}
     {% if settings.showWordCount %}</div>{% endif %}


### PR DESCRIPTION
Does a little work to remove some redundant settings from fields. I've kept the commits pretty granular so you can follow along with what's being changed.

**Remove unused recommendedWords**

This was no longer used to we can safely remove it

**Replace use of settings for date field**

The way `settings` was being used on the date range field was a little counter to it's intention. For this field the values in settings were largely being used inside the field definition so were acting as temporary variables. We can avoid some indirection and getters and setters by using regular variables here. I've done this by extracting a `fieldProjectDateRange` function that can house the temporary variables. Everything left in `settings` is now real field settings that are passed on to the view.

**Simplify dateRange validator**

Added unit tests for `dateRange`, reworked `enDateLimit` to be `maxDate` and match the format of `minDate` as it's doing the same validation and inlined `futureEndDate` into the main validator as it's a sensible default.