### PR TITLE
Simplify the address lookup 

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -1,111 +1,107 @@
 <script>
-import $ from 'jquery';
-import compact from 'lodash/compact';
+    import $ from 'jquery';
+    import compact from 'lodash/compact';
 
-import AddressLine from './address-line.vue';
-import { trackEvent } from '../../helpers/metrics';
+    import AddressLine from './address-line.vue';
+    import { trackEvent } from '../../helpers/metrics';
 
-const states = {
-    NotAsked: 'NotAsked',
-    NotRequired: 'NotRequired',
-    AlreadyAnswered: 'AlreadyAnswered',
-    Editing: 'Editing',
-    Asking: 'Asking',
-    Loading: 'Loading',
-    Failure: 'Failure',
-    Success: 'Success'
-};
+    const states = {
+        NotAsked: 'NotAsked',
+        NotRequired: 'NotRequired',
+        AlreadyAnswered: 'AlreadyAnswered',
+        Editing: 'Editing',
+        Asking: 'Asking',
+        Loading: 'Loading',
+        Failure: 'Failure',
+        Success: 'Success'
+    };
 
-export default {
-    components: { AddressLine },
-    props: {
-        locale: { type: String, default: 'en' },
-        address: { type: String, default: null },
-        fieldName: { type: String, default: null },
-        label: { type: String, default: null },
-        explanation: { type: String, default: null }
-    },
-    data() {
-        return {
-            showFallbackFields: false,
-            currentAddress: null,
-            postcode: null,
-            currentState: states.NotAsked,
-            states: states,
-            fullAddress: {
-                line1: null,
-                line2: null,
-                townCity: null,
-                county: null,
-                postcode: null
-            },
-            fullAddressPreview: '',
-            addressData: [],
-            candidates: [],
-            selectedAddressId: '',
-            fallbackVisible: null
-        };
-    },
-    mounted() {
-        this.$root.$on('update:conditionalRadio', value => {
-            if (value === 'yes') {
-                this.currentState = states.NotRequired;
-            } else if (this.fullAddress.postcode !== null || this.fullAddressPreview !== '') {
-                this.currentState = this.states.AlreadyAnswered;
-            } else {
-                this.currentState = states.NotAsked;
-            }
-        });
-
-        if (this.address) {
-            try {
-                const addressParts = JSON.parse(this.address);
-                // Ensure a blank address doesn't trigger AlreadyAsked state
-                if (addressParts && addressParts.postcode) {
-                    this.currentAddress = addressParts;
-                    const fullAddress = {
-                        line1: this.currentAddress.line1,
-                        line2: this.currentAddress.line2,
-                        townCity: this.currentAddress.townCity,
-                        county: this.currentAddress.county,
-                        postcode: this.currentAddress.postcode
-                    };
-                    this.updateAddressPreview(fullAddress);
-                }
-            } catch (e) {} // eslint-disable-line no-empty
-        }
-
-        const $form = $(this.$el)
-            .parents('form')
-            .find('input[type="submit"]');
-        const that = this;
-        $form.on('click', function() {
-            if (
-                that.candidates.length === 0 &&
-                !that.showFallbackFields &&
-                that.postcode
-            ) {
-                // @TODO i18n
-                alert(
-                    `Please click "Find address" and choose an address from the list.`
-                );
-                trackEvent(
-                    'Form warning',
-                    'Postcode lookup',
-                    'Typed but not submitted'
-                );
-                document.querySelector('.address-lookup').scrollIntoView();
-                // Prevent form submission (for nested)
-                return false;
-            }
-        });
-    },
-    methods: {
-        getAddressFromId(udprn) {
-            return this.addressData.find(_ => _.udprn === udprn);
+    export default {
+        components: { AddressLine },
+        props: {
+            locale: { type: String, default: 'en' },
+            address: { type: String, default: null },
+            fieldName: { type: String, default: null },
+            label: { type: String, default: null },
+            explanation: { type: String, default: null }
         },
-        formatAddress(address) {
-            if (address) {
+        data() {
+            return {
+                currentAddress: null,
+                postcode: null,
+                currentState: states.NotAsked,
+                states: states,
+                fullAddress: {
+                    line1: null,
+                    line2: null,
+                    townCity: null,
+                    county: null,
+                    postcode: null
+                },
+                addressData: [],
+                candidates: [],
+                selectedAddressId: ''
+            };
+        },
+        mounted() {
+            this.$root.$on('update:conditionalRadio', value => {
+                if (value === 'yes') {
+                    this.currentState = states.NotRequired;
+                } else if (this.fullAddress.postcode !== null) {
+                    this.currentState = this.states.AlreadyAnswered;
+                } else {
+                    this.currentState = states.NotAsked;
+                }
+            });
+
+            if (this.address) {
+                try {
+                    const addressParts = JSON.parse(this.address);
+                    // Ensure a blank address doesn't trigger AlreadyAsked state
+                    if (addressParts && addressParts.postcode) {
+                        this.currentAddress = addressParts;
+                        const fullAddress = {
+                            line1: this.currentAddress.line1,
+                            line2: this.currentAddress.line2,
+                            townCity: this.currentAddress.townCity,
+                            county: this.currentAddress.county,
+                            postcode: this.currentAddress.postcode
+                        };
+                        this.currentState = this.states.AlreadyAnswered;
+                        this.fullAddress = fullAddress;
+                    }
+                } catch (e) {} // eslint-disable-line no-empty
+            }
+
+            const $form = $(this.$el)
+                .parents('form')
+                .find('input[type="submit"]');
+            const that = this;
+            $form.on('click', function() {
+                if (
+                    that.candidates.length === 0 &&
+                    that.postcode
+                ) {
+                    // @TODO i18n
+                    alert(
+                        `Please click "Find address" and choose an address from the list.`
+                    );
+                    trackEvent(
+                        'Form warning',
+                        'Postcode lookup',
+                        'Typed but not submitted'
+                    );
+                    document.querySelector('.address-lookup').scrollIntoView();
+                    // Prevent form submission (for nested)
+                    return false;
+                }
+            });
+        },
+        methods: {
+            getAddressFromId(udprn) {
+                return this.addressData.find(_ => _.udprn === udprn);
+            },
+            formatAddress(address) {
                 return {
                     line1: address.line_1,
                     line2: address.line_2,
@@ -113,159 +109,120 @@ export default {
                     county: address.county,
                     postcode: address.postcode
                 };
-            }
-        },
-        handleFailure() {
-            // Handle case of no results for search
-            this.currentState = this.states.Failure;
-            this.handleFallback();
-        },
-        handleLookup() {
-            if (!this.formIsValid) {
-                return;
-            }
-            this.currentState = this.states.Loading;
+            },
+            handleFailure() {
+                // Handle case of no results for search
+                this.currentState = this.states.Failure;
+                this.clearState();
+            },
+            handleLookup() {
+                if (!this.formIsValid) {
+                    return;
+                }
+                this.currentState = this.states.Loading;
 
-            this.clearAddress();
-            this.candidates = [];
-            this.addressData = [];
-            this.selectedAddressId = null;
+                this.clearAddress();
+                this.candidates = [];
+                this.addressData = [];
+                this.selectedAddressId = null;
 
-            const token = document.querySelector('input[name="_csrf"]').value;
-            $.ajax({
-                type: 'post',
-                url: '/api/address-lookup',
-                dataType: 'json',
-                headers: {
-                    'CSRF-Token': token
-                },
-                data: { q: this.postcode }
-            })
-                .then(response => {
-                    if (response.addresses.length > 0) {
-                        this.currentState = this.states.Success;
-                        this.addressData = response.addresses;
-                        this.candidates = this.addressData.map(result => {
-                            const label = compact([
-                                result['line_1'],
-                                result['line_2'],
-                                result['post_town'],
-                                result['county']
-                            ]).join(', ');
-                            return { value: result.udprn, label: label };
-                        });
-                    } else {
-                        this.handleFailure();
-                    }
+                const token = document.querySelector('input[name="_csrf"]').value;
+                $.ajax({
+                    type: 'post',
+                    url: '/api/address-lookup',
+                    dataType: 'json',
+                    headers: {
+                        'CSRF-Token': token
+                    },
+                    data: { q: this.postcode }
                 })
-                .fail(() => {
-                    this.handleFailure();
-                });
-        },
-        clearState() {
-            this.postcode = null;
-            this.candidates = [];
-            this.addressData = [];
-            this.clearAddress();
-            this.showFallbackFields = false;
-        },
-        clearAddress() {
-            this.fullAddress = {
-                line1: null,
-                line2: null,
-                townCity: null,
-                county: null,
-                postcode: null
-            };
-        },
-        removeAddress() {
-            this.currentState = this.states.Asking;
-            this.clearState();
-            this.showFallbackFields = false;
-        },
-        handleFallback() {
-            this.clearState();
-            this.showFallbackFields = true;
-        },
-        startEditing() {
-            this.currentState = this.states.Editing;
-            this.showFallbackFields = true;
-        },
-        finishEditing() {
-            this.currentState = this.states.AlreadyAnswered;
-            this.showFallbackFields = false;
-        },
-        updateAddressPreview(fullAddress) {
-            if (fullAddress) {
-                this.showFallbackFields = false;
-                this.currentState = this.states.AlreadyAnswered;
-                this.fullAddress = fullAddress;
-            }
-        },
-        setSelectedAddress() {
-            if (this.selectedAddressId) {
-                this.currentState = this.states.Success;
-                const address = this.getAddressFromId(this.selectedAddressId);
-                if (address) {
-                    this.updateAddressPreview(this.formatAddress(address));
+                    .then(response => {
+                        if (response.addresses.length > 0) {
+                            this.currentState = this.states.Success;
+                            this.addressData = response.addresses;
+                            this.candidates = this.addressData.map(result => {
+                                const label = compact([
+                                    result['line_1'],
+                                    result['line_2'],
+                                    result['post_town'],
+                                    result['county']
+                                ]).join(', ');
+                                return { value: result.udprn, label: label };
+                            });
+                        } else {
+                            this.handleFailure();
+                        }
+                    })
+                    .fail(() => {
+                        this.handleFailure();
+                    });
+            },
+            clearState() {
+                this.postcode = null;
+                this.candidates = [];
+                this.addressData = [];
+                this.clearAddress();
+            },
+            clearAddress() {
+                this.fullAddress = {
+                    line1: null,
+                    line2: null,
+                    townCity: null,
+                    county: null,
+                    postcode: null
+                };
+            },
+            removeAddress() {
+                this.currentState = this.states.Asking;
+                this.clearState();
+            },
+            setSelectedAddress() {
+                if (this.selectedAddressId) {
+                    const address = this.getAddressFromId(this.selectedAddressId);
+                    if (address) {
+                        this.currentState = this.states.AlreadyAnswered;
+                        this.fullAddress = this.formatAddress(address);
+                    }
                 }
             }
-        }
-    },
-    watch: {
-        fullAddress: {
-            handler() {
-                this.fullAddressPreview = this.fullAddress
-                    ? compact([
-                          this.fullAddress.line1,
-                          this.fullAddress.line2,
-                          this.fullAddress.townCity,
-                          this.fullAddress.postcode
-                      ]).join('<br />')
-                    : '';
+        },
+        computed: {
+            shouldShowPostcodeLookup() {
+                return (
+                    this.currentState === this.states.Asking ||
+                    this.currentState === this.states.NotAsked ||
+                    this.currentState === this.states.Success ||
+                    this.currentState === this.states.Loading
+                );
             },
-            deep: true
-        }
-    },
-    computed: {
-        fieldsAreRequired() {
-            return !this.showFallbackFields && this.shouldShowPostcodeLookup;
-        },
-        shouldShowPostcodeLookup() {
-            return (
-                this.currentState === this.states.Asking ||
-                this.currentState === this.states.NotAsked ||
-                this.currentState === this.states.Success ||
-                this.currentState === this.states.Loading
-            );
-        },
-        formIsValid() {
-            const VALIDATION_REGEX = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i;
-            return (
-                this.postcode &&
-                this.postcode.trim().match(VALIDATION_REGEX) !== null
-            );
-        },
-        lookupLabel() {
-            if (this.currentState === this.states.Loading) {
-                return 'Looking up address…';
-            } else {
-                return 'Find address';
+            formIsValid() {
+                const VALIDATION_REGEX = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i;
+                return (
+                    this.postcode &&
+                    this.postcode.trim().match(VALIDATION_REGEX) !== null
+                );
+            },
+            lookupLabel() {
+                if (this.currentState === this.states.Loading) {
+                    return 'Looking up address…';
+                } else {
+                    return 'Find address';
+                }
+            },
+            id() {
+                return Math.random()
+                    .toString(36)
+                    .substr(2, 9);
+            },
+            ariaId() {
+                return `postcode-lookup-${this.id}`;
             }
-        },
-        id() {
-            return Math.random()
-                .toString(36)
-                .substr(2, 9);
-        },
-        ariaId() {
-            return `postcode-lookup-${this.id}`;
         }
-    }
-};
+    };
 </script>
 
 <template>
+
     <div v-if="currentState !== states.NotRequired">
         <legend class="ff-label ff-address__legend" v-html="label"></legend>
 
@@ -277,9 +234,7 @@ export default {
 
         <!-- @TODO i18n -->
         <div v-if="shouldShowPostcodeLookup" class="address-lookup">
-            <label :for="ariaId" class="ff-label"
-                >Find address by postcode</label
-            >
+            <label :for="ariaId" class="ff-label">Find address by postcode</label>
             <div class="ff-help s-prose"><p>eg. EC4A 1DE</p></div>
             <div class="address-lookup__field">
                 <input
@@ -291,7 +246,7 @@ export default {
                     class="ff-text"
                     v-model="postcode"
                     autocomplete="off"
-                    :required="fieldsAreRequired"
+                    :required="shouldShowPostcodeLookup"
                 />
                 <button
                     type="button"
@@ -318,7 +273,7 @@ export default {
                     name="address-selection"
                     id="address-selection"
                     :disabled="currentState === states.Loading"
-                    :required="fieldsAreRequired"
+                    :required="shouldShowPostcodeLookup"
                     @blur="setSelectedAddress"
                 >
                     <option disabled value="">
@@ -339,96 +294,59 @@ export default {
             There was an error finding your address - please provide it below.
         </p>
 
-        <div
-            v-if="currentState === states.AlreadyAnswered"
-            class="existing-data"
-            data-hj-suppress
-        >
-            <h3 class="existing-data__title">Selected address</h3>
-            <address
-                class="existing-data__address"
-                v-html="fullAddressPreview"
-            ></address>
-            <div class="existing-data__actions">
-                <button type="button" class="btn-link" @click="startEditing">
-                    Edit
-                </button>
-                <button
-                    type="button"
-                    class="btn-link u-margin-left-s"
-                    @click="removeAddress"
-                >
-                    Remove
-                </button>
-            </div>
+        <div class="existing-data"
+             v-if="currentState === states.AlreadyAnswered || currentState === states.Failure">
+            <AddressLine
+                :name="fieldName + '[line1]'"
+                label="Building and street"
+                :is-required="true"
+                v-model="fullAddress.line1"
+            >
+            </AddressLine>
+
+            <AddressLine
+                :name="fieldName + '[line2]'"
+                label="Address line 2"
+                is-required="false"
+                v-model="fullAddress.line2"
+            >
+            </AddressLine>
+
+            <AddressLine
+                :name="fieldName + '[townCity]'"
+                label="Town or city"
+                :is-required="true"
+                v-model="fullAddress.townCity"
+                size="30"
+            >
+            </AddressLine>
+
+            <AddressLine
+                :name="fieldName + '[county]'"
+                label="County"
+                is-required="false"
+                v-model="fullAddress.county"
+                size="30"
+            >
+            </AddressLine>
+
+            <AddressLine
+                :name="fieldName + '[postcode]'"
+                label="Postcode"
+                :is-required="true"
+                v-model="fullAddress.postcode"
+                size="10"
+            >
+            </AddressLine>
+
+            <button
+                type="button"
+                class="btn-link u-margin-top-s"
+                @click="removeAddress"
+            >
+                Remove this address
+            </button>
         </div>
 
-        <!-- fallback fields -->
-        <details
-            class="o-details u-margin-top"
-            :open="showFallbackFields"
-            v-if="currentState !== states.NotRequired"
-        >
-            <summary
-                class="js-only o-details__summary"
-                @click.prevent="showFallbackFields = !showFallbackFields"
-                data-testid="manual-address"
-            >
-                Enter address manually
-            </summary>
-
-            <div class="existing-data">
-                <AddressLine
-                    :name="fieldName + '[line1]'"
-                    label="Building and street"
-                    :is-required="true"
-                    v-model="fullAddress.line1"
-                >
-                </AddressLine>
-
-                <AddressLine
-                    :name="fieldName + '[line2]'"
-                    label="Address line 2"
-                    is-required="false"
-                    v-model="fullAddress.line2"
-                >
-                </AddressLine>
-
-                <AddressLine
-                    :name="fieldName + '[townCity]'"
-                    label="Town or city"
-                    :is-required="true"
-                    v-model="fullAddress.townCity"
-                    size="30"
-                >
-                </AddressLine>
-
-                <AddressLine
-                    :name="fieldName + '[county]'"
-                    label="County"
-                    is-required="false"
-                    v-model="fullAddress.county"
-                    size="30"
-                >
-                </AddressLine>
-
-                <AddressLine
-                    :name="fieldName + '[postcode]'"
-                    label="Postcode"
-                    :is-required="true"
-                    v-model="fullAddress.postcode"
-                    size="10"
-                >
-                </AddressLine>
-
-                <button
-                    type="button"
-                    class="btn-link u-margin-top-s"
-                    @click="finishEditing"
-                >
-                    I'm done editing
-                </button>
-            </div>
-        </details>
     </div>
 </template>

--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -219,7 +219,7 @@
                     this.currentState === states.AlreadyAnswered ||
                     this.currentState === states.Failure ||
                     this.currentState === states.EnteringManually
-                )
+                );
             },
             formIsValid() {
                 const VALIDATION_REGEX = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i;
@@ -248,7 +248,6 @@
 </script>
 
 <template>
-
     <div v-if="currentState !== states.NotRequired">
         <legend class="ff-label ff-address__legend" v-html="label"></legend>
 
@@ -284,7 +283,6 @@
                 >
                     {{ lookupLabel }}
                 </button>
-
             </div>
 
             <button
@@ -381,6 +379,5 @@
                 Remove this address
             </button>
         </div>
-
     </div>
 </template>

--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -13,7 +13,8 @@
         Asking: 'Asking',
         Loading: 'Loading',
         Failure: 'Failure',
-        Success: 'Success'
+        Success: 'Success',
+        EnteringManually: 'EnteringManually'
     };
 
     export default {
@@ -184,6 +185,9 @@
                         this.fullAddress = this.formatAddress(address);
                     }
                 }
+            },
+            enterManually() {
+                this.currentState = this.states.EnteringManually;
             }
         },
         computed: {
@@ -194,6 +198,13 @@
                     this.currentState === this.states.Success ||
                     this.currentState === this.states.Loading
                 );
+            },
+            shouldShowInputFields() {
+                return (
+                    this.currentState === states.AlreadyAnswered ||
+                    this.currentState === states.Failure ||
+                    this.currentState === states.EnteringManually
+                )
             },
             formIsValid() {
                 const VALIDATION_REGEX = /^[a-z]{1,2}\d[a-z\d]?\s*\d[a-z]{2}$/i;
@@ -258,7 +269,16 @@
                 >
                     {{ lookupLabel }}
                 </button>
+
             </div>
+
+            <button
+                type="button"
+                class="btn-link u-margin-top-s"
+                @click="enterManually"
+            >
+                Enter address manually
+            </button>
 
             <div
                 class="address-lookup__candidates"
@@ -294,8 +314,7 @@
             There was an error finding your address - please provide it below.
         </p>
 
-        <div class="existing-data"
-             v-if="currentState === states.AlreadyAnswered || currentState === states.Failure">
+        <div class="existing-data" v-if="shouldShowInputFields">
             <AddressLine
                 :name="fieldName + '[line1]'"
                 label="Building and street"

--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -114,6 +114,11 @@
             handleFailure() {
                 // Handle case of no results for search
                 this.currentState = this.states.Failure;
+                trackEvent(
+                    'Form warning',
+                    'Postcode lookup',
+                    'Error looking up address'
+                );
                 this.clearState();
             },
             handleLookup() {
@@ -174,6 +179,11 @@
                 };
             },
             removeAddress() {
+                trackEvent(
+                    'Form warning',
+                    'Postcode lookup',
+                    'Address removed'
+                );
                 this.currentState = this.states.Asking;
                 this.clearState();
             },
@@ -187,6 +197,11 @@
                 }
             },
             enterManually() {
+                trackEvent(
+                    'Form warning',
+                    'Postcode lookup',
+                    'Enter Manually clicked'
+                );
                 this.currentState = this.states.EnteringManually;
             }
         },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -157,7 +157,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                         {
                             is: 'no',
                             then: Joi.ukAddress().required(),
-                            otherwise: Joi.any()
+                            otherwise: Joi.any().strip()
                         }
                     )
                 });
