### PR TITLE
Beneficiary other debugging

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1053,12 +1053,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         return Joi.when(Joi.ref('beneficiariesGroupsCheck'), {
             is: 'yes',
             then: Joi.when(Joi.ref('beneficiariesGroups'), {
-                is: Joi.array().items(
-                    Joi.string()
-                        .only(match)
-                        .required(),
-                    Joi.any()
-                ),
+                is: Joi.array()
+                    .items(
+                        Joi.string()
+                            .only(match)
+                            .required(),
+                        Joi.any()
+                    )
+                    .required(),
                 then: schema,
                 otherwise: Joi.any().strip()
             }),

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -52,6 +52,20 @@ function mockBudget() {
     });
 }
 
+function mockBeneficiaries() {
+    return {
+        beneficiariesGroupsCheck: 'yes',
+        beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
+        beneficiariesGroupsOther: 'Other value',
+        beneficiariesGroupsEthnicBackground: ['african', 'caribbean'],
+        beneficiariesGroupsGender: ['non-binary'],
+        beneficiariesGroupsAge: ['0-12', '13-24'],
+        beneficiariesGroupsDisabledPeople: ['sensory'],
+        beneficiariesGroupsReligion: ['sikh'],
+        beneficiariesGroupsReligionOther: undefined
+    };
+}
+
 function mockFullForm({
     country = 'scotland',
     organisationType,
@@ -389,14 +403,16 @@ describe('Form validations', () => {
 
             assertValidByKey({
                 beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroupsOther: 'this should be valid'
+                beneficiariesGroupsOther: 'this should be valid',
+                beneficiariesGroupsEthnicBackground: null,
+                beneficiariesGroupsGender: null,
+                beneficiariesGroupsAge: null,
+                beneficiariesGroupsDisabledPeople: null,
+                beneficiariesGroupsReligion: null,
+                beneficiariesGroupsReligionOther: null
             });
 
-            assertValidByKey({
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
-                beneficiariesGroupsOther: 'this should also be valid'
-            });
+            assertValidByKey(mockBeneficiaries());
         });
 
         test('require additional beneficiary questions based on groups', () => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -52,9 +52,9 @@ function mockBudget() {
     });
 }
 
-function mockBeneficiaries() {
+function mockBeneficiaries(checkAnswer = 'yes') {
     return {
-        beneficiariesGroupsCheck: 'yes',
+        beneficiariesGroupsCheck: checkAnswer,
         beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
         beneficiariesGroupsOther: 'Other value',
         beneficiariesGroupsEthnicBackground: ['african', 'caribbean'],
@@ -372,65 +372,18 @@ describe('Form validations', () => {
             });
         });
 
-        test('strip beneficiary data when check is "no"', () => {
-            const dataWithNo = {
-                beneficiariesGroupsCheck: 'no',
-                beneficiariesGroups: null,
-                beneficiariesGroupsOther: null
-            };
-
-            assertValidByKey(dataWithNo);
-            expect(testValidate(dataWithNo).value).toEqual({
-                beneficiariesGroupsCheck: 'no'
-            });
-
-            const dataWithNoStripped = {
-                beneficiariesGroupsCheck: 'no',
-                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
-                beneficiariesGroupsOther: 'this should be stripped'
-            };
-
-            expect(testValidate(dataWithNoStripped).value).toEqual({
-                beneficiariesGroupsCheck: 'no'
-            });
-        });
-
-        test('allow only "other" option for beneficiary groups', () => {
-            assertValidByKey({
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS)
-            });
-
-            assertValidByKey({
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroupsOther: 'this should be valid',
-                beneficiariesGroupsEthnicBackground: null,
-                beneficiariesGroupsGender: null,
-                beneficiariesGroupsAge: null,
-                beneficiariesGroupsDisabledPeople: null,
-                beneficiariesGroupsReligion: null,
-                beneficiariesGroupsReligionOther: null
-            });
-
-            assertValidByKey(mockBeneficiaries());
-        });
-
-        test('require additional beneficiary questions based on groups', () => {
+        test('require beneficiary groups when check is "yes"', () => {
             assertMessagesByKey(
                 {
                     beneficiariesGroupsCheck: 'yes',
                     beneficiariesGroups: null,
-                    beneficiariesGroupsOther: null,
-                    beneficiariesGroupsEthnicBackground: null,
-                    beneficiariesGroupsGender: null,
-                    beneficiariesGroupsAge: null,
-                    beneficiariesGroupsDisabledPeople: null,
-                    beneficiariesGroupsReligion: null,
-                    beneficiariesGroupsReligionOther: null
+                    beneficiariesGroupsOther: null
                 },
                 [expect.stringContaining('Select the specific group')]
             );
+        });
 
+        test('require additional beneficiary questions based on groups', () => {
             assertMessagesByKey(
                 {
                     beneficiariesGroupsCheck: 'yes',
@@ -451,6 +404,30 @@ describe('Form validations', () => {
                     expect.stringContaining('Select the religion')
                 ]
             );
+        });
+
+        test('strip beneficiary data when check is "no"', () => {
+            assertValidByKey(mockBeneficiaries('no'));
+            expect(testValidate(mockBeneficiaries('no')).value).toEqual({
+                beneficiariesGroupsCheck: 'no'
+            });
+        });
+
+        test('allow only "other" option for beneficiary groups', () => {
+            assertValidByKey(mockBeneficiaries('yes'));
+
+            assertValidByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroupsOther: 'this should be valid',
+                beneficiariesGroupsEthnicBackground: null,
+                beneficiariesGroupsGender: null,
+                beneficiariesGroupsAge: null,
+                beneficiariesGroupsDisabledPeople: null,
+                beneficiariesGroupsReligion: null,
+                beneficiariesGroupsReligionOther: null
+            });
+
+            assertValidByKey(mockBeneficiaries('yes'));
         });
 
         test.skip('welsh language question required for applicants in Wales', () => {

--- a/controllers/apply/form-router-next/lib/form-model.js
+++ b/controllers/apply/form-router-next/lib/form-model.js
@@ -212,6 +212,25 @@ class FormModel {
         return flatMap(step.fieldsets, 'fields');
     }
 
+    getErrorsByStep() {
+        const allMessages = this.validation.messages;
+        if (allMessages.length > 0) {
+            return this.getCurrentSteps().map(function(step) {
+                const fields = flatMap(step.fieldsets, 'fields');
+                const fieldNames = fields.map(field => field.name);
+
+                return {
+                    title: step.title,
+                    errors: allMessages.filter(err =>
+                        fieldNames.includes(err.param)
+                    )
+                };
+            });
+        } else {
+            return [];
+        }
+    }
+
     previousSection(sectionSlug) {
         const currentSectionIndex = findIndex(
             this.sections,

--- a/controllers/apply/form-router-next/summary.js
+++ b/controllers/apply/form-router-next/summary.js
@@ -4,6 +4,10 @@ const express = require('express');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 
+const logger = require('../../../common/logger').child({
+    service: 'form-summary'
+});
+
 module.exports = function(formBuilder) {
     const router = express.Router();
 
@@ -30,6 +34,19 @@ module.exports = function(formBuilder) {
             } else {
                 return [];
             }
+        }
+
+        function logValidationWarning() {
+            return (
+                form.progress.isComplete === false &&
+                form.progress.sections.every(
+                    section => section.status === 'complete'
+                ) === true
+            );
+        }
+
+        if (logValidationWarning()) {
+            logger.warn(`All sections complete but form marked as invalid`);
         }
 
         const title = copy.summary.title;

--- a/controllers/apply/form-router-next/summary.js
+++ b/controllers/apply/form-router-next/summary.js
@@ -26,7 +26,7 @@ function logErrorDifference(rawValidationErrors, stepValidationErrors) {
 
     if (errorDifference.length) {
         errorDifference.forEach(function(item) {
-            logger.warn(
+            logger.error(
                 `${item.param} not included in step fields but failed validation`,
                 { messages: item.msg }
             );


### PR DESCRIPTION
@scottoakley flagged an issue where adding _just_ a value for "other" would prevent you from submitting the form, but didn't give an indication as to why. There are two parts to this:

- An issue with the with the `conditionalBeneficiaryChoice` validation which didn't account for the `beneficiariesGroups` being unset
- A limitation with the way we collect validation errors meaning that the errors could be invisible if the fields are not included in the current steps

The changes here:

- Update the unit tests to catch the original validation error
- Adds `.required` to the `.when` check which tells joi to only apply conditional validation when we have a list of choices
- Adds logging to the step so that if any further fields fall into the category of unknown issues we log a warning as this indicates a validation logic issue.

For this last point we should a) do a review of the unit test to make sure we're happy they cover all corner-cases and b) run some more exploratory testing around any of the thornier conditional validations.