### PR TITLE
Add isTestServer guard around cloudwatch logger

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -3,10 +3,18 @@ const config = require('config');
 const { createLogger, format, transports } = require('winston');
 const WinstonCloudWatch = require('winston-cloudwatch');
 
-const { environment, buildNumber } = require('./appData');
+const { environment, buildNumber, isTestServer } = require('./appData');
+
+function enableCloudWatchLogs() {
+    if (process.env.CI || isTestServer === true) {
+        return false;
+    } else {
+        return config.get('features.enableCloudWatchLogs');
+    }
+}
 
 function getTransports() {
-    if (config.get('features.enableCloudWatchLogs')) {
+    if (enableCloudWatchLogs()) {
         return [
             new WinstonCloudWatch({
                 awsRegion: config.get('aws.region'),


### PR DESCRIPTION
The CI server sets the node environment to `test` so uses the `test.json` config which enables cloudwatch logs. 

In our case "test.json" really means the staging site, really the CI server should use the `development.json` config or even its own one. It's not a major problem so for now I've added an extra `isTestServer` check.

At some point we should rework how we determine this to separate the concept of the application environment and the node environment to avoid these kinds of confusion.