@@ -1189,15 +1189,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             },
             isRequired: true,
             get schema() {
-                return (
-                    Joi.budgetItems()
-                        .max(this.attributes.rowLimit)
-                        .validBudgetRange(
-                            MIN_BUDGET_TOTAL_GBP,
-                            MAX_BUDGET_TOTAL_GBP
-                        )
-                        .required()
-                );
+                return Joi.budgetItems()
+                    .max(this.attributes.rowLimit)
+                    .validBudgetRange(
+                        MIN_BUDGET_TOTAL_GBP,
+                        MAX_BUDGET_TOTAL_GBP
+                    )
+                    .required();
             },
             get messages() {
                 return [

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -24,7 +24,9 @@ describe('awards for all', function() {
         }
 
         function fillAddress({ streetAddress, city, county, postcode }) {
-            cy.getByText('Enter address manually').click();
+            const invalidPostcode = 'G61 7BY';
+            cy.getByLabelText('Find address by postcode').type(invalidPostcode);
+            cy.getByText('Find address').click();
 
             cy.getByLabelText('Building and street').type(streetAddress);
 
@@ -35,8 +37,6 @@ describe('awards for all', function() {
             }
 
             cy.getByLabelText('Postcode').type(postcode);
-
-            cy.getByText(`I'm done editing`).click();
         }
 
         function stepProjectDetails() {

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -24,9 +24,7 @@ describe('awards for all', function() {
         }
 
         function fillAddress({ streetAddress, city, county, postcode }) {
-            const invalidPostcode = 'G61 7BY';
-            cy.getByLabelText('Find address by postcode').type(invalidPostcode);
-            cy.getByText('Find address').click();
+            cy.getByText('Enter address manually').click();
 
             cy.getByLabelText('Building and street').type(streetAddress);
 


### PR DESCRIPTION
This change removes the address preview step, eg. this screen:

![image](https://user-images.githubusercontent.com/394376/61728306-de59a180-ad6c-11e9-9a4d-592ded6ef578.png)

The advantage of this is that it removes a bunch of confusing state edge cases, particularly around required fields. The new behaviour is:

- user looks up a postcode
- if found, the dropdown of addresses is populated
- when one is selected (and the field blurred), the form inputs appear, pre-populated
- the user can edit them manually or remove the whole lot and start again
- if the lookup fails, the form inputs appear for manual provision

Here's a demo:

![postcode-new](https://user-images.githubusercontent.com/394376/61728165-963a7f00-ad6c-11e9-95a4-3bd61a8343ce.gif)
