### PR TITLE
Avoid re-calculating form progress

### DIFF
--- a/controllers/apply/form-router-next/lib/form-model.js
+++ b/controllers/apply/form-router-next/lib/form-model.js
@@ -119,6 +119,16 @@ class FormModel {
             return section;
         });
 
+        /**
+         * Form progress
+         */
+        const formIsEmpty = isEmpty(this.validation.value);
+        this.progress = {
+            isComplete: formIsEmpty === false && this.validation.error === null,
+            isPristine: formIsEmpty === true,
+            sections: this.sections.map(section => section.progress)
+        };
+
         this.summary = props.summary;
         this.forSalesforce = props.forSalesforce;
     }
@@ -176,15 +186,6 @@ class FormModel {
             isValid: error === null && messages.length === 0,
             messages: messages,
             featuredMessages: featuredMessages
-        };
-    }
-
-    get progress() {
-        const formIsEmpty = isEmpty(this.validation.value) === true;
-        return {
-            isComplete: !formIsEmpty && this.validation.error === null,
-            isPristine: formIsEmpty,
-            sections: this.sections.map(section => section.progress)
         };
     }
 

--- a/controllers/apply/form-router-next/summary.js
+++ b/controllers/apply/form-router-next/summary.js
@@ -34,7 +34,6 @@ module.exports = function(formBuilder) {
 
         const title = copy.summary.title;
         const showErrors = !!req.query['show-errors'] === true;
-        const formProgress = form.progress;
 
         res.render(path.resolve(__dirname, './views/summary'), {
             form: form,
@@ -46,8 +45,7 @@ module.exports = function(formBuilder) {
             errors: form.validation.messages,
             errorsByStep: errorsByStep(),
             featuredErrors: form.validation.featuredMessages,
-            expandSections: formProgress.isComplete || showErrors,
-            formProgress: formProgress,
+            expandSections: form.progress.isComplete || showErrors,
             startPathSlug: form.sections[0].slug
         });
     });

--- a/controllers/apply/form-router-next/views/summary.njk
+++ b/controllers/apply/form-router-next/views/summary.njk
@@ -7,9 +7,6 @@
 
 {% block title %}{{ title }} | {{ formTitle }} | {% endblock %}
 
-{% set formIsComplete = formProgress.isComplete %}
-{% set formIsPristine = formProgress.isPristine %}
-
 {% macro summariseErrors() %}
     {% if showErrors and errorsByStep.length > 0 %}
         <div class="form-errors" data-testid="form-errors">
@@ -157,7 +154,7 @@
                     title = copy.summary.showQuestions,
                     assistiveText = 'for "' + secTitle + '" section',
                     extraClasses = 'js-toggleable',
-                    isOpen = formIsComplete or section.hasFeaturedErrors
+                    isOpen = form.progress.isComplete or section.hasFeaturedErrors
                 ) %}
                     {% for step in section.steps %}
                         {{ stepSummary(
@@ -191,14 +188,14 @@
             {{ summariseErrors() }}
 
 
-            {% if formIsComplete %}
+            {% if form.progress.isComplete %}
                 <div class="submit-actions submit-actions--complete">
                     <h2 class="submit-actions__title">{{ iconTick('medium') }} {{ copy.summary.completeTitle }}</h2>
                     <p class="submit-actions__text">{{ copy.summary.completeMessage }}</p>
                 </div>
             {% else %}
                 <div class="s-prose">{{ copy.summary.introduction | safe }}</div>
-                {% if formIsPristine %}
+                {% if form.progress.isPristine %}
                     {{ startButton() }}
                 {% endif %}
             {% endif %}
@@ -217,7 +214,7 @@
                 {{ sectionSummary(section, loop.index) }}
             {% endfor %}
 
-            {% if formIsComplete %}
+            {% if form.progress.isComplete %}
                 <form class="submit-actions submit-actions--complete"
                       action="{{ formBaseUrl }}/submission" method="post">
                     <h2 class="submit-actions__title">{{ iconTick('medium') }} {{ copy.summary.completeTitle }}</h2>
@@ -227,9 +224,9 @@
                     {% endif %}
                     <input class="btn u-margin-bottom-s" type="submit" value="{{ copy.submit }}" />
                 </form>
-            {% elseif not formIsPristine %}
+            {% elseif not form.progress.isPristine %}
                 {{ submitActionsIncomplete() }}
-            {% elseif formIsPristine %}
+            {% elseif form.progress.isPristine %}
                 {{ startButton() }}
             {% endif %}
 


### PR DESCRIPTION
Set `progress` in the constructor rather than using a getter method. Allows us to call `form.progress` without excessive recalculation.