### PR TITLE
Tweak clamav script

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -8,6 +8,17 @@ sh -c 'echo deb https://oss-binaries.phusionpassenger.com/apt/passenger xenial m
 apt-get update
 apt-get install -y nginx-extras passenger
 
+# Install ClamAV
+if [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_FLEET ]] ||
+   [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_IN_PLACE ]];
+then
+  apt-get install -y clamav-daemon clamav-freshclam
+  service clamav-daemon start
+  freshclam
+  service clamav-daemon restart
+  service clamav-daemon status
+fi
+
 # Install Node
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 apt-get install -y nodejs

--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -12,11 +12,11 @@ apt-get install -y nginx-extras passenger
 if [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_FLEET ]] ||
    [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_IN_PLACE ]];
 then
-  apt-get install -y clamav-daemon clamav-freshclam
-  service clamav-daemon start
-  freshclam
-  service clamav-daemon restart
-  service clamav-daemon status
+    apt-get install -y clamav clamav-daemon
+    service clamav-freshclam restart
+    wait
+    service clamav-daemon start
+    service clamav-daemon status
 fi
 
 # Install Node


### PR DESCRIPTION
Revised version of clamav script based on some tests on plain EC2 instances. Restarting the service after running `freshclam` seems to kick things off. Including a `service clamav-daemon status` call so we can log the status for debugging.