### PR TITLE
Joi upgrade alias

### DIFF
--- a/controllers/api/index.js
+++ b/controllers/api/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const express = require('express');
-const Joi = require('@hapi/joi');
 const Sentry = require('@sentry/node');
 
 const { sanitise } = require('../../common/sanitise');
@@ -13,6 +12,8 @@ const { Client } = require('@ideal-postcodes/core-node');
 const postcodesClient = new Client({
     api_key: POSTCODES_API_KEY
 });
+
+const { validateFeedback, validateSurvey } = require('./schemas');
 
 const router = express.Router();
 
@@ -66,15 +67,7 @@ router.post('/address-lookup', csrfProtection, async (req, res) => {
  * API: Feedback endpoint
  */
 router.post('/feedback', async (req, res) => {
-    const schema = Joi.object({
-        description: Joi.string().required(),
-        message: Joi.string().required()
-    });
-
-    const validationResult = schema.validate(req.body, {
-        abortEarly: false,
-        stripUnknown: true
-    });
+    const validationResult = validateFeedback(req.body);
 
     const messageSuccess = req.i18n.__('global.feedback.success');
     const messageError = req.i18n.__('global.feedback.error');
@@ -111,18 +104,7 @@ router.post('/feedback', async (req, res) => {
  * API: Survey endpoint
  */
 router.post('/survey', async (req, res) => {
-    const schema = Joi.object({
-        choice: Joi.string()
-            .valid(['yes', 'no'])
-            .required(),
-        path: Joi.string().required(),
-        message: Joi.string().optional()
-    });
-
-    const validationResult = schema.validate(req.body, {
-        abortEarly: false,
-        stripUnknown: true
-    });
+    const validationResult = validateSurvey(req.body);
 
     if (validationResult.error) {
         res.status(400).json({

--- a/controllers/api/schemas.js
+++ b/controllers/api/schemas.js
@@ -1,6 +1,5 @@
 'use strict';
-
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joi16');
 
 function validateFeedback(data = {}) {
     const schema = Joi.object({
@@ -17,7 +16,7 @@ function validateFeedback(data = {}) {
 function validateSurvey(data = {}) {
     const schema = Joi.object({
         choice: Joi.string()
-            .valid(['yes', 'no'])
+            .valid('yes', 'no')
             .required(),
         path: Joi.string().required(),
         message: Joi.string().optional()

--- a/controllers/api/schemas.js
+++ b/controllers/api/schemas.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const Joi = require('@hapi/joi');
+
+function validateFeedback(data = {}) {
+    const schema = Joi.object({
+        description: Joi.string().required(),
+        message: Joi.string().required()
+    });
+
+    return schema.validate(data, {
+        abortEarly: false,
+        stripUnknown: true
+    });
+}
+
+function validateSurvey(data = {}) {
+    const schema = Joi.object({
+        choice: Joi.string()
+            .valid(['yes', 'no'])
+            .required(),
+        path: Joi.string().required(),
+        message: Joi.string().optional()
+    });
+
+    return schema.validate(data, {
+        abortEarly: false,
+        stripUnknown: true
+    });
+}
+
+module.exports = { validateFeedback, validateSurvey };

--- a/controllers/api/schemas.test.js
+++ b/controllers/api/schemas.test.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+'use strict';
+const { validateFeedback, validateSurvey } = require('./schemas');
+const faker = require('faker');
+
+function mapMessages(validationResult) {
+    return validationResult.error.details.map(detail => {
+        return detail.message;
+    });
+}
+
+test('validate feedback schema', () => {
+    const valid = validateFeedback({
+        description: 'description-id',
+        message: faker.lorem.words(25)
+    });
+
+    expect(valid.error).toBeNull();
+
+    expect(mapMessages(validateFeedback({}))).toEqual([
+        '"description" is required',
+        '"message" is required'
+    ]);
+});
+
+test('validate survey schema', () => {
+    const valid = validateSurvey({
+        choice: 'yes',
+        path: '/some/path',
+        message: faker.lorem.words(25)
+    });
+
+    expect(valid.error).toBeNull();
+
+    const invalid = validateSurvey({
+        choice: 'not-a-valid-choice'
+    });
+
+    expect(mapMessages(invalid)).toEqual([
+        '"choice" must be one of [yes, no]',
+        '"path" is required'
+    ]);
+});

--- a/controllers/api/schemas.test.js
+++ b/controllers/api/schemas.test.js
@@ -15,7 +15,7 @@ test('validate feedback schema', () => {
         message: faker.lorem.words(25)
     });
 
-    expect(valid.error).toBeNull();
+    expect(valid.error).toBeUndefined();
 
     expect(mapMessages(validateFeedback({}))).toEqual([
         '"description" is required',
@@ -30,7 +30,7 @@ test('validate survey schema', () => {
         message: faker.lorem.words(25)
     });
 
-    expect(valid.error).toBeNull();
+    expect(valid.error).toBeUndefined();
 
     const invalid = validateSurvey({
         choice: 'not-a-valid-choice'

--- a/controllers/digital-fund/assistance.js
+++ b/controllers/digital-fund/assistance.js
@@ -2,12 +2,13 @@
 const express = require('express');
 const moment = require('moment');
 const path = require('path');
-const Joi = require('@hapi/joi');
 const Sentry = require('@sentry/node');
 
 const { DIGITAL_FUND_EMAIL } = require('../../common/secrets');
 const { sendEmail } = require('../../common/mail');
 const { isNotProduction } = require('../../common/appData');
+
+const { validateAssistance } = require('./schema');
 
 const router = express.Router();
 
@@ -35,14 +36,7 @@ router
     .route('/')
     .get(render)
     .post(async (req, res) => {
-        const validationResult = Joi.object({
-            email: Joi.string()
-                .email()
-                .required()
-        }).validate(req.body, {
-            abortEarly: false,
-            stripUnknown: true
-        });
+        const validationResult = validateAssistance(req.body);
 
         if (validationResult.error) {
             const errors = [

--- a/controllers/digital-fund/schema.js
+++ b/controllers/digital-fund/schema.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const Joi = require('@hapi/joi');
+
+function validateAssistance(data) {
+    const schema = Joi.object({
+        email: Joi.string()
+            .email()
+            .required()
+    });
+
+    return schema.validate(data, {
+        abortEarly: false,
+        stripUnknown: true
+    });
+}
+
+module.exports = { validateAssistance };

--- a/controllers/digital-fund/schema.js
+++ b/controllers/digital-fund/schema.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joi16');
 
 function validateAssistance(data) {
     const schema = Joi.object({

--- a/controllers/digital-fund/schema.test.js
+++ b/controllers/digital-fund/schema.test.js
@@ -2,22 +2,18 @@
 'use strict';
 const { validateAssistance } = require('./schema');
 
-function mapMessages(validationResult) {
-    return validationResult.error.details.map(detail => {
-        return detail.message;
-    });
-}
-
 test('validate assistance schema', () => {
     const valid = validateAssistance({
         email: 'example@example.com'
     });
 
-    expect(valid.error).toBeNull();
+    expect(valid.error).toBeUndefined();
 
     const invalid = validateAssistance({
         email: 'not an email'
     });
 
-    expect(mapMessages(invalid)).toEqual(['"email" must be a valid email']);
+    expect(invalid.error.details.map(detail => detail.message)).toEqual([
+        '"email" must be a valid email'
+    ]);
 });

--- a/controllers/digital-fund/schema.test.js
+++ b/controllers/digital-fund/schema.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+'use strict';
+const { validateAssistance } = require('./schema');
+
+function mapMessages(validationResult) {
+    return validationResult.error.details.map(detail => {
+        return detail.message;
+    });
+}
+
+test('validate assistance schema', () => {
+    const valid = validateAssistance({
+        email: 'example@example.com'
+    });
+
+    expect(valid.error).toBeNull();
+
+    const invalid = validateAssistance({
+        email: 'not an email'
+    });
+
+    expect(mapMessages(invalid)).toEqual(['"email" must be a valid email']);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,15 +1652,22 @@
       }
     },
     "@hapi/joi16": {
-      "version": "npm:@hapi/joi@16.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.0.tgz",
-      "integrity": "sha512-7BADQEJCTj9jmY9JrpJHSXkdvzLANqIVqqihC//A4gLpajB8HPcqp4EbwxuKQP9kKfUf8/P7WV+q3rCiSJXSCw==",
+      "version": "npm:@hapi/joi@16.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.1.tgz",
+      "integrity": "sha512-v/XNMGNz+Nx7578Cx2bMunoQHuY4LFxRltJ6uA1LjS6LWakgPCJC4MTr1ucfCnjjbDtaQizrQx9oWXY3WcFcyw==",
       "requires": {
-        "@hapi/address": "2.x.x",
-        "@hapi/formula": "1.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/pinpoint": "1.x.x",
-        "@hapi/topo": "3.x.x"
+        "@hapi/address": "^2.1.1",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+          "integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow=="
+        }
       }
     },
     "@hapi/pinpoint": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1594,7 +1594,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -1630,6 +1630,11 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
     },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
+    },
     "@hapi/hoek": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
@@ -1645,6 +1650,23 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
+    },
+    "@hapi/joi16": {
+      "version": "npm:@hapi/joi@16.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.1.tgz",
+      "integrity": "sha512-5TdjUnNAaK7+lWZ2HRXtgOnxe4VBoJLoX0XOrfkmw+2n4/VJ6wwOJMoD7u/F9alLsP31kOWDbnQhtS0WAKwD4Q==",
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/formula": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/pinpoint": "1.x.x",
+        "@hapi/topo": "3.x.x"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ=="
     },
     "@hapi/topo": {
       "version": "3.1.3",
@@ -3341,7 +3363,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -4141,7 +4163,7 @@
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -12898,7 +12920,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -13175,7 +13197,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -13730,7 +13752,7 @@
         },
         "rimraf": {
           "version": "2.4.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
           "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
           "optional": true,
           "requires": {
@@ -15238,7 +15260,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -17167,7 +17189,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1652,9 +1652,9 @@
       }
     },
     "@hapi/joi16": {
-      "version": "npm:@hapi/joi@16.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.0.1.tgz",
-      "integrity": "sha512-5TdjUnNAaK7+lWZ2HRXtgOnxe4VBoJLoX0XOrfkmw+2n4/VJ6wwOJMoD7u/F9alLsP31kOWDbnQhtS0WAKwD4Q==",
+      "version": "npm:@hapi/joi@16.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.0.tgz",
+      "integrity": "sha512-7BADQEJCTj9jmY9JrpJHSXkdvzLANqIVqqihC//A4gLpajB8HPcqp4EbwxuKQP9kKfUf8/P7WV+q3rCiSJXSCw==",
       "requires": {
         "@hapi/address": "2.x.x",
         "@hapi/formula": "1.x.x",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@hapi/joi": "15.1.1",
+    "@hapi/joi16": "npm:@hapi/joi@16.0.1",
     "@ideal-postcodes/core-node": "1.1.0",
     "@sentry/browser": "5.6.2",
     "@sentry/integrations": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@hapi/joi": "15.1.1",
-    "@hapi/joi16": "npm:@hapi/joi@16.0.1",
+    "@hapi/joi16": "npm:@hapi/joi@16.1.0",
     "@ideal-postcodes/core-node": "1.1.0",
     "@sentry/browser": "5.6.2",
     "@sentry/integrations": "5.6.1",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@hapi/joi": "15.1.1",
-    "@hapi/joi16": "npm:@hapi/joi@16.1.0",
+    "@hapi/joi16": "npm:@hapi/joi@16.1.1",
     "@ideal-postcodes/core-node": "1.1.0",
     "@sentry/browser": "5.6.2",
     "@sentry/integrations": "5.6.1",


### PR DESCRIPTION
Whilst doing a proof of concept upgrade in https://github.com/biglotteryfund/blf-alpha/pull/2336 it highlighted that there are a _lot_ of changes in joi 16 which means pretty much all the schema code needs upgrading.

It turns out npm 6.9+ supports package aliases so we can run multiple versions of joi at once to aid migration. We would still want to do the upgrade quickly but this might avoid a long running branch or 1000+ line change set in one go. As a proof of concept migrated just the very simple assistance schema to the new version.

We should do this _soon_ but may be worth waiting a week as the documentation is still a little fresh (full docs on the new extension syntax are still forthcoming although there are some basic guides and error messages help you out).

Thoughts very welcome 💭 