### PR TITLE
Fixup check for registration numbers

### DIFF
--- a/assets/js/common/session.js
+++ b/assets/js/common/session.js
@@ -1,4 +1,3 @@
-'use strict';
 import $ from 'jquery';
 import debounce from 'lodash/debounce';
 import { trackEvent } from '../helpers/metrics';

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -774,43 +774,47 @@ describe('awards for all', function() {
                 submitStep();
             }
 
-            cy.queryByLabelText('Companies House number', {
+            /**
+             * Registration numbers
+             * Not all organisation types require a registration number
+             * so we need to check if the step exists first.
+             */
+            cy.queryByText('Registration numbers (Step 4 of 5)', {
                 exact: false,
-                timeout: 1000
-            }).then(el => {
-                if (el) {
-                    const randomCompanyNumber = random(10000, 99999999)
+                timeout: 500
+            }).then(registrationNumbersStepEl => {
+                function randomId(digits) {
+                    return random(10000, 99999999)
                         .toString()
-                        .padStart(8, '0');
-                    cy.wrap(el).type(randomCompanyNumber);
+                        .padStart(digits, '0');
+                }
+
+                if (registrationNumbersStepEl) {
+                    const opts = { exact: false, timeout: 500 };
+
+                    cy.queryByLabelText('Companies House number', opts).then(
+                        function(el) {
+                            el && cy.wrap(el).type(randomId(8));
+                        }
+                    );
+
+                    cy.queryByLabelText(
+                        'Charity registration number',
+                        opts
+                    ).then(function(el) {
+                        el && cy.wrap(el).type(randomId(7));
+                    });
+
+                    cy.queryByLabelText(
+                        'Department for Education number',
+                        opts
+                    ).then(function(el) {
+                        el && cy.wrap(el).type(randomId(6));
+                    });
+
+                    submitStep();
                 }
             });
-
-            cy.queryByLabelText('Charity registration number', {
-                exact: false,
-                timeout: 1000
-            }).then(el => {
-                if (el) {
-                    const randomCharityNumber = random(10000, 9999999)
-                        .toString()
-                        .padStart(7, '0');
-                    cy.wrap(el).type(randomCharityNumber);
-                }
-            });
-
-            cy.queryByLabelText('Department for Education number', {
-                exact: false,
-                timeout: 1000
-            }).then(el => {
-                if (el) {
-                    const randomEducationNumber = random(10000, 999999)
-                        .toString()
-                        .padStart(6, '0');
-                    cy.wrap(el).type(randomEducationNumber);
-                }
-            });
-
-            submitStep();
 
             // Optional accounting year end step
             cy.queryByText('What is your accounting year end date?', {


### PR DESCRIPTION
Found the source of some flakiness with our Cypress tests. For unregistered groups we don't ask for any registration numbers so this step is skipped entirely. Our test code was checking for existence of each of the possible _fields_ but not for the step itself so would try to submit the wrong step in this case. Fixes things by wrapping the whole step in a check.