### PR TITLE
Wales feature switch

### DIFF
--- a/assets/js/common/session.js
+++ b/assets/js/common/session.js
@@ -1,4 +1,3 @@
-'use strict';
 import $ from 'jquery';
 import debounce from 'lodash/debounce';
 import { trackEvent } from '../helpers/metrics';

--- a/config/default.json
+++ b/config/default.json
@@ -40,7 +40,6 @@
   },
   "features": {
     "enableAllowLocalhost": false,
-    "enableAwardsForAllApplications": true,
     "enableCloudWatchLogs": true,
     "enableDigitalFundApplications": false,
     "enableHotjar": false,

--- a/config/development.json
+++ b/config/development.json
@@ -5,7 +5,6 @@
   },
   "features": {
     "enableAllowLocalhost": false,
-    "enableAwardsForAllApplications": true,
     "enableCloudWatchLogs": false,
     "enableSeeders": true,
     "enableSalesforceConnector": true

--- a/config/test.json
+++ b/config/test.json
@@ -6,7 +6,6 @@
   },
   "features": {
     "enableAllowLocalhost": false,
-    "enableAwardsForAllApplications": true,
     "enableDigitalFundApplications": false,
     "enableHotjar": true
   },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -589,9 +589,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         });
 
         // @TODO post-Wales launch, use this in the schema instead of options
-        const activeOptions = options.filter(
-            option => has(option, 'attributes.disabled') === false
-        );
+        // const activeOptions = options.filter(
+        //     option => has(option, 'attributes.disabled') === false
+        // );
 
         return {
             name: 'projectCountry',

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,6 +1,7 @@
 'use strict';
 const config = require('config');
 const moment = require('moment');
+const concat = require('lodash/concat');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 const has = require('lodash/has');
@@ -588,6 +589,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             allowedCountries: config.get('awardsForAll.allowedCountries')
         });
 
+        // @TODO post-Wales launch, use this in the schema instead of options
         const activeOptions = options.filter(
             option => has(option, 'attributes.disabled') === false
         );
@@ -610,7 +612,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             options: options,
             isRequired: true,
             schema: Joi.string()
-                .valid(activeOptions.map(option => option.value))
+                .valid(options.map(option => option.value))
                 .required(),
             messages: [
                 {

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,7 +1,6 @@
 'use strict';
 const config = require('config');
 const moment = require('moment');
-const concat = require('lodash/concat');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 const has = require('lodash/has');

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -3,7 +3,7 @@ const config = require('config');
 const moment = require('moment');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
-const has = require('lodash/has');
+// const has = require('lodash/has');
 const { oneLine } = require('common-tags');
 
 const Joi = require('../form-router-next/joi-extensions');

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -30,8 +30,6 @@ if (features.enableDigitalFundApplications) {
 /**
  * Awards for All
  */
-if (features.enableAwardsForAllApplications) {
-    router.use('/awards-for-all', require('./awards-for-all'));
-}
+router.use('/awards-for-all', require('./awards-for-all'));
 
 module.exports = router;

--- a/controllers/user/views/dashboard.njk
+++ b/controllers/user/views/dashboard.njk
@@ -26,19 +26,17 @@
                     </div>
                 </div>
 
-                {% if enableAwardsForAllApplications %}
-                    <div class="content-sidebar__secondary content-sidebar__secondary--major">
-                        <div class="u-padded u-tone-background-tint">
-                            <h2>{{ __('applyNext.startApplication.title') | safe }}</h2>
-                            <p>{{ __('applyNext.startApplication.intro') }}</p>
-                            <p>
-                                <a class="btn btn--small" href="{{ localify("/apply/awards-for-all/start") }}">
-                                    {{ __('applyNext.startApplication.callToAction') }}
-                                </a>
-                            </p>
-                        </div>
+                <div class="content-sidebar__secondary content-sidebar__secondary--major">
+                    <div class="u-padded u-tone-background-tint">
+                        <h2>{{ __('applyNext.startApplication.title') | safe }}</h2>
+                        <p>{{ __('applyNext.startApplication.intro') }}</p>
+                        <p>
+                            <a class="btn btn--small" href="{{ localify("/apply/awards-for-all/start") }}">
+                                {{ __('applyNext.startApplication.callToAction') }}
+                            </a>
+                        </p>
                     </div>
-                {% endif %}
+                </div>
             </div>
 
         </div>

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -20,8 +20,6 @@ module.exports = function(req, res, next) {
      */
     res.locals.enableSiteSurvey = features.enableSiteSurvey;
     res.locals.enableNameChangeMessage = features.enableNameChangeMessage;
-    res.locals.enableAwardsForAllApplications =
-        features.enableAwardsForAllApplications;
 
     /**
      * Global copy


### PR DESCRIPTION
Two things here: removing the global AFA switch which is redundant now we've launched in Scotland, and allowing Wales to be selected even when the option is disabled.

I'm trying to be pragmatic here as the lifespan of this code can probably be measured in hours – we need to deploy it, run a few tests to verify things, then get rid of it. Adding back in `cookie-parser` in order to read secrets, and then having to juggle the `req` object around in order to allow `wales` conditionally for a specific field is a lot of work/complexity for something trivial/brief like this, IMO.

This change means Wales/NI/England will remain disabled in the UI, but a bit of hackery makes it possible to use their form values when submitting. I think this is acceptable for what we're doing here.