### PR TITLE
Prevent a budget from being submitted with over-maximum rows

### DIFF
--- a/assets/js/vue-apps/form-components/budget-input.vue
+++ b/assets/js/vue-apps/form-components/budget-input.vue
@@ -19,8 +19,12 @@ export default {
         }
     },
     data() {
+        // Add a ready-to-use new row if the budget isn't over the limit already
+        const budgetRowsArr = (this.budgetData.length < this.maxItems)
+            ? concat(this.budgetData, [{ item: '', cost: '' }])
+            : this.budgetData;
         return {
-            budgetRows: concat(this.budgetData, [{ item: '', cost: '' }]),
+            budgetRows: budgetRowsArr,
             error: {}
         };
     },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1189,13 +1189,15 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             },
             isRequired: true,
             get schema() {
-                return Joi.budgetItems()
-                    .maxRows(this.attributes.rowLimit)
-                    .validBudgetRange(
-                        MIN_BUDGET_TOTAL_GBP,
-                        MAX_BUDGET_TOTAL_GBP
-                    )
-                    .required();
+                return (
+                    Joi.budgetItems()
+                        .max(this.attributes.rowLimit)
+                        .validBudgetRange(
+                            MIN_BUDGET_TOTAL_GBP,
+                            MAX_BUDGET_TOTAL_GBP
+                        )
+                        .required()
+                );
             },
             get messages() {
                 return [

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1188,42 +1188,67 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 rowLimit: 10
             },
             isRequired: true,
-            schema: Joi.budgetItems()
-                .validBudgetRange(MIN_BUDGET_TOTAL_GBP, MAX_BUDGET_TOTAL_GBP)
-                .required(),
-            messages: [
-                {
-                    type: 'base',
-                    message: localise({ en: 'Enter a project budget', cy: '' })
-                },
-                {
-                    type: 'any.empty',
-                    key: 'item',
-                    message: localise({
-                        en: 'Enter an item or activity',
-                        cy: ''
-                    })
-                },
-                {
-                    type: 'number.base',
-                    key: 'cost',
-                    message: localise({ en: 'Enter an amount', cy: '' })
-                },
-                {
-                    type: 'budgetItems.overBudget',
-                    message: localise({
-                        en: `Costs you would like us to fund must be less than £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}`,
-                        cy: ``
-                    })
-                },
-                {
-                    type: 'budgetItems.underBudget',
-                    message: localise({
-                        en: `Costs you would like us to fund must be greater than £${MIN_BUDGET_TOTAL_GBP.toLocaleString()}`,
-                        cy: ``
-                    })
-                }
-            ]
+            get schema() {
+                return Joi.budgetItems()
+                    .maxRows(this.attributes.rowLimit)
+                    .validBudgetRange(
+                        MIN_BUDGET_TOTAL_GBP,
+                        MAX_BUDGET_TOTAL_GBP
+                    )
+                    .required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: 'Enter a project budget',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'any.empty',
+                        key: 'item',
+                        message: localise({
+                            en: 'Enter an item or activity',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'number.base',
+                        key: 'cost',
+                        message: localise({ en: 'Enter an amount', cy: '' })
+                    },
+                    {
+                        type: 'array.min',
+                        message: localise({
+                            en: 'Enter at least one item',
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'array.max',
+                        message: localise({
+                            en: `Enter no more than ${this.attributes.rowLimit} items`,
+                            cy: ''
+                        })
+                    },
+                    {
+                        type: 'budgetItems.overBudget',
+                        message: localise({
+                            en: `Costs you would like us to fund must be less than £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}`,
+                            cy: ``
+                        })
+                    },
+                    {
+                        type: 'budgetItems.underBudget',
+                        message: localise({
+                            en: `Costs you would like us to fund must be greater than £${MIN_BUDGET_TOTAL_GBP.toLocaleString()}`,
+                            cy: ``
+                        })
+                    }
+                ];
+            }
         },
         projectTotalCosts: {
             name: 'projectTotalCosts',

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -275,7 +275,8 @@ describe('Form validations', () => {
             assertValidByKey(value(mockBudget()));
 
             const defaultMessages = ['Enter a project budget'];
-            assertMessagesByKey(value([]), defaultMessages);
+            const tooSmallMessage = ['Enter at least one item'];
+            assertMessagesByKey(value([]), tooSmallMessage);
 
             const budgetWithoutCosts = times(5, () => ({
                 item: faker.lorem.words(5)

--- a/controllers/apply/form-router-next/joi-extensions/budget-items.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-items.js
@@ -38,24 +38,6 @@ module.exports = function budgetItems(joi) {
         },
         rules: [
             {
-                name: 'maxRows',
-                params: {
-                    rowLimit: joi.number().required()
-                },
-                validate(params, value, state, options) {
-                    if (value && value.length > params.rowLimit) {
-                        return this.createError(
-                            'array.max',
-                            { v: value, number: params.maxBudget },
-                            state,
-                            options
-                        );
-                    } else {
-                        return value;
-                    }
-                }
-            },
-            {
                 name: 'validBudgetRange',
                 params: {
                     minBudget: joi.number().required(),

--- a/controllers/apply/form-router-next/joi-extensions/budget-items.js
+++ b/controllers/apply/form-router-next/joi-extensions/budget-items.js
@@ -38,6 +38,24 @@ module.exports = function budgetItems(joi) {
         },
         rules: [
             {
+                name: 'maxRows',
+                params: {
+                    rowLimit: joi.number().required()
+                },
+                validate(params, value, state, options) {
+                    if (value && value.length > params.rowLimit) {
+                        return this.createError(
+                            'array.max',
+                            { v: value, number: params.maxBudget },
+                            state,
+                            options
+                        );
+                    } else {
+                        return value;
+                    }
+                }
+            },
+            {
                 name: 'validBudgetRange',
                 params: {
                     minBudget: joi.number().required(),


### PR DESCRIPTION
We didn't check server-side for maximum budget items (weirdly, as I'm sure this was there at one stage) – we also check whether we should add a new blank row when initialising the component in case there were already 10 rows.