### PR TITLE
Prevent invalid form submissions

### DIFF
--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -320,8 +320,13 @@ function initFormRouter({
             service: 'salesforce'
         });
 
+        const form = formBuilder({
+            locale: req.i18n.getLocale(),
+            data: currentApplicationData
+        });
+
         function canSubmit() {
-            return isEmpty(currentApplication) === false;
+            return form.progress.isComplete;
         }
 
         function canSubmitToSalesforce() {
@@ -333,11 +338,6 @@ function initFormRouter({
         }
 
         if (canSubmit() === true) {
-            const form = formBuilder({
-                locale: req.i18n.getLocale(),
-                data: currentApplicationData
-            });
-
             // Extract the fields so we can determine which files to upload to Salesforce
             const steps = flatMap(form.sections, 'steps');
             const fieldsets = flatMap(steps, 'fieldsets');
@@ -395,7 +395,10 @@ function initFormRouter({
                                 filename: field.value.filename
                             };
 
-                            if (!config.get('features.enableLocalAntivirus') && !appData.isTestServer) {
+                            if (
+                                !config.get('features.enableLocalAntivirus') &&
+                                !appData.isTestServer
+                            ) {
                                 try {
                                     await checkAntiVirus(pathConfig);
                                 } catch (err) {

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -6,7 +6,6 @@ const Sentry = require('@sentry/node');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/get');
 const includes = require('lodash/includes');
-const isEmpty = require('lodash/isEmpty');
 const pick = require('lodash/pick');
 const set = require('lodash/set');
 const unset = require('lodash/unset');


### PR DESCRIPTION
Discovered while doing preliminary load testing that a bunch of invalid applications ended up in Salesforce despite failing validation.

Looking deeper, it's because the code we use to check submissions before sending to Salesforce only examines whether the application is empty (not whether it's valid!).

Confirmed this locally using Postman (there's a [Collection file](https://gist.github.com/mattandrews/a71e90abacde166f391283a981747ff6) you can import if you want to demo locally) by submitting just one step of the form and then POSTing to `/submission`, which succeeded:

![image](https://user-images.githubusercontent.com/394376/64856078-1a94da00-d619-11e9-9edd-1c1a10a31dd6.png)

This changes things to only allow valid/complete submissions, so belt-and-braces.