### PR TITLE
Tweak eligibility logs

### DIFF
--- a/controllers/apply/form-router-next/eligibility.js
+++ b/controllers/apply/form-router-next/eligibility.js
@@ -52,11 +52,7 @@ module.exports = function(eligibilityBuilder, formId) {
 
             if (req.body.eligibility === 'yes') {
                 if (currentStepNumber === totalSteps) {
-                    logger.info('Passed eligibility check', {
-                        eligible: req.body.eligibility,
-                        formId: formId,
-                        step: currentStepNumber
-                    });
+                    logger.info('Passed eligibility check', { formId });
 
                     res.render(templatePath, {
                         eligibilityStatus: 'eligible'

--- a/controllers/apply/form-router-next/eligibility.js
+++ b/controllers/apply/form-router-next/eligibility.js
@@ -50,14 +50,14 @@ module.exports = function(eligibilityBuilder, formId) {
         .post(async (req, res) => {
             const { currentStepNumber, totalSteps } = res.locals;
 
-            logger.info('Eligibility check', {
-                eligible: req.body.eligibility,
-                formId: formId,
-                step: currentStepNumber
-            });
-
             if (req.body.eligibility === 'yes') {
                 if (currentStepNumber === totalSteps) {
+                    logger.info('Passed eligibility check', {
+                        eligible: req.body.eligibility,
+                        formId: formId,
+                        step: currentStepNumber
+                    });
+
                     res.render(templatePath, {
                         eligibilityStatus: 'eligible'
                     });
@@ -65,12 +65,17 @@ module.exports = function(eligibilityBuilder, formId) {
                     res.redirect(`${req.baseUrl}/${currentStepNumber + 1}`);
                 }
             } else {
-                res.locals.hotJarTagList = [
-                    'Apply: AFA: Failed eligibility check question'
-                ];
+                logger.info('Failed eligibility check', {
+                    formId: formId,
+                    step: currentStepNumber
+                });
+
                 res.render(templatePath, {
                     eligibilityStatus: 'ineligible',
-                    backUrl: `${req.baseUrl}/${currentStepNumber}`
+                    backUrl: `${req.baseUrl}/${currentStepNumber}`,
+                    hotJarTagList: [
+                        'Apply: AFA: Failed eligibility check question'
+                    ]
                 });
             }
         });


### PR DESCRIPTION
The current eligibility logging is quite noisy, logging 5 times each time someone goes through successfully:

![image](https://user-images.githubusercontent.com/123386/62369669-3c824380-b528-11e9-809f-ac01e8fb5a22.png)

Instead, what we probably want is two logs:

- One when passing eligibility checks
- One when failing, with the step that was failed on

![image](https://user-images.githubusercontent.com/123386/62369747-8c610a80-b528-11e9-991e-3514a4a2b333.png)
