### PR TITLE
Validation tweaks

### DIFF
--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -179,7 +179,7 @@ Array [
   "Enter a total cost for your project",
   "Select yes or no",
   "Enter the full legal name of the organisation",
-  "Enter a day and month",
+  "Enter a month and year",
   "Enter a full UK address",
   "Select a type of organisation",
   "Enter first and last name",
@@ -231,8 +231,8 @@ Array [
 
 exports[`Your organisation valid basic organisation details required 1`] = `
 Array [
-  "Enter a day and month",
   "Enter a full UK address",
+  "Enter a month and year",
   "Enter the full legal name of the organisation",
   "Select a type of organisation",
 ]

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -177,7 +177,7 @@ Array [
   "Tell us how your project involves your community",
   "Enter a project budget",
   "Enter a total cost for your project",
-  "Select yes or no",
+  "Select an option",
   "Enter the full legal name of the organisation",
   "Enter a month and year",
   "Enter a full UK address",

--- a/controllers/apply/awards-for-all/docs/validation-rules.md
+++ b/controllers/apply/awards-for-all/docs/validation-rules.md
@@ -124,7 +124,7 @@ Client-side warnings:
 
 | Rule           | Message          |
 | -------------- | ---------------- |
-| Required field | Select yes or no |
+| Required field | Select an option |
 
 ### What specific groups of people is your project aimed at?
 

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1055,7 +1055,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     type: 'base',
                     message: localise({
                         en: 'Select an option',
-                        cy: 'Dewiswch ie neu na'
+                        cy: 'Dewis opsiwn'
                     })
                 }
             ]

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1054,7 +1054,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Select yes or no',
+                        en: 'Select an option',
                         cy: 'Dewiswch ie neu na'
                     })
                 }

--- a/controllers/apply/awards-for-all/fields/organisation-start-date.js
+++ b/controllers/apply/awards-for-all/fields/organisation-start-date.js
@@ -35,14 +35,14 @@ module.exports = function(locale) {
             {
                 type: 'base',
                 message: localise({
-                    en: 'Enter a day and month',
+                    en: 'Enter a month and year',
                     cy: 'Rhowch ddiwrnod a mis'
                 })
             },
             {
                 type: 'any.invalid',
                 message: localise({
-                    en: 'Enter a real day and month',
+                    en: 'Enter a real month and year',
                     cy: 'Rhowch ddiwrnod a mis go iawn'
                 })
             },

--- a/controllers/apply/awards-for-all/fields/organisation-start-date.js
+++ b/controllers/apply/awards-for-all/fields/organisation-start-date.js
@@ -36,14 +36,14 @@ module.exports = function(locale) {
                 type: 'base',
                 message: localise({
                     en: 'Enter a month and year',
-                    cy: 'Rhowch ddiwrnod a mis'
+                    cy: 'Rhowch fis a blwyddyn'
                 })
             },
             {
                 type: 'any.invalid',
                 message: localise({
                     en: 'Enter a real month and year',
-                    cy: 'Rhowch ddiwrnod a mis go iawn'
+                    cy: 'Rhowch fis a blwyddyn go iawn'
                 })
             },
             {

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -639,7 +639,7 @@
                 {% endif %}
             </div>
             {% if fieldErrors.length > 0 %}
-                {% set errorsNoscript = field.settings.showWordCount or field.type === 'budget' %}
+                {% set errorsNoscript = field.type === 'budget' %}
                 {% if errorsNoscript %}
                     <noscript>
                 {% endif %}


### PR DESCRIPTION
A few tweaks prompted by https://trello.com/c/LE8dx7jB/753-disable-default-in-browser-validation-to-increase-consistency-improve-accessibility-and-resolve-translation-limitations

- Re-enable server messages for idea questions. Currently suppressed if you've not answered the question yet, feels better to turn them on consistently rather than trying to filter based on if it's the base error or not
- Fixes incorrect error message for month-year inputs
- Fixes misleading error message for beneficiaries screener (not phrased as yes or no answer)

Copy changes need review from @scottoakley  and then translating into Welsh