### PR TITLE
Joi upgrade

### DIFF
--- a/controllers/apply/get-advice/schema.js
+++ b/controllers/apply/get-advice/schema.js
@@ -4,12 +4,12 @@ const Joi = require('../lib/joi-extensions');
 const schema = Joi.object({
     projectCountry: Joi.array()
         .items(
-            Joi.string().valid([
+            Joi.string().valid(
                 'england',
                 'scotland',
                 'northern-ireland',
                 'wales'
-            ])
+            )
         )
         .single()
         .required(),
@@ -32,7 +32,7 @@ const schema = Joi.object({
         is: Joi.array()
             .items(
                 Joi.string()
-                    .only('scotland')
+                    .allow('scotland')
                     .required()
             )
             .required(),
@@ -48,25 +48,24 @@ const schema = Joi.object({
             .max(5)
     }),
     projectIdea: Joi.string()
-        .minWords(50)
-        .maxWords(500)
+        // .minWords(50)
+        // .maxWords(500)
         .required(),
     organisationLegalName: Joi.string().required(),
     organisationTradingName: Joi.string()
         .allow('')
         .optional(),
-    organisationAddress: Joi.ukAddress().required(),
-    organisationType: Joi.string().required(),
-    organisationBackground: Joi.string()
-        .minWords(50)
-        .maxWords(500)
-        .required(),
-    contactName: Joi.fullName().required(),
-    contactEmail: Joi.string()
-        .email()
-        .required(),
-    contactPhone: Joi.string()
-        .phoneNumber()
+    // organisationAddress: Joi.ukAddress().required(),
+    // organisationType: Joi.string().required(),
+    // organisationBackground: Joi.string()
+    //     .minWords(50)
+    //     .maxWords(500)
+    //     .required(),
+    // contactName: Joi.fullName().required(),
+    // contactEmail: Joi.string()
+    //     .email()
+    //     .required(),
+    contactPhone: Joi.phone()
         .allow('')
         .optional()
 });

--- a/controllers/apply/get-advice/schema.test.js
+++ b/controllers/apply/get-advice/schema.test.js
@@ -8,7 +8,7 @@ const faker = require('faker');
 const schema = require('./schema');
 
 function validate(data) {
-    return schema.validate(data, { abortEarly: false });
+    return schema.validate(data, { abortEarly: false, allowUnknown: true });
 }
 
 function mapMessages(validationResult) {
@@ -46,9 +46,9 @@ function mockResponse(overrides) {
     return Object.assign(defaults, overrides);
 }
 
-test('minimal valid form', () => {
+test.only('minimal valid form', () => {
     const result = validate(mockResponse());
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
     expect(result.value).toMatchSnapshot({
         projectIdea: expect.any(String),
         organisationBackground: expect.any(String)

--- a/controllers/apply/lib/joi-extensions/friendly-number.js
+++ b/controllers/apply/lib/joi-extensions/friendly-number.js
@@ -3,15 +3,14 @@ const isString = require('lodash/isString');
 
 module.exports = function(joi) {
     return {
-        name: 'friendlyNumber',
+        type: 'friendlyNumber',
         base: joi.number(),
         /* eslint-disable-next-line no-unused-vars */
-        coerce(value, state, options) {
+        coerce(value) {
             if (isString(value)) {
                 // Strip out any non-numeric characters (eg. ,) but keep decimal points
-                return value.replace(/[^0-9.]/g, '');
+                return { value: parseFloat(value.replace(/[^0-9.]/g, '')) };
             }
-            return value;
         }
     };
 };

--- a/controllers/apply/lib/joi-extensions/index.js
+++ b/controllers/apply/lib/joi-extensions/index.js
@@ -1,17 +1,22 @@
 'use strict';
 const baseJoi = require('@hapi/joi');
 
-module.exports = baseJoi.extend([
-    require('./compare-object'),
+// const joi = baseJoi.extend([
+//     require('./compare-object'),
+//     require('./friendly-number'),
+//     require('./budget-items'),
+//     require('./date-parts'),
+//     require('./date-range'),
+//     require('./day-month'),
+//     require('./full-name'),
+//     require('./month-year'),
+//     require('./phone-number'),
+//     require('./postcode'),
+//     require('./uk-address'),
+//     require('./word-count')
+// ]);
+
+module.exports = baseJoi.extend(
     require('./friendly-number'),
-    require('./budget-items'),
-    require('./date-parts'),
-    require('./date-range'),
-    require('./day-month'),
-    require('./full-name'),
-    require('./month-year'),
-    require('./phone-number'),
-    require('./postcode'),
-    require('./uk-address'),
-    require('./word-count')
-]);
+    require('./phone-number')
+);

--- a/controllers/apply/lib/joi-extensions/phone-number.js
+++ b/controllers/apply/lib/joi-extensions/phone-number.js
@@ -3,52 +3,32 @@
 const { PhoneNumberUtil, PhoneNumberFormat } = require('google-libphonenumber');
 const phoneUtil = PhoneNumberUtil.getInstance();
 
-/**
- * Allows you to do `Joi.string().phoneNumber()`
- *
- * @param {Object} joi Joi instance
- * @return {Object} Joi plugin object
- */
-module.exports = function phoneNumber(joi) {
+module.exports = function(joi) {
     return {
         base: joi.string(),
-        name: 'string',
-        language: {
-            phonenumber: 'did not seem to be a phone number'
+        type: 'phone',
+        messages: {
+            'phonenumber.invalid': 'did not seem to be a phone number'
         },
-        rules: [
-            {
-                name: 'phoneNumber',
-                validate(params, value, state, options) {
-                    try {
-                        const parsedValue = phoneUtil.parse(value, 'GB');
-                        if (phoneUtil.isValidNumber(parsedValue)) {
-                            if (options.convert) {
-                                return phoneUtil.format(
-                                    parsedValue,
-                                    PhoneNumberFormat.NATIONAL
-                                );
-                            } else {
-                                return value;
-                            }
-                        } else {
-                            return this.createError(
-                                'string.phonenumber',
-                                { value },
-                                state,
-                                options
-                            );
-                        }
-                    } catch (err) {
-                        return this.createError(
-                            'string.phonenumber',
-                            { value },
-                            state,
-                            options
-                        );
-                    }
+        validate(value, helpers) {
+            try {
+                const parsedValue = phoneUtil.parse(value, 'GB');
+                if (phoneUtil.isValidNumber(parsedValue)) {
+                    return {
+                        value: phoneUtil.format(
+                            parsedValue,
+                            PhoneNumberFormat.NATIONAL
+                        )
+                    };
+                } else {
+                    return {
+                        value,
+                        errors: helpers.error('phonenumber.invalid')
+                    };
                 }
+            } catch (err) {
+                return { value, errors: helpers.error('phonenumber.invalid') };
             }
-        ]
+        }
     };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,7 +1594,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -1628,23 +1628,35 @@
     "@hapi/bourne": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
-      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/hoek": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
-      "integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+      "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
     },
     "@hapi/joi": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
-      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.1.tgz",
+      "integrity": "sha512-5TdjUnNAaK7+lWZ2HRXtgOnxe4VBoJLoX0XOrfkmw+2n4/VJ6wwOJMoD7u/F9alLsP31kOWDbnQhtS0WAKwD4Q==",
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/bourne": "1.x.x",
+        "@hapi/formula": "1.x.x",
         "@hapi/hoek": "8.x.x",
+        "@hapi/pinpoint": "1.x.x",
         "@hapi/topo": "3.x.x"
       }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
     },
     "@hapi/topo": {
       "version": "3.1.3",
@@ -3347,7 +3359,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -4147,7 +4159,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -12897,7 +12909,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -13174,7 +13186,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -13729,7 +13741,7 @@
         },
         "rimraf": {
           "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "optional": true,
           "requires": {
@@ -15237,7 +15249,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -17166,7 +17178,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -20157,6 +20169,18 @@
         "rx": "^4.1.0"
       },
       "dependencies": {
+        "@hapi/joi": {
+          "version": "15.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+          "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/address": "2.x.x",
+            "@hapi/bourne": "1.x.x",
+            "@hapi/hoek": "8.x.x",
+            "@hapi/topo": "3.x.x"
+          }
+        },
         "core-js": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ext": "js,json,yml"
   },
   "dependencies": {
-    "@hapi/joi": "15.1.1",
+    "@hapi/joi": "16.0.1",
     "@ideal-postcodes/core-node": "1.1.0",
     "@sentry/browser": "5.6.2",
     "@sentry/integrations": "5.6.1",


### PR DESCRIPTION
This is a proof of concept of upgrading to joi v16 which has a _lot_ of breaking changes. Does the bare minimum to get a subset of the standard form schema working with the new version. Quite a lot changes, interested to see if there is another way to do this to avoid a mega upgrade PR.