### PR TITLE
Remove mainContactIsValid field

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -39,8 +39,7 @@
     "enableNoValidate": true
   },
   "awardsForAll": {
-    "allowedCountries": ["scotland", "wales"],
-    "showContactConfirmationQuestion": false
+    "allowedCountries": ["scotland", "wales"]
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/config/production.json
+++ b/config/production.json
@@ -9,8 +9,5 @@
   "features": {
     "enableHotjar": true,
     "enableNoValidate": false
-  },
-  "awardsForAll": {
-    "showContactConfirmationQuestion": false
   }
 }

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -25,10 +25,6 @@ const {
     FREE_TEXT_MAXLENGTH
 } = require('./constants');
 
-const showContactConfirmationQuestion = config.get(
-    'awardsForAll.showContactConfirmationQuestion'
-);
-
 const countriesFor = require('./lib/countries');
 const locationsFor = require('./lib/locations');
 const fieldContactLanguagePreference = require('./fields/contact-language-preference');
@@ -748,7 +744,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         };
     }
 
-    let allFields = {
+    return {
         projectName: {
             name: 'projectName',
             label: localise({
@@ -2583,40 +2579,4 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true
         }
     };
-
-    if (showContactConfirmationQuestion) {
-        allFields.mainContactIsValid = {
-            name: 'mainContactIsValid',
-            label: localise({
-                en: `I confirm that the main and senior contacts aren't married or in a long-term relationship with each other, living together at the same address, or related by blood`,
-                cy: ''
-            }),
-            type: 'checkbox',
-            options: [
-                {
-                    value: 'yes',
-                    label: localise({
-                        en: 'Yes',
-                        cy: ''
-                    })
-                }
-            ],
-            isRequired: true,
-            get schema() {
-                return multiChoice(this.options).required();
-            },
-            get messages() {
-                return [
-                    {
-                        type: 'base',
-                        message: localise({
-                            en: `Main and senior contact can't be married or in a long-term relationship with each other, living together at the same address, or related by blood `,
-                            cy: ''
-                        })
-                    }
-                ];
-            }
-        };
-    }
-    return allFields;
 };

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -761,14 +761,8 @@ module.exports = function({
                         });
                     },
                     get fields() {
-                        const showContactConfirmationQuestion = config.get(
-                            'awardsForAll.showContactConfirmationQuestion'
-                        );
-
                         const allFields = compact([
                             fields.mainContactName,
-                            showContactConfirmationQuestion &&
-                                fields.mainContactIsValid,
                             fields.mainContactDateOfBirth,
                             fields.mainContactAddress,
                             fields.mainContactAddressHistory,
@@ -782,8 +776,6 @@ module.exports = function({
                             allFields,
                             compact([
                                 fields.mainContactName,
-                                showContactConfirmationQuestion &&
-                                    fields.mainContactIsValid,
                                 includeAddressAndDob() &&
                                     fields.mainContactDateOfBirth,
                                 includeAddressAndDob() &&


### PR DESCRIPTION
Based on the limited numbers of applications we've seen with possibly related contacts and revisiting approaches for this I think we are safe to remove this field.