### PR TITLE
Fix links to be absolute in emails

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1124,7 +1124,7 @@ user:
 
         <p>Helo,</p>
         <p>E-bost byr i roi gwybod eich bod wedi newid eich cyfrinair ar-lein yn llwyddiannus.</p>
-        <p>Os nad mai chi oedd hwn – ac nad ydych yn gwybod unrhyw beth am unrhyw newidiadau i gyfrinair – cysylltwch <a href="/welsh/contact">â ni</a> ar unwaith.</p>
+        <p>Os nad mai chi oedd hwn – ac nad ydych yn gwybod unrhyw beth am unrhyw newidiadau i gyfrinair – cysylltwch <a href="https://www.tnlcommunityfund.org.uk/welsh/contact">â ni</a> ar unwaith.</p>
 
         <p>Diolch,</p>
         <p>Cronfa Gymunedol y Loteri Genedlaethol</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1233,7 +1233,7 @@ user:
 
         <p>Hello,</p>
         <p>Just an email to let you know you’ve successfully changed your online password.</p>
-        <p>If this wasn’t you – and you don’t know about any password changes – please <a href="/contact">talk to us</a> straight away.</p>
+        <p>If this wasn’t you – and you don’t know about any password changes – please <a href="https://www.tnlcommunityfund.org.uk/contact">talk to us</a> straight away.</p>
 
         <p>Thanks,</p>
         <p>The National Lottery Community Fund</p>


### PR DESCRIPTION
Our friend Gideon spotted that these links don't work (and don't render properly in some email clients) as they're relative when they should be absolute.