### PR TITLE
Direct import of rate-limiter modules

### DIFF
--- a/middleware/rate-limiter.js
+++ b/middleware/rate-limiter.js
@@ -1,11 +1,9 @@
 'use strict';
-const {
-    RateLimiterMySQL,
-    RateLimiterMemory
-} = require('rate-limiter-flexible');
-const moment = require('moment');
-const { get } = require('lodash');
 const crypto = require('crypto');
+const moment = require('moment');
+const get = require('lodash/get');
+const RateLimiterMySQL = require('rate-limiter-flexible/lib/RateLimiterMySQL');
+const RateLimiterMemory = require('rate-limiter-flexible/lib/RateLimiterMemory');
 
 const { sequelize } = require('../db/models/index');
 const appData = require('../common/appData');


### PR DESCRIPTION
Spotted whilst debugging the `clamav` install step. We have a persistent warning in our logs about a cluster module being imported. This is causes by the direct import of `rate-limiter-flexible` which contains an implicit import of `RateLimiterCluster`. Importing the modules we want directly avoids this implicit import.