### PR TITLE
Enable all countries in test

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -12,6 +12,6 @@
     "enableMailSendMetrics": true
   },
   "awardsForAll": {
-    "allowedCountries": ["england", "scotland"]
+    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]
   }
 }

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -483,86 +483,63 @@ describe('Who will benefit', () => {
         );
     });
 
-    test('welsh language question required for applicants in Wales', () => {
-        assertValidByKey({
-            projectCountry: 'england',
-            beneficiariesWelshLanguage: undefined
-        });
-
-        assertValidByKey({
-            projectCountry: 'scotland',
-            beneficiariesWelshLanguage: undefined
-        });
-
+    test('welsh language question required in wales', () => {
         assertValidByKey({
             projectCountry: 'wales',
             beneficiariesWelshLanguage: 'all'
         });
 
-        const expectedMessage = expect.stringContaining(
-            'Select the amount of people who speak Welsh'
-        );
-
-        assertMessagesByKey(
-            {
-                projectCountry: 'wales',
-                beneficiariesWelshLanguage: undefined
-            },
-            [expectedMessage]
-        );
-
-        assertMessagesByKey(
-            {
-                projectCountry: 'wales',
-                beneficiariesWelshLanguage: 'not-a-valid-choice'
-            },
-            [expectedMessage]
-        );
+        [undefined, 'not-a-valid-choice'].forEach(input => {
+            assertMessagesByKey(
+                {
+                    projectCountry: 'wales',
+                    beneficiariesWelshLanguage: input
+                },
+                [
+                    expect.stringContaining(
+                        'Select the amount of people who speak Welsh'
+                    )
+                ]
+            );
+        });
     });
 
-    test('additional community question in Northern Ireland', () => {
-        assertValidByKey({
-            projectCountry: 'england',
-            beneficiariesNorthernIrelandCommunity: undefined
-        });
+    test.each(['england', 'scotland', 'northern-ireland'])(
+        `welsh language question not required in %p`,
+        function(country) {
+            assertValidByKey({
+                projectCountry: country,
+                beneficiariesWelshLanguage: undefined
+            });
+        }
+    );
 
-        assertValidByKey({
-            projectCountry: 'scotland',
-            beneficiariesNorthernIrelandCommunity: undefined
-        });
-
-        assertValidByKey({
-            projectCountry: 'wales',
-            beneficiariesNorthernIrelandCommunity: undefined
-        });
-
+    test('additional community question required in Northern Ireland', () => {
         assertValidByKey({
             projectCountry: 'northern-ireland',
             beneficiariesNorthernIrelandCommunity: 'mainly-catholic'
         });
 
-        assertValidByKey({
-            projectCountry: 'northern-ireland',
-            beneficiariesNorthernIrelandCommunity: 'mainly-protestant'
+        [undefined, 'not-a-valid-choice'].forEach(input => {
+            assertMessagesByKey(
+                {
+                    projectCountry: 'northern-ireland',
+                    beneficiariesNorthernIrelandCommunity: input
+                },
+                [expect.stringContaining('Select the community')]
+            );
         });
-
-        const expectedMessage = expect.stringContaining('Select the community');
-        assertMessagesByKey(
-            {
-                projectCountry: 'northern-ireland',
-                beneficiariesNorthernIrelandCommunity: undefined
-            },
-            [expectedMessage]
-        );
-
-        assertMessagesByKey(
-            {
-                projectCountry: 'northern-ireland',
-                beneficiariesNorthernIrelandCommunity: 'not-a-valid-choice'
-            },
-            [expectedMessage]
-        );
     });
+
+    test.each(['england', 'scotland', 'wales'])(
+        `northern ireland community questions not required in %p`,
+        function(country) {
+            assertValidByKey({
+                projectCountry: country,
+                beneficiariesNorthernIrelandCommunity: undefined
+            });
+        }
+    );
 });
 
 describe('Your organisation', () => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -483,40 +483,85 @@ describe('Who will benefit', () => {
         );
     });
 
-    test.skip('welsh language question required for applicants in Wales', () => {
-        function value(country, val) {
-            return {
-                projectCountry: country,
-                beneficiariesWelshLanguage: val
-            };
-        }
+    test('welsh language question required for applicants in Wales', () => {
+        assertValidByKey({
+            projectCountry: 'england',
+            beneficiariesWelshLanguage: undefined
+        });
 
-        assertValidByKey(value('england'));
-        assertValidByKey(value('scotland'));
-        assertValidByKey(value('wales', 'all'));
-        assertMessagesByKey(value('wales'), ['Choose an option']);
-        assertMessagesByKey(value('wales', 'not-a-valid-choice'), [
-            'Choose an option'
-        ]);
+        assertValidByKey({
+            projectCountry: 'scotland',
+            beneficiariesWelshLanguage: undefined
+        });
+
+        assertValidByKey({
+            projectCountry: 'wales',
+            beneficiariesWelshLanguage: 'all'
+        });
+
+        const expectedMessage = expect.stringContaining(
+            'Select the amount of people who speak Welsh'
+        );
+
+        assertMessagesByKey(
+            {
+                projectCountry: 'wales',
+                beneficiariesWelshLanguage: undefined
+            },
+            [expectedMessage]
+        );
+
+        assertMessagesByKey(
+            {
+                projectCountry: 'wales',
+                beneficiariesWelshLanguage: 'not-a-valid-choice'
+            },
+            [expectedMessage]
+        );
     });
 
-    test.skip('additional community question in Northern Ireland', () => {
-        function value(country, val) {
-            return {
-                projectCountry: country,
-                beneficiariesNorthernIrelandCommunity: val
-            };
-        }
+    test('additional community question in Northern Ireland', () => {
+        assertValidByKey({
+            projectCountry: 'england',
+            beneficiariesNorthernIrelandCommunity: undefined
+        });
 
-        assertValidByKey(value('england'));
-        assertValidByKey(value('scotland'));
-        assertValidByKey(value('wales'));
-        assertValidByKey(value('northern-ireland', 'mainly-catholic'));
-        assertValidByKey(value('northern-ireland', 'mainly-protestant'));
-        assertMessagesByKey(value('northern-ireland'), ['Choose an option']);
-        assertMessagesByKey(value('northern-ireland', 'not-a-valid-choice'), [
-            'Choose an option'
-        ]);
+        assertValidByKey({
+            projectCountry: 'scotland',
+            beneficiariesNorthernIrelandCommunity: undefined
+        });
+
+        assertValidByKey({
+            projectCountry: 'wales',
+            beneficiariesNorthernIrelandCommunity: undefined
+        });
+
+        assertValidByKey({
+            projectCountry: 'northern-ireland',
+            beneficiariesNorthernIrelandCommunity: 'mainly-catholic'
+        });
+
+        assertValidByKey({
+            projectCountry: 'northern-ireland',
+            beneficiariesNorthernIrelandCommunity: 'mainly-protestant'
+        });
+
+        const expectedMessage = expect.stringContaining('Select the community');
+        assertMessagesByKey(
+            {
+                projectCountry: 'northern-ireland',
+                beneficiariesNorthernIrelandCommunity: undefined
+            },
+            [expectedMessage]
+        );
+
+        assertMessagesByKey(
+            {
+                projectCountry: 'northern-ireland',
+                beneficiariesNorthernIrelandCommunity: 'not-a-valid-choice'
+            },
+            [expectedMessage]
+        );
     });
 });
 


### PR DESCRIPTION
Enable all countries in test environment, mainly to allow reviewing the form for all countries to aid with creating offline applications but also allows us to reinstate the skipped tests.