### PR TITLE
Add local to enable account message

### DIFF
--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -20,6 +20,8 @@ module.exports = function(req, res, next) {
      */
     res.locals.enableSiteSurvey = features.enableSiteSurvey;
     res.locals.enableNameChangeMessage = features.enableNameChangeMessage;
+    res.locals.enableAwardsForAllApplications =
+        features.enableAwardsForAllApplications;
 
     /**
      * Global copy


### PR DESCRIPTION
We needed `enableAwardsForAllApplications` to be set in the locals in order for the account message to show.

![image](https://user-images.githubusercontent.com/123386/62202086-8a5c4780-b380-11e9-9291-59e3b0f8c656.png)
