### PR TITLE
Enforce four digit year for org start date

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -18,7 +18,6 @@ const {
     MIN_AGE_SENIOR_CONTACT,
     MIN_BUDGET_TOTAL_GBP,
     MIN_START_DATE,
-    ORG_MIN_AGE,
     ORGANISATION_TYPES,
     STATUTORY_BODY_TYPES,
     CHARITY_NUMBER_TYPES,
@@ -38,6 +37,7 @@ const fieldYourIdeaPriorities = require('./fields/your-idea-priorities');
 const fieldYourIdeaCommunity = require('./fields/your-idea-community');
 const fieldOrganisationType = require('./fields/organisation-type');
 const fieldSeniorContactRole = require('./fields/senior-contact-role');
+const fieldOrganisationStartDate = require('./fields/organisation-start-date');
 
 module.exports = function fieldsFor({ locale, data = {} }) {
     const localise = get(locale);
@@ -1822,48 +1822,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        organisationStartDate: {
-            name: 'organisationStartDate',
-            type: 'month-year',
-            label: localise({
-                en: `When was your organisation set up?`,
-                cy: `Pryd sefydlwyd eich sefydliad?`
-            }),
-            explanation: localise({
-                en: `<p>Please tell us the month and year.</p>
-                     <p><strong>For example: 11 2017</strong></p>`,
-                cy: `<p>Dywedwch wrthym y mis a’r flwyddyn.</p>
-                     <p><strong>Er enghraifft: 11 2017</strong></p>`
-            }),
-            isRequired: true,
-            schema: Joi.monthYear()
-                .pastDate()
-                .minTimeAgo(ORG_MIN_AGE.amount, ORG_MIN_AGE.unit)
-                .required(),
-            messages: [
-                {
-                    type: 'base',
-                    message: localise({
-                        en: 'Enter a day and month',
-                        cy: 'Rhowch ddiwrnod a mis'
-                    })
-                },
-                {
-                    type: 'any.invalid',
-                    message: localise({
-                        en: 'Enter a real day and month',
-                        cy: 'Rhowch ddiwrnod a mis go iawn'
-                    })
-                },
-                {
-                    type: 'monthYear.pastDate',
-                    message: localise({
-                        en: 'Date you enter must be in the past',
-                        cy: 'Rhaid i’r dyddiad fod yn y gorffennol'
-                    })
-                }
-            ]
-        },
+        organisationStartDate: fieldOrganisationStartDate(locale),
         organisationAddress: addressField({
             name: 'organisationAddress',
             label: localise({

--- a/controllers/apply/awards-for-all/fields/organisation-start-date.js
+++ b/controllers/apply/awards-for-all/fields/organisation-start-date.js
@@ -1,0 +1,66 @@
+'use strict';
+const get = require('lodash/fp/get');
+const moment = require('moment');
+
+const Joi = require('../../form-router-next/joi-extensions');
+
+const { ORG_MIN_AGE } = require('../constants');
+
+module.exports = function(locale) {
+    const localise = get(locale);
+
+    const exampleYear = moment()
+        .subtract('5', 'years')
+        .format('YYYY');
+
+    return {
+        name: 'organisationStartDate',
+        type: 'month-year',
+        label: localise({
+            en: `When was your organisation set up?`,
+            cy: `Pryd sefydlwyd eich sefydliad?`
+        }),
+        explanation: localise({
+            en: `<p>Please tell us the month and year.</p>
+                 <p><strong>For example: 11 ${exampleYear}</strong></p>`,
+            cy: `<p>Dywedwch wrthym y mis a’r flwyddyn.</p>
+                 <p><strong>Er enghraifft: 11 ${exampleYear}</strong></p>`
+        }),
+        isRequired: true,
+        schema: Joi.monthYear()
+            .pastDate()
+            .minTimeAgo(ORG_MIN_AGE.amount, ORG_MIN_AGE.unit)
+            .required(),
+        messages: [
+            {
+                type: 'base',
+                message: localise({
+                    en: 'Enter a day and month',
+                    cy: 'Rhowch ddiwrnod a mis'
+                })
+            },
+            {
+                type: 'any.invalid',
+                message: localise({
+                    en: 'Enter a real day and month',
+                    cy: 'Rhowch ddiwrnod a mis go iawn'
+                })
+            },
+            {
+                type: 'number.min',
+                key: 'year',
+                message: localise({
+                    en: `Enter a full year e.g. ${exampleYear}`,
+                    cy: ``
+                })
+            },
+            {
+                type: 'monthYear.pastDate',
+                message: localise({
+                    en: 'Date you enter must be in the past',
+                    cy: 'Rhaid i’r dyddiad fod yn y gorffennol'
+                })
+            }
+        ]
+    };
+};

--- a/controllers/apply/awards-for-all/fields/organisation-start-date.js
+++ b/controllers/apply/awards-for-all/fields/organisation-start-date.js
@@ -50,8 +50,8 @@ module.exports = function(locale) {
                 type: 'number.min',
                 key: 'year',
                 message: localise({
-                    en: `Enter a full year e.g. ${exampleYear}`,
-                    cy: ``
+                    en: `Must be a full year e.g. ${exampleYear}`,
+                    cy: `Rhaid bod yn flwyddyn gyfan e.e ${exampleYear}`
                 })
             },
             {

--- a/controllers/apply/form-router-next/joi-extensions/month-year.js
+++ b/controllers/apply/form-router-next/joi-extensions/month-year.js
@@ -10,7 +10,7 @@ const valueToDate = value => {
     });
 };
 
-module.exports = function monthYear(joi) {
+module.exports = function(joi) {
     return {
         name: 'monthYear',
         base: joi.object({
@@ -21,8 +21,12 @@ module.exports = function monthYear(joi) {
             year: joi
                 .number()
                 .integer()
+                .min(1000)
                 .required()
         }),
+        language: {
+            pastDate: 'must be in the past'
+        },
         pre(value, state, options) {
             const date = valueToDate(value);
             if (date.isValid()) {

--- a/controllers/apply/form-router-next/joi-extensions/month-year.test.js
+++ b/controllers/apply/form-router-next/joi-extensions/month-year.test.js
@@ -17,6 +17,20 @@ test('valid month-year', () => {
     const missingYear = schema.validate({ month: 2 });
     expect(missingYear.error.message).toContain('"year" is required');
 
-    const invalidDate = schema.validate({ month: 31, year: 100 });
+    const invalidDate = schema.validate({ month: 31, year: 2000 });
     expect(invalidDate.error.message).toContain('contains an invalid value');
+});
+
+test('four digit year', () => {
+    const schema = Joi.monthYear();
+    const invalidDate = schema.validate({ month: 3, year: 100 });
+    expect(invalidDate.error.message).toContain(
+        '"year" must be larger than or equal to'
+    );
+});
+
+test('date must be in the past', () => {
+    const schema = Joi.monthYear().pastDate();
+    const invalidDate = schema.validate({ month: 3, year: 2100 });
+    expect(invalidDate.error.message).toContain('must be in the past');
 });


### PR DESCRIPTION
Currently it is possible to enter a short year for the organisation start date, such as 11 06. This is treated as 6AD which is a valid year but not a useful one.

Salesforce requires years to be four digits so enforcing this here. Error message text needs reviewing and then translating before this can be merged.

I've also extracted this field into its own file as part of this PR. @scottoakley would you mind reviewing the error message text for this?

![image](https://user-images.githubusercontent.com/123386/63927119-ffd13b80-ca44-11e9-97ca-a92192c2254e.png)
