### PR TITLE
CSRF fix

### DIFF
--- a/controllers/apply/awards-for-all/docs/schema.md
+++ b/controllers/apply/awards-for-all/docs/schema.md
@@ -115,7 +115,7 @@ Each submission has two top-level keys: `meta` which contains metadata about the
         "mainContactEmail": "Lizzie87@example.com",
         "mainContactPhone": "0345 4 10 20 30",
         "mainContactLanguagePreference": "english",
-        "mainContactCommunicationNeeds": [],
+        "mainContactCommunicationNeeds": "email",
         "seniorContactName": {
             "firstName": "Maribel",
             "lastName": "D'Amore"
@@ -135,7 +135,7 @@ Each submission has two top-level keys: `meta` which contains metadata about the
         "seniorContactEmail": "Leora.Walker66@example.org",
         "seniorContactPhone": "020 7211 1888",
         "seniorContactLanguagePreference": "english",
-        "seniorContactCommunicationNeeds": [],
+        "seniorContactCommunicationNeeds": "email",
         "bankAccountName": "Kulas - Greenfelder",
         "bankSortCode": "108800",
         "bankAccountNumber": "00012345",

--- a/controllers/errors/index.js
+++ b/controllers/errors/index.js
@@ -24,6 +24,10 @@ function renderError(err, req, res) {
     res.locals.title = err.friendlyText ? err.friendlyText : 'Error';
     res.locals.sentry = res.sentry;
 
+    if (err.code === 'EBADCSRFTOKEN' && req.method === 'POST') {
+        return res.redirect(req.originalUrl);
+    }
+
     res.status(res.locals.status).render(
         path.resolve(__dirname, './views/error')
     );


### PR DESCRIPTION
Currently, if you leave a page open for 2 hours and then submit a form (eg. login/register), you'll get a 403 error because the CSRF token will be wrong.

This is a bit rubbish as we don't handle it so the user just sees a hard-to-recover-from generic error page.

This change means that any CSRF failures are redirected back to the original page, so the user can resubmit.

This is more of an experimental suggestion rather than a feature request so thoughts welcome – I just think the current behaviour is quite unhelpful to the user.