### PR TITLE
Enable survey and tweak wording for single-option lists on page

### DIFF
--- a/controllers/apply/form-router-next/questions.js
+++ b/controllers/apply/form-router-next/questions.js
@@ -19,6 +19,8 @@ module.exports = function(formId, formBuilder, eligibilityBuilder) {
             locale: req.i18n.getLocale()
         });
 
+        res.locals.enableSiteSurvey = true;
+
         const output = {
             templates: {
                 html: path.resolve(__dirname, './views/questions-html.njk'),

--- a/controllers/apply/form-router-next/views/questions-list.njk
+++ b/controllers/apply/form-router-next/views/questions-list.njk
@@ -1,6 +1,11 @@
+{# @TODO i18n #}
 {% macro fieldTypeHelpText(field, step) %}
     {% if field.type === 'checkbox' %}
-        Choose as many options as you like from a selection
+        {% if field.options.length === 1 %}
+            Confirm the following criteria
+        {% else %}
+            Choose as many options as you like from a selection
+        {% endif %}
     {% elseif field.type === 'radio' or field.type === 'select' %}
         Pick one option from a selection
     {% elseif field.type === 'budget' %}


### PR DESCRIPTION
Makes this scenario (eg. one item in `field.options`) a bit more logical:
![image](https://user-images.githubusercontent.com/394376/61868379-2c87b580-aed1-11e9-9b7c-29256e35aa26.png)

And adds the survey here:
![image](https://user-images.githubusercontent.com/394376/61868391-31e50000-aed1-11e9-85b1-011bca4188b5.png)
