### PR TITLE
Allow only one activation link to be current at a time

### DIFF
--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const express = require('express');
 const Sentry = require('@sentry/node');
-const moment = require('moment');
 
 const { Users } = require('../../db/models');
 const {
@@ -67,18 +66,11 @@ router
     })
     .post(async function(req, res, next) {
         try {
-            const dateOfActivationAttempt = moment().unix();
 
             await sendActivationEmail(
                 req,
-                req.user.userData,
-                dateOfActivationAttempt
+                req.user.userData
             );
-
-            await Users.updateDateOfActivationAttempt({
-                id: req.user.userData.id,
-                dateOfActivationAttempt: dateOfActivationAttempt
-            });
 
             res.locals.resendSuccessful = true;
             logger.info('Activation email sent');

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const express = require('express');
 const Sentry = require('@sentry/node');
+const moment = require('moment');
 
 const { Users } = require('../../db/models');
 const {
@@ -66,7 +67,19 @@ router
     })
     .post(async function(req, res, next) {
         try {
-            await sendActivationEmail(req, req.user.userData);
+            const dateOfActivationAttempt = moment().unix();
+
+            await sendActivationEmail(
+                req,
+                req.user.userData,
+                dateOfActivationAttempt
+            );
+
+            await Users.updateDateOfActivationAttempt({
+                id: req.user.userData.id,
+                dateOfActivationAttempt: dateOfActivationAttempt
+            });
+
             res.locals.resendSuccessful = true;
             logger.info('Activation email sent');
             renderTemplate(req, res);

--- a/controllers/user/lib/activation-email.js
+++ b/controllers/user/lib/activation-email.js
@@ -1,16 +1,18 @@
 'use strict';
 const path = require('path');
+const moment = require('moment');
 
 const { sendHtmlEmail } = require('../../../common/mail');
 const { getAbsoluteUrl } = require('../../../common/urls');
+const { Users } = require('../../../db/models');
 
 const { signTokenActivate } = require('./jwt');
 
 module.exports = async function sendActivationEmail(
     req,
-    user,
-    dateOfActivationAttempt = null
+    user
 ) {
+    const dateOfActivationAttempt = moment().unix();
     const token = signTokenActivate(user.id, dateOfActivationAttempt);
 
     const mailParams = {
@@ -36,6 +38,11 @@ module.exports = async function sendActivationEmail(
         },
         mailParams
     );
+
+    await Users.updateDateOfActivationAttempt({
+        id: user.id,
+        dateOfActivationAttempt: dateOfActivationAttempt
+    });
 
     return {
         email: email,

--- a/controllers/user/lib/activation-email.js
+++ b/controllers/user/lib/activation-email.js
@@ -9,9 +9,9 @@ const { signTokenActivate } = require('./jwt');
 module.exports = async function sendActivationEmail(
     req,
     user,
-    isExisting = false
+    dateOfActivationAttempt = null
 ) {
-    const token = signTokenActivate(user.id);
+    const token = signTokenActivate(user.id, dateOfActivationAttempt);
 
     const mailParams = {
         name: 'user_activate_account',
@@ -31,8 +31,7 @@ module.exports = async function sendActivationEmail(
                     req,
                     `/user/activate?token=${token}`
                 ),
-                email: user.username,
-                isExisting: isExisting
+                email: user.username
             }
         },
         mailParams

--- a/controllers/user/lib/jwt.js
+++ b/controllers/user/lib/jwt.js
@@ -1,32 +1,58 @@
 'use strict';
 const jwt = require('jsonwebtoken');
+const moment = require('moment');
 
 const { JWT_SIGNING_TOKEN } = require('../../../common/secrets');
+const { Users } = require('../../../db/models');
 
-function signTokenActivate(userId) {
-    const payload = { data: { userId: userId, reason: 'activate' } };
+function signTokenActivate(userId, dateOfActivationAttempt) {
+    const payload = {
+        data: {
+            userId: userId,
+            reason: 'activate',
+            dateOfActivationAttempt: dateOfActivationAttempt
+        }
+    };
 
     return jwt.sign(payload, JWT_SIGNING_TOKEN, {
-        expiresIn: '7d' // allow a week to activate
+        expiresIn: '1h' // Short-lived token
     });
 }
 
 function verifyTokenActivate(token, userId) {
-    return new Promise((resolve, reject) => {
-        jwt.verify(token, JWT_SIGNING_TOKEN, (err, decoded) => {
-            if (err) {
-                reject(err);
+    return new Promise(async (resolve, reject) => {
+        // We have to use try/catch here because jwt.verify() doesn't support async callbacks
+        // @see https://stackoverflow.com/a/54419385
+        try {
+            const decoded = jwt.verify(token, JWT_SIGNING_TOKEN);
+            const user = await Users.findByUserId(userId);
+
+            const mostRecentActivationTokenSent = moment.unix(
+                user.date_activation_sent
+            );
+
+            const dateThisTokenWasSent = moment.unix(
+                decoded.data.dateOfActivationAttempt
+            );
+
+            // Ensure that the token's stored date matches the one in the database
+            // (eg. it's the most recently-generated link)
+            const isNewestLink = mostRecentActivationTokenSent.isSame(
+                dateThisTokenWasSent
+            );
+
+            if (
+                decoded.data.reason === 'activate' &&
+                decoded.data.userId === userId &&
+                isNewestLink
+            ) {
+                resolve(decoded.data);
             } else {
-                if (
-                    decoded.data.reason === 'activate' &&
-                    decoded.data.userId === userId
-                ) {
-                    resolve(decoded.data);
-                } else {
-                    reject(new Error('Invalid token reason'));
-                }
+                reject(new Error('Invalid token reason'));
             }
-        });
+        } catch (err) {
+            reject(err);
+        }
     });
 }
 

--- a/controllers/user/lib/jwt.js
+++ b/controllers/user/lib/jwt.js
@@ -1,6 +1,5 @@
 'use strict';
 const jwt = require('jsonwebtoken');
-const moment = require('moment');
 
 const { JWT_SIGNING_TOKEN } = require('../../../common/secrets');
 const { Users } = require('../../../db/models');
@@ -27,19 +26,11 @@ function verifyTokenActivate(token, userId) {
             const decoded = jwt.verify(token, JWT_SIGNING_TOKEN);
             const user = await Users.findByUserId(userId);
 
-            const mostRecentActivationTokenSent = moment.unix(
-                user.date_activation_sent
-            );
-
-            const dateThisTokenWasSent = moment.unix(
-                decoded.data.dateOfActivationAttempt
-            );
-
             // Ensure that the token's stored date matches the one in the database
             // (eg. it's the most recently-generated link)
-            const isNewestLink = mostRecentActivationTokenSent.isSame(
-                dateThisTokenWasSent
-            );
+            const isNewestLink =
+                user.date_activation_sent ===
+                decoded.data.dateOfActivationAttempt;
 
             if (
                 decoded.data.reason === 'activate' &&

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -77,7 +77,7 @@ router
                         newEmail: username
                     });
                     const updatedUser = await Users.findById(userId);
-                    await sendActivationEmail(req, updatedUser, true);
+                    await sendActivationEmail(req, updatedUser);
                     logger.info('Update email change successful');
                     redirectForLocale(req, res, '/user?s=emailUpdated');
                 }

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -18,6 +18,10 @@ class User extends Model {
                 allowNull: false,
                 defaultValue: false
             },
+            date_activation_sent: {
+                type: DataTypes.INTEGER,
+                allowNull: true
+            },
             is_password_reset: {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,
@@ -43,6 +47,12 @@ class User extends Model {
     static findByUsername(username) {
         return this.findOne({
             where: { username: { [Op.eq]: username } }
+        });
+    }
+
+    static findByUserId(userId) {
+        return this.findOne({
+            where: { id: { [Op.eq]: userId } }
         });
     }
 
@@ -75,6 +85,13 @@ class User extends Model {
         );
     }
 
+    static updateDateOfActivationAttempt({ id, dateOfActivationAttempt }) {
+        return this.update(
+            { date_activation_sent: dateOfActivationAttempt },
+            { where: { id: { [Op.eq]: id } } }
+        );
+    }
+
     static findWithActivePasswordReset(id) {
         return this.findOne({
             where: {
@@ -93,7 +110,7 @@ class User extends Model {
 
     static activateUser(id) {
         return this.update(
-            { is_active: true },
+            { is_active: true, date_activation_sent: null },
             { where: { id: { [Op.eq]: id } } }
         );
     }


### PR DESCRIPTION
Changes the user model to store a unix timestamp of the date of the most recent activation request. This number is stored in the JSON Web Token too. When a user activates their account, we check that the number in the JWT matches the one in the database. If it doesn't, we reject the activation (eg. because it's an older link).

This will require dropping/recreating the `users` table on production but I think we can get around this (or just manually adding the column) quite easily as nobody's using it yet.