### PR TITLE
Fixup date tests

### DIFF
--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -332,14 +332,11 @@ describe('Project details', () => {
             [expect.stringMatching(/Date you start the project must be after/)]
         );
 
-        const validStartDate = moment().add('25', 'weeks');
-        const invalidEndDate = validStartDate.clone().add('100', 'years');
-
         assertMessagesByKey(
             {
                 projectDateRange: {
-                    startDate: toDateParts(validStartDate),
-                    endDate: toDateParts(invalidEndDate)
+                    startDate: toDateParts(moment().add('25', 'weeks')),
+                    endDate: toDateParts(moment().add('2', 'years'))
                 }
             },
             [expect.stringMatching(/Date you end the project must be within/)]

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -338,16 +338,8 @@ describe('Project details', () => {
         assertMessagesByKey(
             {
                 projectDateRange: {
-                    startDate: {
-                        day: validStartDate.day(),
-                        month: validStartDate.month(),
-                        year: validStartDate.year()
-                    },
-                    endDate: {
-                        day: invalidEndDate.day(),
-                        month: invalidEndDate.month(),
-                        year: invalidEndDate.year()
-                    }
+                    startDate: toDateParts(validStartDate),
+                    endDate: toDateParts(invalidEndDate)
                 }
             },
             [expect.stringMatching(/Date you end the project must be within/)]


### PR DESCRIPTION
`.month()` is 0 indexed so these tests were using an unexpected month, switch to use `toDateParts` helper to fix the tests.