### PR TITLE
Use translated copy for Welsh post-submission feedback survey

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1349,6 +1349,10 @@ applyNext:
       errorScanInfected: Mae’r ffeil wedi ei gloi am resymau diogelwch.
       errorScanUnknown: Mae’r ffeil hwn yn dal i gael ei sganio am risgiau diogelwch—gwiriwch eto yn fuan.
       errorOther: Roedd yna broblem wrth adfer eich ffeil—trïwch eto’n fuan.
+  feedback:
+    promptLabel: "Oes gennych funud sbâr i roi adborth i ni?"
+    fieldLabel: "Sut oedd eich profiad o'r broses hon?"
+    helpText: "Mae hwn yn gwbl ddienw ac nid yw'n ffurfio rhan o'ch cyflwyniad. Peidiwch â chynnwys unrhyw fanylion am eich syniad, dim ond sut brofiad yr oedd."
   common:
     delete: Dileu
     exit: Gadael

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1616,12 +1616,16 @@ applyNext:
     successfulTitle: Great! You're eligible to apply to %s
     unsuccessfulTitle: Sorry, you're not eligible to apply at this time
     whatNow: What now?
-  #  @TODO: Move other common text to common:
   errors:
     file:
       errorScanInfected: This file has been blocked for security reasons.
       errorScanUnknown: This file is still being scanned for security risks - please check back shortly.
       errorOther: There was an issue retrieving your file - please try again soon.
+  feedback:
+    promptLabel: "Can you spare a minute to give us some feedback?"
+    fieldLabel: "How was your experience of this process?"
+    helpText: "This is completely anonymous and doesn't form part of your submission. Don't include any details about your idea, just tell us how you found the experience."
+  #  @TODO: Move other common text to common:
   common:
     delete: Delete
     exit: Exit

--- a/controllers/apply/form-router-next/views/confirmation.njk
+++ b/controllers/apply/form-router-next/views/confirmation.njk
@@ -20,9 +20,9 @@
 
             {{ inlineFeedback(
                 description = formTitle,
-                promptLabel = "Can you spare a minute to give us some feedback?",
-                fieldLabel = "How was your experience of submitting an application?",
-                helpText = "This is completely anonymous and doesn't form part of your submission. Don't include any details about your idea, just tell us how you found the experience.",
+                promptLabel = copy.feedback.promptLabel,
+                fieldLabel = copy.feedback.fieldLabel,
+                helpText = copy.feedback.helpText,
                 isToggleable = false
             )  }}
         </section>


### PR DESCRIPTION
Noticed this was hard-coded to English when doing a test Welsh application:

![Screenshot 2019-08-29 16 25 18](https://user-images.githubusercontent.com/394376/63954560-3629ad80-ca7b-11e9-8032-b047c9c9a116.png)
