### PR TITLE
Improved Bank API error handling

### DIFF
--- a/common/secrets.js
+++ b/common/secrets.js
@@ -79,8 +79,8 @@ const SALESFORCE_AUTH = {
 
 // These expire in July 2020
 const BANK_API = {
-    KEY: process.env.SALESFORCE_TOKEN || getSecret('bank.api.key'),
-    PASSWORD: process.env.SALESFORCE_TOKEN || getSecret('bank.api.password')
+    KEY: process.env.BANK_API_TOKEN || getSecret('bank.api.key'),
+    PASSWORD: process.env.BANK_API_PASSWORD || getSecret('bank.api.password')
 };
 
 /**

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -25,7 +25,7 @@ const fieldsFor = require('./fields');
 const terms = require('./terms');
 
 const { isTestServer } = require('../../../common/appData');
-const checkBankApi = require('../../../common/bank-api');
+const checkBankApi = require('./lib/bank-api');
 
 module.exports = function({
     locale = 'en',

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -25,7 +25,7 @@ const fieldsFor = require('./fields');
 const terms = require('./terms');
 
 const { isTestServer } = require('../../../common/appData');
-const checkBankApi = require('./lib/bank-api');
+const { checkBankAccountDetails } = require('./lib/bank-api');
 
 module.exports = function({
     locale = 'en',
@@ -707,38 +707,45 @@ module.exports = function({
 
         function messagesForStatus(bankStatus) {
             let messages = [];
-            if (bankStatus.code === 'INVALID') {
-                messages = [
-                    {
-                        msg: localise({
-                            en: `This sort code is not valid with this account number`,
-                            cy: ''
-                        }),
-                        param: 'bankSortCode',
-                        field: fields.bankSortCode
-                    },
-                    {
-                        msg: localise({
-                            en: `This account number is not valid with this sort code`,
-                            cy: ''
-                        }),
-                        param: 'bankAccountNumber',
-                        field: fields.bankAccountNumber
-                    }
-                ];
-            } else if (bankStatus.supportsBacsPayment === false) {
-                messages = [
-                    {
-                        msg: localise({
-                            en: oneLine`This bank account cannot receive BACS payments,
-                                which is a requirement for funding`,
-                            cy: ''
-                        }),
-                        param: 'bankAccountNumber',
-                        field: fields.bankAccountNumber
-                    }
-                ];
+            switch (bankStatus.code) {
+                case 'INVALID_ACCOUNT':
+                    messages = [
+                        {
+                            msg: localise({
+                                en: `This sort code is not valid with this account number`,
+                                cy: ''
+                            }),
+                            param: 'bankSortCode',
+                            field: fields.bankSortCode
+                        },
+                        {
+                            msg: localise({
+                                en: `This account number is not valid with this sort code`,
+                                cy: ''
+                            }),
+                            param: 'bankAccountNumber',
+                            field: fields.bankAccountNumber
+                        }
+                    ];
+                    break;
+                case 'INVALID_BACS':
+                    messages = [
+                        {
+                            msg: localise({
+                                en: oneLine`This bank account cannot receive BACS payments,
+                                    which is a requirement for funding`,
+                                cy: ''
+                            }),
+                            param: 'bankAccountNumber',
+                            field: fields.bankAccountNumber
+                        }
+                    ];
+                    break;
+                default:
+                    messages = [];
+                    break;
             }
+
             return messages;
         }
 
@@ -746,10 +753,9 @@ module.exports = function({
             return Promise.resolve();
         } else {
             return new Promise((resolve, reject) => {
-                checkBankApi(sortCode, accountNumber)
+                checkBankAccountDetails(sortCode, accountNumber)
                     .then(bankStatus => {
                         const messages = messagesForStatus(bankStatus);
-
                         if (messages.length > 0) {
                             return reject(messages);
                         } else {

--- a/controllers/apply/awards-for-all/lib/bank-api.js
+++ b/controllers/apply/awards-for-all/lib/bank-api.js
@@ -1,6 +1,6 @@
 'use strict';
 const request = require('request-promise-native');
-const { BANK_API } = require('../common/secrets');
+const { BANK_API } = require('../../../../common/secrets');
 
 function normaliseResultCode(resultCode) {
     let result;

--- a/controllers/apply/awards-for-all/lib/bank-api.js
+++ b/controllers/apply/awards-for-all/lib/bank-api.js
@@ -2,11 +2,6 @@
 const request = require('request-promise-native');
 const { BANK_API } = require('../../../../common/secrets');
 
-function normaliseBacsCheck(accountProperties) {
-    // Coerce a string ("true") into a boolean
-    return accountProperties ? !!accountProperties.bacs_credit : false;
-}
-
 function checkBankAccountDetails(sortCode, accountNumber) {
     return request
         .get({
@@ -28,19 +23,14 @@ function normalizeResponse(response) {
     switch (response.resultCode) {
         case '01':
             return {
-                code: 'VALID',
-                originalCode: response.resultCode,
-                supportsBacsPayment: normaliseBacsCheck(
-                    response.accountProperties
-                )
+                code:
+                    response.accountProperties.bacs_credit === 'true'
+                        ? 'VALID'
+                        : 'INVALID_BACS'
             };
         case '02':
             return {
-                code: 'INVALID',
-                originalCode: response.resultCode,
-                supportsBacsPayment: normaliseBacsCheck(
-                    response.accountProperties
-                )
+                code: 'INVALID_ACCOUNT'
             };
         default:
             throw new Error(response.resultDescription);

--- a/controllers/apply/awards-for-all/lib/bank-api.test.js
+++ b/controllers/apply/awards-for-all/lib/bank-api.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+'use strict';
+
+const { normalizeResponse } = require('./bank-api');
+
+test('should normalise valid response', () => {
+    const mockValidResponse = {
+        resultCode: '01',
+        resultDescription: 'Sortcode and Bank Account are valid',
+        accountProperties: {
+            institution: 'TSB BANK PLC',
+            branch: '160/2 HIGH ST ACTON 308087',
+            fast_payment: 'true',
+            bacs_credit: 'true',
+            bacs_direct_debit: 'true',
+            chaps: 'true',
+            cheque: 'false'
+        }
+    };
+
+    expect(normalizeResponse(mockValidResponse)).toEqual({
+        code: 'VALID',
+        originalCode: '01',
+        supportsBacsPayment: true
+    });
+});
+
+test('should normalise invalid response', () => {
+    const mockInvalidResponse = {
+        resultCode: '02',
+        resultDescription: 'Sortcode and Bank Account are not valid'
+    };
+
+    expect(normalizeResponse(mockInvalidResponse)).toEqual({
+        code: 'INVALID',
+        originalCode: '02',
+        supportsBacsPayment: false
+    });
+});
+
+test('should throw an error for bad response', () => {
+    const mockBadResponse = {
+        resultCode: '05',
+        resultDescription: 'Key and/or password are invalid.'
+    };
+
+    expect(() => normalizeResponse(mockBadResponse)).toThrow(mockBadResponse.resultDescription);
+});

--- a/controllers/apply/awards-for-all/lib/bank-api.test.js
+++ b/controllers/apply/awards-for-all/lib/bank-api.test.js
@@ -19,9 +19,27 @@ test('should normalise valid response', () => {
     };
 
     expect(normalizeResponse(mockValidResponse)).toEqual({
-        code: 'VALID',
-        originalCode: '01',
-        supportsBacsPayment: true
+        code: 'VALID'
+    });
+});
+
+test('should normalise invalid bacs response', () => {
+    const mockValidResponse = {
+        resultCode: '01',
+        resultDescription: 'Sortcode and Bank Account are valid',
+        accountProperties: {
+            institution: 'TSB BANK PLC',
+            branch: '160/2 HIGH ST ACTON 308087',
+            fast_payment: 'true',
+            bacs_credit: 'false',
+            bacs_direct_debit: 'false',
+            chaps: 'true',
+            cheque: 'false'
+        }
+    };
+
+    expect(normalizeResponse(mockValidResponse)).toEqual({
+        code: 'INVALID_BACS'
     });
 });
 
@@ -32,9 +50,7 @@ test('should normalise invalid response', () => {
     };
 
     expect(normalizeResponse(mockInvalidResponse)).toEqual({
-        code: 'INVALID',
-        originalCode: '02',
-        supportsBacsPayment: false
+        code: 'INVALID_ACCOUNT'
     });
 });
 
@@ -44,5 +60,7 @@ test('should throw an error for bad response', () => {
         resultDescription: 'Key and/or password are invalid.'
     };
 
-    expect(() => normalizeResponse(mockBadResponse)).toThrow(mockBadResponse.resultDescription);
+    expect(() => normalizeResponse(mockBadResponse)).toThrow(
+        mockBadResponse.resultDescription
+    );
 });


### PR DESCRIPTION
- Unit tests for VALID, INVALID_BACS, INVALID_ACCOUNT, bad response
- simplified API response to return a single `statusCode`.
- correctly threw an error for bad responses. eg. where the API key/pwd is invalid.
- moved the `bank-api.js` from `./common` to `awards-for-all/lib` folder as its not used elsewhere.