### PR TITLE
Change application duration stats to use minutes for fastest application

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -69,9 +69,16 @@ function measureTimeTaken(data) {
     const appDurations = data.map(row => {
         const created = moment(row.startedAt);
         const submitted = moment(row.createdAt);
-        return submitted.diff(created, 'days');
+        return submitted.diff(created, 'minutes');
     });
-    return minMaxAvg(appDurations);
+    let results = minMaxAvg(appDurations);
+
+    // convert the larger amounts to days
+    const minutesToDays = input => input / 60 / 24;
+    results.average = minutesToDays(results.average);
+    results.highest = minutesToDays(results.highest);
+
+    return results;
 }
 
 function measureWordCounts(data) {

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -229,7 +229,7 @@
                     [
                         {
                             prefix: 'Quickest applicant took',
-                            value: statistics.appDurations.lowest + ' days',
+                            value: statistics.appDurations.lowest | round(2) + ' minutes',
                             title: 'to submit their form',
                             showNumberBeforeTitle: true
                         },
@@ -241,7 +241,7 @@
                         },
                         {
                             prefix: 'Slowest applicant took',
-                            value: statistics.appDurations.highest + ' days',
+                            value: statistics.appDurations.highest | round(2) + ' days',
                             title: 'to submit their form',
                             showNumberBeforeTitle: true
                         }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/394376/64270914-3ff85880-cf34-11e9-8c5a-e67861ef2228.png)

After:

![image](https://user-images.githubusercontent.com/394376/64270920-45ee3980-cf34-11e9-9dd9-58b2944e5d4e.png)

(I think the changes in number comes from the greater precision involved in measuring everything in minutes then converting this into days, rather than averaging everything into days to begin with)