### PR TITLE
Strip invalid files

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -2485,6 +2485,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         bankStatement: {
             name: 'bankStatement',
             label: localise({ en: 'Upload a bank statement', cy: '' }),
+            // Used when editing an existing bank statement
+            labelExisting: localise({
+                en: 'Upload a new bank statement',
+                cy: ''
+            }),
             type: 'file',
             attributes: {
                 accept: FILE_LIMITS.TYPES.map(type => type.mime).join(',')

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -557,7 +557,9 @@
 
 {% macro inputFile(field) %}
 
-    {% if field.value and field.displayValue %}
+    {% set fieldErrors = errors | filter('param', field.name) %}
+
+    {% if fieldErrors.length === 0 and field.value and field.displayValue %}
         <div class="existing-data u-margin-bottom">
             <h3>Existing file</h3>
             <p>{{ field.displayValue }}</p>
@@ -567,8 +569,16 @@
         </div>
     {% endif %}
 
-    <label class="ff-label{% if field.settings.hideLabel %} u-visually-hidden{% endif %}" for="field-{{ field.name }}">
-        {{ labelFor(field) }}
+    <label class="ff-label{% if field.settings.hideLabel %} u-visually-hidden{% endif %}"
+           for="field-{{ field.name }}">
+        {% if not field.value or not field.labelExisting %}
+            {{ labelFor(field) }}
+        {% else %}
+            {{ labelFor({
+                "label": field.labelExisting,
+                "isRequired": field.isRequired
+            }) }}
+        {% endif %}
     </label>
 
     {{ explanationFor(field) }}


### PR DESCRIPTION
This change means that when uploading an invalid file (and navigating away), invalid file data is no longer persisted in the database. 

Although we follow this pattern for all other fields, in the case of the file it's misleading as we then provide a panel that suggests the file can be downloaded etc.

This change also hides that panel upon step submission when errors are present, so even in-flight data isn't misrepresented. It also adds a new label when replacing the file, eg:

![image](https://user-images.githubusercontent.com/394376/61866167-994c8100-aecc-11e9-8556-7e6be6d04b54.png)
