### PR TITLE
Clone the minimum project start date before modifying it

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -459,6 +459,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
         function formatAfterDate() {
             return minDate
+                .clone()
                 .subtract(1, 'days')
                 .locale(locale)
                 .format('D MMMM YYYY');

--- a/controllers/apply/awards-for-all/fields/organisation-type.js
+++ b/controllers/apply/awards-for-all/fields/organisation-type.js
@@ -66,7 +66,7 @@ module.exports = function fieldOrganisationType(locale) {
                 en: oneLine`My organisation is a not-for-profit company
                     registered with Companies House, and <strong>may also</strong>
                     be registered as a charity`,
-                cy: oneLine`Mae fy sefydliad yn gwmni dielw sydd yn gofrestredig
+                cy: oneLine`Mae fy sefydliad yn gwmni di-elw sydd yn gofrestredig
                     â Thŷ’r Cwmnïau, a <strong>gall hefyd</strong> fod wedi’i
                     gofrestru fel elusen.`
             })

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -329,7 +329,7 @@ describe('Project details', () => {
                     endDate: { day: 1, month: 1, year: 2030 }
                 }
             },
-            [expect.stringMatching(/Date you end the project must be within/)]
+            [expect.stringMatching(/Date you start the project must be after/)]
         );
     });
 

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -326,10 +326,31 @@ describe('Project details', () => {
             {
                 projectDateRange: {
                     startDate: { day: 1, month: 1, year: 2020 },
-                    endDate: { day: 1, month: 1, year: 2030 }
+                    endDate: { day: 1, month: 1, year: 2021 }
                 }
             },
             [expect.stringMatching(/Date you start the project must be after/)]
+        );
+
+        const validStartDate = moment().add('25', 'weeks');
+        const invalidEndDate = validStartDate.clone().add('100', 'years');
+
+        assertMessagesByKey(
+            {
+                projectDateRange: {
+                    startDate: {
+                        day: validStartDate.day(),
+                        month: validStartDate.month(),
+                        year: validStartDate.year()
+                    },
+                    endDate: {
+                        day: invalidEndDate.day(),
+                        month: invalidEndDate.month(),
+                        year: invalidEndDate.year()
+                    }
+                }
+            },
+            [expect.stringMatching(/Date you end the project must be within/)]
         );
     });
 


### PR DESCRIPTION
Here's a funny one, spotted by Osian:

![image](https://user-images.githubusercontent.com/394376/64016024-cd474180-cb1d-11e9-97c6-5513431abe06.png)

Logging `minDate` each time we format it, we see:

```
moment("2020-01-03T11:55:15.083")
moment("2020-01-02T11:55:15.083")
moment("2020-01-01T11:55:15.083")
moment("2019-12-31T11:55:15.083")
```

eg. each time we called `formatAfterDate()` it was removing a day from the date, which meant the validations would change each time too...!

This change calls `clone()` on `minDate` so we're not modifying it. I checked the codebase and everywhere else we use `.add()` or `.subtract()`, we're either doing it against the default `moment()` object or already cloning the original date, so we should be safe.

Afterwards:

```
moment("2020-01-03T11:56:28.774")
moment("2020-01-03T11:56:28.774")
moment("2020-01-03T11:56:28.774")
moment("2020-01-03T11:56:28.774")
```