### PR TITLE
Extend AFA session

### DIFF
--- a/middleware/authed.js
+++ b/middleware/authed.js
@@ -56,7 +56,7 @@ function requireUserAuth(req, res, next) {
     }
 }
 
-function requireActiveUser(req, res, next) {
+function requireActiveUser(req, res, next, cb = null) {
     if (req.isAuthenticated() && isStaff(req.user) === false) {
         if (isActivated(req.user) === true) {
             next();
@@ -64,8 +64,15 @@ function requireActiveUser(req, res, next) {
             redirectWithReturnUrl(req, res, '/user/activate');
         }
     } else {
+        if (cb) {
+            cb(req, res);
+        }
         redirectWithReturnUrl(req, res, '/user/login');
     }
+}
+
+function requireActiveUserWithCallback(cb) {
+    return (req, res, next) => requireActiveUser(req, res, next, cb);
 }
 
 /**
@@ -109,5 +116,6 @@ module.exports = {
     requireActiveUser,
     requireStaffAuth,
     requireNotStaffAuth,
-    redirectUrlWithFallback
+    redirectUrlWithFallback,
+    requireActiveUserWithCallback
 };

--- a/middleware/session.js
+++ b/middleware/session.js
@@ -19,7 +19,7 @@ module.exports = function(app) {
     /**
      * Configure session
      */
-    const IDLE_TIMEOUT_MINUTES = 60;
+    const IDLE_TIMEOUT_MINUTES = 120;
     const sessionConfig = {
         store: store,
         name: config.get('cookies.session'),


### PR DESCRIPTION
Increases session timeouts to 2 hours, but also logs when someone makes a `POST` request to any of the form endpoints when their user is invalid, so we can at least monitor when this is happening.