### PR TITLE
Explicitly set ownership of app directory

### DIFF
--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Change ownership of app directory to web user
+chown -R www-data:www-data /var/www/biglotteryfund/
+
 # Configure the patterns for the CodeDeploy deployment group names
 TEST_FLEET="Test_Fleet";
 TEST_IN_PLACE="Test_In_Place";


### PR DESCRIPTION
After a 🐰 🕳 of a day debugging an issue where some folders under `node_modules` had stricter permissions in the deploy artefact we realised that this was really making a wider issue that we are not setting an explicit owner for the app directory. Setting the owner to `www-data` which is what `nginx` runs as is the most direct way to ensure the web servers can read everything without relying on implicit word read permissions.