### PR TITLE
Hash rate limit key, exclude value from logs

### DIFF
--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -62,12 +62,13 @@ router
     .post(async (req, res, next) => {
         logger.info('Login attempted');
 
-        // Key all rate-limited login attempts by the user's IP and the attempted username
-        const RATE_LIMIT_UNIQUE_KEY = `${req.ip}_${req.body.username}`;
-
+        /**
+         * Key all rate-limited login attempts by
+         * the user's IP and the attempted username
+         */
         const LoginRateLimiter = await new RateLimiter(
             rateLimiterConfigs.failByUsername,
-            RATE_LIMIT_UNIQUE_KEY
+            [req.ip, req.body.username]
         ).init();
 
         if (LoginRateLimiter.isRateLimited()) {


### PR DESCRIPTION
Removes rate key value from the logs, we only need to log the event happening not additional metadata and performs a basic hash on the key parts rather than a raw string.