### PR TITLE
Fix bug with beneficiariesGroupsOther

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1189,15 +1189,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             },
             isRequired: true,
             get schema() {
-                return (
-                    Joi.budgetItems()
-                        .max(this.attributes.rowLimit)
-                        .validBudgetRange(
-                            MIN_BUDGET_TOTAL_GBP,
-                            MAX_BUDGET_TOTAL_GBP
-                        )
-                        .required()
-                );
+                return Joi.budgetItems()
+                    .max(this.attributes.rowLimit)
+                    .validBudgetRange(
+                        MIN_BUDGET_TOTAL_GBP,
+                        MAX_BUDGET_TOTAL_GBP
+                    )
+                    .required();
             },
             get messages() {
                 return [
@@ -1399,7 +1397,12 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             get schema() {
                 return Joi.when('beneficiariesGroupsCheck', {
                     is: 'yes',
-                    then: multiChoice(this.options).required(),
+                    then: multiChoice(this.options)
+                        .required()
+                        .when('beneficiariesGroupsOther', {
+                            is: Joi.string().required(),
+                            then: Joi.optional()
+                        }),
                     otherwise: Joi.any().strip()
                 });
             },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1422,9 +1422,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             type: 'text',
             isRequired: false,
-            schema: Joi.string()
-                .allow('')
-                .optional(),
+            schema: Joi.when('beneficiariesGroupsCheck', {
+                is: 'yes',
+                then: Joi.string()
+                    .allow('')
+                    .optional(),
+                otherwise: Joi.any().strip()
+            }),
             messages: []
         },
         beneficiariesEthnicBackground: {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -358,19 +358,48 @@ describe('Form validations', () => {
             });
         });
 
-        test('require beneficiaries groups if check question was yes', () => {
-            assertValidByKey({
+        test('strip beneficiary data when check is "no"', () => {
+            const dataWithNo = {
                 beneficiariesGroupsCheck: 'no',
                 beneficiariesGroups: null,
-                beneficiariesGroupsOther: null,
-                beneficiariesGroupsEthnicBackground: null,
-                beneficiariesGroupsGender: null,
-                beneficiariesGroupsAge: null,
-                beneficiariesGroupsDisabledPeople: null,
-                beneficiariesGroupsReligion: null,
-                beneficiariesGroupsReligionOther: null
+                beneficiariesGroupsOther: null
+            };
+
+            assertValidByKey(dataWithNo);
+            expect(testValidate(dataWithNo).value).toEqual({
+                beneficiariesGroupsCheck: 'no'
             });
 
+            const dataWithNoStripped = {
+                beneficiariesGroupsCheck: 'no',
+                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
+                beneficiariesGroupsOther: 'this should be stripped'
+            };
+
+            expect(testValidate(dataWithNoStripped).value).toEqual({
+                beneficiariesGroupsCheck: 'no'
+            });
+        });
+
+        test('allow only "other" option for beneficiary groups', () => {
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS)
+            });
+
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroupsOther: 'this should be valid'
+            });
+
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
+                beneficiariesGroupsOther: 'this should also be valid'
+            });
+        });
+
+        test('require additional beneficiary questions based on groups', () => {
             assertMessagesByKey(
                 {
                     beneficiariesGroupsCheck: 'yes',


### PR DESCRIPTION
- Fixes a bug where `beneficiariesGroupsOther` wasn't stripped if going back and changing your response to the screener question
- Fixes a bug where you weren't able to provide _only_ an "other" value to the beneficiary groups question.