### PR TITLE
Date formats

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -26,13 +26,6 @@
     "indexable": ["www.biglotteryfund.org.uk", "www.tnlcommunityfund.org.uk"],
     "base": "https://www.tnlcommunityfund.org.uk"
   },
-  "dateFormats": {
-    "month": "MMMM YYYY",
-    "short": "D MMMM, YYYY",
-    "numeric": "D/MM/YYYY",
-    "full": "dddd D MMMM YYYY",
-    "fullTimestamp": "dddd D MMM YYYY (hh:mm a)"
-  },
   "i18n": {
     "urlPrefix": {
       "cy": "/welsh"

--- a/controllers/apply/form-router-next/views/dashboard.njk
+++ b/controllers/apply/form-router-next/views/dashboard.njk
@@ -52,8 +52,8 @@
                 <p class="application-card__minor-title">{{ copy.dashboard.applicationStatus }}:</p>
                 <h4>{{ copy.dashboard.notSubmitted }}</h4>
                 {{ __('applyNext.dashboard.expiryMessage',
-                    formatDate(application.createdAt.toISOString(), DATE_FORMATS.short),
-                    formatDate(application.expiresAt.toISOString(), DATE_FORMATS.short)
+                    formatDate(application.createdAt.toISOString()),
+                    formatDate(application.expiresAt.toISOString())
                 ) | safe }}
             </div>
 
@@ -95,7 +95,7 @@
         <div class="application-card__progress">
             <div class="application-card__progress__status">
                 <p class="application-card__minor-title">{{ copy.dashboard.applicationStatus }}:</p>
-                <h4>{{ copy.dashboard.submitted }} {{ formatDate(application.createdAt.toISOString(), DATE_FORMATS.short) }}</h4>
+                <h4>{{ copy.dashboard.submitted }} {{ formatDate(application.createdAt.toISOString()) }}</h4>
                 <div class="s-prose">
                     <p>{{ __('applyNext.dashboard.decisionMessage', 18) | safe }}</p>
                 </div>

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -58,7 +58,7 @@
                         <aside class="grant-summary">
                             <p class="grant-summary__amount">£{{ grant.amountAwarded | numberWithCommas }}</p>
                             <p class="grant-summary__title">{{ grant.title }}</p>
-                            <p class="grant-summary__date">{{ formatDate(grant.awardDate, DATE_FORMATS.short) }}</p>
+                            <p class="grant-summary__date">{{ formatDate(grant.awardDate) }}</p>
                         </aside>
 
                         <dl class="o-definition-list o-definition-list--compact u-text-small">
@@ -67,8 +67,8 @@
                                 {% for dates in grant.plannedDates %}
                                     <dd>
                                         {{ fields.area.label }}
-                                        {{ formatDate(dates.startDate, DATE_FORMATS.short) }}{% if dates.endDate -%}
-                                            &ndash;{{ formatDate(dates.endDate, DATE_FORMATS.short) }}
+                                        {{ formatDate(dates.startDate) }}{% if dates.endDate -%}
+                                            &ndash;{{ formatDate(dates.endDate) }}
                                         {%- endif %}
                                     </dd>
                                 {% endfor %}

--- a/controllers/grants/views/grant-results.njk
+++ b/controllers/grants/views/grant-results.njk
@@ -7,7 +7,7 @@
         {% set mainRecipient = grant.recipientOrganization[0] %}
         £{{ grant.amountAwarded | numberWithCommas}} {{ __('global.misc.to') }}
         <strong><a href="{{ localify("/funding/grants/recipients/" + mainRecipient.id) }}">{{ mainRecipient.name | striptags }}</a></strong>
-        {{ __('global.misc.on') }} {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}
+        {{ __('global.misc.on') }} {{ formatDate(grant.awardDate) }}
     {% endset %}
     {% set description = false if grant.description === grant.title else grant.description %}
     {% call promoCard({

--- a/controllers/grants/views/recipient-detail.njk
+++ b/controllers/grants/views/recipient-detail.njk
@@ -103,7 +103,7 @@
                                 </header>
                                 <div class="card__body">
                                     <p class="project-caption">£{{ grant.amountAwarded | numberWithCommas}}
-                                        on {{ formatDate(grant.awardDate, DATE_FORMATS.short) }}</p>
+                                        on {{ formatDate(grant.awardDate) }}</p>
                                     <dl class="o-definition-list o-definition-list--compact u-margin-top-s u-text-small">
                                         <dt>{{ copy.grantDetail.fields.programme }}</dt>
                                         {% for programme in grant.grantProgramme %}

--- a/controllers/grants/views/search.njk
+++ b/controllers/grants/views/search.njk
@@ -39,8 +39,8 @@
                         <p class="u-no-margin">
                             {{ __(
                                 "funding.pastGrants.search.dateRange",
-                                formatDate(grantDataDates.start, DATE_FORMATS.short),
-                                formatDate(grantDataDates.end, DATE_FORMATS.short)
+                                formatDate(grantDataDates.start),
+                                formatDate(grantDataDates.end)
                             ) | safe }}
                         </p>
                     {% endif %}

--- a/controllers/insights/views/insights-detail.njk
+++ b/controllers/insights/views/insights-detail.njk
@@ -40,7 +40,7 @@
                     <div class="content-meta">
                         <dl class="o-definition-list o-definition-list--compact">
                             <dt>{{ extraCopy.datePublished }}</dt>
-                            <dd>{{ formatDate(entry.postDate.date, DATE_FORMATS.month) }}</dd>
+                            <dd>{{ formatDate(entry.postDate.date, 'MMMM YYYY') }}</dd>
                             {% if entry.researchPartners %}
                                 <dt>{{ extraCopy.partners }}</dt>
                                 <dd>{{ entry.researchPartners }}</dd>

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -63,8 +63,8 @@
             <h2>
                 Date range:
                 {% if dateRange %}
-                    {{ formatDate(dateRange.start, DATE_FORMATS.short) }} &mdash;
-                    {{ formatDate(dateRange.end, DATE_FORMATS.short) }}
+                    {{ formatDate(dateRange.start) }} &mdash;
+                    {{ formatDate(dateRange.end) }}
                 {% else %}
                     {# @TODO - what is this range? #}
                     the last five months
@@ -308,7 +308,7 @@
                                         {{ f.message | safe }}
                                     </div>
                                     <cite class="blockquote__cite">
-                                        {{ formatDate(f.createdAt.toISOString(), DATE_FORMATS.short) }}
+                                        {{ formatDate(f.createdAt.toISOString()) }}
                                     </cite>
                                 </blockquote>
                             </li>

--- a/controllers/tools/views/feedback.njk
+++ b/controllers/tools/views/feedback.njk
@@ -15,7 +15,7 @@
                             id="msg-{{ response.id }}">
                         <div class="d-flex w-100 justify-content-between">
                             <h3 class="h6">
-                                {{ formatDate(response.createdAt, DATE_FORMATS.fullTimestamp) }}
+                                {{ formatDate(response.createdAt, 'dddd D MMM YYYY (hh:mm a)') }}
                             </h3>
                             <a href="#msg-{{ response.id }}">
                                 <small title="{{ response.createdAt }}">{{ timeFromNow(response.createdAt) }}</small>

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -42,8 +42,8 @@
         <small class="text-muted">
             <br />
             {% if dateRange %}
-                {{ formatDate(dateRange.start, DATE_FORMATS.short) }} &mdash;
-                {{ formatDate(dateRange.end, DATE_FORMATS.short) }}
+                {{ formatDate(dateRange.start) }} &mdash;
+                {{ formatDate(dateRange.end) }}
             {% else %}
                 in the last five months
             {% endif %}

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -30,7 +30,7 @@
                                 <li class="article-listing__item">
                                     {% set subtitle %}
                                         <time class="article-teaser__pubdate" datetime="{{ props.postDate.date }}">
-                                            {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
+                                            {{ formatDate(entry.postDate.date) }}
                                         </time>
 
                                         {% if entry.regions.length > 0 %}

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -46,7 +46,7 @@
             <p class="u-margin-bottom-s">
                 <strong>{{ copy.datePublished }}:</strong>
                 <time datetime="{{ entry.postDate.date }}">
-                    {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
+                    {{ formatDate(entry.postDate.date) }}
                 </time>
             </p>
         {% endif %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -17,7 +17,7 @@
             <dt>{{ copy.datePublished }}</dt>
             <dd>
                 <time datetime="{{ entry.postDate.date }}">
-                    {{ formatDate(entry.postDate.date, DATE_FORMATS.short) }}
+                    {{ formatDate(entry.postDate.date) }}
                 </time>
             </dd>
         {% endif %}

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -14,7 +14,7 @@
 {% macro blogTrail(entry, promoted = false, showAuthor = true, updateType = 'blog') %}
     {% call promoCard({
         "title": entry.trailText or entry.title,
-        subtitle: formatDate(entry.postDate.date, DATE_FORMATS.short),
+        subtitle: formatDate(entry.postDate.date),
         "trailText": entry.summary,
         "image": {
             "url": entry.thumbnail.large,

--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -139,7 +139,7 @@ module.exports = function(req, res, next) {
      * @param {String} format
      * @return {String}
      */
-    res.locals.formatDate = function(dateString, format) {
+    res.locals.formatDate = function(dateString, format = 'D MMMM, YYYY') {
         return moment(dateString)
             .locale(locale)
             .format(format);

--- a/server.js
+++ b/server.js
@@ -143,9 +143,7 @@ function initAppLocals() {
      */
     app.locals.DATE_FORMATS = {
         month: 'MMMM YYYY',
-        short: 'D MMMM, YYYY',
-        numeric: 'D/MM/YYYY',
-        full: 'dddd D MMMM YYYY'
+        short: 'D MMMM, YYYY'
     };
 
     /**

--- a/server.js
+++ b/server.js
@@ -145,8 +145,7 @@ function initAppLocals() {
         month: 'MMMM YYYY',
         short: 'D MMMM, YYYY',
         numeric: 'D/MM/YYYY',
-        full: 'dddd D MMMM YYYY',
-        fullTimestamp: 'dddd D MMM YYYY (hh:mm a)'
+        full: 'dddd D MMMM YYYY'
     };
 
     /**

--- a/server.js
+++ b/server.js
@@ -141,7 +141,13 @@ function initAppLocals() {
     /**
      * Common date formats
      */
-    app.locals.DATE_FORMATS = config.get('dateFormats');
+    app.locals.DATE_FORMATS = {
+        month: 'MMMM YYYY',
+        short: 'D MMMM, YYYY',
+        numeric: 'D/MM/YYYY',
+        full: 'dddd D MMMM YYYY',
+        fullTimestamp: 'dddd D MMM YYYY (hh:mm a)'
+    };
 
     /**
      * Is this page bilingual?

--- a/server.js
+++ b/server.js
@@ -139,13 +139,6 @@ function initAppLocals() {
     app.locals.appData = appData;
 
     /**
-     * Common date formats
-     */
-    app.locals.DATE_FORMATS = {
-        short: 'D MMMM, YYYY'
-    };
-
-    /**
      * Is this page bilingual?
      * i.e. do we have a Welsh translation
      * Default to true unless overridden by a route

--- a/server.js
+++ b/server.js
@@ -142,7 +142,6 @@ function initAppLocals() {
      * Common date formats
      */
     app.locals.DATE_FORMATS = {
-        month: 'MMMM YYYY',
         short: 'D MMMM, YYYY'
     };
 

--- a/views/components/research-card/macro.njk
+++ b/views/components/research-card/macro.njk
@@ -4,7 +4,7 @@
     {% call promoCard({
         "headingLevel": 2,
         "title": research.title,
-        "subtitle": formatDate(research.postDate.date, DATE_FORMATS.month),
+        "subtitle": formatDate(research.postDate.date, 'MMMM YYYY'),
         "trailText": research.trailText,
         "image": { "url": research.trailImage, "alt": research.title },
         "link": { "url": research.linkUrl, "label": __('global.misc.readMore') }


### PR DESCRIPTION
Began by inlining the config value as these don't change per-environment and in the process discovered that it is only really `DATE_FORMATS.short` that was used commonly and all the other values were either single use or not used at all.

This PR reduces indirection and boilerplate in templates by setting the short format as the default argument to `formatDate` and inlines all other uses. I've left the commits granular to show this process.