### PR TITLE
Don't log users in after password reset

### DIFF
--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -267,22 +267,11 @@ router
 
                             logger.info('Password reset email sent');
 
-                            // Log the user in
-                            req.logIn(user, function(loginErr) {
-                                if (loginErr) {
-                                    redirectForLocale(
-                                        req,
-                                        res,
-                                        '/user/login?s=passwordUpdated'
-                                    );
-                                } else {
-                                    redirectForLocale(
-                                        req,
-                                        res,
-                                        '/user?s=passwordUpdated'
-                                    );
-                                }
-                            });
+                            return redirectForLocale(
+                                req,
+                                res,
+                                '/user/login?s=passwordUpdated'
+                            );
                         } else {
                             logger.info('Password reset not valid for user');
                             redirectForLocale(req, res, '/user/login');


### PR DESCRIPTION
This is a weird one. We saw repeatable behaviour where resetting a password would trigger an endlessly hanging page (which Cloudfront eventually catches as a 504 timeout).

Initially I thought this was due to a mixture of upper/lowercase in emails (eg. registering with one variant and changing password with another). Extensive testing suggests this is a red herring though – it's possible to register/login with differently-cased email addresses just fine.

Instead I think it's down to some slightly hacky code I wrote before launch around `req.login()` which tries to auto-login the user when they change their password. It seems like this is the cause of the error. 

At the point where `res.redirect()` gets called, nothing happens. I tried lots of debugging/logging and was really struggling to figure out what was happening. Possibly some weird loop/race condition where the login didn't complete in time and then we tried to send users to a login screen which in turn required them to be unauthed... I don't know. I tried wrapping the code in `req.session.save(() => {`... didn't work. Tried wrapping it in a full Passport login function... didn't work. Giving up and removing the autologin because I think the timeout risk is worse for UX than having to sign-in a second time.