### PR TITLE
Prevent three fields from showing errors when they shouldn't be validated

### DIFF
--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -172,9 +172,6 @@ exports[`Global validation default validations for an empty form 1`] = `
 Array [
   "Enter a project name",
   "Select a country",
-  "Select a location",
-  "Tell us the towns, villages or wards your beneficiaries live in",
-  "Enter a real postcode",
   "Tell us about your project",
   "Tell us how your project meets at least one of our funding priorities",
   "Tell us how your project involves your community",

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1057,9 +1057,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true,
             get schema() {
                 const options = flatMap(this.optgroups, group => group.options);
-                return Joi.string()
-                    .valid(options.map(option => option.value))
-                    .required();
+                return Joi.when('projectCountry', {
+                    is: Joi.exist(),
+                    then: Joi.string()
+                        .valid(options.map(option => option.value))
+                        .required(),
+                    otherwise: Joi.any().strip()
+                });
             },
             messages: [
                 {
@@ -1079,7 +1083,11 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 size: 60
             },
             isRequired: true,
-            schema: Joi.string().required(),
+            schema: Joi.when('projectCountry', {
+                is: Joi.exist(),
+                then: Joi.string().required(),
+                otherwise: Joi.any().strip()
+            }),
             messages: [
                 {
                     type: 'base',
@@ -1106,9 +1114,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 autocomplete: 'postal-code'
             },
             isRequired: true,
-            schema: Joi.string()
-                .postcode()
-                .required(),
+            schema: Joi.when('projectCountry', {
+                is: Joi.exist(),
+                then: Joi.string()
+                    .postcode()
+                    .required(),
+                otherwise: Joi.any().strip()
+            }),
             messages: [
                 {
                     type: 'base',

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -335,9 +335,18 @@ describe('Project details', () => {
 
     test('project postcode must be a valid UK postcode', () => {
         const invalidMessages = ['Enter a real postcode'];
-        assertMessagesByKey({ projectPostcode: null }, invalidMessages);
         assertMessagesByKey(
-            { projectPostcode: 'not a postcode' },
+            {
+                projectCountry: 'scotland',
+                projectPostcode: null
+            },
+            invalidMessages
+        );
+        assertMessagesByKey(
+            {
+                projectCountry: 'scotland',
+                projectPostcode: 'not a postcode'
+            },
             invalidMessages
         );
     });


### PR DESCRIPTION
Starting a new application and viewing the summary gives these logging errors:

```
[error] projectLocation not included in step fields but failed validation
[error] projectLocationDescription not included in step fields but failed validation
[error] projectPostcode not included in step fields but failed validation
```

This change makes these fields conditional based on `projectCountry` (which `form.js` already does), matching the work we did last week and removing this noise from logs:

![image](https://user-images.githubusercontent.com/394376/62060734-911e7980-b21d-11e9-9454-502f9502df44.png)
