### PR TITLE
Unit test cleanup

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -51,7 +51,7 @@
     "enableSeeders": false,
     "enableSiteSurvey": true
   },
-  "awardsForAllApplications": {
+  "awardsForAll": {
     "allowedCountries": ["scotland"]
   },
   "cookies": {

--- a/config/test.json
+++ b/config/test.json
@@ -11,7 +11,7 @@
     "enableHotjar": true,
     "enableMailSendMetrics": true
   },
-  "awardsForAllApplications": {
+  "awardsForAll": {
     "allowedCountries": ["england", "scotland"]
   }
 }

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -1,0 +1,242 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bank details requires valid bank details 1`] = `
+Array [
+  "Enter a sort code",
+  "Enter an account number",
+  "Enter the name of your organisation, as it appears on your bank statement",
+]
+`;
+
+exports[`Contacts include all roles if no organisation type is provided 1`] = `
+Array [
+  "chair",
+  "chancellor",
+  "chief-executive",
+  "chief-executive-officer",
+  "company-director",
+  "company-secretary",
+  "deputy-parish-clerk",
+  "director",
+  "elected-member",
+  "head-teacher",
+  "parish-clerk",
+  "religious-leader",
+  "secretary",
+  "treasurer",
+  "trustee",
+  "vice-chair",
+  "vice-chancellor",
+]
+`;
+
+exports[`Contacts include expected roles for "charitable-incorporated-organisation" 1`] = `
+Array [
+  "trustee",
+  "chief-executive-officer",
+]
+`;
+
+exports[`Contacts include expected roles for "college-or-university" 1`] = `
+Array [
+  "chancellor",
+  "vice-chancellor",
+]
+`;
+
+exports[`Contacts include expected roles for "faith-group" 1`] = `
+Array [
+  "chair",
+  "vice-chair",
+  "secretary",
+  "treasurer",
+  "religious-leader",
+]
+`;
+
+exports[`Contacts include expected roles for "not-for-profit-company" 1`] = `
+Array [
+  "company-director",
+  "company-secretary",
+]
+`;
+
+exports[`Contacts include expected roles for "school" 1`] = `
+Array [
+  "head-teacher",
+]
+`;
+
+exports[`Contacts include expected roles for "statutory-body" 1`] = `
+Array [
+  "chair",
+  "chancellor",
+  "chief-executive",
+  "chief-executive-officer",
+  "company-director",
+  "company-secretary",
+  "deputy-parish-clerk",
+  "director",
+  "elected-member",
+  "head-teacher",
+  "parish-clerk",
+  "religious-leader",
+  "secretary",
+  "treasurer",
+  "trustee",
+  "vice-chair",
+  "vice-chancellor",
+]
+`;
+
+exports[`Contacts include expected roles for "unincorporated-registered-charity" 1`] = `
+Array [
+  "trustee",
+]
+`;
+
+exports[`Contacts include expected roles for "unregistered-vco" 1`] = `
+Array [
+  "chair",
+  "vice-chair",
+  "secretary",
+  "treasurer",
+]
+`;
+
+exports[`Contacts include role warning for "CIO" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "CIO" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "CIO" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "CIO" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "COLLEGE_OR_UNIVERSITY" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "COLLEGE_OR_UNIVERSITY" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "COLLEGE_OR_UNIVERSITY" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "COLLEGE_OR_UNIVERSITY" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "FAITH_GROUP" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "FAITH_GROUP" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "FAITH_GROUP" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "FAITH_GROUP" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "NOT_FOR_PROFIT_COMPANY" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "NOT_FOR_PROFIT_COMPANY" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "NOT_FOR_PROFIT_COMPANY" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "NOT_FOR_PROFIT_COMPANY" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "SCHOOL" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "SCHOOL" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "SCHOOL" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "SCHOOL" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "STATUTORY_BODY" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "STATUTORY_BODY" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "STATUTORY_BODY" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "STATUTORY_BODY" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "UNINCORPORATED_REGISTERED_CHARITY" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "UNINCORPORATED_REGISTERED_CHARITY" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "UNINCORPORATED_REGISTERED_CHARITY" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "UNINCORPORATED_REGISTERED_CHARITY" 4`] = `Array []`;
+
+exports[`Contacts include role warning for "UNREGISTERED_VCO" 1`] = `Array []`;
+
+exports[`Contacts include role warning for "UNREGISTERED_VCO" 2`] = `Array []`;
+
+exports[`Contacts include role warning for "UNREGISTERED_VCO" 3`] = `Array []`;
+
+exports[`Contacts include role warning for "UNREGISTERED_VCO" 4`] = `Array []`;
+
+exports[`Global validation default validations for an empty form 1`] = `
+Array [
+  "Enter a project name",
+  "Select a country",
+  "Select a location",
+  "Tell us the towns, villages or wards your beneficiaries live in",
+  "Enter a real postcode",
+  "Tell us about your project",
+  "Tell us how your project meets at least one of our funding priorities",
+  "Tell us how your project involves your community",
+  "Enter a project budget",
+  "Enter a total cost for your project",
+  "Select yes or no",
+  "Enter the full legal name of the organisation",
+  "Enter a day and month",
+  "Enter a full UK address",
+  "Select a type of organisation",
+  "Enter first and last name",
+  "Enter a date of birth",
+  "Enter a full UK address",
+  "Enter a UK telephone number",
+  "Choose a role",
+  "Enter first and last name",
+  "Enter a date of birth",
+  "Enter a full UK address",
+  "Enter an email address",
+  "Enter a UK telephone number",
+  "Enter the name of your organisation, as it appears on your bank statement",
+  "Enter a sort code",
+  "Enter an account number",
+  "Provide a bank statement",
+  "You must confirm that you're authorised to submit this application",
+  "You must confirm that the information you've provided in this application is accurate",
+  "You must confirm that you understand how we'll use any personal information you've provided",
+  "You must confirm that you understand your application is subject to our Freedom of Information policy",
+  "Enter the full name of the person completing this form",
+  "Enter the position of the person completing this form",
+]
+`;
+
+exports[`Who will benefit require additional beneficiary questions based on groups 1`] = `
+Array [
+  "Select the age group(s) of the people that will benefit from your project",
+  "Select the disabled people that will benefit from your project",
+  "Select the ethnic background(s) of the people that will benefit from your project",
+  "Select the gender(s) of the people that will benefit from your project",
+  "Select the religion(s) or belief(s) of the people that will benefit from your project",
+]
+`;
+
+exports[`Your organisation finance details required if organisation is over 15 months old 1`] = `
+Array [
+  "Enter a day and month",
+  "Enter a total income for the year (eg. a whole number with no commas or decimal points)",
+]
+`;
+
+exports[`Your organisation finance details required if organisation is over 15 months old 2`] = `
+Array [
+  "Enter a day and month",
+  "Total income must be a real number",
+]
+`;
+
+exports[`Your organisation valid basic organisation details required 1`] = `
+Array [
+  "Enter a day and month",
+  "Enter a full UK address",
+  "Enter the full legal name of the organisation",
+  "Select a type of organisation",
+]
+`;

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -24,8 +24,10 @@ const {
     CHARITY_NUMBER_TYPES,
     EDUCATION_NUMBER_TYPES
 } = require('./constants');
+
 const countriesFor = require('./lib/countries');
 const locationsFor = require('./lib/locations');
+const rolesFor = require('./lib/roles');
 
 module.exports = function fieldsFor({ locale, data = {} }) {
     const localise = get(locale);
@@ -448,9 +450,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             type: 'radio',
             options: countriesFor({
                 locale: locale,
-                allowedCountries: config.get(
-                    'awardsForAllApplications.allowedCountries'
-                )
+                allowedCountries: config.get('awardsForAll.allowedCountries')
             }),
             isRequired: true,
             get schema() {
@@ -892,154 +892,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     }
 
     function fieldSeniorContactRole() {
-        function rolesFor(organisationType, organisationSubType) {
-            const ROLES = {
-                CHAIR: {
-                    value: 'chair',
-                    label: localise({ en: 'Chair', cy: '' })
-                },
-                CHANCELLOR: {
-                    value: 'chancellor',
-                    label: localise({ en: 'Chancellor', cy: '' })
-                },
-                CHIEF_EXECUTIVE: {
-                    value: 'chief-executive',
-                    label: localise({ en: 'Chief Executive', cy: '' })
-                },
-                CHIEF_EXECUTIVE_OFFICER: {
-                    value: 'chief-executive-officer',
-                    label: localise({ en: 'Chief Executive Officer', cy: '' })
-                },
-                COMPANY_DIRECTOR: {
-                    value: 'company-director',
-                    label: localise({ en: 'Company Director', cy: '' })
-                },
-                COMPANY_SECRETARY: {
-                    value: 'company-secretary',
-                    label: localise({ en: 'Company Secretary', cy: '' })
-                },
-                DEPUTY_PARISH_CLERK: {
-                    value: 'deputy-parish-clerk',
-                    label: localise({ en: 'Deputy Parish Clerk', cy: '' })
-                },
-                DIRECTOR: {
-                    value: 'director',
-                    label: localise({ en: 'Director', cy: '' })
-                },
-                ELECTED_MEMBER: {
-                    value: 'elected-member',
-                    label: localise({ en: 'Elected Member', cy: '' })
-                },
-                HEAD_TEACHER: {
-                    value: 'head-teacher',
-                    label: localise({ en: 'Head Teacher', cy: '' })
-                },
-                PARISH_CLERK: {
-                    value: 'parish-clerk',
-                    label: localise({ en: 'Parish Clerk', cy: '' })
-                },
-                RELIGIOUS_LEADER: {
-                    value: 'religious-leader',
-                    label: localise({
-                        en: 'Religious leader (eg. rabbi, imam, vicar)',
-                        cy: ''
-                    })
-                },
-                SECRETARY: {
-                    value: 'secretary',
-                    label: localise({ en: 'Secretary', cy: '' })
-                },
-                TREASURER: {
-                    value: 'treasurer',
-                    label: localise({ en: 'Treasurer', cy: '' })
-                },
-                TRUSTEE: {
-                    value: 'trustee',
-                    label: localise({ en: 'Trustee', cy: '' })
-                },
-                VICE_CHAIR: {
-                    value: 'vice-chair',
-                    label: localise({ en: 'Vice-chair', cy: '' })
-                },
-                VICE_CHANCELLOR: {
-                    value: 'vice-chancellor',
-                    label: localise({ en: 'Vice-chancellor', cy: '' })
-                }
-            };
-
-            let options = [];
-            switch (organisationType) {
-                case ORGANISATION_TYPES.UNREGISTERED_VCO:
-                    options = [
-                        ROLES.CHAIR,
-                        ROLES.VICE_CHAIR,
-                        ROLES.SECRETARY,
-                        ROLES.TREASURER
-                    ];
-                    break;
-                case ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY:
-                    options = [ROLES.TRUSTEE];
-                    break;
-                case ORGANISATION_TYPES.CIO:
-                    options = [ROLES.TRUSTEE, ROLES.CHIEF_EXECUTIVE_OFFICER];
-                    break;
-                case ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY:
-                    options = [ROLES.COMPANY_DIRECTOR, ROLES.COMPANY_SECRETARY];
-                    break;
-                case ORGANISATION_TYPES.SCHOOL:
-                    options = [ROLES.HEAD_TEACHER];
-                    break;
-                case ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY:
-                    options = [ROLES.CHANCELLOR, ROLES.VICE_CHANCELLOR];
-                    break;
-                case ORGANISATION_TYPES.FAITH_GROUP:
-                    options = [
-                        ROLES.CHAIR,
-                        ROLES.VICE_CHAIR,
-                        ROLES.SECRETARY,
-                        ROLES.TREASURER,
-                        ROLES.RELIGIOUS_LEADER
-                    ];
-                    break;
-                default:
-                    options = Object.values(ROLES);
-                    break;
-            }
-
-            // Add custom options for statutory bodies
-            if (
-                organisationType === ORGANISATION_TYPES.STATUTORY_BODY &&
-                organisationSubType
-            ) {
-                switch (organisationSubType) {
-                    case STATUTORY_BODY_TYPES.PARISH_COUNCIL:
-                        options = [
-                            ROLES.PARISH_CLERK,
-                            ROLES.DEPUTY_PARISH_CLERK
-                        ];
-                        break;
-                    case STATUTORY_BODY_TYPES.TOWN_COUNCIL:
-                        options = [ROLES.ELECTED_MEMBER, ROLES.CHAIR];
-                        break;
-                    case STATUTORY_BODY_TYPES.LOCAL_AUTHORITY:
-                        options = [
-                            ROLES.CHAIR,
-                            ROLES.CHIEF_EXECUTIVE,
-                            ROLES.DIRECTOR
-                        ];
-                        break;
-                    case STATUTORY_BODY_TYPES.NHS_TRUST:
-                        options = [ROLES.CHIEF_EXECUTIVE, ROLES.DIRECTOR];
-                        break;
-                    default:
-                        options = Object.values(ROLES);
-                        break;
-                }
-            }
-
-            return options;
-        }
-
         /**
          * Statutory bodies require a sub-type,
          * some of which allow free text input for roles.
@@ -1130,10 +982,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 return result;
             },
             type: isFreeText() ? 'text' : 'radio',
-            options: rolesFor(
-                currentOrganisationType,
-                currentOrganisationSubType
-            ),
+            options: rolesFor({
+                locale: locale,
+                organisationType: currentOrganisationType,
+                organisationSubType: currentOrganisationSubType
+            }),
             isRequired: true,
             get schema() {
                 if (isFreeText()) {

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -27,7 +27,11 @@ const terms = require('./terms');
 const { isTestServer } = require('../../../common/appData');
 const checkBankApi = require('../../../common/bank-api');
 
-module.exports = function({ locale, data = {}, showAllFields = false }) {
+module.exports = function({
+    locale = 'en',
+    data = {},
+    showAllFields = false
+} = {}) {
     const localise = get(locale);
 
     const conditionalFields = (fields, filteredFields) => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -5,8 +5,8 @@ const concat = require('lodash/concat');
 const difference = require('lodash/difference');
 const includes = require('lodash/includes');
 const map = require('lodash/map');
+const partition = require('lodash/partition');
 const random = require('lodash/random');
-const range = require('lodash/range');
 const sample = require('lodash/sample');
 const times = require('lodash/times');
 const faker = require('faker');
@@ -21,14 +21,12 @@ const {
     CHARITY_NUMBER_TYPES,
     EDUCATION_NUMBER_TYPES
 } = require('./constants');
+const rolesFor = require('./lib/roles');
+
 const validateModel = require('../form-router-next/lib/validate-model');
 
 function toDateParts(dt) {
     return { day: dt.date(), month: dt.month() + 1, year: dt.year() };
-}
-
-function mockStartDate(weeks) {
-    return toDateParts(moment().add(weeks, 'weeks'));
 }
 
 function mockDateOfBirth(minAge, maxAge = 75) {
@@ -74,6 +72,7 @@ function mockBeneficiaries(checkAnswer = 'yes') {
 function mockFullForm({
     country = 'scotland',
     organisationType,
+    organisationSubType = null,
     seniorContactRole,
     companyNumber = null,
     charityNumber = null,
@@ -83,15 +82,15 @@ function mockFullForm({
         projectName: faker.lorem.words(5),
         projectCountry: country,
         projectDateRange: {
-            startDate: mockStartDate(18),
-            endDate: mockStartDate(30)
+            startDate: toDateParts(moment().add(18, 'weeks')),
+            endDate: toDateParts(moment().add(30, 'weeks'))
         },
         projectLocation: 'east-lothian',
         projectLocationDescription: faker.lorem.sentence(),
         projectPostcode: 'B15 1TR',
-        yourIdeaProject: faker.lorem.words(250),
-        yourIdeaPriorities: faker.lorem.words(100),
-        yourIdeaCommunity: faker.lorem.words(150),
+        yourIdeaProject: faker.lorem.words(random(50, 250)),
+        yourIdeaPriorities: faker.lorem.words(random(50, 100)),
+        yourIdeaCommunity: faker.lorem.words(random(50, 150)),
         projectBudget: mockBudget(),
         projectTotalCosts: 20000,
         beneficiariesGroupsCheck: 'yes',
@@ -108,11 +107,12 @@ function mockFullForm({
         organisationStartDate: { month: 9, year: 1986 },
         organisationAddress: mockAddress(),
         organisationType: organisationType,
+        organisationSubType: organisationSubType,
         companyNumber: companyNumber,
         charityNumber: charityNumber,
         educationNumber: educationNumber,
         accountingYearDate: { day: 1, month: 3 },
-        totalIncomeYear: faker.random.number({ min: 10000, max: 1000000 }),
+        totalIncomeYear: random(1000, 1000000),
         mainContactName: {
             firstName: faker.name.firstName(),
             lastName: faker.name.lastName()
@@ -158,26 +158,21 @@ function mockFullForm({
     };
 }
 
-function testValidate(data) {
-    return formBuilder({ locale: 'en', data }).validation;
-}
-
-function fieldFor(fieldName, data) {
-    const form = formBuilder({ locale: 'en', data: data });
-    return form.allFields[fieldName];
-}
-
-function assertMessagesByKey(data, messages) {
-    const validationResult = testValidate(data);
-    const messagesByKey = validationResult.messages.filter(message => {
+function messagesByKey(data) {
+    const validationResult = formBuilder({ data }).validation;
+    const matches = validationResult.messages.filter(message => {
         return includes(Object.keys(data), message.param);
     });
 
-    expect(map(messagesByKey, 'msg').sort()).toEqual(messages.sort());
+    return map(matches, 'msg').sort();
+}
+
+function assertMessagesByKey(data, messages) {
+    expect(messagesByKey(data)).toEqual(messages.sort());
 }
 
 function assertValidByKey(data) {
-    const validationResult = testValidate(data);
+    const validationResult = formBuilder({ data }).validation;
     const messagesByKey = validationResult.messages.filter(message => {
         return includes(Object.keys(data), message.param);
     });
@@ -185,1048 +180,115 @@ function assertValidByKey(data) {
     expect(messagesByKey).toHaveLength(0);
 }
 
-describe('Form validations', () => {
-    describe('Project details', () => {
-        test('project name must be provided', () => {
-            function value(val) {
-                return { projectName: val };
-            }
-
-            assertMessagesByKey(value(null), ['Enter a project name']);
-            assertValidByKey(value(faker.lorem.words()));
-        });
-
-        test('project dates must be within range', () => {
-            function value(startDate, endDate) {
-                return { projectDateRange: { startDate, endDate } };
-            }
-
-            assertValidByKey(value(mockStartDate(18), mockStartDate(30)));
-            assertMessagesByKey(value(null, null), [
-                'Enter a project start and end date'
-            ]);
-            assertMessagesByKey(
-                value(
-                    { day: 31, month: 2, year: 2030 },
-                    { day: 31, month: 24, year: 2030 }
-                ),
-                ['Project start and end dates must be real dates']
-            );
-            assertMessagesByKey(
-                value(
-                    { day: 1, month: 1, year: 2020 },
-                    { day: 1, month: 1, year: 2030 }
-                ),
-                [
-                    expect.stringMatching(
-                        /Date you end the project must be within/
-                    )
-                ]
-            );
-        });
-
-        test('project country must be provided', () => {
-            function value(val) {
-                return { projectCountry: val };
-            }
-
-            const randomCountry = sample([
-                // 'england',
-                // 'northern-ireland',
-                'scotland'
-                // 'wales'
-            ]);
-
-            assertValidByKey(value(randomCountry));
-            assertMessagesByKey(value('not-a-country'), ['Select a country']);
-        });
-
-        test('project postcode must be a valid UK postcode', () => {
-            function value(val) {
-                return { projectPostcode: val };
-            }
-
-            assertValidByKey(value('B15 1TR'));
-
-            const invalidMessages = ['Enter a real postcode'];
-            assertMessagesByKey(value(null), invalidMessages);
-            assertMessagesByKey(value('not a postcode'), invalidMessages);
-        });
-    });
-
-    describe('Project idea', () => {
-        test('project questions must be within word-counts', () => {
-            function testWordCountRange(fieldName, min, max) {
-                range(min, max, 50).forEach(wordCount => {
-                    assertValidByKey({
-                        [fieldName]: faker.lorem.words(wordCount)
-                    });
-                });
-
-                assertMessagesByKey(
-                    { [fieldName]: faker.lorem.words(min - 1) },
-                    [expect.stringMatching(/Answer must be at least/)]
-                );
-
-                assertMessagesByKey(
-                    { [fieldName]: faker.lorem.words(max + 1) },
-                    [expect.stringMatching(/Answer must be no more than/)]
-                );
-            }
-
-            testWordCountRange('yourIdeaProject', 50, 300);
-            testWordCountRange('yourIdeaPriorities', 50, 150);
-            testWordCountRange('yourIdeaCommunity', 50, 200);
-        });
-    });
-
-    describe('Project budget', () => {
-        function value(budget, totalCosts = 20000) {
-            return { projectBudget: budget, projectTotalCosts: totalCosts };
-        }
-
-        test('must provide a valid budget', () => {
-            assertValidByKey(value(mockBudget()));
-
-            const defaultMessages = ['Enter a project budget'];
-            const tooSmallMessage = ['Enter at least one item'];
-            assertMessagesByKey(value([]), tooSmallMessage);
-
-            const budgetWithoutCosts = times(5, () => ({
-                item: faker.lorem.words(5)
-            }));
-
-            assertMessagesByKey(value(budgetWithoutCosts), defaultMessages);
-        });
-
-        test('project costs must be less than £10,000', () => {
-            const budget = times(10, () => ({
-                item: faker.lorem.words(5),
-                cost: 1100
-            }));
-
-            assertMessagesByKey(value(budget), [
-                'Costs you would like us to fund must be less than £10,000'
-            ]);
-        });
-
-        test('project total costs must be at least value of project budget', () => {
-            assertValidByKey(value(mockBudget()));
-
-            assertMessagesByKey(value(mockBudget(), null), [
-                'Enter a total cost for your project'
-            ]);
-            assertMessagesByKey(value(mockBudget(), Infinity), [
-                'Enter a total cost for your project'
-            ]);
-            assertMessagesByKey(value(mockBudget(), 1000), [
-                'Total cost must be the same as or higher than the amount you’re asking us to fund'
-            ]);
-        });
-    });
-
-    describe('Who will benefit', () => {
-        test('skip section based on screening question', () => {
-            const formWithYes = formBuilder({
-                locale: 'en',
-                data: { beneficiariesGroupsCheck: 'yes' }
-            });
-
-            const formWithNo = formBuilder({
-                locale: 'en',
-                data: { beneficiariesGroupsCheck: 'no' }
-            });
-
-            expect(
-                formWithYes.pagination({
-                    baseUrl: '/apply/awards-for-all',
-                    sectionSlug: 'beneficiaries',
-                    currentStepIndex: 0
-                })
-            ).toEqual({
-                nextPage: {
-                    label: 'Specific groups of people',
-                    url: '/apply/awards-for-all/beneficiaries/2'
-                },
-                previousPage: {
-                    label: 'Project costs',
-                    url: '/apply/awards-for-all/your-project/5'
-                }
-            });
-
-            expect(
-                formWithNo.pagination({
-                    baseUrl: '/apply/awards-for-all',
-                    sectionSlug: 'organisation',
-                    currentStepIndex: 0
-                })
-            ).toEqual({
-                nextPage: {
-                    label: 'Organisation type',
-                    url: '/apply/awards-for-all/organisation/2'
-                },
-                previousPage: {
-                    label: 'Specific groups of people',
-                    url: '/apply/awards-for-all/beneficiaries/1'
-                }
-            });
-        });
-
-        test('require beneficiary groups when check is "yes"', () => {
-            assertMessagesByKey(
-                {
-                    beneficiariesGroupsCheck: 'yes',
-                    beneficiariesGroups: null,
-                    beneficiariesGroupsOther: null
-                },
-                [expect.stringContaining('Select the specific group')]
-            );
-        });
-
-        test('require additional beneficiary questions based on groups', () => {
-            assertMessagesByKey(
-                {
-                    beneficiariesGroupsCheck: 'yes',
-                    beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
-                    beneficiariesGroupsOther: null,
-                    beneficiariesGroupsEthnicBackground: null,
-                    beneficiariesGroupsGender: null,
-                    beneficiariesGroupsAge: null,
-                    beneficiariesGroupsDisabledPeople: null,
-                    beneficiariesGroupsReligion: null,
-                    beneficiariesGroupsReligionOther: null
-                },
-                [
-                    expect.stringContaining('Select the age group'),
-                    expect.stringContaining('Select the disabled people'),
-                    expect.stringContaining('Select the ethnic background'),
-                    expect.stringContaining('Select the gender'),
-                    expect.stringContaining('Select the religion')
-                ]
-            );
-        });
-
-        test('strip beneficiary data when check is "no"', () => {
-            assertValidByKey(mockBeneficiaries('no'));
-            expect(testValidate(mockBeneficiaries('no')).value).toEqual({
-                beneficiariesGroupsCheck: 'no'
-            });
-        });
-
-        test('allow only "other" option for beneficiary groups', () => {
-            assertValidByKey(mockBeneficiaries('yes'));
-
-            assertValidByKey({
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroupsOther: 'this should be valid',
-                beneficiariesGroupsEthnicBackground: null,
-                beneficiariesGroupsGender: null,
-                beneficiariesGroupsAge: null,
-                beneficiariesGroupsDisabledPeople: null,
-                beneficiariesGroupsReligion: null,
-                beneficiariesGroupsReligionOther: null
-            });
-
-            assertValidByKey(mockBeneficiaries('yes'));
-        });
-
-        test.skip('welsh language question required for applicants in Wales', () => {
-            function value(country, val) {
-                return {
-                    projectCountry: country,
-                    beneficiariesWelshLanguage: val
-                };
-            }
-
-            assertValidByKey(value('england'));
-            assertValidByKey(value('scotland'));
-            assertValidByKey(value('wales', 'all'));
-            assertMessagesByKey(value('wales'), ['Choose an option']);
-            assertMessagesByKey(value('wales', 'not-a-valid-choice'), [
-                'Choose an option'
-            ]);
-
-            [
-                { country: 'england', expected: [] },
-                { country: 'scotland', expected: [] },
-                { country: 'northern-ireland', expected: [] },
-                { country: 'wales', expected: ['beneficiariesWelshLanguage'] }
-            ].forEach(item => {
-                const fieldNames = formBuilder({
-                    locale: 'en',
-                    data: { projectCountry: item.country }
-                })
-                    .getCurrentFieldsForStep('beneficiaries', 7)
-                    .map(field => field.name);
-
-                expect(fieldNames).toEqual(item.expected);
-            });
-        });
-
-        test.skip('additional community question in Northern Ireland', () => {
-            function value(country, val) {
-                return {
-                    projectCountry: country,
-                    beneficiariesNorthernIrelandCommunity: val
-                };
-            }
-
-            assertValidByKey(value('england'));
-            assertValidByKey(value('scotland'));
-            assertValidByKey(value('wales'));
-            assertValidByKey(value('northern-ireland', 'mainly-catholic'));
-            assertValidByKey(value('northern-ireland', 'mainly-protestant'));
-            assertMessagesByKey(value('northern-ireland'), [
-                'Choose an option'
-            ]);
-            assertMessagesByKey(
-                value('northern-ireland', 'not-a-valid-choice'),
-                ['Choose an option']
-            );
-
-            [
-                { country: 'england', expected: [] },
-                { country: 'scotland', expected: [] },
-                {
-                    country: 'northern-ireland',
-                    expected: ['beneficiariesNorthernIrelandCommunity']
-                },
-                { country: 'wales', expected: [] }
-            ].forEach(item => {
-                const fieldNames = formBuilder({
-                    locale: 'en',
-                    data: { projectCountry: item.country }
-                })
-                    .getCurrentFieldsForStep('beneficiaries', 8)
-                    .map(field => field.name);
-
-                expect(fieldNames).toEqual(item.expected);
-            });
-        });
-    });
-
-    describe('Your organisation', () => {
-        test('organisation legal name must be provided', () => {
-            function value(val) {
-                return { organisationLegalName: val };
-            }
-
-            assertValidByKey(value(faker.company.companyName()));
-            assertMessagesByKey(value(null), [
-                'Enter the full legal name of the organisation'
-            ]);
-        });
-
-        test('organisation age must be provided', () => {
-            function value(val) {
-                return { organisationStartDate: val };
-            }
-
-            assertValidByKey(value({ month: 3, year: 2000 }));
-            assertMessagesByKey(value(null), ['Enter a day and month']);
-        });
-
-        test('organisation address must be provided', () => {
-            function value(val) {
-                return { organisationAddress: val };
-            }
-
-            assertValidByKey(value(mockAddress()));
-            assertMessagesByKey(value(null), ['Enter a full UK address']);
-            assertMessagesByKey(
-                value({
-                    line1: '3 Embassy Drive',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR'
-                }),
-                ['Enter a full UK address']
-            );
-            assertMessagesByKey(
-                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
-                ['Enter a real postcode']
-            );
-        });
-
-        test('must be a valid organisation type', () => {
-            function value(val) {
-                return { organisationType: val };
-            }
-
-            assertValidByKey(value(sample(Object.values(ORGANISATION_TYPES))));
-            const defaultMessages = ['Select a type of organisation'];
-            assertMessagesByKey(value(null), defaultMessages);
-            assertMessagesByKey(value('not-an-option'), defaultMessages);
-        });
-
-        test('accounting year end must be a valid day and month', () => {
-            function value(day, month) {
-                return {
-                    organisationStartDate: { month: 3, year: 2000 },
-                    accountingYearDate: { day, month }
-                };
-            }
-
-            assertValidByKey(value(12, 12));
-            assertMessagesByKey(value(null), ['Enter a day and month']);
-            assertMessagesByKey(value(31, 2), ['Enter a real day and month']);
-        });
-
-        test('total income for year must be a valid number', () => {
-            function value(val) {
-                return {
-                    organisationStartDate: { month: 3, year: 2000 },
-                    totalIncomeYear: val
-                };
-            }
-
-            assertValidByKey(value(random(1000, 1000000)));
-            assertMessagesByKey(value(null), [
-                'Enter a total income for the year (eg. a whole number with no commas or decimal points)'
-            ]);
-            assertMessagesByKey(value(Infinity), [
-                'Total income must be a real number'
-            ]);
-        });
-    });
-
-    describe('Registration numbers', function() {
-        const noRegistrationNumbers = difference(
-            Object.values(ORGANISATION_TYPES),
-            concat(
-                COMPANY_NUMBER_TYPES,
-                CHARITY_NUMBER_TYPES.required,
-                CHARITY_NUMBER_TYPES.optional,
-                EDUCATION_NUMBER_TYPES
-            )
-        );
-
-        test.each(noRegistrationNumbers)(
-            'no registration numbers required for %p',
-            function(organisationType) {
-                assertValidByKey({
-                    organisationType: organisationType,
-                    companyNumber: null,
-                    charityNumber: null,
-                    educationNumber: null
-                });
-            }
-        );
-
-        test.each(COMPANY_NUMBER_TYPES)(
-            'company number required for %p',
-            function(organisationType) {
-                assertValidByKey({
-                    organisationType: organisationType,
-                    companyNumber: '12345678'
-                });
-
-                assertMessagesByKey(
-                    {
-                        organisationType: organisationType,
-                        companyNumber: undefined
-                    },
-                    ['Enter your organisation’s Companies House number']
-                );
-            }
-        );
-
-        test.each(CHARITY_NUMBER_TYPES.required)(
-            'charity number required for %p',
-            function(organisationType) {
-                const data = {
-                    organisationType: organisationType,
-                    charityNumber: '23456789'
-                };
-
-                assertValidByKey(data);
-
-                assertMessagesByKey(
-                    {
-                        organisationType: organisationType,
-                        charityNumber: null
-                    },
-                    ['Enter your organisation’s charity number']
-                );
-
-                expect(
-                    formBuilder({
-                        locale: 'en',
-                        data: {
-                            organisationType,
-                            companyNumber: '12345678',
-                            charityNumber: '23456789',
-                            educationNumber: '345678'
-                        }
-                    }).validation.value
-                ).toEqual(data);
-            }
-        );
-
-        test.each(CHARITY_NUMBER_TYPES.optional)(
-            'charity number optional for %p',
-            function(organisationType) {
-                const data = {
-                    organisationType: organisationType,
-                    charityNumber: '23456789'
-                };
-
-                assertValidByKey(data);
-                assertValidByKey({
-                    organisationType: organisationType,
-                    charityNumber: null
-                });
-
-                assertValidByKey({
-                    organisationType: organisationType,
-                    charityNumber: ''
-                });
-
-                const fullNumbers = {
-                    organisationType,
-                    charityNumber: '23456789',
-                    educationNumber: '345678'
-                };
-
-                expect(
-                    formBuilder({
-                        locale: 'en',
-                        data: fullNumbers
-                    }).validation.value
-                ).toEqual(data);
-            }
-        );
-
-        test.each(EDUCATION_NUMBER_TYPES)(
-            'education number required for %p',
-            function(organisationType) {
-                assertMessagesByKey(
-                    {
-                        organisationType: organisationType,
-                        educationNumber: undefined
-                    },
-                    [
-                        'Enter your organisation’s Department for Education number'
-                    ]
-                );
-
-                assertValidByKey({
-                    organisationType: organisationType,
-                    educationNumber: '1160580'
-                });
-            }
-        );
-
-        test('registration numbers shown based on organisation type', () => {
-            const mappings = {
-                companyNumber: COMPANY_NUMBER_TYPES,
-                charityNumber: concat(
-                    CHARITY_NUMBER_TYPES.required,
-                    CHARITY_NUMBER_TYPES.optional
-                ),
-                educationNumber: EDUCATION_NUMBER_TYPES
-            };
-
-            map(mappings, (types, fieldName) => {
-                types.forEach(type => {
-                    const fieldNames = formBuilder({
-                        locale: 'en',
-                        data: { organisationType: type }
-                    })
-                        .getCurrentFieldsForStep('organisation', 3)
-                        .map(field => field.name);
-
-                    expect(fieldNames).toContain(fieldName);
-                });
-            });
-        });
-    });
-
-    function testNameFields(fieldName) {
-        test('first and last name must be provided', () => {
-            function value(firstName, lastName) {
-                return {
-                    [fieldName]: {
-                        firstName: firstName,
-                        lastName: lastName
-                    }
-                };
-            }
-
-            assertValidByKey(
-                value(faker.name.firstName(), faker.name.lastName())
-            );
-
-            assertMessagesByKey(value(null, null), [
-                'Enter first and last name'
-            ]);
-        });
-    }
-
-    function testEmailPhoneFields(emailFieldName, phoneFieldName) {
-        test('email address and phone number must be provided', () => {
-            function value(email, phone) {
-                return {
-                    [emailFieldName]: email,
-                    [phoneFieldName]: phone
-                };
-            }
-
-            assertValidByKey(
-                value(faker.internet.exampleEmail(), '0345 4 10 20 30')
-            );
-
-            assertMessagesByKey(value('not@anemail', 'not a phone number'), [
-                'Email address must be in the correct format, like name@example.com',
-                'Enter a real UK telephone number'
-            ]);
-        });
-    }
-
-    function testDateOfBirthField(fieldName, minAge) {
-        test(`date of birth must be at least ${minAge}`, () => {
-            function value(val) {
-                return {
-                    [fieldName]: val
-                };
-            }
-
-            assertMessagesByKey(value(null), ['Enter a date of birth']);
-            assertMessagesByKey(value({ year: 2000, month: 2, day: 31 }), [
-                'Enter a real date'
-            ]);
-            assertMessagesByKey(value(mockDateOfBirth(0, minAge - 1)), [
-                `Must be at least ${minAge} years old`
-            ]);
-            assertValidByKey(value(mockDateOfBirth(minAge, 90)));
-        });
-
-        test('date of birth is included if there is no organisation type', () => {
-            const dobWithoutOrgType = {
-                [fieldName]: mockDateOfBirth(minAge, 90)
-            };
-            expect(testValidate(dobWithoutOrgType).value).toEqual(
-                dobWithoutOrgType
-            );
-        });
-
-        test('date of birth is included when there is a required organisation type', () => {
-            const dobWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                [fieldName]: mockDateOfBirth(minAge, 90)
-            };
-            expect(testValidate(dobWithOrgType).value).toEqual(dobWithOrgType);
-        });
-
-        test.each(CONTACT_EXCLUDED_TYPES)(
-            'date of birth value stripped for %p',
-            function(excludedOrgType) {
-                const dobWithOrgType = {
-                    organisationType: excludedOrgType,
-                    [fieldName]: mockDateOfBirth(minAge, 90)
-                };
-
-                expect(testValidate(dobWithOrgType).value).toEqual({
-                    organisationType: excludedOrgType
-                });
-
-                const invalidDobWithOrgType = {
-                    organisationType: excludedOrgType,
-                    [fieldName]: mockDateOfBirth(1, minAge - 1)
-                };
-
-                expect(testValidate(invalidDobWithOrgType).value).toEqual({
-                    organisationType: excludedOrgType
-                });
-
-                assertValidByKey({
-                    organisationType: excludedOrgType
-                });
-            }
-        );
-    }
-
-    function testAddressField(fieldName) {
-        test('address is valid', () => {
-            function value(val) {
-                return {
-                    [fieldName]: val
-                };
-            }
-
-            assertValidByKey(value(mockAddress()));
-            assertMessagesByKey(value(null), ['Enter a full UK address']);
-            assertMessagesByKey(
-                value({
-                    line1: '3 Embassy Drive',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR'
-                }),
-                ['Enter a full UK address']
-            );
-            assertMessagesByKey(
-                value({ ...mockAddress(), ...{ postcode: 'not a postcode' } }),
-                ['Enter a real postcode']
-            );
-        });
-
-        test('address is included when there is a required organisation type', () => {
-            const valueWithOrgType = {
-                organisationType: ORGANISATION_TYPES.CIO,
-                [fieldName]: mockAddress()
-            };
-            expect(testValidate(valueWithOrgType).value).toEqual(
-                valueWithOrgType
-            );
-        });
-
-        test('address is included when there is no organisation type', () => {
-            const valueWithoutOrgType = {
-                [fieldName]: mockAddress()
-            };
-            expect(testValidate(valueWithoutOrgType).value).toEqual(
-                valueWithoutOrgType
-            );
-        });
-
-        test.each(CONTACT_EXCLUDED_TYPES)(
-            'address value stripped for %p',
-            function(excludedOrgType) {
-                const validAddressWithOrgType = {
-                    organisationType: excludedOrgType,
-                    [fieldName]: mockAddress()
-                };
-
-                expect(testValidate(validAddressWithOrgType).value).toEqual({
-                    organisationType: excludedOrgType
-                });
-
-                const invalidAddressWithOrgType = {
-                    organisationType: excludedOrgType,
-                    [fieldName]: {
-                        line1: faker.address.streetAddress(),
-                        townCity: faker.address.city(),
-                        county: faker.address.county()
-                    }
-                };
-
-                expect(testValidate(invalidAddressWithOrgType).value).toEqual({
-                    organisationType: excludedOrgType
-                });
-
-                assertValidByKey({
-                    organisationType: excludedOrgType
-                });
-            }
-        );
-    }
-
-    function testAddressHistoryField(fieldName) {
-        test('require address history if less than three years at current address', () => {
-            function value(meetsMinimum, previousAddress = null) {
-                return {
-                    [fieldName]: {
-                        currentAddressMeetsMinimum: meetsMinimum,
-                        previousAddress: previousAddress
-                    }
-                };
-            }
-
-            assertValidByKey(value('yes'));
-            assertValidByKey(value('no', mockAddress()));
-
-            assertMessagesByKey(
-                value('no', {
-                    line1: faker.address.streetAddress(),
-                    townCity: faker.address.city()
-                }),
-                ['Enter a full UK address']
-            );
-        });
-
-        test.each(CONTACT_EXCLUDED_TYPES)(
-            'optional if organisationType is %p',
-            function(excludedOrgType) {
-                assertValidByKey({
-                    organisationType: excludedOrgType,
-                    [fieldName]: null
-                });
-
-                assertMessagesByKey(
-                    {
-                        organisationType:
-                            ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY,
-                        [fieldName]: null
-                    },
-                    ['Enter a full UK address']
-                );
-            }
-        );
-    }
-
-    describe('Senior contact', () => {
-        testNameFields('seniorContactName');
-        testEmailPhoneFields('seniorContactEmail', 'seniorContactPhone');
-        testDateOfBirthField('seniorContactDateOfBirth', 18);
-        testAddressField('seniorContactAddress');
-        testAddressHistoryField('seniorContactAddressHistory');
-
-        test('include all roles if no organisation type is provided', () => {
-            const field = fieldFor('seniorContactRole', {
-                organisationType: null
-            });
-            expect(field.options.map(option => option.value)).toEqual([
-                'chair',
-                'chancellor',
-                'chief-executive',
-                'chief-executive-officer',
-                'company-director',
-                'company-secretary',
-                'deputy-parish-clerk',
-                'director',
-                'elected-member',
-                'head-teacher',
-                'parish-clerk',
-                'religious-leader',
-                'secretary',
-                'treasurer',
-                'trustee',
-                'vice-chair',
-                'vice-chancellor'
-            ]);
-        });
-
-        test('include roles based on organisation type', () => {
-            function assertRolesForType(type, expected) {
-                const roles = fieldFor('seniorContactRole', {
-                    organisationType: type
-                }).options.map(option => option.value);
-                expect(roles).toEqual(expected);
-
-                assertValidByKey({
-                    organisationType: type,
-                    seniorContactRole: sample(roles)
-                });
-
-                assertMessagesByKey(
-                    {
-                        organisationType: type,
-                        seniorContactRole: 'not-an-option'
-                    },
-                    ['Senior contact role is not valid']
-                );
-            }
-
-            assertRolesForType(ORGANISATION_TYPES.UNREGISTERED_VCO, [
-                'chair',
-                'vice-chair',
-                'secretary',
-                'treasurer'
-            ]);
-
-            assertRolesForType(
-                ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                ['trustee']
-            );
-
-            assertRolesForType(ORGANISATION_TYPES.CIO, [
-                'trustee',
-                'chief-executive-officer'
-            ]);
-
-            assertRolesForType(ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY, [
-                'company-director',
-                'company-secretary'
-            ]);
-
-            assertRolesForType(ORGANISATION_TYPES.SCHOOL, ['head-teacher']);
-
-            assertRolesForType(ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY, [
-                'chancellor',
-                'vice-chancellor'
-            ]);
-        });
-
-        test('include role warning based on organisation type', () => {
-            function assertWarningsFor(data, expected) {
-                const field = fieldFor('seniorContactRole', data);
-                expect(field.warnings).toEqual(expected);
-            }
-
-            assertWarningsFor({ organisationType: ORGANISATION_TYPES.CIO }, [
-                expect.stringContaining(
-                    `Your senior contact must be listed as a member`
-                ),
-                expect.stringContaining(
-                    `As a charity, your senior contact can be one of`
-                )
-            ]);
-
-            assertWarningsFor(
-                {
-                    organisationType: ORGANISATION_TYPES.CIO,
-                    projectCountry: 'scotland'
-                },
-                [
-                    expect.stringContaining(
-                        `As a charity, your senior contact can be one of`
-                    )
-                ]
-            );
-
-            assertWarningsFor(
-                {
-                    organisationType:
-                        ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY,
-                    projectCountry: 'scotland'
-                },
-                [
-                    expect.stringContaining(
-                        `As a registered charity, your senior contact must be`
-                    )
-                ]
-            );
-
-            assertWarningsFor({ organisationType: ORGANISATION_TYPES.SCHOOL }, [
-                expect.stringContaining(
-                    `As a school, your senior contact must be`
-                )
-            ]);
-        });
-
-        test.each(CONTACT_EXCLUDED_TYPES)(
-            'contact fields not included for %p',
-            function(excludedOrgType) {
-                const fieldNames = formBuilder({
-                    locale: 'en',
-                    data: { organisationType: excludedOrgType }
-                })
-                    .getCurrentFieldsForStep('senior-contact', 0)
-                    .map(field => field.name);
-
-                expect(fieldNames).toEqual([
-                    'seniorContactRole',
-                    'seniorContactName',
-                    'seniorContactEmail',
-                    'seniorContactPhone',
-                    'seniorContactCommunicationNeeds'
-                ]);
-            }
-        );
-    });
-
-    describe('Main contact', () => {
-        testNameFields('mainContactName');
-        testEmailPhoneFields('mainContactEmail', 'mainContactPhone');
-        testDateOfBirthField('mainContactDateOfBirth', 16);
-        testAddressField('mainContactAddress');
-        testAddressHistoryField('mainContactAddressHistory');
-
-        test('contact fields not included for schools and statutory bodies', () => {
-            const defaultFieldNames = formBuilder({ locale: 'en' })
-                .getCurrentFieldsForStep('main-contact', 0)
-                .map(field => field.name);
-
-            expect(defaultFieldNames).toEqual([
-                'mainContactName',
-                'mainContactDateOfBirth',
-                'mainContactAddress',
-                'mainContactAddressHistory',
-                'mainContactEmail',
-                'mainContactPhone',
-                'mainContactCommunicationNeeds'
-            ]);
-
-            CONTACT_EXCLUDED_TYPES.forEach(orgType => {
-                const fieldNames = formBuilder({
-                    locale: 'en',
-                    data: { organisationType: orgType }
-                })
-                    .getCurrentFieldsForStep('main-contact', 0)
-                    .map(field => field.name);
-
-                expect(fieldNames).toEqual([
-                    'mainContactName',
-                    'mainContactEmail',
-                    'mainContactPhone',
-                    'mainContactCommunicationNeeds'
-                ]);
-            });
-        });
-
-        test('include warning if contact last names match', () => {
-            expect(fieldFor('mainContactName', null).warnings).toEqual([]);
-
-            const lastName = faker.name.lastName();
-            expect(
-                fieldFor('mainContactName', {
-                    seniorContactName: {
-                        firstName: faker.name.firstName(),
-                        lastName: lastName
-                    },
-                    mainContactName: {
-                        firstName: faker.name.firstName(),
-                        lastName: lastName
-                    }
-                }).warnings
-            ).toEqual([expect.stringContaining('have the same surname')]);
-        });
-    });
-
-    describe('Bank details', () => {
-        test('valid account name', () => {
-            function value(val) {
-                return { bankAccountName: val };
-            }
-
-            assertValidByKey(value(faker.company.companyName()));
-            assertMessagesByKey(value(null), [
-                'Enter the name of your organisation, as it appears on your bank statement'
-            ]);
-        });
-
-        test('valid sort code', () => {
-            function value(val) {
-                return { bankSortCode: val };
-            }
-
-            assertValidByKey(value('108800'));
-            assertMessagesByKey(value(null), ['Enter a sort code']);
-        });
-
-        test('valid account number', () => {
-            function value(val) {
-                return { bankAccountNumber: val };
-            }
-
-            assertValidByKey(value('00012345'));
-            assertMessagesByKey(value(null), ['Enter an account number']);
-        });
-
-        test('valid bank statement upload', () => {
-            function value(val) {
-                return { bankStatement: val };
-            }
-
-            assertValidByKey(
-                value({
-                    filename: 'example.pdf',
-                    size: 123,
-                    type: 'application/pdf'
-                })
-            );
-            assertMessagesByKey(value(null), ['Provide a bank statement']);
-        });
-    });
-});
-
-describe('form shape', () => {
+describe('Global validation', () => {
     test('validate model shape', () => {
-        validateModel(formBuilder({ locale: 'en' }));
+        validateModel(formBuilder());
     });
 
-    test('featured errors from allow list', () => {
+    test('default validations for an empty form', () => {
+        const form = formBuilder();
+
+        expect(
+            form.validation.messages.map(item => item.msg)
+        ).toMatchSnapshot();
+
+        expect(form.progress.isComplete).toBeFalsy();
+        expect(form.progress.isPristine).toBeTruthy();
+
+        const allSectionsEmpty = form.progress.sections.every(
+            section => section.status === 'empty'
+        );
+        expect(allSectionsEmpty).toBeTruthy();
+    });
+
+    test('progress for a partially complete form', () => {
         const form = formBuilder({
-            locale: 'en',
+            data: mockFullForm({ country: 'scotland' })
+        });
+
+        expect(form.progress.isComplete).toBeFalsy();
+        expect(form.progress.isPristine).toBeFalsy();
+
+        const [complete, incomplete] = partition(
+            form.progress.sections,
+            function(section) {
+                return section.status === 'complete';
+            }
+        );
+
+        expect(map(complete, 'slug')).toEqual([
+            'your-project',
+            'beneficiaries',
+            'main-contact',
+            'bank-details',
+            'terms-and-conditions'
+        ]);
+
+        expect(map(incomplete, 'slug')).toEqual([
+            'organisation',
+            'senior-contact'
+        ]);
+    });
+
+    test.each(
+        Object.values(ORGANISATION_TYPES).map(function(organisationType) {
+            let data = {};
+            switch (organisationType) {
+                case ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY:
+                case ORGANISATION_TYPES.CIO:
+                    data = { charityNumber: '12345678' };
+                    break;
+                case ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY:
+                    data = { companyNumber: '12345678' };
+                    break;
+                case ORGANISATION_TYPES.SCHOOL:
+                case ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY:
+                    data = { educationNumber: '345678' };
+                    break;
+                case ORGANISATION_TYPES.STATUTORY_BODY:
+                    data = { organisationSubType: 'parish-council' };
+                    break;
+                default:
+                    data = {};
+                    break;
+            }
+
+            return [organisationType, data];
+        })
+    )('validate a complete form for %s', function(orgType, data = {}) {
+        const roles = rolesFor({
+            organisationType: orgType,
+            organisationSubType: data.organisationSubType
+        });
+
+        const sampleRole = sample(roles.map(role => role.value));
+
+        const form = formBuilder({
+            data: mockFullForm({
+                country: 'scotland', // @TODO: Vary country
+                organisationType: orgType,
+                organisationSubType: data.organisationSubType,
+                companyNumber: data.companyNumber,
+                charityNumber: data.charityNumber,
+                educationNumber: data.educationNumber,
+                seniorContactRole: sampleRole
+            })
+        });
+
+        expect(form.validation.isValid).toBeTruthy();
+        expect(form.validation.messages).toHaveLength(0);
+
+        expect(form.progress.isComplete).toBeTruthy();
+        expect(form.progress.isPristine).toBeFalsy();
+
+        const allSectionsComplete = form.progress.sections.every(
+            section => section.status === 'complete'
+        );
+        expect(allSectionsComplete).toBeTruthy();
+    });
+
+    test('list featured errors based on allow list', () => {
+        const form = formBuilder({
             data: {
                 projectDateRange: {
                     startDate: { day: 31, month: 1, year: 2019 },
@@ -1236,164 +298,726 @@ describe('form shape', () => {
             }
         });
 
-        expect(form.validation.featuredMessages).toEqual([
+        expect(form.validation.featuredMessages.map(item => item.msg)).toEqual([
+            expect.stringMatching(/Date you start the project must be after/),
+            'Senior contact role is not valid'
+        ]);
+    });
+});
+
+describe('Project details', () => {
+    test('project dates must be within range', () => {
+        assertMessagesByKey(
+            { projectDateRange: { startDate: null, endDate: null } },
+            ['Enter a project start and end date']
+        );
+
+        assertMessagesByKey(
             {
-                msg: expect.stringMatching(
-                    /Date you start the project must be after/
-                ),
-                param: 'projectDateRange',
-                type: 'dateRange.minDate.invalid',
-                field: expect.any(Object)
+                projectDateRange: {
+                    startDate: { day: 31, month: 2, year: 2030 },
+                    endDate: { day: 31, month: 24, year: 2030 }
+                }
             },
+            [expect.stringMatching('must be real dates')]
+        );
+
+        assertMessagesByKey(
             {
-                msg: 'Senior contact role is not valid',
-                param: 'seniorContactRole',
-                type: 'any.allowOnly',
-                field: expect.any(Object)
-            }
+                projectDateRange: {
+                    startDate: { day: 1, month: 1, year: 2020 },
+                    endDate: { day: 1, month: 1, year: 2030 }
+                }
+            },
+            [expect.stringMatching(/Date you end the project must be within/)]
+        );
+    });
+
+    test('project postcode must be a valid UK postcode', () => {
+        const invalidMessages = ['Enter a real postcode'];
+        assertMessagesByKey({ projectPostcode: null }, invalidMessages);
+        assertMessagesByKey(
+            { projectPostcode: 'not a postcode' },
+            invalidMessages
+        );
+    });
+
+    test.each([
+        ['yourIdeaProject', 50, 300],
+        ['yourIdeaPriorities', 50, 150],
+        ['yourIdeaCommunity', 50, 200]
+    ])('%p must be within %p and %p words', (fieldName, min, max) => {
+        assertMessagesByKey({ [fieldName]: faker.lorem.words(min - 1) }, [
+            expect.stringMatching(/Answer must be at least/)
+        ]);
+
+        assertMessagesByKey({ [fieldName]: faker.lorem.words(max + 1) }, [
+            expect.stringMatching(/Answer must be no more than/)
+        ]);
+    });
+});
+
+describe('Project budget', () => {
+    function value(budget, totalCosts = 20000) {
+        return { projectBudget: budget, projectTotalCosts: totalCosts };
+    }
+
+    test('must provide a valid budget', () => {
+        assertValidByKey(value(mockBudget()));
+
+        const defaultMessages = ['Enter a project budget'];
+        const tooSmallMessage = ['Enter at least one item'];
+        assertMessagesByKey(value([]), tooSmallMessage);
+
+        const budgetWithoutCosts = times(5, () => ({
+            item: faker.lorem.words(5)
+        }));
+
+        assertMessagesByKey(value(budgetWithoutCosts), defaultMessages);
+    });
+
+    test('project costs must be less than £10,000', () => {
+        const budget = times(10, () => ({
+            item: faker.lorem.words(5),
+            cost: 1100
+        }));
+
+        assertMessagesByKey(value(budget), [
+            'Costs you would like us to fund must be less than £10,000'
         ]);
     });
 
-    test('progress', () => {
-        const emptyForm = formBuilder({ locale: 'en' });
-        expect(emptyForm.progress).toEqual({
-            isComplete: false,
-            isPristine: true,
-            sections: [
-                {
-                    label: 'Your project',
-                    slug: 'your-project',
-                    status: 'empty'
-                },
-                {
-                    label: 'Who will benefit',
-                    slug: 'beneficiaries',
-                    status: 'empty'
-                },
-                {
-                    label: 'Your organisation',
-                    slug: 'organisation',
-                    status: 'empty'
-                },
-                {
-                    label: 'Senior contact',
-                    slug: 'senior-contact',
-                    status: 'empty'
-                },
-                {
-                    label: 'Main contact',
-                    slug: 'main-contact',
-                    status: 'empty'
-                },
-                {
-                    label: 'Bank details',
-                    slug: 'bank-details',
-                    status: 'empty'
-                },
-                {
-                    label: 'Terms and conditions',
-                    slug: 'terms-and-conditions',
-                    status: 'empty'
-                }
-            ]
-        });
+    test('project total costs must be at least value of project budget', () => {
+        assertValidByKey(value(mockBudget()));
 
-        const partialForm = formBuilder({
-            locale: 'en',
-            data: mockFullForm({ country: 'scotland' })
-        });
+        assertMessagesByKey(value(mockBudget(), null), [
+            'Enter a total cost for your project'
+        ]);
+        assertMessagesByKey(value(mockBudget(), Infinity), [
+            'Enter a total cost for your project'
+        ]);
+        assertMessagesByKey(value(mockBudget(), 1000), [
+            'Total cost must be the same as or higher than the amount you’re asking us to fund'
+        ]);
+    });
+});
 
-        expect(partialForm.progress).toEqual({
-            isComplete: false,
-            isPristine: false,
-            sections: [
-                {
-                    label: 'Your project',
-                    slug: 'your-project',
-                    status: 'complete'
-                },
-                {
-                    label: 'Who will benefit',
-                    slug: 'beneficiaries',
-                    status: 'complete'
-                },
-                {
-                    label: 'Your organisation',
-                    slug: 'organisation',
-                    status: 'incomplete'
-                },
-                {
-                    label: 'Senior contact',
-                    slug: 'senior-contact',
-                    status: 'incomplete'
-                },
-                {
-                    label: 'Main contact',
-                    slug: 'main-contact',
-                    status: 'complete'
-                },
-                {
-                    label: 'Bank details',
-                    slug: 'bank-details',
-                    status: 'complete'
-                },
-                {
-                    label: 'Terms and conditions',
-                    slug: 'terms-and-conditions',
-                    status: 'complete'
-                }
-            ]
-        });
+describe('Who will benefit', () => {
+    test('require beneficiary groups when check is "yes"', () => {
+        assertMessagesByKey(
+            {
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: null,
+                beneficiariesGroupsOther: null
+            },
+            [expect.stringContaining('Select the specific group')]
+        );
+    });
 
-        const completeForm = formBuilder({
-            locale: 'en',
-            data: mockFullForm({
-                country: 'scotland',
-                organisationType: ORGANISATION_TYPES.UNREGISTERED_VCO,
-                seniorContactRole: 'chair'
+    test('require additional beneficiary questions based on groups', () => {
+        expect(
+            messagesByKey({
+                beneficiariesGroupsCheck: 'yes',
+                beneficiariesGroups: Object.values(BENEFICIARY_GROUPS),
+                beneficiariesGroupsOther: null,
+                beneficiariesGroupsEthnicBackground: null,
+                beneficiariesGroupsGender: null,
+                beneficiariesGroupsAge: null,
+                beneficiariesGroupsDisabledPeople: null,
+                beneficiariesGroupsReligion: null,
+                beneficiariesGroupsReligionOther: null
             })
+        ).toMatchSnapshot();
+    });
+
+    test('strip beneficiary data when check is "no"', () => {
+        assertValidByKey(mockBeneficiaries('no'));
+        expect(
+            formBuilder({
+                data: mockBeneficiaries('no')
+            }).validation.value
+        ).toEqual({
+            beneficiariesGroupsCheck: 'no'
+        });
+    });
+
+    test('allow only "other" option for beneficiary groups', () => {
+        assertValidByKey(mockBeneficiaries('yes'));
+
+        assertValidByKey({
+            beneficiariesGroupsCheck: 'yes',
+            beneficiariesGroupsOther: 'this should be valid',
+            beneficiariesGroupsEthnicBackground: null,
+            beneficiariesGroupsGender: null,
+            beneficiariesGroupsAge: null,
+            beneficiariesGroupsDisabledPeople: null,
+            beneficiariesGroupsReligion: null,
+            beneficiariesGroupsReligionOther: null
         });
 
-        expect(completeForm.progress).toEqual({
-            isComplete: true,
-            isPristine: false,
-            sections: [
-                {
-                    label: 'Your project',
-                    slug: 'your-project',
-                    status: 'complete'
-                },
-                {
-                    label: 'Who will benefit',
-                    slug: 'beneficiaries',
-                    status: 'complete'
-                },
-                {
-                    label: 'Your organisation',
-                    slug: 'organisation',
-                    status: 'complete'
-                },
-                {
-                    label: 'Senior contact',
-                    slug: 'senior-contact',
-                    status: 'complete'
-                },
-                {
-                    label: 'Main contact',
-                    slug: 'main-contact',
-                    status: 'complete'
-                },
-                {
-                    label: 'Bank details',
-                    slug: 'bank-details',
-                    status: 'complete'
-                },
-                {
-                    label: 'Terms and conditions',
-                    slug: 'terms-and-conditions',
-                    status: 'complete'
-                }
-            ]
+        assertValidByKey(mockBeneficiaries('yes'));
+    });
+
+    test.each([
+        ['northern-ireland', ['beneficiariesNorthernIrelandCommunity']],
+        ['wales', ['beneficiariesWelshLanguage']]
+    ])('additional beneficiary field in %p - %p', function(
+        country,
+        additionalFieldNames
+    ) {
+        const form = formBuilder({
+            data: { projectCountry: country }
         });
+
+        expect(form.getCurrentFields().map(field => field.name)).toEqual(
+            expect.arrayContaining(additionalFieldNames)
+        );
+    });
+
+    test.skip('welsh language question required for applicants in Wales', () => {
+        function value(country, val) {
+            return {
+                projectCountry: country,
+                beneficiariesWelshLanguage: val
+            };
+        }
+
+        assertValidByKey(value('england'));
+        assertValidByKey(value('scotland'));
+        assertValidByKey(value('wales', 'all'));
+        assertMessagesByKey(value('wales'), ['Choose an option']);
+        assertMessagesByKey(value('wales', 'not-a-valid-choice'), [
+            'Choose an option'
+        ]);
+    });
+
+    test.skip('additional community question in Northern Ireland', () => {
+        function value(country, val) {
+            return {
+                projectCountry: country,
+                beneficiariesNorthernIrelandCommunity: val
+            };
+        }
+
+        assertValidByKey(value('england'));
+        assertValidByKey(value('scotland'));
+        assertValidByKey(value('wales'));
+        assertValidByKey(value('northern-ireland', 'mainly-catholic'));
+        assertValidByKey(value('northern-ireland', 'mainly-protestant'));
+        assertMessagesByKey(value('northern-ireland'), ['Choose an option']);
+        assertMessagesByKey(value('northern-ireland', 'not-a-valid-choice'), [
+            'Choose an option'
+        ]);
+    });
+});
+
+describe('Your organisation', () => {
+    test('valid basic organisation details required', () => {
+        const invalidOrganisationData = {
+            organisationLegalName: null,
+            organisationStartDate: {
+                month: 2
+            },
+            organisationAddress: {
+                line1: '3 Embassy Drive',
+                county: 'West Midlands',
+                postcode: 'B15 1TR'
+            },
+            organisationType: sample([null, 'not-a-valid-option'])
+        };
+
+        expect(messagesByKey(invalidOrganisationData)).toMatchSnapshot();
+    });
+
+    test('finance details required if organisation is over 15 months old', function() {
+        const now = moment();
+        const requiredDate = now.clone().subtract('15', 'months');
+
+        assertValidByKey({
+            organisationStartDate: {
+                month: now.month() + 1,
+                year: now.year()
+            },
+            accountingYearDate: null,
+            totalIncomeYear: null
+        });
+
+        expect(
+            messagesByKey({
+                organisationStartDate: {
+                    month: requiredDate.month() + 1,
+                    year: requiredDate.year()
+                },
+                accountingYearDate: null,
+                totalIncomeYear: null
+            })
+        ).toMatchSnapshot();
+
+        expect(
+            messagesByKey({
+                organisationStartDate: {
+                    month: requiredDate.month() + 1,
+                    year: requiredDate.year()
+                },
+                accountingYearDate: {
+                    month: 22,
+                    year: 2021
+                },
+                totalIncomeYear: Infinity
+            })
+        ).toMatchSnapshot();
+    });
+});
+describe('Registration numbers', function() {
+    const noRegistrationNumbers = difference(
+        Object.values(ORGANISATION_TYPES),
+        concat(
+            COMPANY_NUMBER_TYPES,
+            CHARITY_NUMBER_TYPES.required,
+            CHARITY_NUMBER_TYPES.optional,
+            EDUCATION_NUMBER_TYPES
+        )
+    );
+
+    test.each(noRegistrationNumbers)(
+        'no registration numbers required for %p',
+        function(organisationType) {
+            assertValidByKey({
+                organisationType: organisationType,
+                companyNumber: null,
+                charityNumber: null,
+                educationNumber: null
+            });
+        }
+    );
+
+    test.each(COMPANY_NUMBER_TYPES)('company number required for %p', function(
+        organisationType
+    ) {
+        assertValidByKey({
+            organisationType: organisationType,
+            companyNumber: '12345678'
+        });
+
+        assertMessagesByKey(
+            {
+                organisationType: organisationType,
+                companyNumber: undefined
+            },
+            ['Enter your organisation’s Companies House number']
+        );
+    });
+
+    test.each(CHARITY_NUMBER_TYPES.required)(
+        'charity number required for %p',
+        function(organisationType) {
+            const data = {
+                organisationType: organisationType,
+                charityNumber: '23456789'
+            };
+
+            assertValidByKey(data);
+
+            assertMessagesByKey(
+                {
+                    organisationType: organisationType,
+                    charityNumber: null
+                },
+                ['Enter your organisation’s charity number']
+            );
+
+            expect(
+                formBuilder({
+                    locale: 'en',
+                    data: {
+                        organisationType,
+                        companyNumber: '12345678',
+                        charityNumber: '23456789',
+                        educationNumber: '345678'
+                    }
+                }).validation.value
+            ).toEqual(data);
+        }
+    );
+
+    test.each(CHARITY_NUMBER_TYPES.optional)(
+        'charity number optional for %p',
+        function(organisationType) {
+            const data = {
+                organisationType: organisationType,
+                charityNumber: '23456789'
+            };
+
+            assertValidByKey(data);
+            assertValidByKey({
+                organisationType: organisationType,
+                charityNumber: null
+            });
+
+            assertValidByKey({
+                organisationType: organisationType,
+                charityNumber: ''
+            });
+
+            const fullNumbers = {
+                organisationType,
+                charityNumber: '23456789',
+                educationNumber: '345678'
+            };
+
+            expect(
+                formBuilder({
+                    locale: 'en',
+                    data: fullNumbers
+                }).validation.value
+            ).toEqual(data);
+        }
+    );
+
+    test.each(EDUCATION_NUMBER_TYPES)(
+        'education number required for %p',
+        function(organisationType) {
+            assertMessagesByKey(
+                {
+                    organisationType: organisationType,
+                    educationNumber: undefined
+                },
+                ['Enter your organisation’s Department for Education number']
+            );
+
+            assertValidByKey({
+                organisationType: organisationType,
+                educationNumber: '1160580'
+            });
+        }
+    );
+
+    test('registration numbers shown based on organisation type', () => {
+        const mappings = {
+            companyNumber: COMPANY_NUMBER_TYPES,
+            charityNumber: concat(
+                CHARITY_NUMBER_TYPES.required,
+                CHARITY_NUMBER_TYPES.optional
+            ),
+            educationNumber: EDUCATION_NUMBER_TYPES
+        };
+
+        map(mappings, (types, fieldName) => {
+            types.forEach(type => {
+                const fieldNames = formBuilder({
+                    locale: 'en',
+                    data: { organisationType: type }
+                })
+                    .getCurrentFieldsForStep('organisation', 3)
+                    .map(field => field.name);
+
+                expect(fieldNames).toContain(fieldName);
+            });
+        });
+    });
+});
+
+describe('Contacts', () => {
+    test.each(['seniorContactName', 'mainContactName'])(
+        'first and last name must be provided for %p',
+        function(fieldName) {
+            assertMessagesByKey(
+                {
+                    [fieldName]: {
+                        firstName: null,
+                        lastName: null
+                    }
+                },
+                ['Enter first and last name']
+            );
+        }
+    );
+
+    test('include warning if contact last names match', () => {
+        const form = formBuilder();
+
+        expect(form.allFields.mainContactName.warnings).toEqual([]);
+
+        const lastName = faker.name.lastName();
+        const formWithMatchingLastNames = formBuilder({
+            data: {
+                seniorContactName: {
+                    firstName: faker.name.firstName(),
+                    lastName: lastName
+                },
+                mainContactName: {
+                    firstName: faker.name.firstName(),
+                    lastName: lastName
+                }
+            }
+        });
+
+        expect(
+            formWithMatchingLastNames.allFields.mainContactName.warnings
+        ).toEqual([expect.stringContaining('have the same surname')]);
+    });
+
+    test.each(['seniorContactEmail', 'mainContactEmail'])(
+        'email address must be valid for %p',
+        function(fieldName) {
+            assertMessagesByKey(
+                {
+                    [fieldName]: 'not@anemail'
+                },
+                [
+                    'Email address must be in the correct format, like name@example.com'
+                ]
+            );
+        }
+    );
+
+    test.each(['seniorContactPhone', 'mainContactPhone'])(
+        'phone number must be valid for %p',
+        function(fieldName) {
+            assertMessagesByKey(
+                {
+                    [fieldName]: 'not a phone number'
+                },
+                ['Enter a real UK telephone number']
+            );
+        }
+    );
+
+    test.each([
+        ['seniorContactDateOfBirth', 18],
+        ['mainContactDateOfBirth', 16]
+    ])(`date of birth must be valid for %p`, function(fieldName, minAge) {
+        assertMessagesByKey({ [fieldName]: null }, ['Enter a date of birth']);
+
+        assertMessagesByKey(
+            { [fieldName]: { year: 2000, month: 2, day: 31 } },
+            ['Enter a real date']
+        );
+
+        assertMessagesByKey({ [fieldName]: mockDateOfBirth(0, minAge - 1) }, [
+            `Must be at least ${minAge} years old`
+        ]);
+
+        assertValidByKey({
+            [fieldName]: mockDateOfBirth(minAge, 90)
+        });
+    });
+
+    test.each(CONTACT_EXCLUDED_TYPES)(
+        'dates of birth and addresses stripped for %p',
+        function(excludedOrgType) {
+            const validForm = formBuilder({
+                data: {
+                    organisationType: excludedOrgType,
+                    seniorContactDateOfBirth: mockDateOfBirth(18, 90),
+                    mainContactDateOfBirth: mockDateOfBirth(16, 90),
+                    seniorContactAddress: mockAddress(),
+                    seniorContactAddressHistory: {
+                        currentAddressMeetsMinimum: 'yes',
+                        previousAddress: mockAddress()
+                    },
+                    mainContactAddress: mockAddress(),
+                    mainContactAddressHistory: {
+                        currentAddressMeetsMinimum: 'yes',
+                        previousAddress: mockAddress()
+                    }
+                }
+            });
+
+            // Should strip even when values are invalid
+            const invalidForm = formBuilder({
+                data: {
+                    organisationType: excludedOrgType,
+                    seniorContactDateOfBirth: mockDateOfBirth(1, 17),
+                    mainContactDateOfBirth: mockDateOfBirth(1, 17),
+                    seniorContactAddress: {
+                        line1: faker.address.streetAddress(),
+                        townCity: faker.address.city(),
+                        county: faker.address.county()
+                    },
+                    mainContactAddress: {
+                        line1: faker.address.streetAddress(),
+                        townCity: faker.address.city(),
+                        county: faker.address.county()
+                    }
+                }
+            });
+
+            const expectedData = {
+                organisationType: excludedOrgType
+            };
+
+            assertValidByKey(expectedData);
+
+            expect(validForm.validation.value).toEqual(expectedData);
+
+            expect(invalidForm.validation.value).toEqual(expectedData);
+
+            // Check fields are not shown
+            function checkFieldsForSection(section, expectedFields) {
+                const fields = validForm
+                    .getCurrentFieldsForStep(section, 0)
+                    .map(field => field.name);
+
+                expect(fields).toEqual(expectedFields);
+            }
+
+            checkFieldsForSection('senior-contact', [
+                'seniorContactRole',
+                'seniorContactName',
+                'seniorContactEmail',
+                'seniorContactPhone',
+                'seniorContactCommunicationNeeds'
+            ]);
+
+            checkFieldsForSection('main-contact', [
+                'mainContactName',
+                'mainContactEmail',
+                'mainContactPhone',
+                'mainContactCommunicationNeeds'
+            ]);
+        }
+    );
+
+    test.each(['seniorContactAddress', 'mainContactAddress'])(
+        'address is valid for %p',
+        function(fieldName) {
+            const partialAddress = {
+                line1: '3 Embassy Drive',
+                county: 'West Midlands',
+                postcode: 'B15 1TR'
+            };
+
+            const addressWithInvalidPostcode = {
+                ...mockAddress(),
+                ...{ postcode: 'not a postcode' }
+            };
+
+            assertMessagesByKey({ [fieldName]: null }, [
+                'Enter a full UK address'
+            ]);
+
+            assertMessagesByKey({ [fieldName]: partialAddress }, [
+                'Enter a full UK address'
+            ]);
+
+            assertMessagesByKey({ [fieldName]: addressWithInvalidPostcode }, [
+                'Enter a real postcode'
+            ]);
+        }
+    );
+
+    test.each(['seniorContactAddressHistory', 'mainContactAddressHistory'])(
+        'address history is valid for %p',
+        function(fieldName) {
+            assertValidByKey({
+                [fieldName]: {
+                    currentAddressMeetsMinimum: 'yes',
+                    previousAddress: null
+                }
+            });
+
+            assertValidByKey({
+                [fieldName]: {
+                    currentAddressMeetsMinimum: 'no',
+                    previousAddress: mockAddress()
+                }
+            });
+
+            assertMessagesByKey(
+                {
+                    [fieldName]: {
+                        currentAddressMeetsMinimum: 'no',
+                        previousAddress: {
+                            line1: faker.address.streetAddress(),
+                            townCity: faker.address.city()
+                        }
+                    }
+                },
+                ['Enter a full UK address']
+            );
+        }
+    );
+
+    test('include all roles if no organisation type is provided', () => {
+        const form = formBuilder({
+            data: { organisationType: null }
+        });
+
+        const roleOptions = form.allFields.seniorContactRole.options.map(
+            option => option.value
+        );
+
+        expect(roleOptions).toMatchSnapshot();
+    });
+
+    test.each(Object.values(ORGANISATION_TYPES))(
+        `include expected roles for %p`,
+        function(orgType) {
+            const form = formBuilder({
+                data: { organisationType: orgType, organisationSubType: null }
+            });
+
+            const roles = form.allFields.seniorContactRole.options.map(
+                option => option.value
+            );
+
+            expect(roles).toMatchSnapshot();
+
+            assertValidByKey({
+                organisationType: orgType,
+                seniorContactRole: sample(roles)
+            });
+
+            assertMessagesByKey(
+                {
+                    organisationType: orgType,
+                    seniorContactRole: 'not-an-option'
+                },
+                ['Senior contact role is not valid']
+            );
+        }
+    );
+
+    test.each(Object.keys(ORGANISATION_TYPES))(
+        'include role warning for %p',
+        function(organisationType) {
+            ['england', 'scotland', 'northern-ireland', 'wales'].forEach(
+                function(country) {
+                    const form = formBuilder({
+                        organisationType: organisationType,
+                        projectCountry: country
+                    });
+                    const field = form.allFields.seniorContactRole;
+                    expect(field.warnings).toMatchSnapshot();
+                }
+            );
+        }
+    );
+});
+
+describe('Bank details', () => {
+    test('requires valid bank details', () => {
+        expect(
+            messagesByKey({
+                bankAccountName: null,
+                bankSortCode: null,
+                bankAccountNumber: null
+            })
+        ).toMatchSnapshot();
+    });
+
+    test('valid bank statement upload', () => {
+        assertValidByKey({
+            bankStatement: {
+                filename: 'example.pdf',
+                size: 123,
+                type: 'application/pdf'
+            }
+        });
+
+        assertMessagesByKey({ bankStatement: null }, [
+            'Provide a bank statement'
+        ]);
     });
 });

--- a/controllers/apply/awards-for-all/lib/roles.js
+++ b/controllers/apply/awards-for-all/lib/roles.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const get = require('lodash/fp/get');
+
+const { ORGANISATION_TYPES, STATUTORY_BODY_TYPES } = require('../constants');
+
+module.exports = function rolesFor({
+    locale = 'en',
+    organisationType,
+    organisationSubType
+}) {
+    const localise = get(locale);
+    const ROLES = {
+        CHAIR: {
+            value: 'chair',
+            label: localise({ en: 'Chair', cy: '' })
+        },
+        CHANCELLOR: {
+            value: 'chancellor',
+            label: localise({ en: 'Chancellor', cy: '' })
+        },
+        CHIEF_EXECUTIVE: {
+            value: 'chief-executive',
+            label: localise({ en: 'Chief Executive', cy: '' })
+        },
+        CHIEF_EXECUTIVE_OFFICER: {
+            value: 'chief-executive-officer',
+            label: localise({ en: 'Chief Executive Officer', cy: '' })
+        },
+        COMPANY_DIRECTOR: {
+            value: 'company-director',
+            label: localise({ en: 'Company Director', cy: '' })
+        },
+        COMPANY_SECRETARY: {
+            value: 'company-secretary',
+            label: localise({ en: 'Company Secretary', cy: '' })
+        },
+        DEPUTY_PARISH_CLERK: {
+            value: 'deputy-parish-clerk',
+            label: localise({ en: 'Deputy Parish Clerk', cy: '' })
+        },
+        DIRECTOR: {
+            value: 'director',
+            label: localise({ en: 'Director', cy: '' })
+        },
+        ELECTED_MEMBER: {
+            value: 'elected-member',
+            label: localise({ en: 'Elected Member', cy: '' })
+        },
+        HEAD_TEACHER: {
+            value: 'head-teacher',
+            label: localise({ en: 'Head Teacher', cy: '' })
+        },
+        PARISH_CLERK: {
+            value: 'parish-clerk',
+            label: localise({ en: 'Parish Clerk', cy: '' })
+        },
+        RELIGIOUS_LEADER: {
+            value: 'religious-leader',
+            label: localise({
+                en: 'Religious leader (eg. rabbi, imam, vicar)',
+                cy: ''
+            })
+        },
+        SECRETARY: {
+            value: 'secretary',
+            label: localise({ en: 'Secretary', cy: '' })
+        },
+        TREASURER: {
+            value: 'treasurer',
+            label: localise({ en: 'Treasurer', cy: '' })
+        },
+        TRUSTEE: {
+            value: 'trustee',
+            label: localise({ en: 'Trustee', cy: '' })
+        },
+        VICE_CHAIR: {
+            value: 'vice-chair',
+            label: localise({ en: 'Vice-chair', cy: '' })
+        },
+        VICE_CHANCELLOR: {
+            value: 'vice-chancellor',
+            label: localise({ en: 'Vice-chancellor', cy: '' })
+        }
+    };
+
+    let options = [];
+    switch (organisationType) {
+        case ORGANISATION_TYPES.UNREGISTERED_VCO:
+            options = [
+                ROLES.CHAIR,
+                ROLES.VICE_CHAIR,
+                ROLES.SECRETARY,
+                ROLES.TREASURER
+            ];
+            break;
+        case ORGANISATION_TYPES.UNINCORPORATED_REGISTERED_CHARITY:
+            options = [ROLES.TRUSTEE];
+            break;
+        case ORGANISATION_TYPES.CIO:
+            options = [ROLES.TRUSTEE, ROLES.CHIEF_EXECUTIVE_OFFICER];
+            break;
+        case ORGANISATION_TYPES.NOT_FOR_PROFIT_COMPANY:
+            options = [ROLES.COMPANY_DIRECTOR, ROLES.COMPANY_SECRETARY];
+            break;
+        case ORGANISATION_TYPES.SCHOOL:
+            options = [ROLES.HEAD_TEACHER];
+            break;
+        case ORGANISATION_TYPES.COLLEGE_OR_UNIVERSITY:
+            options = [ROLES.CHANCELLOR, ROLES.VICE_CHANCELLOR];
+            break;
+        case ORGANISATION_TYPES.FAITH_GROUP:
+            options = [
+                ROLES.CHAIR,
+                ROLES.VICE_CHAIR,
+                ROLES.SECRETARY,
+                ROLES.TREASURER,
+                ROLES.RELIGIOUS_LEADER
+            ];
+            break;
+        default:
+            options = Object.values(ROLES);
+            break;
+    }
+
+    // Add custom options for statutory bodies
+    if (
+        organisationType === ORGANISATION_TYPES.STATUTORY_BODY &&
+        organisationSubType
+    ) {
+        switch (organisationSubType) {
+            case STATUTORY_BODY_TYPES.PARISH_COUNCIL:
+                options = [ROLES.PARISH_CLERK, ROLES.DEPUTY_PARISH_CLERK];
+                break;
+            case STATUTORY_BODY_TYPES.TOWN_COUNCIL:
+                options = [ROLES.ELECTED_MEMBER, ROLES.CHAIR];
+                break;
+            case STATUTORY_BODY_TYPES.LOCAL_AUTHORITY:
+                options = [ROLES.CHAIR, ROLES.CHIEF_EXECUTIVE, ROLES.DIRECTOR];
+                break;
+            case STATUTORY_BODY_TYPES.NHS_TRUST:
+                options = [ROLES.CHIEF_EXECUTIVE, ROLES.DIRECTOR];
+                break;
+            default:
+                options = Object.values(ROLES);
+                break;
+        }
+    }
+
+    return options;
+};


### PR DESCRIPTION
Went through the forms test and restructured everything to be more streamlined and wherever possible to avoid repeating the logic that is defined in the source in the tests. This is done either by generating values from the code or by using snapshot tests to validate output.

Makes two structural changes

- Set a default locale for the form builder to allow us to remove a bunch of abstractions from the tests
- Extract `rolesFor` to a lib method to avoid basically duplicating the entire mapping in both the form and the tests.