### PR TITLE
Launch prep

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -47,7 +47,7 @@
     "enableMailSendMetrics": false,
     "enableNameChangeMessage": true,
     "enableRelatedGrants": false,
-    "enableSalesforceConnector": false,
+    "enableSalesforceConnector": true,
     "enableSeeders": false,
     "enableSiteSurvey": true
   },

--- a/config/test.json
+++ b/config/test.json
@@ -9,8 +9,7 @@
     "enableAwardsForAllApplications": true,
     "enableDigitalFundApplications": false,
     "enableHotjar": true,
-    "enableMailSendMetrics": true,
-    "enableSalesforceConnector": true
+    "enableMailSendMetrics": true
   },
   "awardsForAllApplications": {
     "allowedCountries": ["england", "scotland"]

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const Sequelize = require('sequelize');
 
-const appData = require('../../common/appData');
 const logger = require('../../common/logger').child({ service: 'db' });
 
 const env = process.env.NODE_ENV || 'development';
@@ -33,16 +32,13 @@ sequelize
 const db = {
     Users: Users.init(sequelize, Sequelize),
     Staff: Staff.init(sequelize, Sequelize),
+    PendingApplication: PendingApplication.init(sequelize, Sequelize),
+    SubmittedApplication: SubmittedApplication.init(sequelize, Sequelize),
     Feedback: Feedback.init(sequelize, Sequelize),
     SurveyAnswer: SurveyAnswer.init(sequelize, Sequelize),
     Order: Order.init(sequelize, Sequelize),
     OrderItem: OrderItem.init(sequelize, Sequelize)
 };
-
-if (appData.isNotProduction) {
-    db.PendingApplication = PendingApplication.init(sequelize, Sequelize);
-    db.SubmittedApplication = SubmittedApplication.init(sequelize, Sequelize);
-}
 
 Object.keys(db).forEach(modelName => {
     if ('associate' in db[modelName]) {


### PR DESCRIPTION
- Create applications tables in production ahead of time (remove `appData.isNotProduction` check)
-  Enable salesforce connector by default to allow test submissions to production (this only becomes active if `enableAwardsForAllApplications` is also triggered)