### PR TITLE
Cleanup middleware

### DIFF
--- a/common/authed.js
+++ b/common/authed.js
@@ -1,5 +1,5 @@
 'use strict';
-const { localify, redirectForLocale } = require('../common/urls');
+const { localify, redirectForLocale } = require('./urls');
 
 function isStaff(user) {
     return user.userType === 'staff';

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -3,8 +3,8 @@ const { flatten, get, getOr } = require('lodash/fp');
 const moment = require('moment');
 const Sentry = require('@sentry/node');
 
-const { localify } = require('../common/urls');
-const contentApi = require('../common/content-api');
+const { localify } = require('./urls');
+const contentApi = require('./content-api');
 
 /*
  * Populate hero image (with social image URLs too)

--- a/common/passport.js
+++ b/common/passport.js
@@ -8,8 +8,8 @@ const passport = require('passport');
 const LocalStrategy = require('passport-local').Strategy;
 const OIDCStrategy = require('passport-azure-ad').OIDCStrategy;
 
-const appData = require('../common/appData');
-const { AZURE_AUTH } = require('../common/secrets');
+const appData = require('./appData');
+const { AZURE_AUTH } = require('./secrets');
 const { Users, Staff } = require('../db/models');
 
 /**

--- a/common/preview.js
+++ b/common/preview.js
@@ -1,5 +1,5 @@
 'use strict';
-const { requireStaffAuth } = require('../common/authed');
+const { requireStaffAuth } = require('./authed');
 
 /**
  * Preview mode

--- a/common/rate-limiter.js
+++ b/common/rate-limiter.js
@@ -5,9 +5,9 @@ const get = require('lodash/get');
 const RateLimiterMySQL = require('rate-limiter-flexible/lib/RateLimiterMySQL');
 const RateLimiterMemory = require('rate-limiter-flexible/lib/RateLimiterMemory');
 
-const { sequelize } = require('../db/models/index');
-const appData = require('../common/appData');
-const logger = require('../common/logger').child({
+const { sequelize } = require('../db/models');
+const appData = require('./appData');
+const logger = require('./logger').child({
     service: 'rate-limiter'
 });
 

--- a/common/session.js
+++ b/common/session.js
@@ -3,8 +3,8 @@ const config = require('config');
 const session = require('express-session');
 const SequelizeStore = require('connect-session-sequelize')(session.Store);
 
-const { SESSION_SECRET } = require('../common/secrets');
-const { isDev } = require('../common/appData');
+const { SESSION_SECRET } = require('./secrets');
+const { isDev } = require('./appData');
 const { sequelize } = require('../db/models');
 
 module.exports = function(app) {

--- a/controllers/apply/form-router-next/eligibility.js
+++ b/controllers/apply/form-router-next/eligibility.js
@@ -3,7 +3,7 @@ const express = require('express');
 const path = require('path');
 
 const commonLogger = require('../../../common/logger');
-const { injectCopy } = require('../../../middleware/inject-content');
+const { injectCopy } = require('../../../common/inject-content');
 
 const logger = commonLogger.child({
     service: 'apply'

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -22,7 +22,7 @@ const commonLogger = require('../../../common/logger');
 const appData = require('../../../common/appData');
 const { localify } = require('../../../common/urls');
 const { noStore } = require('../../../common/cached');
-const { requireActiveUserWithCallback } = require('../../../middleware/authed');
+const { requireActiveUserWithCallback } = require('../../../common/authed');
 const { injectCopy } = require('../../../middleware/inject-content');
 
 const salesforceService = require('./lib/salesforce');

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -23,7 +23,7 @@ const appData = require('../../../common/appData');
 const { localify } = require('../../../common/urls');
 const { noStore } = require('../../../common/cached');
 const { requireActiveUserWithCallback } = require('../../../common/authed');
-const { injectCopy } = require('../../../middleware/inject-content');
+const { injectCopy } = require('../../../common/inject-content');
 
 const salesforceService = require('./lib/salesforce');
 const {

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -10,7 +10,7 @@ const {
     injectFlexibleContent,
     injectHeroImage,
     injectListingContent
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const { isWelsh } = require('../../common/urls');
 const contentApi = require('../../common/content-api');
 

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -4,10 +4,7 @@ const express = require('express');
 const { get } = require('lodash');
 
 const contentApi = require('../../common/content-api');
-const {
-    injectCopy,
-    injectHeroImage
-} = require('../../middleware/inject-content');
+const { injectCopy, injectHeroImage } = require('../../common/inject-content');
 
 const router = express.Router();
 

--- a/controllers/digital-fund/index.js
+++ b/controllers/digital-fund/index.js
@@ -2,10 +2,7 @@
 const path = require('path');
 const express = require('express');
 
-const {
-    injectCopy,
-    injectHeroImage
-} = require('../../middleware/inject-content');
+const { injectCopy, injectHeroImage } = require('../../common/inject-content');
 
 const router = express.Router();
 

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -2,10 +2,7 @@
 const path = require('path');
 const express = require('express');
 
-const {
-    injectCopy,
-    injectHeroImage
-} = require('../../middleware/inject-content');
+const { injectCopy, injectHeroImage } = require('../../common/inject-content');
 const { sMaxAge } = require('../../common/cached');
 const contentApi = require('../../common/content-api');
 

--- a/controllers/grants/index.js
+++ b/controllers/grants/index.js
@@ -12,7 +12,7 @@ const {
     injectCopy,
     injectHeroImage,
     setHeroLocals
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const { sMaxAge } = require('../../common/cached');
 const contentApi = require('../../common/content-api');
 

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const express = require('express');
 const contentApi = require('../../common/content-api');
-const { injectCopy } = require('../../middleware/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const router = express.Router();
 

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -11,7 +11,7 @@ const {
     injectHeroImage,
     injectResearch,
     injectResearchEntry
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const { buildArchiveUrl } = require('../../common/archived');
 const { localify } = require('../../common/urls');
 const { buildPagination } = require('../../common/pagination');

--- a/controllers/materials/index.js
+++ b/controllers/materials/index.js
@@ -18,7 +18,7 @@ const {
     injectBreadcrumbs,
     injectListingContent,
     injectMerchandise
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const { csrfProtection, noStore } = require('../../common/cached');
 const { Order } = require('../../db/models');
 

--- a/controllers/our-people/index.js
+++ b/controllers/our-people/index.js
@@ -3,7 +3,12 @@ const express = require('express');
 const path = require('path');
 const { find } = require('lodash');
 
-const { injectCopy, injectHeroImage, injectOurPeople, setCommonLocals } = require('../../middleware/inject-content');
+const {
+    injectCopy,
+    injectHeroImage,
+    injectOurPeople,
+    setCommonLocals
+} = require('../../common/inject-content');
 
 const router = express.Router();
 
@@ -28,7 +33,10 @@ router.get('/', injectHeroImage('mental-health-foundation-new'), (req, res) => {
 });
 
 router.get('/:slug', (req, res, next) => {
-    const entry = find(res.locals.ourPeople, item => item.slug === req.params.slug);
+    const entry = find(
+        res.locals.ourPeople,
+        item => item.slug === req.params.slug
+    );
     if (entry) {
         setCommonLocals({ res, entry });
         res.render(path.resolve(__dirname, './views/profiles'), { entry });

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -9,7 +9,7 @@ const {
     injectHeroImage,
     injectFundingProgramme,
     setCommonLocals
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const { basicContent } = require('../common');
 const { buildArchiveUrl } = require('../../common/archived');
 const { getValidLocation, programmeFilters } = require('./helpers');

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -9,7 +9,7 @@ const {
     injectStrategicProgramme,
     injectStrategicProgrammes,
     setCommonLocals
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 
 const router = express.Router();
 

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const express = require('express');
 
-const { requireStaffAuth } = require('../../middleware/authed');
+const { requireStaffAuth } = require('../../common/authed');
 const { noStore } = require('../../common/cached');
 
 const router = express.Router();

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -11,7 +11,7 @@ const reverse = require('lodash/reverse');
 const sortBy = require('lodash/sortBy');
 const take = require('lodash/take');
 
-const { injectMerchandise } = require('../../middleware/inject-content');
+const { injectMerchandise } = require('../../common/inject-content');
 const { Order } = require('../../db/models');
 const { getDateRange } = require('./helpers');
 

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -10,7 +10,7 @@ const {
     injectBreadcrumbs,
     injectCopy,
     injectHeroImage
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const contentApi = require('../../common/content-api');
 
 const router = express.Router();

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -11,7 +11,7 @@ const {
 const {
     injectCopy,
     injectBreadcrumbs
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({
     service: 'user'

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -7,7 +7,7 @@ const { Users } = require('../../db/models');
 const {
     requireUserAuth,
     redirectUrlWithFallback
-} = require('../../middleware/authed');
+} = require('../../common/authed');
 const {
     injectCopy,
     injectBreadcrumbs

--- a/controllers/user/dashboard.js
+++ b/controllers/user/dashboard.js
@@ -3,7 +3,7 @@ const path = require('path');
 const express = require('express');
 
 const { requireUserAuth } = require('../../common/authed');
-const { injectCopy } = require('../../middleware/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const router = express.Router();
 

--- a/controllers/user/dashboard.js
+++ b/controllers/user/dashboard.js
@@ -2,7 +2,7 @@
 const path = require('path');
 const express = require('express');
 
-const { requireUserAuth } = require('../../middleware/authed');
+const { requireUserAuth } = require('../../common/authed');
 const { injectCopy } = require('../../middleware/inject-content');
 
 const router = express.Router();

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -8,7 +8,7 @@ const { Users } = require('../../db/models');
 const { localify, redirectForLocale } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
 const { requireNotStaffAuth } = require('../../common/authed');
-const { injectCopy } = require('../../middleware/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({
     service: 'user'

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -7,7 +7,7 @@ const moment = require('moment');
 const { Users } = require('../../db/models');
 const { localify, redirectForLocale } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
-const { requireNotStaffAuth } = require('../../middleware/authed');
+const { requireNotStaffAuth } = require('../../common/authed');
 const { injectCopy } = require('../../middleware/inject-content');
 
 const logger = require('../../common/logger').child({

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -15,7 +15,7 @@ const {
 const {
     injectCopy,
     injectBreadcrumbs
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -19,7 +19,7 @@ const {
 const {
     requireNoAuth,
     redirectUrlWithFallback
-} = require('../../middleware/authed');
+} = require('../../common/authed');
 const { csrfProtection } = require('../../common/cached');
 
 const router = express.Router();

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -10,7 +10,7 @@ const logger = require('../../common/logger').child({
 const {
     rateLimiterConfigs,
     RateLimiter
-} = require('../../middleware/rate-limiter');
+} = require('../../common/rate-limiter');
 
 const {
     injectCopy,

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -12,7 +12,7 @@ const {
     redirectForLocale,
     localify
 } = require('../../common/urls');
-const { requireNoAuth } = require('../../middleware/authed');
+const { requireNoAuth } = require('../../common/authed');
 const {
     injectCopy,
     injectBreadcrumbs

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -16,7 +16,7 @@ const { requireNoAuth } = require('../../common/authed');
 const {
     injectCopy,
     injectBreadcrumbs
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({
     service: 'user'

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -16,7 +16,7 @@ const {
 const {
     requireNoAuth,
     redirectUrlWithFallback
-} = require('../../middleware/authed');
+} = require('../../common/authed');
 
 const validateSchema = require('./lib/validate-schema');
 const { newAccounts } = require('./lib/account-schemas');

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -12,7 +12,7 @@ const { csrfProtection } = require('../../common/cached');
 const {
     injectCopy,
     injectBreadcrumbs
-} = require('../../middleware/inject-content');
+} = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -6,7 +6,7 @@ const express = require('express');
 const { Users } = require('../../db/models');
 const { redirectForLocale } = require('../../common/urls');
 const { csrfProtection } = require('../../common/cached');
-const { requireUserAuth } = require('../../middleware/authed');
+const { requireUserAuth } = require('../../common/authed');
 const { injectCopy } = require('../../middleware/inject-content');
 
 const logger = require('../../common/logger').child({ service: 'user' });

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -7,7 +7,7 @@ const { Users } = require('../../db/models');
 const { redirectForLocale } = require('../../common/urls');
 const { csrfProtection } = require('../../common/cached');
 const { requireUserAuth } = require('../../common/authed');
-const { injectCopy } = require('../../middleware/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({ service: 'user' });
 

--- a/middleware/preview.js
+++ b/middleware/preview.js
@@ -1,5 +1,5 @@
 'use strict';
-const { requireStaffAuth } = require('./authed');
+const { requireStaffAuth } = require('../common/authed');
 
 /**
  * Preview mode

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ const viewFilters = require('./common/filters');
 const cspDirectives = require('./common/csp-directives');
 const contentApi = require('./common/content-api');
 const { defaultMaxAge } = require('./common/cached');
-const passportMiddleware = require('./middleware/passport');
+const passportMiddleware = require('./common/passport');
 const sessionMiddleware = require('./middleware/session');
 
 const { renderError, renderNotFound } = require('./controllers/errors');

--- a/server.js
+++ b/server.js
@@ -40,9 +40,6 @@ const viewFilters = require('./common/filters');
 const cspDirectives = require('./common/csp-directives');
 const contentApi = require('./common/content-api');
 const { defaultMaxAge } = require('./common/cached');
-const passportMiddleware = require('./common/passport');
-const sessionMiddleware = require('./common/session');
-
 const { renderError, renderNotFound } = require('./controllers/errors');
 
 /**
@@ -196,8 +193,8 @@ app.use([
     }),
     express.json(),
     express.urlencoded({ extended: true }),
-    sessionMiddleware(app),
-    passportMiddleware(),
+    require('./common/session')(app),
+    require('./common/passport')(),
     require('./common/locals'),
     require('./common/preview')
 ]);

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ const cspDirectives = require('./common/csp-directives');
 const contentApi = require('./common/content-api');
 const { defaultMaxAge } = require('./common/cached');
 const passportMiddleware = require('./common/passport');
-const sessionMiddleware = require('./middleware/session');
+const sessionMiddleware = require('./common/session');
 
 const { renderError, renderNotFound } = require('./controllers/errors');
 

--- a/server.js
+++ b/server.js
@@ -41,7 +41,6 @@ const cspDirectives = require('./common/csp-directives');
 const contentApi = require('./common/content-api');
 const { defaultMaxAge } = require('./common/cached');
 const passportMiddleware = require('./middleware/passport');
-const previewMiddleware = require('./middleware/preview');
 const sessionMiddleware = require('./middleware/session');
 
 const { renderError, renderNotFound } = require('./controllers/errors');
@@ -196,13 +195,12 @@ app.use([
         }
     }),
     express.json(),
-    express.urlencoded({ extended: true })
+    express.urlencoded({ extended: true }),
+    sessionMiddleware(app),
+    passportMiddleware(),
+    require('./common/locals'),
+    require('./common/preview')
 ]);
-
-app.use(sessionMiddleware(app));
-app.use(passportMiddleware());
-app.use(require('./common/locals'));
-app.use(previewMiddleware);
 
 /**
  * Mount utility routes


### PR DESCRIPTION
Moves remaining code from `middleware` to `common` and removes reference to it from the README. Limits the number of different places to put shared code, now either in `common` for genuinely cross-cutting code or in `controllers` alongside the router the code is used in.