### PR TITLE
Return the address component to setting addresses on selection

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -40,7 +40,9 @@ export default {
             },
             addressData: [],
             candidates: [],
-            selectedAddressId: ''
+            selectedAddressId: '',
+            initialSelectValue: null,
+            selectHasChanged: false
         };
     },
     mounted() {
@@ -203,6 +205,35 @@ export default {
                 'Enter Manually clicked'
             );
             this.currentState = this.states.EnteringManually;
+        },
+        selectChanged() {
+            if (!this.selectHasChanged) {
+                return false;
+            }
+            this.setSelectedAddress();
+        },
+        selectClicked() {
+            this.selectHasChanged = true;
+        },
+        selectFocused() {
+            this.initialSelectValue = this.value;
+        },
+        selectKeyed(e) {
+            const keyCodeTab = 9;
+            const keyCodeEnter = 13;
+            const keyCodeEsc = 27;
+
+            if (
+                (e.keyCode === keyCodeEnter || e.keyCode === keyCodeTab) &&
+                this.selectedAddressId !== this.initialSelectValue
+            ) {
+                this.selectHasChanged = true;
+                this.selectChanged();
+            } else if (e.keyCode === keyCodeEsc) {
+                this.selectedAddressId = this.initialSelectValue;
+            } else {
+                this.selectHasChanged = false;
+            }
         }
     },
     computed: {
@@ -314,7 +345,10 @@ export default {
                     id="address-selection"
                     :disabled="currentState === states.Loading"
                     :required="shouldShowPostcodeLookup"
-                    @blur="setSelectedAddress"
+                    @focus="selectFocused"
+                    @keydown="selectKeyed"
+                    @change="selectChanged"
+                    @click="selectClicked"
                     data-hj-suppress
                 >
                     <option disabled value="">


### PR DESCRIPTION
We've seen a bit of UX confusion around people selecting addresses from the lookup (eg. having to blur the field to set selection).

Thanks to [this article](http://www.themaninblue.com/writing/perspective/2004/10/19/), I've been able to re-add the old behaviour (eg. selecting an element in the dropdown will set the address), as well as supporting keyboard navigation (the reason for the earlier change). It's a little convoluted (lots of event listeners to handle the various cases) but works well and should improve things for everyone.

## Mouse behaviour
![mouse](https://user-images.githubusercontent.com/394376/62528556-f0d7de80-b834-11e9-94f2-13fd51f8c0ce.gif)

## Keyboard behaviour
![keyboard](https://user-images.githubusercontent.com/394376/62528560-f3d2cf00-b834-11e9-99a3-a78925855a13.gif)
