### PR TITLE
Clean up breadcrumb code

### DIFF
--- a/assets/sass/components/_navigation.scss
+++ b/assets/sass/components/_navigation.scss
@@ -241,7 +241,7 @@
 
 .user-nav {
     font-size: 15px;
-    padding-bottom: $spacingUnit / 2;
+    padding-bottom: $spacingUnit;
 
     // Swap the borders/padding for use at bottom of page
     &.user-nav--footer {

--- a/controllers/apply/form-router-next/delete.js
+++ b/controllers/apply/form-router-next/delete.js
@@ -22,9 +22,6 @@ module.exports = function(formId) {
                 if (application) {
                     res.render(path.resolve(__dirname, './views/delete'), {
                         title: res.locals.copy.delete.title,
-                        breadcrumbs: res.locals.breadcrumbs.concat([
-                            { label: res.locals.copy.delete.title }
-                        ]),
                         csrfToken: req.csrfToken()
                     });
                 } else {

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -69,7 +69,6 @@ function initFormRouter({
         res.locals.formTitle = form.title;
         res.locals.formId = formId;
         res.locals.formBaseUrl = req.baseUrl;
-        res.locals.breadcrumbs = [{ label: form.title, url: req.baseUrl }];
 
         res.locals.user = req.user;
         res.locals.isBilingual = form.isBilingual;

--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -43,17 +43,8 @@ module.exports = function(formId, formBuilder) {
                         });
 
                         if (step.isRequired) {
-                            const breadcrumbs = res.locals.breadcrumbs.concat([
-                                {
-                                    label: section.shortTitle || section.title,
-                                    url: sectionUrl
-                                },
-                                { label: step.title }
-                            ]);
-
                             const viewData = {
                                 csrfToken: req.csrfToken(),
-                                breadcrumbs: breadcrumbs,
                                 section: section,
                                 step: step,
                                 stepNumber: stepNumber,

--- a/controllers/apply/form-router-next/summary.js
+++ b/controllers/apply/form-router-next/summary.js
@@ -80,7 +80,6 @@ module.exports = function(formBuilder) {
             form: form,
             csrfToken: req.csrfToken(),
             title: title,
-            breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
             currentProjectName: get('projectName')(currentApplicationData),
             showErrors: showErrors,
             errors: form.validation.messages,

--- a/controllers/apply/form-router-next/views/delete.njk
+++ b/controllers/apply/form-router-next/views/delete.njk
@@ -1,10 +1,11 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/user-navigation/macro.njk" import userNavigation with context %}
 
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner u-inner-wide-only">
-            {{ breadcrumbTrail(breadcrumbs) }}
+            {{ userNavigation(userNavigationLinks) }}
+
 
             <div class="form-header">
                 <p class="form-header__prefix">{{ formTitle }}</p>

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -3,7 +3,6 @@
 {% from "components/form-header/macro.njk" import formHeaderWithData with context %}
 
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 
 {% set stepCount = __('global.misc.stepProgress', stepNumber, totalSteps) %}
 {% block title %}{{ step.title }} ({{ stepCount }}) | {{ section.shortTitle or section.title }} | {{ formTitle }} | {% endblock %}

--- a/controllers/apply/form-router-next/views/summary.njk
+++ b/controllers/apply/form-router-next/views/summary.njk
@@ -1,5 +1,4 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/details/macro.njk" import details %}
 {% from "components/form-header/macro.njk" import formHeaderWithData with context %}
 {% from "components/icons.njk" import iconTick %}


### PR DESCRIPTION
We had one place on the form where we were still using breadcrumbs rather than the user navigation

<img width="1028" alt="Screenshot 2019-07-31 at 11 53 31" src="https://user-images.githubusercontent.com/123386/62208064-add9bf00-b38d-11e9-94a1-0fc4aef9f792.png">

<img width="1020" alt="Screenshot 2019-07-31 at 11 53 11" src="https://user-images.githubusercontent.com/123386/62208063-add9bf00-b38d-11e9-9898-5641d14326cd.png">

Also cleans up any unused breadcrumb code from the other routes.