### PR TITLE
Remove awards-for-all-preview cookie

### DIFF
--- a/common/__snapshots__/cloudfront.test.js.snap
+++ b/common/__snapshots__/cloudfront.test.js.snap
@@ -33,9 +33,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -92,13 +91,7 @@ Object {
         "FieldLevelEncryptionId": "",
         "ForwardedValues": Object {
           "Cookies": Object {
-            "Forward": "whitelist",
-            "WhitelistedNames": Object {
-              "Items": Array [
-                "awards-for-all-preview",
-              ],
-              "Quantity": 1,
-            },
+            "Forward": "none",
           },
           "Headers": Object {
             "Items": Array [
@@ -153,9 +146,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -219,9 +211,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -282,9 +273,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -351,9 +341,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -418,9 +407,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -481,9 +469,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -547,13 +534,7 @@ Object {
         "FieldLevelEncryptionId": "",
         "ForwardedValues": Object {
           "Cookies": Object {
-            "Forward": "whitelist",
-            "WhitelistedNames": Object {
-              "Items": Array [
-                "awards-for-all-preview",
-              ],
-              "Quantity": 1,
-            },
+            "Forward": "none",
           },
           "Headers": Object {
             "Items": Array [
@@ -608,9 +589,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -674,9 +654,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -737,9 +716,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -806,9 +784,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -873,9 +850,8 @@ Object {
             "WhitelistedNames": Object {
               "Items": Array [
                 "blf-alpha-session",
-                "awards-for-all-preview",
               ],
-              "Quantity": 2,
+              "Quantity": 1,
             },
           },
           "Headers": Object {
@@ -1043,9 +1019,8 @@ Object {
         "WhitelistedNames": Object {
           "Items": Array [
             "blf-alpha-session",
-            "awards-for-all-preview",
           ],
-          "Quantity": 2,
+          "Quantity": 1,
         },
       },
       "Headers": Object {

--- a/common/cloudfront.js
+++ b/common/cloudfront.js
@@ -115,8 +115,8 @@ function makeBehaviourItem({
  * construct array of behaviours from a URL list
  */
 function generateBehaviours(origins) {
-    const defaultCookies = [cookies.session, cookies.awardsForAllPreview];
-    const cookiesWithoutSession = [cookies.awardsForAllPreview];
+    const defaultCookies = [cookies.session];
+    const cookiesWithoutSession = [];
 
     const defaultBehaviour = makeBehaviourItem({
         originId: origins.site,

--- a/config/cloudfront/live.json
+++ b/config/cloudfront/live.json
@@ -48,10 +48,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "blf-alpha-session",
-            "awards-for-all-preview"
+            "blf-alpha-session"
           ],
-          "Quantity": 2
+          "Quantity": 1
         }
       }
     },
@@ -112,10 +111,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -172,13 +170,7 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "whitelist",
-            "WhitelistedNames": {
-              "Items": [
-                "awards-for-all-preview"
-              ],
-              "Quantity": 1
-            }
+            "Forward": "none"
           }
         },
         "TrustedSigners": {
@@ -240,10 +232,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -303,10 +294,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -372,10 +362,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -439,10 +428,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -497,10 +485,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -567,10 +554,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -627,13 +613,7 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "whitelist",
-            "WhitelistedNames": {
-              "Items": [
-                "awards-for-all-preview"
-              ],
-              "Quantity": 1
-            }
+            "Forward": "none"
           }
         },
         "TrustedSigners": {
@@ -695,10 +675,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -758,10 +737,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -827,10 +805,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -894,10 +871,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -952,10 +928,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },

--- a/config/cloudfront/test.json
+++ b/config/cloudfront/test.json
@@ -48,10 +48,9 @@
         "Forward": "whitelist",
         "WhitelistedNames": {
           "Items": [
-            "blf-alpha-session",
-            "awards-for-all-preview"
+            "blf-alpha-session"
           ],
-          "Quantity": 2
+          "Quantity": 1
         }
       }
     },
@@ -112,10 +111,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -172,13 +170,7 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "whitelist",
-            "WhitelistedNames": {
-              "Items": [
-                "awards-for-all-preview"
-              ],
-              "Quantity": 1
-            }
+            "Forward": "none"
           }
         },
         "TrustedSigners": {
@@ -240,10 +232,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -303,10 +294,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -372,10 +362,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -439,10 +428,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -497,10 +485,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -567,10 +554,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -627,13 +613,7 @@
           },
           "QueryString": true,
           "Cookies": {
-            "Forward": "whitelist",
-            "WhitelistedNames": {
-              "Items": [
-                "awards-for-all-preview"
-              ],
-              "Quantity": 1
-            }
+            "Forward": "none"
           }
         },
         "TrustedSigners": {
@@ -695,10 +675,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -758,10 +737,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -827,10 +805,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -894,10 +871,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },
@@ -952,10 +928,9 @@
             "Forward": "whitelist",
             "WhitelistedNames": {
               "Items": [
-                "blf-alpha-session",
-                "awards-for-all-preview"
+                "blf-alpha-session"
               ],
-              "Quantity": 2
+              "Quantity": 1
             }
           }
         },

--- a/config/default.json
+++ b/config/default.json
@@ -55,8 +55,7 @@
     "allowedCountries": ["scotland"]
   },
   "cookies": {
-    "session": "blf-alpha-session",
-    "awardsForAllPreview": "awards-for-all-preview"
+    "session": "blf-alpha-session"
   },
   "hotjarId": 1036292,
   "googleAnalyticsCode": "UA-98908627-1"


### PR DESCRIPTION
Post-launch clean up to remove the preview cookie from the CloudFront rules.