### PR TITLE
Add clamav install wrapped in test group check

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -8,6 +8,15 @@ sh -c 'echo deb https://oss-binaries.phusionpassenger.com/apt/passenger xenial m
 apt-get update
 apt-get install -y nginx-extras passenger
 
+# Installing clamav and clamav-daemon (anti-virus scan)
+if [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_FLEET ]] ||
+   [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_IN_PLACE ]];
+then
+    apt-get install clamav clamav-daemon
+    freshclam
+    service clamav-daemon start
+fi
+
 # Install Node
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 apt-get install -y nodejs


### PR DESCRIPTION
Thinking about how we can unblock https://github.com/biglotteryfund/blf-alpha/pull/2186 and the simplest way to test clamav provisioning only in the test environment might be to wrap in a deploy group check. Is this as bad idea? 💭 