### PR TITLE
🚀 Launch awards for all

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,7 @@
   },
   "features": {
     "enableAllowLocalhost": false,
-    "enableAwardsForAllApplications": false,
+    "enableAwardsForAllApplications": true,
     "enableCloudWatchLogs": true,
     "enableDigitalFundApplications": false,
     "enableHotjar": false,

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const features = require('config').get('features');
 
-const { renderNotFound } = require('../errors');
 const digitalFund = require('./digital-fund');
 const reachingCommunities = require('./reaching-communities');
 
@@ -30,18 +29,9 @@ if (features.enableDigitalFundApplications) {
 
 /**
  * Awards for All
- * Guard access with feature flag
  */
-router.use(
-    '/awards-for-all',
-    function(req, res, next) {
-        if (res.locals.enableAwardsForAllApplications) {
-            next();
-        } else {
-            renderNotFound(req, res);
-        }
-    },
-    require('./awards-for-all')
-);
+if (features.enableAwardsForAllApplications) {
+    router.use('/awards-for-all', require('./awards-for-all'));
+}
 
 module.exports = router;

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -4,10 +4,8 @@ const moment = require('moment');
 const { isString } = require('lodash');
 
 const { getCurrentUrl, getAbsoluteUrl, localify } = require('../common/urls');
-const { AWARDS_FOR_ALL_SECRET } = require('../common/secrets');
 
 const features = config.get('features');
-const cookies = config.get('cookies');
 
 /**
  * Set request locals
@@ -22,15 +20,6 @@ module.exports = function(req, res, next) {
      */
     res.locals.enableSiteSurvey = features.enableSiteSurvey;
     res.locals.enableNameChangeMessage = features.enableNameChangeMessage;
-
-    const cookie = req.cookies[cookies.awardsForAllPreview];
-
-    if (cookie === AWARDS_FOR_ALL_SECRET) {
-        res.locals.enableAwardsForAllApplications = true;
-    } else {
-        res.locals.enableAwardsForAllApplications =
-            features.enableAwardsForAllApplications;
-    }
 
     /**
      * Global copy


### PR DESCRIPTION
- Enables `enableAwardsForAllApplications` flag by default
- Removes cookie flag

There is a clean up job after this to remove the preview cookie from the cloudfront rules.
