### PR TITLE
Misc AFA fixes

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -50,7 +50,7 @@ export default {
         this.$root.$on('update:conditionalRadio', value => {
             if (value === 'yes') {
                 this.currentState = states.NotRequired;
-            } else if (this.fullAddress) {
+            } else if (this.fullAddressPreview !== '') {
                 this.currentState = this.states.AlreadyAnswered;
             } else {
                 this.currentState = states.NotAsked;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1381,7 +1381,8 @@ applyNext:
     introduction: >
       <p>Here you can keep going with an application you've already started.
       You can also <a href="%s">start a brand new application</a> and see any
-      applications you've previously submitted online.</p>
+      applications you've previously submitted online. You can also see the
+      <a href="%s">questions you'll be asked</a> when you apply.</p>
     inProgressTitle: In progress
     submittedTitle: Submitted
   summary:

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -31,7 +31,7 @@ module.exports = function({ locale, data = {}, showAllFields = false }) {
             return f;
         });
 
-        return showAllFields ? fields : filteredFields;
+        return showAllFields ? allFields : filteredFields;
     };
 
     const currentOrganisationType = get('organisationType')(data);

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -140,7 +140,7 @@ function initFormRouter({
     /**
      * Publicly accessible routes.
      */
-    router.use('/questions', require('./questions')(formId, formBuilder));
+    router.use('/questions', require('./questions')(formId, formBuilder, eligibilityBuilder));
     router.use('/eligibility', require('./eligibility')(eligibilityBuilder));
 
     /**

--- a/controllers/apply/form-router-next/joi-extensions/budget-items.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-items.js
@@ -44,7 +44,10 @@ module.exports = function budgetItems(joi) {
                     maxBudget: joi.number().required()
                 },
                 validate(params, value, state, options) {
-                    const total = sumBy(value, item => item.cost);
+                    const total = sumBy(
+                        value,
+                        item => parseInt(item.cost) || 0
+                    );
                     if (total > params.maxBudget) {
                         return this.createError(
                             'budgetItems.overBudget',

--- a/controllers/apply/form-router-next/joi-extensions/budget-items.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-items.js
@@ -46,7 +46,7 @@ module.exports = function budgetItems(joi) {
                 validate(params, value, state, options) {
                     const total = sumBy(
                         value,
-                        item => parseInt(item.cost) || 0
+                        item => parseInt(item.cost, 10) || 0
                     );
                     if (total > params.maxBudget) {
                         return this.createError(

--- a/controllers/apply/form-router-next/joi-extensions/budget-total-costs.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-total-costs.js
@@ -1,5 +1,5 @@
 'use strict';
-const { get, sumBy } = require('lodash');
+const { get, sumBy, isString } = require('lodash');
 
 // @TODO: Merge this and budget items into a single budget fields
 module.exports = function budgetTotalCosts(joi) {
@@ -10,10 +10,21 @@ module.exports = function budgetTotalCosts(joi) {
             underBudget: 'under project budget total'
         },
         /* eslint-disable-next-line no-unused-vars */
+        coerce(value, state, options) {
+            if (isString(value)) {
+                // Strip out any non-numeric characters (eg. ,) but keep decimal points
+                return value.replace(/[^0-9.]/g, '');
+            }
+            return value;
+        },
+        /* eslint-disable-next-line no-unused-vars */
         pre(value, state, options) {
             const projectBudget = get(state.parent, 'projectBudget');
             if (projectBudget) {
-                const total = sumBy(projectBudget, item => item.cost);
+                const total = sumBy(
+                    projectBudget,
+                    item => parseInt(item.cost) || 0
+                );
                 if (value < total) {
                     return this.createError(
                         'budgetTotalCosts.underBudget',

--- a/controllers/apply/form-router-next/joi-extensions/budget-total-costs.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-total-costs.js
@@ -23,7 +23,7 @@ module.exports = function budgetTotalCosts(joi) {
             if (projectBudget) {
                 const total = sumBy(
                     projectBudget,
-                    item => parseInt(item.cost) || 0
+                    item => parseInt(item.cost, 10) || 0
                 );
                 if (value < total) {
                     return this.createError(

--- a/controllers/apply/form-router-next/lib/formatters.js
+++ b/controllers/apply/form-router-next/lib/formatters.js
@@ -117,7 +117,7 @@ function formatBudget(value) {
     if (!isArray(value)) {
         return value;
     } else {
-        const total = sumBy(value, item => parseInt(item.cost || 0));
+        const total = sumBy(value, item => parseInt(item.cost, 10) || 0);
         return [
             value
                 .filter(line => line.item && line.cost)

--- a/controllers/apply/form-router-next/lib/formatters.js
+++ b/controllers/apply/form-router-next/lib/formatters.js
@@ -130,9 +130,9 @@ function formatBudget(value) {
 
 function formatFile(value) {
     if (value) {
-        return `${value.filename} (${mime
-            .extension(value.type)
-            .toUpperCase()}, ${filesize(value.size, { round: 0 })})`;
+        const mimeType = mime.extension(value.type) || 'File';
+        const fileSize = filesize(value.size, { round: 0 });
+        return `${value.filename} (${mimeType.toUpperCase()}, ${fileSize})`;
     } else {
         return '';
     }

--- a/controllers/apply/form-router-next/questions.js
+++ b/controllers/apply/form-router-next/questions.js
@@ -11,7 +11,8 @@ module.exports = function(formId, formBuilder, eligibilityBuilder) {
 
     router.get('/:pdf?', (req, res, next) => {
         const form = formBuilder({
-            locale: req.i18n.getLocale()
+            locale: req.i18n.getLocale(),
+            showAllFields: true
         });
 
         const eligibility = eligibilityBuilder({

--- a/controllers/apply/form-router-next/questions.js
+++ b/controllers/apply/form-router-next/questions.js
@@ -6,11 +6,15 @@ const nunjucks = require('nunjucks');
 const path = require('path');
 const pdf = require('html-pdf');
 
-module.exports = function(formId, formBuilder) {
+module.exports = function(formId, formBuilder, eligibilityBuilder) {
     const router = express.Router();
 
     router.get('/:pdf?', (req, res, next) => {
         const form = formBuilder({
+            locale: req.i18n.getLocale()
+        });
+
+        const eligibility = eligibilityBuilder({
             locale: req.i18n.getLocale()
         });
 
@@ -21,7 +25,8 @@ module.exports = function(formId, formBuilder) {
             },
             context: {
                 title: form.title,
-                form: form
+                form: form,
+                eligibility: eligibility
             }
         };
 

--- a/controllers/apply/form-router-next/views/dashboard.njk
+++ b/controllers/apply/form-router-next/views/dashboard.njk
@@ -126,7 +126,7 @@
 
             <div class="s-prose">
                 <h1 class="t--underline">{{ copy.dashboard.title }}</h1>
-                {{ __(copy.dashboard.introduction, '#new') | safe }}
+                {{ __(copy.dashboard.introduction, '#new', formBaseUrl + '/questions') | safe }}
             </div>
 
             {% if pendingApplications.length > 0 %}

--- a/controllers/apply/form-router-next/views/questions-html.njk
+++ b/controllers/apply/form-router-next/views/questions-html.njk
@@ -1,7 +1,8 @@
 {% from "./questions-list.njk" import questionsIntro, questionList with context %}
 {% from "components/icons.njk" import iconDownload %}
 {% from "components/print-button/macro.njk" import printButton %}
-
+{% from "components/user-status/macro.njk" import userStatus with context %}
+{% from "components/user-navigation/macro.njk" import userNavigation with context %}
 
 {% extends "layouts/main.njk" %}
 {% set bodyClass = 'has-static-header' %}
@@ -11,7 +12,11 @@
 
         <section class="content-box u-inner-wide-only">
 
+            {{ userNavigation(userNavigationLinks) }}
+
             {{ questionsIntro(form) }}
+
+            {{ userStatus(user) }}
 
             <div class="o-button-group u-dont-print">
                 {{ printButton(label = 'Print these questions') }}

--- a/controllers/apply/form-router-next/views/questions-html.njk
+++ b/controllers/apply/form-router-next/views/questions-html.njk
@@ -1,4 +1,4 @@
-{% from "./questions-list.njk" import questionsIntro, questionList %}
+{% from "./questions-list.njk" import questionsIntro, questionList with context %}
 {% from "components/icons.njk" import iconDownload %}
 {% from "components/print-button/macro.njk" import printButton %}
 
@@ -23,7 +23,7 @@
         </section>
 
         <section class="content-box u-inner-wide-only">
-            {{ questionList(form) }}
+            {{ questionList(form, eligibility) }}
         </section>
 
     </main>

--- a/controllers/apply/form-router-next/views/questions-list.njk
+++ b/controllers/apply/form-router-next/views/questions-list.njk
@@ -61,7 +61,7 @@
     </div>
 {% endmacro %}
 
-{% macro questionList(form) %}
+{% macro questionList(form, eligibility) %}
 
     <section class="application-questions">
 
@@ -70,7 +70,7 @@
         {% endcall %}
 
         <div class="application-questions__set">
-            {% for field in form.eligibilityQuestions %}
+            {% for field in eligibility.questions %}
                 {% call question(first = loop.first) %}
                     <dt class="application-questions__q">{{ field.question | safe }}</dt>
                     {% if field.explanation %}

--- a/controllers/apply/form-router-next/views/questions-list.njk
+++ b/controllers/apply/form-router-next/views/questions-list.njk
@@ -1,8 +1,8 @@
 {% macro fieldTypeHelpText(field, step) %}
-    {% if field.type === 'checkbox' %}
-        Pick one of:
-    {% elseif field.type === 'radio' %}
-        Choose as many as you like from:
+    {% if field.type === 'checkbox' or field.type === 'select' %}
+        Choose as many options as you like from a selection
+    {% elseif field.type === 'radio' or field.type === 'select' %}
+        Pick one option from a selection
     {% elseif field.type === 'budget' %}
         Provide an itemised budget
         {% if field.attributes.max %}
@@ -10,14 +10,16 @@
         {% endif %}
     {% elseif field.type === 'currency' %}
         Provide a financial figure
-    {% elseif field.type === 'address' %}
+    {% elseif field.type === 'address' or field.type === 'address-history' %}
         Provide an address
-    {% elseif field.type === 'date' or field.type === 'day-month' %}
+    {% elseif field.type === 'date' or field.type === 'day-month' or field.type === 'date-range' or field.type === 'month-year' %}
         Provide a date
     {% elseif field.type === 'email' %}
         Provide an email address
     {% elseif field.type === 'file' %}
         Upload a file
+    {% elseif field.type === 'full-name' %}
+        Provide a person's full name
     {% elseif field.type === 'number' %}
         Provide a number
     {% elseif field.type === 'tel' %}
@@ -37,6 +39,14 @@
         &mdash; optional, but may be required depending on your circumstances
     {% elseif field.isRequired %}
         &mdash; required
+    {% elseif not field.isRequired %}
+        &mdash; optional
+    {% endif %}
+
+    {% if field.isConditional %}
+        <p class="u-margin-top-s u-margin-bottom-s">
+            (<strong>Note</strong>: this field may be optional depending on your other answers)
+        </p>
     {% endif %}
 {% endmacro %}
 
@@ -57,7 +67,7 @@
     <div class="s-prose">
         <h1 class="t--underline">{{ form.title }}</h1>
         <h3>Questions you'll be asked</h3>
-        <p>Below is a list of all of the questions you may be asked when applying for {{ form.title }}. Please note that some questions are optional depending on your other answers to the form. You may find it helpful to revise our <a href="{{ form.programmePage }}">{{ form.title }} guidance</a>. <strong>Please note</strong>: in order to submit your application you'll need to agree to our terms and conditions.</p>
+        <p>Below is a list of all of the questions you may be asked when applying for {{ form.title }}. Please note that some questions are optional depending on your other answers to the form. You may find it helpful to revise our <a href="{{ localify('/funding/under10k') }}">{{ form.title }} guidance</a>. <strong>Please note</strong>: in order to submit your application you'll need to agree to our terms and conditions.</p>
     </div>
 {% endmacro %}
 
@@ -81,21 +91,26 @@
         </div>
 
         {% for section in form.sections %}
-            {% set count = loop.index %}
 
-            {% call header('Section ' + count + ': ' + section.title) %}
+            {% call header(section.title) %}
                 <p class="u-no-margin u-text-x-small">{{ section.summary }}</p>
             {% endcall %}
 
             {% for step in section.steps %}
                 <div class="application-questions__set">
-                    <h4 class="t--underline">Step {{ loop.index }}: {{ step.title }}</h4>
+                    <h4 class="t--underline">{{ step.title }}</h4>
 
                     {% for fieldset in step.fieldsets %}
                         {% for field in fieldset.fields %}
                             {% call question(first = loop.first) %}
                                 <dt class="application-questions__q">{{ field.label | safe }}</dt>
                                 <dd class="application-questions__help">{{ fieldTypeHelpText(field, step) }}</dd>
+
+                                {% if field.explanation %}
+                                    <dd class="u-margin-bottom-s u-text-x-small s-prose">
+                                        {{ field.explanation | safe }}
+                                    </dd>
+                                {% endif %}
 
                                 {% if field.options %}
                                     <div class="s-prose u-text-x-small">
@@ -106,11 +121,20 @@
                                         </ul>
                                     </div>
                                 {% endif %}
-                                {% if field.explanation %}
-                                    <dd class="u-margin-bottom-s u-text-x-small s-prose">
-                                        {{ field.explanation | safe }}
-                                    </dd>
+
+                                {% if field.optgroups %}
+                                    {% for optgroup in field.optgroups %}
+                                        <h5>{{ optgroup.label }}</h5>
+                                        <div class="s-prose u-text-x-small">
+                                            <ul>
+                                                {% for option in optgroup.options %}
+                                                    <li>{{ option.label }}</li>
+                                                {% endfor %}
+                                            </ul>
+                                        </div>
+                                    {% endfor %}
                                 {% endif %}
+
                             {% endcall %}
                         {% endfor %}
                     {% endfor %}

--- a/controllers/apply/form-router-next/views/questions-list.njk
+++ b/controllers/apply/form-router-next/views/questions-list.njk
@@ -1,5 +1,5 @@
 {% macro fieldTypeHelpText(field, step) %}
-    {% if field.type === 'checkbox' or field.type === 'select' %}
+    {% if field.type === 'checkbox' %}
         Choose as many options as you like from a selection
     {% elseif field.type === 'radio' or field.type === 'select' %}
         Pick one option from a selection

--- a/controllers/apply/form-router-next/views/questions-pdf.njk
+++ b/controllers/apply/form-router-next/views/questions-pdf.njk
@@ -5,7 +5,7 @@
 {% block content %}
     {{ questionsIntro(form) }}
 
-    {{ questionList(form) }}
+    {{ questionList(form, eligibility) }}
 
     <div id="pageFooter">
         <p>Application form questions for {{ form.title}} &ndash; <strong>Please do not attempt to fill out this form or send it to The National Lottery Community Fund.</strong> We will not accept paper copies of this form.</p>


### PR DESCRIPTION
A few things in here:

- There was an issue where the Address lookup thought an address had already been supplied (because we changed the default address to contain `null` fieldnames). This fixes things so it knows it's not been provided.

- Budget totals now have commas removed automatically, and this also fixes a totalling error where an invalid line budget wasn't being summed properly (eg. 12 + 34 = 1234).

- Fixes an issue with file upload mimetypes which caused a 500 error when the file's type wasn't known (saw this via the pen test data)

- Re-adds the eligibility questions into `/questions`

- Updates templates for `/questions` and adds `conditionalFields()` method to output all fields for a step, regardless of conditions (eg. for the question list):

![image](https://user-images.githubusercontent.com/394376/61289771-10de2a00-a7c2-11e9-8c51-3cb659bb60c8.png)
