### PR TITLE
Log tweaks

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -27,6 +27,7 @@ function getTransports() {
     } else {
         return [
             new transports.Console({
+                silent: process.env.CI,
                 format: format.combine(
                     format.colorize(),
                     format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),

--- a/controllers/apply/form-router-next/delete.js
+++ b/controllers/apply/form-router-next/delete.js
@@ -3,6 +3,7 @@ const express = require('express');
 const path = require('path');
 
 const { PendingApplication } = require('../../../db/models');
+const logger = require('../../../common/logger').child({ service: 'apply' });
 
 module.exports = function(formId) {
     const router = express.Router();
@@ -31,12 +32,15 @@ module.exports = function(formId) {
                 res.redirect(res.locals.formBaseUrl);
             }
         })
-        .post(async (req, res, next) => {
+        .post(async function(req, res, next) {
             try {
                 await PendingApplication.deleteApplication(
                     req.params.applicationId,
                     req.user.userData.id
                 );
+                logger.info('Application deleted', {
+                    applicationId: req.params.applicationId
+                });
                 res.redirect(res.locals.formBaseUrl + '?s=applicationDeleted');
             } catch (error) {
                 next(error);

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -66,14 +66,10 @@ router
     })
     .post(async function(req, res, next) {
         try {
-
-            await sendActivationEmail(
-                req,
-                req.user.userData
-            );
+            await sendActivationEmail(req, req.user.userData);
 
             res.locals.resendSuccessful = true;
-            logger.info('Activation email sent');
+            logger.info('Activation email re-sent');
             renderTemplate(req, res);
         } catch (err) {
             logger.error('Activation email failed', err);


### PR DESCRIPTION
A few logging tweaks

- We had a log for "Activation email sent" which is misleading because this log event is for when an activation email is **re**-sent, which is an important distinction.
- Add logging for when an application is deleted
- Silence console logs solely in CI. We previously had this silenced for all test servers, and removed it because it was useful locally, but I'd still like to remove CI noise.