### PR TITLE
Share contact detail check

### DIFF
--- a/controllers/apply/awards-for-all/constants.js
+++ b/controllers/apply/awards-for-all/constants.js
@@ -21,6 +21,16 @@ const ORGANISATION_TYPES = {
     FAITH_GROUP: 'faith-group'
 };
 
+/**
+ * Define which organisation types should
+ * exclude contact details.
+ */
+const CONTACT_EXCLUDED_TYPES = [
+    ORGANISATION_TYPES.SCHOOL,
+    ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY,
+    ORGANISATION_TYPES.STATUTORY_BODY
+];
+
 const STATUTORY_BODY_TYPES = {
     PARISH_COUNCIL: 'parish-council', // ⛪️
     TOWN_COUNCIL: 'town-council', // 🏙
@@ -55,6 +65,7 @@ const FILE_LIMITS = {
 
 module.exports = {
     BENEFICIARY_GROUPS,
+    CONTACT_EXCLUDED_TYPES,
     MIN_BUDGET_TOTAL_GBP,
     MAX_BUDGET_TOTAL_GBP,
     MIN_AGE_MAIN_CONTACT,

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -161,10 +161,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 });
 
                 return Joi.when(Joi.ref('organisationType'), {
-                    is: Joi.exist().valid(
-                        ORGANISATION_TYPES.SCHOOL,
-                        ORGANISATION_TYPES.STATUTORY_BODY
-                    ),
+                    is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
                     then: Joi.any().strip(),
                     otherwise: addressHistorySchema.required()
                 });
@@ -267,10 +264,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             schema: Joi.dateParts()
                 .dob(minAge)
                 .when(Joi.ref('organisationType'), {
-                    is: Joi.exist().valid(
-                        ORGANISATION_TYPES.SCHOOL,
-                        ORGANISATION_TYPES.STATUTORY_BODY
-                    ),
+                    is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
                     then: Joi.any().strip(),
                     otherwise: Joi.required()
                 }),
@@ -2169,10 +2163,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 schema: Joi.ukAddress()
                     .mainContact()
                     .when(Joi.ref('organisationType'), {
-                        is: Joi.exist().valid(
-                            ORGANISATION_TYPES.SCHOOL,
-                            ORGANISATION_TYPES.STATUTORY_BODY
-                        ),
+                        is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
                         then: Joi.any().strip()
                     })
             },
@@ -2271,10 +2262,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 schema: Joi.ukAddress()
                     .seniorContact()
                     .when(Joi.ref('organisationType'), {
-                        is: Joi.exist().valid(
-                            ORGANISATION_TYPES.SCHOOL,
-                            ORGANISATION_TYPES.STATUTORY_BODY
-                        ),
+                        is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
                         then: Joi.any().strip()
                     })
             },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -9,6 +9,7 @@ const { oneLine } = require('common-tags');
 const Joi = require('../form-router-next/joi-extensions');
 const {
     BENEFICIARY_GROUPS,
+    CONTACT_EXCLUDED_TYPES,
     MIN_BUDGET_TOTAL_GBP,
     MAX_BUDGET_TOTAL_GBP,
     MIN_AGE_MAIN_CONTACT,

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -11,7 +11,11 @@ const { safeHtml, oneLine } = require('common-tags');
 const { FormModel } = require('../form-router-next/lib/form-model');
 const { fromDateParts } = require('../form-router-next/lib/date-parts');
 const { formatDateRange } = require('../form-router-next/lib/formatters');
-const { BENEFICIARY_GROUPS, ORGANISATION_TYPES } = require('./constants');
+const {
+    BENEFICIARY_GROUPS,
+    CONTACT_EXCLUDED_TYPES,
+    ORGANISATION_TYPES
+} = require('./constants');
 
 const fieldsFor = require('./fields');
 const terms = require('./terms');
@@ -543,11 +547,9 @@ module.exports = function({ locale, data = {}, showAllFields = false }) {
      * for the organisation types listed here.
      */
     function includeAddressAndDob() {
-        return ![
-            ORGANISATION_TYPES.SCHOOL,
-            ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY,
-            ORGANISATION_TYPES.STATUTORY_BODY
-        ].includes(currentOrganisationType);
+        return (
+            CONTACT_EXCLUDED_TYPES.includes(currentOrganisationType) === false
+        );
     }
 
     function stepSeniorContact() {


### PR DESCRIPTION
Caught this error whilst working on https://github.com/biglotteryfund/blf-alpha/pull/2077. We were duplicating the list of organisation types that should exclude contact details which had got out of sync. This updates this list to come from a shared value.