### PR TITLE
Allow previewing awards for all through access cookie

### DIFF
--- a/common/__snapshots__/cloudfront.test.js.snap
+++ b/common/__snapshots__/cloudfront.test.js.snap
@@ -33,8 +33,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -91,7 +92,13 @@ Object {
         "FieldLevelEncryptionId": "",
         "ForwardedValues": Object {
           "Cookies": Object {
-            "Forward": "none",
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "awards-for-all-preview",
+              ],
+              "Quantity": 1,
+            },
           },
           "Headers": Object {
             "Items": Array [
@@ -146,8 +153,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -211,8 +219,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -273,8 +282,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -341,8 +351,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -407,8 +418,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -469,8 +481,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -534,7 +547,13 @@ Object {
         "FieldLevelEncryptionId": "",
         "ForwardedValues": Object {
           "Cookies": Object {
-            "Forward": "none",
+            "Forward": "whitelist",
+            "WhitelistedNames": Object {
+              "Items": Array [
+                "awards-for-all-preview",
+              ],
+              "Quantity": 1,
+            },
           },
           "Headers": Object {
             "Items": Array [
@@ -589,8 +608,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -654,8 +674,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -716,8 +737,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -784,8 +806,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -850,8 +873,9 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
+                "awards-for-all-preview",
               ],
-              "Quantity": 1,
+              "Quantity": 2,
             },
           },
           "Headers": Object {
@@ -1019,8 +1043,9 @@ Object {
         "WhitelistedNames": Object {
           "Items": Array [
             "blf-alpha-session",
+            "awards-for-all-preview",
           ],
-          "Quantity": 1,
+          "Quantity": 2,
         },
       },
       "Headers": Object {

--- a/common/cloudfront.js
+++ b/common/cloudfront.js
@@ -115,10 +115,13 @@ function makeBehaviourItem({
  * construct array of behaviours from a URL list
  */
 function generateBehaviours(origins) {
+    const defaultCookies = [cookies.session, cookies.awardsForAllPreview];
+    const cookiesWithoutSession = [cookies.awardsForAllPreview];
+
     const defaultBehaviour = makeBehaviourItem({
         originId: origins.site,
         isPostable: true,
-        cookiesInUse: [cookies.session]
+        cookiesInUse: defaultCookies
     });
 
     /**
@@ -143,21 +146,53 @@ function generateBehaviours(origins) {
      */
     const customPaths = [
         { path: '/api/*', isPostable: true, allowAllQueryStrings: true },
-        { path: '/funding/grants*', isPostable: true, allowAllQueryStrings: true, isBilingual: true, noSession: true },
-        { path: '/funding/programmes', queryStrings: ['location', 'amount', 'min', 'max'], isBilingual: true },
-        { path: '/funding/programmes/all', queryStrings: ['location'], isBilingual: true },
-        { path: '/news/*', queryStrings: ['page', 'tag', 'author', 'category', 'region'], isBilingual: true },
+        {
+            path: '/funding/grants*',
+            isPostable: true,
+            allowAllQueryStrings: true,
+            isBilingual: true,
+            noSession: true
+        },
+        {
+            path: '/funding/programmes',
+            queryStrings: ['location', 'amount', 'min', 'max'],
+            isBilingual: true
+        },
+        {
+            path: '/funding/programmes/all',
+            queryStrings: ['location'],
+            isBilingual: true
+        },
+        {
+            path: '/news/*',
+            queryStrings: ['page', 'tag', 'author', 'category', 'region'],
+            isBilingual: true
+        },
         {
             path: '/insights/documents*',
-            queryStrings: ['page', 'programme', 'tag', 'doctype', 'portfolio', 'q', 'sort'],
+            queryStrings: [
+                'page',
+                'programme',
+                'tag',
+                'doctype',
+                'portfolio',
+                'q',
+                'sort'
+            ],
             isBilingual: true
         },
         { path: '/search', allowAllQueryStrings: true, isBilingual: true },
-        { path: '/user/*', isPostable: true, queryStrings: ['redirectUrl', 's', 'token'] }
+        {
+            path: '/user/*',
+            isPostable: true,
+            queryStrings: ['redirectUrl', 's', 'token']
+        }
     ];
 
     const primaryBehaviours = flatMap(customPaths, rule => {
-        const cookiesForRule = rule.noSession ? [] : [cookies.session];
+        const cookiesForRule = rule.noSession
+            ? cookiesWithoutSession
+            : defaultCookies;
 
         const behaviour = makeBehaviourItem({
             originId: origins.site,

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -8,6 +8,9 @@ const { getSecret } = require('./parameter-store');
 const SESSION_SECRET =
     process.env.SESSION_SECRET || getSecret('session.secret', true);
 
+const AWARDS_FOR_ALL_SECRET =
+    process.env.AWARDS_FOR_ALL_SECRET || getSecret('awardsForAll.secret');
+
 /**
  * Database connection uri
  * Note: Our RDS databases are not accessible outside of a VPC.
@@ -100,6 +103,7 @@ const POSTCODES_API_KEY =
 const S3_KMS_KEY_ID = process.env.S3_KMS_KEY_ID || getSecret('s3.kms.key.id');
 
 module.exports = {
+    AWARDS_FOR_ALL_SECRET,
     AZURE_AUTH,
     CONTENT_API_URL,
     DB_CONNECTION_URI,

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -48,9 +48,10 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "blf-alpha-session"
+            "blf-alpha-session",
+            "awards-for-all-preview"
           ],
-          "Quantity": 1
+          "Quantity": 2
         }
       }
     },
@@ -111,9 +112,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -170,7 +172,13 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "none"
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "awards-for-all-preview"
+              ],
+              "Quantity": 1
+            }
           }
         },
         "TrustedSigners": {
@@ -232,9 +240,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -294,9 +303,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -362,9 +372,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -428,9 +439,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -485,9 +497,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -554,9 +567,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -613,7 +627,13 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "none"
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "awards-for-all-preview"
+              ],
+              "Quantity": 1
+            }
           }
         },
         "TrustedSigners": {
@@ -675,9 +695,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -737,9 +758,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -805,9 +827,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -871,9 +894,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -928,9 +952,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -48,9 +48,10 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "blf-alpha-session"
+            "blf-alpha-session",
+            "awards-for-all-preview"
           ],
-          "Quantity": 1
+          "Quantity": 2
         }
       }
     },
@@ -111,9 +112,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -170,7 +172,13 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "none"
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "awards-for-all-preview"
+              ],
+              "Quantity": 1
+            }
           }
         },
         "TrustedSigners": {
@@ -232,9 +240,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -294,9 +303,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -362,9 +372,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -428,9 +439,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -485,9 +497,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -554,9 +567,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -613,7 +627,13 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "none"
+            "Forward": "whitelist",
+            "WhitelistedNames": {
+              "Items": [
+                "awards-for-all-preview"
+              ],
+              "Quantity": 1
+            }
           }
         },
         "TrustedSigners": {
@@ -675,9 +695,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -737,9 +758,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -805,9 +827,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -871,9 +894,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },
@@ -928,9 +952,10 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session"
+                "blf-alpha-session",
+                "awards-for-all-preview"
               ],
-              "Quantity": 1
+              "Quantity": 2
             }
           }
         },

--- a/config/default.json
+++ b/config/default.json
@@ -55,7 +55,8 @@
     "allowedCountries": ["scotland"]
   },
   "cookies": {
-    "session": "blf-alpha-session"
+    "session": "blf-alpha-session",
+    "awardsForAllPreview": "awards-for-all-preview"
   },
   "hotjarId": 1036292,
   "googleAnalyticsCode": "UA-98908627-1"

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const features = require('config').get('features');
 
+const { renderNotFound } = require('../errors');
 const digitalFund = require('./digital-fund');
 const reachingCommunities = require('./reaching-communities');
 
@@ -9,8 +10,14 @@ const router = express.Router();
 
 router.get('/', (req, res) => res.redirect('/'));
 
+/**
+ * Reaching Communities
+ */
 router.use('/your-idea', reachingCommunities);
 
+/**
+ * Digital Fund
+ */
 if (features.enableDigitalFundApplications) {
     router.use('/digital-fund-strand-1', digitalFund.strand1);
     router.use('/digital-fund-strand-2', digitalFund.strand2);
@@ -21,8 +28,20 @@ if (features.enableDigitalFundApplications) {
     router.use('/digital-fund-strand-2', redirectToProgramme);
 }
 
-if (features.enableAwardsForAllApplications) {
-    router.use('/awards-for-all', require('./awards-for-all'));
-}
+/**
+ * Awards for All
+ * Guard access with feature flag
+ */
+router.use(
+    '/awards-for-all',
+    function(req, res, next) {
+        if (res.locals.enableAwardsForAllApplications) {
+            next();
+        } else {
+            renderNotFound(req, res);
+        }
+    },
+    require('./awards-for-all')
+);
 
 module.exports = router;

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -4,8 +4,10 @@ const moment = require('moment');
 const { isString } = require('lodash');
 
 const { getCurrentUrl, getAbsoluteUrl, localify } = require('../common/urls');
+const { AWARDS_FOR_ALL_SECRET } = require('../common/secrets');
 
 const features = config.get('features');
+const cookies = config.get('cookies');
 
 /**
  * Set request locals
@@ -20,8 +22,15 @@ module.exports = function(req, res, next) {
      */
     res.locals.enableSiteSurvey = features.enableSiteSurvey;
     res.locals.enableNameChangeMessage = features.enableNameChangeMessage;
-    res.locals.enableAwardsForAllApplications =
-        features.enableAwardsForAllApplications;
+
+    const cookie = req.cookies[cookies.awardsForAllPreview];
+
+    if (cookie === AWARDS_FOR_ALL_SECRET) {
+        res.locals.enableAwardsForAllApplications = true;
+    } else {
+        res.locals.enableAwardsForAllApplications =
+            features.enableAwardsForAllApplications;
+    }
 
     /**
      * Global copy


### PR DESCRIPTION
Adds the ability to preview the new awards for all form in production by settings

Rationale: We might typically use staff-auth to preview access to certain sections but it's not possible to be logged in as both staff and a regular user which makes previewing the awards for all forms impossible. Allowing staff to be logged in as both types of users at the same time would add a lot of complexity so the simplest option for this short-lived preview is to look for a secret cookie value to allow access.