### PR TITLE
Log format

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -3,18 +3,10 @@ const { createLogger, format, transports } = require('winston');
 const WinstonCloudWatch = require('winston-cloudwatch');
 const features = require('config').get('features');
 
-const { isDev, isTestServer, environment, buildNumber } = require('./appData');
-
-function enableCloudWatchLogs() {
-    if (isTestServer) {
-        return false;
-    } else {
-        return features.enableCloudWatchLogs;
-    }
-}
+const { isDev, environment, buildNumber } = require('./appData');
 
 function transport() {
-    if (enableCloudWatchLogs()) {
+    if (features.enableCloudWatchLogs) {
         return new WinstonCloudWatch({
             awsRegion: 'eu-west-2',
             logGroupName: `/tnlcf/${environment}/app`,
@@ -24,7 +16,6 @@ function transport() {
         });
     } else {
         return new transports.Console({
-            silent: isTestServer,
             format: format.combine(format.colorize(), format.simple())
         });
     }

--- a/common/logger.js
+++ b/common/logger.js
@@ -1,28 +1,38 @@
 'use strict';
+const config = require('config');
 const { createLogger, format, transports } = require('winston');
 const WinstonCloudWatch = require('winston-cloudwatch');
-const features = require('config').get('features');
 
-const { isDev, environment, buildNumber } = require('./appData');
+const { environment, buildNumber } = require('./appData');
 
-function transport() {
-    if (features.enableCloudWatchLogs) {
-        return new WinstonCloudWatch({
-            awsRegion: 'eu-west-2',
-            logGroupName: `/tnlcf/${environment}/app`,
-            logStreamName: `build-${buildNumber}`,
-            jsonMessage: true,
-            retentionInDays: 30
-        });
+function getTransports() {
+    if (config.get('features.enableCloudWatchLogs')) {
+        return [
+            new WinstonCloudWatch({
+                awsRegion: config.get('aws.region'),
+                logGroupName: `/tnlcf/${environment}/app`,
+                logStreamName: `build-${buildNumber}`,
+                jsonMessage: true,
+                retentionInDays: 30
+            })
+        ];
     } else {
-        return new transports.Console({
-            format: format.combine(format.colorize(), format.simple())
-        });
+        return [
+            new transports.Console({
+                format: format.combine(
+                    format.colorize(),
+                    format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+                    format.printf(function(info) {
+                        return `${info.timestamp} [${info.level}] ${info.message}`;
+                    })
+                )
+            })
+        ];
     }
 }
 
 module.exports = createLogger({
-    level: isDev ? 'debug' : 'info',
+    level: process.env.LOG_LEVEL || config.get('logLevel'),
     format: format.combine(format.errors({ stack: true }), format.json()),
-    transports: [transport()]
+    transports: getTransports()
 });

--- a/config/default.json
+++ b/config/default.json
@@ -1,4 +1,5 @@
 {
+  "logLevel": "info",
   "aws": {
     "region": "eu-west-2",
     "cloudfrontDistributions": {

--- a/config/development.json
+++ b/config/development.json
@@ -1,4 +1,5 @@
 {
+  "logLevel": "debug",
   "domains": {
     "base": "http://localhost:3000"
   },


### PR DESCRIPTION
During the process of running a large batch of test application submissions I realised that having console logging for the test server is actually useful, we were previously suppressing it.

- Updates the logger code so that we allow console output in test environments
- Makes the log level configurable through the environment, or defaulting to the config
-  Improves the console log format with timestamps

<img width="825" alt="Screenshot 2019-07-19 at 14 48 49" src="https://user-images.githubusercontent.com/123386/61540093-d6c88e80-aa34-11e9-9704-032b80f71e8f.png">
