### PR TITLE
Enable local antivirus scanning in production

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -22,12 +22,6 @@
       "formUploadBucket": "tnlcf-uploads-dev"
     }
   },
-  "clamdscan": {
-    "socket": "/var/run/clamav/clamd.ctl",
-    "timeout": 120000,
-    "path": "/var/lib/clamav",
-    "config_file": "/etc/clamav/clamd.conf"
-  },
   "domains": {
     "indexable": ["www.biglotteryfund.org.uk", "www.tnlcommunityfund.org.uk"],
     "base": "https://www.tnlcommunityfund.org.uk"
@@ -41,7 +35,7 @@
     "enableSalesforceConnector": true,
     "enableSeeders": false,
     "enableSiteSurvey": true,
-    "enableLocalAntivirus": false
+    "enableLocalAntivirus": true
   },
   "awardsForAll": {
     "allowedCountries": ["scotland", "wales"]

--- a/config/development.json
+++ b/config/development.json
@@ -7,8 +7,7 @@
     "enableAllowLocalhost": false,
     "enableCloudWatchLogs": false,
     "enableSeeders": true,
-    "enableSalesforceConnector": true,
-    "enableLocalAntivirus": true
+    "enableSalesforceConnector": true
   },
   "awardsForAll": {
     "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]

--- a/config/test.json
+++ b/config/test.json
@@ -6,8 +6,7 @@
   },
   "features": {
     "enableAllowLocalhost": false,
-    "enableHotjar": true,
-    "enableLocalAntivirus": true
+    "enableHotjar": true
   },
   "awardsForAll": {
     "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]

--- a/controllers/apply/form-router-next/lib/file-uploads.js
+++ b/controllers/apply/form-router-next/lib/file-uploads.js
@@ -5,13 +5,14 @@ const AWS = require('aws-sdk');
 const get = require('lodash/get');
 const keyBy = require('lodash/keyBy');
 const mapValues = require('lodash/mapValues');
-const NodeClam = require('clamscan');
 
-const { isTestServer, isDev } = require('../../../../common/appData');
+const { isTestServer } = require('../../../../common/appData');
 const { S3_KMS_KEY_ID } = require('../../../../common/secrets');
 const logger = require('../../../../common/logger').child({
     service: 's3-uploads'
 });
+
+const scanFile = require('./scan-file');
 
 const S3_UPLOAD_BUCKET = config.get('aws.s3.formUploadBucket');
 
@@ -108,37 +109,6 @@ function uploadFile({ formId, applicationId, fileMetadata }) {
             }
         });
     });
-}
-
-async function scanFile(filePath) {
-    logger.info(`Attempting virus scan for ${filePath}`);
-
-    const clamdscanConfig = {
-        socket: process.env.CLAMDSCAN_SOCKET || config.get('clamdscan.socket'),
-        timeout: config.get('clamdscan.timeout'),
-        local_fallback: true,
-        path: process.env.CLAMDSCAN_PATH || config.get('clamdscan.path'),
-        config_file:
-            process.env.CLAMDSCAN_CONFIG_FILE ||
-            config.get('clamdscan.config_file')
-    };
-
-    const clamscan = await new NodeClam().init({
-        remove_infected: true,
-        debug_mode: isDev,
-        scan_recursively: false,
-        clamdscan: clamdscanConfig
-    });
-
-    const { is_infected, viruses } = await clamscan.scan_file(filePath);
-
-    if (is_infected) {
-        logger.error(`Virus scan failed, file INFECTED`, { filePath, viruses });
-    } else {
-        logger.info(`Virus scan OK`, { filePath });
-    }
-
-    return { is_infected, viruses };
 }
 
 function checkAntiVirus({ formId, applicationId, filename }) {

--- a/controllers/apply/form-router-next/lib/scan-file.js
+++ b/controllers/apply/form-router-next/lib/scan-file.js
@@ -1,0 +1,35 @@
+'use strict';
+const NodeClam = require('clamscan');
+
+const { isDev } = require('../../../../common/appData');
+const logger = require('../../../../common/logger').child({
+    service: 'scan-file'
+});
+
+module.exports = async function scanFile(filePath) {
+    logger.info(`Attempting virus scan for ${filePath}`);
+
+    const clamscan = await new NodeClam().init({
+        remove_infected: true,
+        debug_mode: isDev,
+        scan_recursively: false,
+        clamdscan: {
+            socket: process.env.CLAMDSCAN_SOCKET || '/var/run/clamav/clamd.ctl',
+            timeout: 120000,
+            local_fallback: true,
+            path: process.env.CLAMDSCAN_PATH || '/var/lib/clamav',
+            config_file:
+                process.env.CLAMDSCAN_CONFIG_FILE || '/etc/clamav/clamd.conf'
+        }
+    });
+
+    const { is_infected, viruses } = await clamscan.scan_file(filePath);
+
+    if (is_infected) {
+        logger.error(`Virus scan failed, file INFECTED`, { filePath, viruses });
+    } else {
+        logger.info(`Virus scan OK`, { filePath });
+    }
+
+    return { is_infected, viruses };
+};


### PR DESCRIPTION
Extracts scanFile to a standalone module, and inlines static config. Enables local antivirus scanning by default. Merge once we've run some more smoke tests in the test environment.