### PR TITLE
Allow filtering by a specific research document

### DIFF
--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -18,20 +18,41 @@ const { buildPagination } = require('../../common/pagination');
 
 const router = express.Router();
 
-router.get('/', injectHeroImage('insights-letterbox-new'), injectCopy('insights'), injectResearch, (req, res) => {
-    res.render(path.resolve(__dirname, './views/insights-landing'), {
-        researchArchiveUrl: buildArchiveUrl(localify(req.i18n.getLocale())('/research'))
-    });
-});
+router.get(
+    '/',
+    injectHeroImage('insights-letterbox-new'),
+    injectCopy('insights'),
+    injectResearch,
+    (req, res) => {
+        res.render(path.resolve(__dirname, './views/insights-landing'), {
+            researchArchiveUrl: buildArchiveUrl(
+                localify(req.i18n.getLocale())('/research')
+            )
+        });
+    }
+);
 
 router.get(
-    '/documents',
+    '/documents/:slug?',
     injectHeroImage('insights-letterbox-new'),
     injectCopy('insights.documents'),
     async (req, res, next) => {
-        let query = pick(req.query, ['page', 'programme', 'tag', 'doctype', 'portfolio', 'q', 'sort']);
+        let query = pick(req.query, [
+            'page',
+            'programme',
+            'tag',
+            'doctype',
+            'portfolio',
+            'q',
+            'sort'
+        ]);
         res.locals.queryParams = clone(query);
         query['page-limit'] = 10;
+
+        if (req.params.slug) {
+            res.locals.documentSlug = req.params.slug;
+            query['slug'] = req.params.slug;
+        }
 
         try {
             const research = await contentApi.getResearch({
@@ -53,16 +74,21 @@ router.get(
     }
 );
 
-router.get('/:slug', injectResearchEntry, injectBreadcrumbs, (req, res, next) => {
-    const { researchEntry } = res.locals;
-    if (researchEntry) {
-        res.render(path.resolve(__dirname, './views/insights-detail'), {
-            extraCopy: req.i18n.__('insights.detail'),
-            entry: researchEntry
-        });
-    } else {
-        next();
+router.get(
+    '/:slug',
+    injectResearchEntry,
+    injectBreadcrumbs,
+    (req, res, next) => {
+        const { researchEntry } = res.locals;
+        if (researchEntry) {
+            res.render(path.resolve(__dirname, './views/insights-detail'), {
+                extraCopy: req.i18n.__('insights.detail'),
+                entry: researchEntry
+            });
+        } else {
+            next();
+        }
     }
-});
+);
 
 module.exports = router;

--- a/controllers/insights/views/insights-documents.njk
+++ b/controllers/insights/views/insights-documents.njk
@@ -70,14 +70,15 @@
                     {# Filter summary #}
 
                     <ul class="filter-list">
-                        {% if entriesMeta.activeProgramme or entriesMeta.activePortfolio or entriesMeta.activeDocType or entriesMeta.activeTag or queryParams.q %}
+                        {% if entriesMeta.activeProgramme or entriesMeta.activePortfolio or entriesMeta.activeDocType or entriesMeta.activeTag or queryParams.q or documentSlug %}
 
-                            {% macro filterField(fieldName, param) %}
+                            {% macro filterField(fieldName, param, customLink = false) %}
                                 {% if fieldName %}
+                                    {% set url = '?' + queryParams | removeQueryParam(param) if not customLink else customLink %}
                                     <li class="filter-list__item">
                                         <a class="active-filter"
                                            title="{{ fieldName }}"
-                                           href="?{{ queryParams | removeQueryParam(param) }}">
+                                           href="{{ url }}">
                                             {{ fieldName }}
                                             {{ iconClose() }}
                                         </a>
@@ -86,6 +87,11 @@
                             {% endmacro %}
 
                             {{ filterField(queryParams.q, 'q') }}
+
+                            {% if documentSlug %}
+                                {{ filterField(documentSlug, false, './') }}
+                            {% endif %}
+
                             {{ filterField(entriesMeta.activeProgramme.label, 'programme') }}
                             {{ filterField(entriesMeta.activePortfolio.label, 'portfolio') }}
                             {{ filterField(entriesMeta.activeDocType.label, 'doctype') }}


### PR DESCRIPTION
Fixes https://github.com/biglotteryfund/blf-alpha/issues/2139

This allows URLs like `/insights/documents/so-what-headstart-wolverhampton-2017-2018` to work (paired with https://github.com/biglotteryfund/craft-dev/pull/186)

![image](https://user-images.githubusercontent.com/394376/62451880-febf2e00-b766-11e9-9a2a-4a4910f3c84b.png)
