### PR TITLE
Revert endDateLimit change

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -298,8 +298,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     function fieldProjectDateRange() {
         const minDate = moment().add(12, 'weeks');
         const minDateAfter = minDate.subtract(1, 'days');
-        const maxDate = moment().add(1, 'years');
-        const maxDateLabel = localise({
+        const maxDuration = { amount: 12, unit: 'months' };
+        const maxDurationLabel = localise({
             en: `twelve months`,
             cy: ``
         });
@@ -321,9 +321,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 </p>
                 <p>
                     We usually only fund projects that last
-                    ${maxDateLabel} or less.
+                    ${maxDurationLabel} or less.
                     So, the end date can't be more than
-                    ${maxDateLabel} after the start date.    
+                    ${maxDurationLabel} after the start date.    
                 </p>
                 <p><strong>If your project is a one-off event</strong></p>
                 <p>
@@ -336,7 +336,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true,
             schema: Joi.dateRange()
                 .minDate(minDate.format('YYYY-MM-DD'))
-                .maxDate(maxDate.format('YYYY-MM-DD')),
+                .endDateLimit(maxDuration.amount, maxDuration.unit),
             messages: [
                 {
                     type: 'base',
@@ -375,10 +375,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     })
                 },
                 {
-                    type: 'dateRange.maxDate.invalid',
+                    type: 'dateRange.endDate.outsideLimit',
                     message: localise({
                         en: oneLine`Date you end the project must be within
-                            ${maxDateLabel} of the start date.`,
+                            ${maxDurationLabel} of the start date.`,
                         cy: ''
                     })
                 },

--- a/controllers/apply/form-router-next/joi-extensions/date-range.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.js
@@ -39,6 +39,7 @@ module.exports = function dateParts(joi) {
             },
             endDate: {
                 invalid: 'Invalid endDate',
+                outsideLimit: 'Date is outside limit',
                 beforeStartDate: 'endDate must not be before startDate'
             },
             minDate: {
@@ -110,23 +111,28 @@ module.exports = function dateParts(joi) {
                 }
             },
             {
-                name: 'maxDate',
+                name: 'endDateLimit',
                 params: {
-                    max: joi.string().required()
+                    amount: joi.number().required(),
+                    unit: joi.string().required()
                 },
                 validate(params, value, state, options) {
                     const dates = toRange(value);
 
+                    const maximumEndDate = dates.startDate
+                        .clone()
+                        .add(params.amount, params.unit);
+
                     if (
                         dates.startDate.isValid() &&
                         dates.endDate.isValid() &&
-                        dates.endDate.isSameOrBefore(params.max)
+                        dates.endDate.isSameOrBefore(maximumEndDate)
                     ) {
                         return value;
                     } else {
                         return this.createError(
-                            'dateRange.maxDate.invalid',
-                            { v: value, max: params.max },
+                            'dateRange.endDate.outsideLimit',
+                            { v: value },
                             state,
                             options
                         );

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -67,8 +67,8 @@ describe('dateRange', () => {
         );
     });
 
-    test('maxDate', () => {
-        const schema = Joi.dateRange().maxDate('2100-02-28');
+    test('endDateLimit', () => {
+        const schema = Joi.dateRange().endDateLimit(7, 'days');
 
         const valid = schema.validate({
             startDate: { day: 1, month: 2, year: 2100 },
@@ -78,8 +78,8 @@ describe('dateRange', () => {
         expect(valid.error).toBeNull();
 
         const invalid = schema.validate({
-            startDate: { day: 1, month: 2, year: 2100 },
-            endDate: { day: 1, month: 3, year: 2100 }
+            startDate: { day: 1, month: 2, year: 2099 },
+            endDate: { day: 1, month: 3, year: 2099 }
         });
 
         expect(invalid.error.message).toContain('Date is outside limit');

--- a/controllers/apply/form-router-next/joi-extensions/date-range.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/date-range.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 // @ts-nocheck
 'use strict';
+const moment = require('moment');
 const baseJoi = require('@hapi/joi');
 const Joi = baseJoi.extend(require('./date-range'));
 
@@ -68,18 +69,24 @@ describe('dateRange', () => {
     });
 
     test('endDateLimit', () => {
-        const schema = Joi.dateRange().endDateLimit(7, 'days');
+        function toDateParts(dt) {
+            return { day: dt.date(), month: dt.month() + 1, year: dt.year() };
+        }
+        const schema = Joi.dateRange().endDateLimit(12, 'months');
+
+        const dynamicStartDate = moment().add('12', 'weeks');
+        const dynamicEndDate = dynamicStartDate.clone().add('12', 'months');
 
         const valid = schema.validate({
-            startDate: { day: 1, month: 2, year: 2100 },
-            endDate: { day: 7, month: 2, year: 2100 }
+            startDate: toDateParts(dynamicStartDate),
+            endDate: toDateParts(dynamicEndDate)
         });
 
         expect(valid.error).toBeNull();
 
         const invalid = schema.validate({
-            startDate: { day: 1, month: 2, year: 2099 },
-            endDate: { day: 1, month: 3, year: 2099 }
+            startDate: toDateParts(dynamicStartDate),
+            endDate: toDateParts(dynamicEndDate.clone().add('1', 'day'))
         });
 
         expect(invalid.error.message).toContain('Date is outside limit');


### PR DESCRIPTION
Changing `endDateLimit` to `maxDate` on https://github.com/biglotteryfund/blf-alpha/pull/2071 was the wrong change as the date needs to be relative to the _submitted_ start date not the minimum start date. This reverts this change back to use the `endDateLimit` validator.