### PR TITLE
Add a field for confirmation about different contacts

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -51,7 +51,8 @@
     "enableSiteSurvey": true
   },
   "awardsForAll": {
-    "allowedCountries": ["scotland"]
+    "allowedCountries": ["scotland"],
+    "showContactConfirmationQuestion": false
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/config/default.json
+++ b/config/default.json
@@ -52,7 +52,7 @@
   },
   "awardsForAll": {
     "allowedCountries": ["scotland"],
-    "showContactConfirmationQuestion": false
+    "showContactConfirmationQuestion": true
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/config/production.json
+++ b/config/production.json
@@ -8,5 +8,8 @@
   "googleAnalyticsCode": "UA-637620-2",
   "features": {
     "enableHotjar": true
+  },
+  "awardsForAll": {
+    "showContactConfirmationQuestion": false
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -11,7 +11,6 @@
     "enableHotjar": true
   },
   "awardsForAll": {
-    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"],
-    "showContactConfirmationQuestion": true
+    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -11,6 +11,7 @@
     "enableHotjar": true
   },
   "awardsForAll": {
-    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]
+    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"],
+    "showContactConfirmationQuestion": true
   }
 }

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -182,7 +182,6 @@ Array [
   "Enter a day and month",
   "Enter a full UK address",
   "Select a type of organisation",
-  "Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood ",
   "Enter first and last name",
   "Enter a date of birth",
   "Enter a full UK address",
@@ -203,6 +202,7 @@ Array [
   "You must confirm that you understand your application is subject to our Freedom of Information policy",
   "Enter the full name of the person completing this form",
   "Enter the position of the person completing this form",
+  "Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood ",
 ]
 `;
 

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -182,6 +182,7 @@ Array [
   "Enter a day and month",
   "Enter a full UK address",
   "Select a type of organisation",
+  "Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood ",
   "Enter first and last name",
   "Enter a date of birth",
   "Enter a full UK address",

--- a/controllers/apply/awards-for-all/docs/schema.md
+++ b/controllers/apply/awards-for-all/docs/schema.md
@@ -94,6 +94,7 @@ Each submission has two top-level keys: `meta` which contains metadata about the
             "firstName": "Nelda",
             "lastName": "Nolan"
         },
+        "mainContactIsValid": "yes",
         "mainContactDateOfBirth": "1975-10-12",
         "mainContactAddress": {
             "line1": "41465 Bashirian Oval",
@@ -427,6 +428,11 @@ Object with properties:
 | **firstName** | `string` |
 | **lastName**  | `string` |
 
+### mainContactIsValid
+
+type: `string`
+
+Will always be "yes" (required field)
 
 ### mainContactDateOfBirth
 

--- a/controllers/apply/awards-for-all/docs/schema.md
+++ b/controllers/apply/awards-for-all/docs/schema.md
@@ -94,7 +94,6 @@ Each submission has two top-level keys: `meta` which contains metadata about the
             "firstName": "Nelda",
             "lastName": "Nolan"
         },
-        "mainContactIsValid": "yes",
         "mainContactDateOfBirth": "1975-10-12",
         "mainContactAddress": {
             "line1": "41465 Bashirian Oval",
@@ -428,11 +427,6 @@ Object with properties:
 | **firstName** | `string` |
 | **lastName**  | `string` |
 
-### mainContactIsValid
-
-type: `string`
-
-Will always be "yes" (required fields)
 
 ### mainContactDateOfBirth
 

--- a/controllers/apply/awards-for-all/docs/schema.md
+++ b/controllers/apply/awards-for-all/docs/schema.md
@@ -94,6 +94,7 @@ Each submission has two top-level keys: `meta` which contains metadata about the
             "firstName": "Nelda",
             "lastName": "Nolan"
         },
+        "mainContactIsValid": "yes",
         "mainContactDateOfBirth": "1975-10-12",
         "mainContactAddress": {
             "line1": "41465 Bashirian Oval",
@@ -426,6 +427,12 @@ Object with properties:
 | ------------- | -------- |
 | **firstName** | `string` |
 | **lastName**  | `string` |
+
+### mainContactIsValid
+
+type: `string`
+
+Will always be "yes" (required fields)
 
 ### mainContactDateOfBirth
 

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -25,6 +25,10 @@ const {
     EDUCATION_NUMBER_TYPES
 } = require('./constants');
 
+const showContactConfirmationQuestion = config.get(
+    'awardsForAll.showContactConfirmationQuestion'
+);
+
 const countriesFor = require('./lib/countries');
 const locationsFor = require('./lib/locations');
 const rolesFor = require('./lib/roles');
@@ -1015,7 +1019,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         };
     }
 
-    return {
+    let allFields = {
         projectName: {
             name: 'projectName',
             label: localise({
@@ -2057,38 +2061,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        mainContactIsValid: {
-            name: 'mainContactIsValid',
-            label: localise({
-                en: `I confirm that the main and senior contacts aren't married or in a long-term relationship with each other, living together at the same address, or related by blood`,
-                cy: ''
-            }),
-            type: 'checkbox',
-            options: [
-                {
-                    value: 'yes',
-                    label: localise({
-                        en: 'Yes',
-                        cy: ''
-                    })
-                }
-            ],
-            isRequired: true,
-            get schema() {
-                return multiChoice(this.options).required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood `,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        },
         mainContactName: nameField(
             {
                 name: 'mainContactName',
@@ -2563,4 +2535,40 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true
         }
     };
+
+    if (showContactConfirmationQuestion) {
+        allFields.mainContactIsValid = {
+            name: 'mainContactIsValid',
+            label: localise({
+                en: `I confirm that the main and senior contacts aren't married or in a long-term relationship with each other, living together at the same address, or related by blood`,
+                cy: ''
+            }),
+            type: 'checkbox',
+            options: [
+                {
+                    value: 'yes',
+                    label: localise({
+                        en: 'Yes',
+                        cy: ''
+                    })
+                }
+            ],
+            isRequired: true,
+            get schema() {
+                return multiChoice(this.options).required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: `Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood `,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        };
+    }
+    return allFields;
 };

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -2057,6 +2057,38 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
+        mainContactIsValid: {
+            name: 'mainContactIsValid',
+            label: localise({
+                en: `I confirm that the main and senior contacts aren't married or in a long-term relationship with each other, living together at the same address, or related by blood`,
+                cy: ''
+            }),
+            type: 'checkbox',
+            options: [
+                {
+                    value: 'yes',
+                    label: localise({
+                        en: 'Yes',
+                        cy: ''
+                    })
+                }
+            ],
+            isRequired: true,
+            get schema() {
+                return multiChoice(this.options).required();
+            },
+            get messages() {
+                return [
+                    {
+                        type: 'base',
+                        message: localise({
+                            en: `Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood `,
+                            cy: ''
+                        })
+                    }
+                ];
+            }
+        },
         mainContactName: nameField(
             {
                 name: 'mainContactName',

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -38,12 +38,14 @@ module.exports = function({
 
     const conditionalFields = (fields, filteredFields) => {
         const filteredFieldNames = filteredFields.map(_ => _.name);
-        const allFields = fields.map(f => {
-            if (filteredFieldNames.indexOf(f.name) === -1) {
-                f.isConditional = true;
-            }
-            return f;
-        });
+        const allFields = compact(
+            fields.map(f => {
+                if (filteredFieldNames.indexOf(f.name) === -1) {
+                    f.isConditional = true;
+                }
+                return f;
+            })
+        );
 
         return showAllFields ? allFields : filteredFields;
     };
@@ -626,7 +628,9 @@ module.exports = function({
                         cy: ''
                     }),
                     get introduction() {
-                        const seniorName = getContactFullName(data, 'senior');
+                        const seniorName = getContactFullName(
+                            get('seniorContactName')(data)
+                        );
                         const seniorNameMsg = seniorName
                             ? `, ${seniorName}`
                             : '';

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -8,6 +8,7 @@ const getOr = require('lodash/fp/getOr');
 const has = require('lodash/fp/has');
 const sumBy = require('lodash/sumBy');
 const { safeHtml, oneLine } = require('common-tags');
+const config = require('config');
 
 const { FormModel } = require('../form-router-next/lib/form-model');
 const { fromDateParts } = require('../form-router-next/lib/date-parts');
@@ -23,6 +24,7 @@ const {
 
 const fieldsFor = require('./fields');
 const terms = require('./terms');
+const { getContactFullName } = require('./lib/contacts');
 
 const { isTestServer } = require('../../../common/appData');
 const checkBankApi = require('../../../common/bank-api');
@@ -624,16 +626,10 @@ module.exports = function({
                         cy: ''
                     }),
                     get introduction() {
-                        const seniorFirstName = get(
-                            'seniorContactName.firstName'
-                        )(data);
-                        const seniorSurname = get('seniorContactName.lastName')(
-                            data
-                        );
-                        const seniorName =
-                            seniorFirstName && seniorSurname
-                                ? safeHtml`, <strong data-hj-suppress>${seniorFirstName} ${seniorSurname}</strong>`
-                                : '';
+                        const seniorName = getContactFullName(data, 'senior');
+                        const seniorNameMsg = seniorName
+                            ? `, ${seniorName}`
+                            : '';
 
                         return localise({
                             en:
@@ -646,31 +642,43 @@ module.exports = function({
                                 need to hold a particular position.    
                             </p>
                             <p>
-                                The main contact must be a different person from
-                                the senior contact` +
-                                seniorName +
-                                `. The two contacts
-                                also can't be married or in a long-term relationship
-                                with each other, living together at the same address,
-                                or related by blood.
-                            </p>`,
+                                The main contact must be a different person from the senior contact` +
+                                seniorNameMsg +
+                                `. The two contacts also can't be:
+                            </p>
+                            <ul>                            
+                                <li>married to each other</li>
+                                <li>in a long-term relationship together</li>
+                                <li>living at the same address</li>
+                                <li>or related by blood.</li> 
+                            </ul>
+                            `,
                             cy: ''
                         });
                     },
                     get fields() {
-                        const allFields = [
+                        const showContactConfirmationQuestion = config.get(
+                            'awardsForAll.showContactConfirmationQuestion'
+                        );
+
+                        const allFields = compact([
                             fields.mainContactName,
+                            showContactConfirmationQuestion &&
+                                fields.mainContactIsValid,
                             fields.mainContactDateOfBirth,
                             fields.mainContactAddress,
                             fields.mainContactAddressHistory,
                             fields.mainContactEmail,
                             fields.mainContactPhone,
                             fields.mainContactCommunicationNeeds
-                        ];
+                        ]);
+
                         return conditionalFields(
                             allFields,
                             compact([
                                 fields.mainContactName,
+                                showContactConfirmationQuestion &&
+                                    fields.mainContactIsValid,
                                 includeAddressAndDob() &&
                                     fields.mainContactDateOfBirth,
                                 includeAddressAndDob() &&

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -117,6 +117,7 @@ function mockFullForm({
             firstName: faker.name.firstName(),
             lastName: faker.name.lastName()
         },
+        mainContactIsValid: 'yes',
         mainContactDateOfBirth: mockDateOfBirth(16),
         mainContactAddress: mockAddress(),
         mainContactAddressHistory: {
@@ -903,6 +904,7 @@ describe('Contacts', () => {
 
             checkFieldsForSection('main-contact', [
                 'mainContactName',
+                'mainContactIsValid',
                 'mainContactEmail',
                 'mainContactPhone',
                 'mainContactCommunicationNeeds'

--- a/controllers/apply/awards-for-all/lib/contacts.js
+++ b/controllers/apply/awards-for-all/lib/contacts.js
@@ -1,0 +1,19 @@
+'use strict';
+const get = require('lodash/fp/get');
+const { safeHtml } = require('common-tags');
+
+function getContactFullName(data, type) {
+    const fieldName =
+        type === 'senior' ? 'seniorContactName' : 'mainContactName';
+    const contactFirstName = get(`${fieldName}.firstName`)(data);
+    const contactSurname = get(`${fieldName}.lastName`)(data);
+    const contactName =
+        contactFirstName && contactSurname
+            ? safeHtml`<strong data-hj-suppress>${contactFirstName} ${contactSurname}</strong>`
+            : null;
+    return contactName;
+}
+
+module.exports = {
+    getContactFullName
+};

--- a/controllers/apply/awards-for-all/lib/contacts.js
+++ b/controllers/apply/awards-for-all/lib/contacts.js
@@ -2,11 +2,9 @@
 const get = require('lodash/fp/get');
 const { safeHtml } = require('common-tags');
 
-function getContactFullName(data, type) {
-    const fieldName =
-        type === 'senior' ? 'seniorContactName' : 'mainContactName';
-    const contactFirstName = get(`${fieldName}.firstName`)(data);
-    const contactSurname = get(`${fieldName}.lastName`)(data);
+function getContactFullName(contactData) {
+    const contactFirstName = get('firstName')(contactData);
+    const contactSurname = get('lastName')(contactData);
     const contactName =
         contactFirstName && contactSurname
             ? safeHtml`<strong data-hj-suppress>${contactFirstName} ${contactSurname}</strong>`

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -477,10 +477,16 @@ describe('awards for all', function() {
             });
         }
 
-        function fillContact(contact) {
+        function fillContact(contact, type) {
             cy.getByLabelText('First name').type(contact.firstName);
 
             cy.getByLabelText('Last name').type(contact.lastName);
+
+            if (type === 'main') {
+                cy.getByLabelText('Yes')
+                    .first()
+                    .click();
+            }
 
             fillDateOfBirth(contact.dateOfBirth);
 
@@ -509,7 +515,7 @@ describe('awards for all', function() {
 
         function sectionMainContact(contact) {
             cy.checkA11y();
-            fillContact(contact);
+            fillContact(contact, 'main');
             submitStep();
         }
 

--- a/cypress/integration/awards-for-all.js
+++ b/cypress/integration/awards-for-all.js
@@ -477,16 +477,23 @@ describe('awards for all', function() {
             });
         }
 
-        function fillContact(contact, type) {
+        function fillContact(contact) {
             cy.getByLabelText('First name').type(contact.firstName);
 
             cy.getByLabelText('Last name').type(contact.lastName);
 
-            if (type === 'main') {
-                cy.getByLabelText('Yes')
-                    .first()
-                    .click();
-            }
+            cy.queryByText('I confirm that the main and senior contacts', {
+                exact: false,
+                timeout: 500
+            }).then(el => {
+                if (el) {
+                    cy.wrap(el)
+                        .parent()
+                        .within(() => {
+                            cy.getByLabelText('Yes').click();
+                        });
+                }
+            });
 
             fillDateOfBirth(contact.dateOfBirth);
 
@@ -515,7 +522,7 @@ describe('awards for all', function() {
 
         function sectionMainContact(contact) {
             cy.checkA11y();
-            fillContact(contact, 'main');
+            fillContact(contact);
             submitStep();
         }
 
@@ -598,7 +605,7 @@ describe('awards for all', function() {
                 firstName: faker.name.firstName(),
                 lastName: faker.name.lastName(),
                 email: Cypress.env('afa_senior_contact_email'),
-                dateOfBirth: moment().subtract(random(16, 90), 'years'),
+                dateOfBirth: moment().subtract(random(18, 90), 'years'),
                 address: {
                     streetAddress: `The Bar, 2 St James' Blvd`,
                     city: 'Newcastle',

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -638,7 +638,7 @@
                 {% endif %}
                 <ol class="form-field__errors">
                     {% for error in fieldErrors %}
-                        <li>{{ error.msg }}</li>
+                        <li>{{ error.msg | safe }}</li>
                     {% endfor %}
                 </ol>
                 {% if errorsNoscript %}


### PR DESCRIPTION
As suggested by @scottoakley, this adds a new question to the Main Contact screen to ask the user to confirm the contacts aren't related.

![MicrosoftTeams-image](https://user-images.githubusercontent.com/394376/62693484-848ee380-b9ca-11e9-820f-975ee0f1d8d1.png)

I don't think we need to pass this field to Salesforce, though?

It's off by default and only enabled in TEST so we can verify it with the team.