### PR TITLE
Test improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
+*.iml
 .css.map
 .DS_Store
 .env
 .idea
-*.iml
 .map
 .vscode/
 always_restart.txt
@@ -10,6 +10,7 @@ assets.json
 config/app/server-dev.conf
 config/cloudfront/backup/
 coverage/
+cypress.env.json
 cypress/screenshots
 cypress/videos
 deploy.json

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -409,8 +409,8 @@ describe('awards for all', function() {
             }).then(el => {
                 if (el) {
                     cy.checkA11y();
-                    cy.getByLabelText('Day').type(31);
-                    cy.getByLabelText('Month').type(3);
+                    cy.getByLabelText('Day').type(random(1, 28).toString());
+                    cy.getByLabelText('Month').type(random(1, 12).toString());
                     cy.getByLabelText(
                         'What is your total income for the year?',
                         {

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -35,6 +35,19 @@ describe('awards for all', function() {
             cy.getByLabelText('Postcode').type(postcode);
         }
 
+        function startApplication() {
+            cy.getByText('Start new application').click();
+            times(5, function() {
+                cy.getByLabelText('Yes').click();
+                cy.getByText('Continue').click();
+            });
+            cy.getByText('Start your application').click();
+
+            cy.getAllByText('Start your application')
+                .first()
+                .click();
+        }
+
         function stepProjectDetails() {
             cy.checkA11y();
 
@@ -483,9 +496,13 @@ describe('awards for all', function() {
 
             fillHomeAddress(contact.address);
 
-            cy.getByLabelText('Email').type(contact.email);
+            cy.getByLabelText('Email').type(
+                contact.email || faker.internet.exampleEmail()
+            );
 
-            cy.getByLabelText('Telephone number').type(contact.phone);
+            cy.getByLabelText('Telephone number').type(
+                faker.phone.phoneNumber()
+            );
 
             submitStep();
         }
@@ -501,9 +518,13 @@ describe('awards for all', function() {
 
             fillHomeAddress(contact.address);
 
-            cy.getByLabelText('Email').type(contact.email);
+            cy.getByLabelText('Email').type(
+                contact.email || faker.internet.exampleEmail()
+            );
 
-            cy.getByLabelText('Telephone number').type(contact.phone);
+            cy.getByLabelText('Telephone number').type(
+                faker.phone.phoneNumber()
+            );
 
             submitStep();
         }
@@ -560,21 +581,22 @@ describe('awards for all', function() {
             submitStep();
         }
 
+        function submitApplication() {
+            cy.getAllByText('Submit application')
+                .first()
+                .click();
+
+            cy.get('h1').should(
+                'contain',
+                'Your application has been submitted. Good luck!'
+            );
+        }
+
         cy.seedAndLogin().then(() => {
             cy.visit('/apply/awards-for-all');
 
             cy.get('.cookie-consent button').click();
-
-            cy.getByText('Start new application').click();
-            times(5, function() {
-                cy.getByLabelText('Yes').click();
-                cy.getByText('Continue').click();
-            });
-            cy.getByText('Start your application').click();
-
-            cy.getAllByText('Start your application')
-                .first()
-                .click();
+            startApplication();
 
             const organisationName = faker.company.companyName();
 
@@ -585,8 +607,7 @@ describe('awards for all', function() {
             sectionSeniorContact({
                 firstName: faker.name.firstName(),
                 lastName: faker.name.lastName(),
-                email: faker.internet.exampleEmail(),
-                phone: faker.phone.phoneNumber(),
+                email: Cypress.env('afa_senior_contact_email'),
                 address: {
                     streetAddress: `The Bar, 2 St James' Blvd`,
                     city: 'Newcastle',
@@ -597,8 +618,7 @@ describe('awards for all', function() {
             sectionMainContact({
                 firstName: faker.name.firstName(),
                 lastName: faker.name.lastName(),
-                email: faker.internet.exampleEmail(),
-                phone: faker.phone.phoneNumber(),
+                email: Cypress.env('afa_main_contact_email'),
                 address: {
                     streetAddress: 'Pacific House, 70 Wellington St',
                     city: 'Glasgow',
@@ -611,14 +631,8 @@ describe('awards for all', function() {
 
             cy.checkA11y();
             cy.get('h1').should('contain', 'Summary');
-            cy.getAllByText('Submit application')
-                .first()
-                .click();
 
-            cy.get('h1').should(
-                'contain',
-                'Your application has been submitted. Good luck!'
-            );
+            submitApplication();
         });
     });
 });

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -11,8 +11,6 @@ describe('awards for all', function() {
     it('should submit full awards for all application', () => {
         const country = 'Scotland';
 
-        cy.log(`Country: ${country}`);
-
         function shouldDisplayErrors(errorDescriptions = []) {
             errorDescriptions.forEach(description => {
                 cy.getByTestId('form-errors').should('contain', description);
@@ -472,56 +470,41 @@ describe('awards for all', function() {
             });
         }
 
-        function sectionSeniorContact() {
+        function sectionSeniorContact(contact) {
             cy.checkA11y();
-            cy.getByLabelText('First name', { exact: false }).type(
-                faker.name.firstName()
-            );
-            cy.getByLabelText('Last name', { exact: false }).type(
-                faker.name.lastName()
-            );
+
+            cy.getByLabelText('First name').type(contact.firstName);
+
+            cy.getByLabelText('Last name').type(contact.lastName);
 
             cy.get('label[for="field-seniorContactRole-1"]').click();
 
             fillDateOfBirth(18);
-            fillHomeAddress({
-                streetAddress: 'Pacific House, 70 Wellington St',
-                city: 'Glasgow',
-                postcode: 'G2 6UA'
-            });
 
-            cy.getByLabelText('Email', { exact: false }).type(
-                faker.internet.exampleEmail()
-            );
+            fillHomeAddress(contact.address);
 
-            cy.getByLabelText('Telephone number', { exact: false }).type(
-                faker.phone.phoneNumber()
-            );
+            cy.getByLabelText('Email').type(contact.email);
+
+            cy.getByLabelText('Telephone number').type(contact.phone);
+
             submitStep();
         }
 
-        function sectionMainContact() {
+        function sectionMainContact(contact) {
             cy.checkA11y();
-            cy.getByLabelText('First name', { exact: false }).type(
-                faker.name.firstName()
-            );
-            cy.getByLabelText('Last name', { exact: false }).type(
-                faker.name.lastName()
-            );
+
+            cy.getByLabelText('First name').type(contact.firstName);
+
+            cy.getByLabelText('Last name').type(contact.lastName);
 
             fillDateOfBirth(16);
-            fillHomeAddress({
-                streetAddress: `The Bar, 2 St James' Blvd`,
-                city: 'Newcastle',
-                postcode: 'NE4 7JH'
-            });
 
-            cy.getByLabelText('Email', { exact: false }).type(
-                faker.internet.exampleEmail()
-            );
-            cy.getByLabelText('Telephone number', { exact: false }).type(
-                faker.phone.phoneNumber()
-            );
+            fillHomeAddress(contact.address);
+
+            cy.getByLabelText('Email').type(contact.email);
+
+            cy.getByLabelText('Telephone number').type(contact.phone);
+
             submitStep();
         }
 
@@ -599,8 +582,30 @@ describe('awards for all', function() {
             sectionBeneficiaries();
             sectionOrganisation(organisationName);
 
-            sectionSeniorContact();
-            sectionMainContact();
+            sectionSeniorContact({
+                firstName: faker.name.firstName(),
+                lastName: faker.name.lastName(),
+                email: faker.internet.exampleEmail(),
+                phone: faker.phone.phoneNumber(),
+                address: {
+                    streetAddress: `The Bar, 2 St James' Blvd`,
+                    city: 'Newcastle',
+                    postcode: 'NE4 7JH'
+                }
+            });
+
+            sectionMainContact({
+                firstName: faker.name.firstName(),
+                lastName: faker.name.lastName(),
+                email: faker.internet.exampleEmail(),
+                phone: faker.phone.phoneNumber(),
+                address: {
+                    streetAddress: 'Pacific House, 70 Wellington St',
+                    city: 'Glasgow',
+                    postcode: 'G2 6UA'
+                }
+            });
+
             sectionBankDetails(organisationName);
             sectionTermsAndConditions();
 


### PR DESCRIPTION
Couple of small test improvements needed whilst working on Salesforce testing.

**Randomise accounting year end date**

Makes it easier to correlate that the data is as expected.

**Allow configuring contact emails**

Cypress supports a local `cypress.env.json` file which is useful for customising test runs. For now I'm only using it for the main and senior contact email addresses to enable fixing those to real email addresses for testing.

You can add a file called `cypress.env.json` with the following values:

```json
{
  "afa_main_contact_email": "main.contact@example.com",
  "afa_senior_contact_email": "senior.contact@example.com"
}
```

If these are not set the test will use a random email for each.