### PR TITLE
Improve use of .when() in validations to avoid invisible errors

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -263,13 +263,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     .format('YYYY-MM-DD')
             },
             isRequired: true,
-            schema: Joi.dateParts()
-                .dob(minAge)
-                .when(Joi.ref('organisationType'), {
-                    is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
-                    then: Joi.any().strip(),
-                    otherwise: Joi.required()
-                }),
+            schema: Joi.any().when(Joi.ref('organisationType'), {
+                is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
+                then: Joi.any().strip(),
+                otherwise: Joi.dateParts()
+                    .dob(minAge)
+                    .required()
+            }),
             messages: [
                 {
                     type: 'base',

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -36,6 +36,41 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             .single();
     }
 
+    function conditionalBeneficiaryChoice({ match, schema }) {
+        return Joi.when(Joi.ref('beneficiariesGroupsCheck'), {
+            is: 'yes',
+            then: Joi.when(Joi.ref('beneficiariesGroups'), {
+                is: Joi.array()
+                    .items(
+                        Joi.string()
+                            .only(match)
+                            .required(),
+                        Joi.any()
+                    )
+                    .required(),
+                then: schema,
+                otherwise: Joi.any().strip()
+            }),
+            otherwise: Joi.any().strip()
+        });
+    }
+
+    function stripIfExcludedOrgType(schema) {
+        return Joi.when(Joi.ref('organisationType'), {
+            is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
+            then: Joi.any().strip(),
+            otherwise: schema
+        });
+    }
+
+    function stripUnlessOrgTypes(types, schema) {
+        return Joi.when(Joi.ref('organisationType'), {
+            is: Joi.exist().valid(types),
+            then: schema,
+            otherwise: Joi.any().strip()
+        });
+    }
+
     function emailField(props, additionalMessages = []) {
         const defaultProps = {
             label: localise({ en: 'Email', cy: '' }),
@@ -147,8 +182,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         const defaultProps = {
             type: 'address-history',
             isRequired: true,
-            get schema() {
-                const addressHistorySchema = Joi.object({
+            schema: stripIfExcludedOrgType(
+                Joi.object({
                     currentAddressMeetsMinimum: Joi.string()
                         .valid(['yes', 'no'])
                         .required(),
@@ -160,14 +195,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                             otherwise: Joi.any().strip()
                         }
                     )
-                });
-
-                return Joi.when(Joi.ref('organisationType'), {
-                    is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
-                    then: Joi.any().strip(),
-                    otherwise: addressHistorySchema.required()
-                });
-            },
+                }).required()
+            ),
             messages: [
                 {
                     type: 'base',
@@ -263,13 +292,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     .format('YYYY-MM-DD')
             },
             isRequired: true,
-            schema: Joi.any().when(Joi.ref('organisationType'), {
-                is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
-                then: Joi.any().strip(),
-                otherwise: Joi.dateParts()
+            schema: stripIfExcludedOrgType(
+                Joi.dateParts()
                     .dob(minAge)
                     .required()
-            }),
+            ),
             messages: [
                 {
                     type: 'base',
@@ -778,6 +805,86 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         };
     }
 
+    function fieldCompanyNumber() {
+        const requiredOrgTypes = [ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY];
+
+        return {
+            name: 'companyNumber',
+            label: localise({ en: 'Companies House number', cy: '' }),
+            type: 'text',
+            isRequired: true,
+            schema: stripUnlessOrgTypes(
+                requiredOrgTypes,
+                Joi.string().required()
+            ),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter your organisation’s Companies House number',
+                        cy: ''
+                    })
+                }
+            ]
+        };
+    }
+
+    function fieldCharityNumber() {
+        const requiredOrgTypes = [
+            ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
+            ORGANISATION_TYPES.CIO
+        ];
+
+        return {
+            name: 'charityNumber',
+            label: localise({ en: 'Charity registration number', cy: '' }),
+            type: 'text',
+            attributes: { size: 20 },
+            isRequired: requiredOrgTypes.includes(currentOrganisationType),
+            schema: stripUnlessOrgTypes(
+                requiredOrgTypes,
+                Joi.string().required()
+            ),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: 'Enter your organisation’s charity number',
+                        cy: ''
+                    })
+                }
+            ]
+        };
+    }
+
+    function fieldEducationNumber() {
+        const requiredOrgTypes = [
+            ORGANISATION_TYPES.SCHOOL,
+            ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY
+        ];
+
+        return {
+            name: 'educationNumber',
+            label: localise({ en: 'Department for Education number', cy: '' }),
+            type: 'text',
+            attributes: { size: 20 },
+            isRequired: true,
+            schema: stripUnlessOrgTypes(
+                requiredOrgTypes,
+                Joi.string().required()
+            ),
+            messages: [
+                {
+                    type: 'base',
+                    message: localise({
+                        en: `Enter your organisation’s Department for Education number`,
+                        cy: ''
+                    })
+                }
+            ]
+        };
+    }
+
     function fieldSeniorContactRole() {
         function rolesFor(organisationType, organisationSubType) {
             const ROLES = {
@@ -1047,25 +1154,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         };
-    }
-
-    function conditionalBeneficiaryChoice({ match, schema }) {
-        return Joi.when(Joi.ref('beneficiariesGroupsCheck'), {
-            is: 'yes',
-            then: Joi.when(Joi.ref('beneficiariesGroups'), {
-                is: Joi.array()
-                    .items(
-                        Joi.string()
-                            .only(match)
-                            .required(),
-                        Joi.any()
-                    )
-                    .required(),
-                then: schema,
-                otherwise: Joi.any().strip()
-            }),
-            otherwise: Joi.any().strip()
-        });
     }
 
     return {
@@ -2019,75 +2107,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        companyNumber: {
-            name: 'companyNumber',
-            label: localise({ en: 'Companies House number', cy: '' }),
-            type: 'text',
-            isRequired: true,
-            schema: Joi.when('organisationType', {
-                is: ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY,
-                then: Joi.string().required(),
-                otherwise: Joi.any().strip()
-            }),
-            messages: [
-                {
-                    type: 'base',
-                    message: localise({
-                        en: 'Enter your organisation’s Companies House number',
-                        cy: ''
-                    })
-                }
-            ]
-        },
-        charityNumber: {
-            name: 'charityNumber',
-            label: localise({ en: 'Charity registration number', cy: '' }),
-            type: 'text',
-            attributes: { size: 20 },
-            isRequired: [
-                ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                ORGANISATION_TYPES.CIO
-            ].includes(currentOrganisationType),
-            schema: Joi.when('organisationType', {
-                is: ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                then: Joi.string().required()
-            }).when('organisationType', {
-                is: ORGANISATION_TYPES.CIO,
-                then: Joi.string().required()
-            }),
-            messages: [
-                {
-                    type: 'base',
-                    message: localise({
-                        en: 'Enter your organisation’s charity number',
-                        cy: ''
-                    })
-                }
-            ]
-        },
-        educationNumber: {
-            name: 'educationNumber',
-            label: localise({ en: 'Department for Education number', cy: '' }),
-            type: 'text',
-            attributes: { size: 20 },
-            isRequired: true,
-            schema: Joi.when('organisationType', {
-                is: Joi.exist().valid(
-                    ORGANISATION_TYPES.SCHOOL,
-                    ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY
-                ),
-                then: Joi.string().required()
-            }),
-            messages: [
-                {
-                    type: 'base',
-                    message: localise({
-                        en: `Enter your organisation’s Department for Education number`,
-                        cy: ''
-                    })
-                }
-            ]
-        },
+        companyNumber: fieldCompanyNumber(),
+        charityNumber: fieldCharityNumber(),
+        educationNumber: fieldEducationNumber(),
         accountingYearDate: {
             name: 'accountingYearDate',
             label: localise({
@@ -2222,12 +2244,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     en: `We need your home address to help confirm who you are. And we do check your address. So make sure you've entered it right. If you don't, it could delay your application.`,
                     cy: ''
                 }),
-                schema: Joi.ukAddress()
-                    .mainContact()
-                    .when(Joi.ref('organisationType'), {
-                        is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
-                        then: Joi.any().strip()
-                    })
+                schema: stripIfExcludedOrgType(Joi.ukAddress().mainContact())
             },
             [
                 {
@@ -2321,12 +2338,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     en: `We need your home address to help confirm who you are. And we do check your address. So make sure you've entered it right. If you don't, it could delay your application.`,
                     cy: ''
                 }),
-                schema: Joi.ukAddress()
-                    .seniorContact()
-                    .when(Joi.ref('organisationType'), {
-                        is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
-                        then: Joi.any().strip()
-                    })
+                schema: stripIfExcludedOrgType(Joi.ukAddress().seniorContact())
             },
             [
                 {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -778,6 +778,15 @@ describe('Form validations', () => {
                     organisationType: excludedOrgType
                 });
 
+                const invalidDobWithSchool = {
+                    organisationType: excludedOrgType,
+                    [fieldName]: mockDateOfBirth(1, minAge - 1)
+                };
+
+                expect(testValidate(invalidDobWithSchool).value).toEqual({
+                    organisationType: excludedOrgType
+                });
+
                 assertValidByKey({
                     organisationType: excludedOrgType
                 });

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -652,9 +652,26 @@ describe('Form validations', () => {
             const mock = mockFullForm({
                 country: 'scotland',
                 organisationType: ORGANISATION_TYPES.UNREGISTERED_VCO,
-                seniorContactRole: 'chair'
+                seniorContactRole: 'chair',
+                charityNumber: '12345678',
+                companyNumber: '2345678',
+                educationNumber: '34567'
             });
+
             assertValid(mock);
+        });
+
+        test('registration numbers stripped if not required', () => {
+            const withRegistrationNumbers = {
+                organisationType: ORGANISATION_TYPES.UNREGISTERED_VCO,
+                charityNumber: '12345678',
+                companyNumber: '2345678',
+                educationNumber: '34567'
+            };
+
+            expect(testValidate(withRegistrationNumbers).value).toEqual({
+                organisationType: ORGANISATION_TYPES.UNREGISTERED_VCO
+            });
         });
 
         test('registration numbers shown based on organisation type', () => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -769,21 +769,21 @@ describe('Form validations', () => {
         test.each(CONTACT_EXCLUDED_TYPES)(
             'date of birth value stripped for %p',
             function(excludedOrgType) {
-                const dobWithSchool = {
+                const dobWithOrgType = {
                     organisationType: excludedOrgType,
                     [fieldName]: mockDateOfBirth(minAge, 90)
                 };
 
-                expect(testValidate(dobWithSchool).value).toEqual({
+                expect(testValidate(dobWithOrgType).value).toEqual({
                     organisationType: excludedOrgType
                 });
 
-                const invalidDobWithSchool = {
+                const invalidDobWithOrgType = {
                     organisationType: excludedOrgType,
                     [fieldName]: mockDateOfBirth(1, minAge - 1)
                 };
 
-                expect(testValidate(invalidDobWithSchool).value).toEqual({
+                expect(testValidate(invalidDobWithOrgType).value).toEqual({
                     organisationType: excludedOrgType
                 });
 
@@ -840,12 +840,25 @@ describe('Form validations', () => {
         test.each(CONTACT_EXCLUDED_TYPES)(
             'address value stripped for %p',
             function(excludedOrgType) {
-                expect(
-                    testValidate({
-                        organisationType: excludedOrgType,
-                        [fieldName]: mockAddress()
-                    }).value
-                ).toEqual({
+                const validAddressWithOrgType = {
+                    organisationType: excludedOrgType,
+                    [fieldName]: mockAddress()
+                };
+
+                expect(testValidate(validAddressWithOrgType).value).toEqual({
+                    organisationType: excludedOrgType
+                });
+
+                const invalidAddressWithOrgType = {
+                    organisationType: excludedOrgType,
+                    [fieldName]: {
+                        line1: faker.address.streetAddress(),
+                        townCity: faker.address.city(),
+                        county: faker.address.county()
+                    }
+                };
+
+                expect(testValidate(invalidAddressWithOrgType).value).toEqual({
                     organisationType: excludedOrgType
                 });
 


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/blf-alpha/pull/2107 – prevents now-optional fields from being validated when conditions change.