### PR TITLE
Add sanitiser for nested request bodies

### DIFF
--- a/common/sanitise.js
+++ b/common/sanitise.js
@@ -1,10 +1,52 @@
 'use strict';
 const { JSDOM } = require('jsdom');
 const createDOMPurify = require('dompurify');
+const isArray = require('lodash/isArray');
+const isObject = require('lodash/isObject');
+const isString = require('lodash/isString');
+const mapValues = require('lodash/mapValues');
 
 const window = new JSDOM('').window;
 const DOMPurify = createDOMPurify(window);
 
-module.exports = function sanitise(input) {
+function sanitise(input) {
     return DOMPurify.sanitize(input);
+}
+
+/**
+ * Sanitise request body
+ *
+ * Accounts for body-parse urlencoded extended values
+ * where data is expanded into nested objects and arrays.
+ *
+ * Only sanitises if the value is a string to avoid
+ * unwanted stringify-ing of other values.
+ */
+function sanitiseRequestBody(body) {
+    function sanitiseIfString(value) {
+        return isString(value) ? sanitise(value) : value;
+    }
+
+    function sanitiseNested(value) {
+        if (isObject(value)) {
+            return mapValues(value, function(nestedValue) {
+                return sanitiseIfString(nestedValue);
+            });
+        } else {
+            return sanitiseIfString(value);
+        }
+    }
+
+    return mapValues(body, function(value) {
+        if (isArray(value)) {
+            return value.map(sanitiseNested);
+        } else {
+            return sanitiseNested(value);
+        }
+    });
+}
+
+module.exports = {
+    sanitise,
+    sanitiseRequestBody
 };

--- a/common/sanitise.js
+++ b/common/sanitise.js
@@ -27,8 +27,12 @@ function sanitise(input) {
 function sanitiseRequestBody(body) {
     function sanitiseIfString(value, key) {
         if (isString(value)) {
-            logger.debug(`sanitising ${key}`);
-            return sanitise(value);
+            const sanitisedValue = sanitise(value);
+            if (sanitisedValue !== value) {
+                logger.info(`sanitising ${key}`);
+            }
+
+            return sanitisedValue;
         } else {
             return value;
         }

--- a/common/sanitise.test.js
+++ b/common/sanitise.test.js
@@ -19,7 +19,10 @@ describe('sanitiseRequestBody', () => {
             arrayOfObjects: [
                 { a: 'good', b: 'bad<script>alert(1)</script>' },
                 { a: 'good', b: '<script>alert(1)</script>' }
-            ]
+            ],
+            nestedObject: {
+                a: { x: 'good', y: 'bad<script>alert(1)</script>' }
+            }
         });
 
         expect(result).toEqual({
@@ -27,7 +30,8 @@ describe('sanitiseRequestBody', () => {
             numberValue: 1000,
             objectValue: { a: 'this value is OK', b: 'this one is not OK' },
             arrayValue: ['something', 'this one is bad'],
-            arrayOfObjects: [{ a: 'good', b: 'bad' }, { a: 'good', b: '' }]
+            arrayOfObjects: [{ a: 'good', b: 'bad' }, { a: 'good', b: '' }],
+            nestedObject: { a: { x: 'good', y: 'bad' } }
         });
     });
 });

--- a/common/sanitise.test.js
+++ b/common/sanitise.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+'use strict';
+
+const { sanitiseRequestBody } = require('./sanitise');
+
+describe('sanitiseRequestBody', () => {
+    test('should sanitise nested request bodies', () => {
+        const result = sanitiseRequestBody({
+            stringValue: 'Test<script>alert(1)</script>',
+            numberValue: 1000,
+            objectValue: {
+                a: 'this value is OK',
+                b: 'this one is not OK<script>alert(1)</script>'
+            },
+            arrayValue: [
+                'something',
+                'this one is bad<script>alert(1)</script>'
+            ],
+            arrayOfObjects: [
+                { a: 'good', b: 'bad<script>alert(1)</script>' },
+                { a: 'good', b: '<script>alert(1)</script>' }
+            ]
+        });
+
+        expect(result).toEqual({
+            stringValue: 'Test',
+            numberValue: 1000,
+            objectValue: { a: 'this value is OK', b: 'this one is not OK' },
+            arrayValue: ['something', 'this one is bad'],
+            arrayOfObjects: [{ a: 'good', b: 'bad' }, { a: 'good', b: '' }]
+        });
+    });
+});

--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -3,7 +3,7 @@ const express = require('express');
 const Joi = require('@hapi/joi');
 const Sentry = require('@sentry/node');
 
-const sanitise = require('../../common/sanitise');
+const { sanitise } = require('../../common/sanitise');
 const { Feedback, SurveyAnswer } = require('../../db/models');
 const appData = require('../../common/appData');
 const { POSTCODES_API_KEY } = require('../../common/secrets');

--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -5,6 +5,7 @@ const findIndex = require('lodash/findIndex');
 const Sentry = require('@sentry/node');
 
 const logger = require('../../../common/logger');
+const { sanitiseRequestBody } = require('../../../common/sanitise');
 const { PendingApplication } = require('../../../db/models');
 const { prepareFilesForUpload, uploadFile } = require('./lib/file-uploads');
 
@@ -109,9 +110,11 @@ module.exports = function(formId, formBuilder) {
                 currentApplicationData
             } = res.locals;
 
+            const sanitisedBody = sanitiseRequestBody(req.body);
+
             const applicationData = {
                 ...currentApplicationData,
-                ...req.body
+                ...sanitisedBody
             };
 
             const form = formBuilder({

--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const express = require('express');
 const findIndex = require('lodash/findIndex');
+const omit = require('lodash/omit');
 const Sentry = require('@sentry/node');
 
 const logger = require('../../../common/logger');
@@ -110,7 +111,9 @@ module.exports = function(formId, formBuilder) {
                 currentApplicationData
             } = res.locals;
 
-            const sanitisedBody = sanitiseRequestBody(req.body);
+            const sanitisedBody = sanitiseRequestBody(
+                omit(req.body, ['_csrf'])
+            );
 
             const applicationData = {
                 ...currentApplicationData,

--- a/controllers/materials/index.js
+++ b/controllers/materials/index.js
@@ -11,7 +11,7 @@ const Sentry = require('@sentry/node');
 const router = express.Router();
 
 const appData = require('../../common/appData');
-const sanitise = require('../../common/sanitise');
+const { sanitise } = require('../../common/sanitise');
 const { MATERIAL_SUPPLIER } = require('../../common/secrets');
 const { generateHtmlEmail, sendEmail } = require('../../common/mail');
 const {

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -5,7 +5,7 @@ const concat = require('lodash/concat');
 const Sentry = require('@sentry/node');
 
 const { Users } = require('../../db/models');
-const sanitise = require('../../common/sanitise');
+const { sanitise } = require('../../common/sanitise');
 const { sendHtmlEmail } = require('../../common/mail');
 const { getAbsoluteUrl, redirectForLocale } = require('../../common/urls');
 const { requireNoAuth } = require('../../middleware/authed');

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -6,7 +6,7 @@ const Sentry = require('@sentry/node');
 
 const { Users } = require('../../db/models');
 const { localify } = require('../../common/urls');
-const sanitise = require('../../common/sanitise');
+const { sanitise } = require('../../common/sanitise');
 const logger = require('../../common/logger').child({ service: 'user' });
 const { csrfProtection } = require('../../middleware/cached');
 const {


### PR DESCRIPTION
Add sanitiser for nested request bodies. Accounts for body-parse urlencoded extended values where data is expanded into nested objects and arrays.

Attempts to only sanitises if the value is string-like to avoid unwanted stringify-ing of other values.