### PR TITLE
England launch

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -37,7 +37,7 @@
     "enableSiteSurvey": true
   },
   "awardsForAll": {
-    "allowedCountries": ["scotland", "wales"]
+    "allowedCountries": ["england", "scotland", "wales"]
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/config/development.json
+++ b/config/development.json
@@ -8,8 +8,5 @@
     "enableCloudWatchLogs": false,
     "enableSeeders": true,
     "enableSalesforceConnector": true
-  },
-  "awardsForAll": {
-    "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1236,14 +1236,6 @@ applyNext:
     title: Dechrau cais am Arian i Bawb y Loteri Genedlaethol
     intro: Ffordd sydyn a syml i gael grantiau Loteri Genedlaethol bychan rhwng £300 a £10,000
     callToAction: Dechrau cais newydd
-  locationMessage: >
-      <p>Croeso i’n cais ar-lein newydd ar gyfer Arian i Bawb y Loteri Genedlaethol.</p>
-      <p><strong>Ymgeisio am brosiect yng Nghymru neu’r Alban?</strong></p>
-      <p>Gwych – rydych yn y lle cywir. Bydd angen ichi <a href="/welsh/user/register">greu cyfrif newydd</a> i ymgeisio. Oni bai eich bod eisoes wedi creu cyfrif i’n ffurflen gais ar-lein newydd.</p>
-      <p><strong>Ymgeisio am brosiect yn Lloegr?</strong></p>
-      <p><a href="https://apply.tnlcommunityfund.org.uk">Byddwch angen defnyddio’r ffurflen hwn yn lle.</a>.</p>
-      <p><strong>Ymgeisio am brosiect yng Ngogledd Iwerddon?</strong></p>
-      <p><a href="/funding/programmes/awards-for-all-northern-ireland">Bydd angen ichi lawrlwytho ffurflen gais i ymgeisio</a>.</p>
   dashboard:
     title: Eich ceisiadau
     introduction: >
@@ -1266,12 +1258,6 @@ applyNext:
         Efallai hoffech edrych ar gyngor ac awgrymiadau defnyddiol am <a href="/welsh/funding/under10k">ymgeisio am arian ar ein gwefan</a>.
     decisionMessage: Rydym yn anelu i adael i chi wybod am ein penderfyniad mewn oddeutu %s wythnos. Os oes unrhyw gwestiwn gennych,
       <a href="/contact">cysylltwch ag aelod o’n tîm cynghori</a>.
-    locationMessage: >
-      <p><strong>Ymgeisio am brosiect yn Lloegr?</strong></p>
-      <p><a href="https://apply.tnlcommunityfund.org.uk">Byddwch angen defnyddio’r ffurflen hwn yn lle</a>.</p>
-      <p><strong>Ymgeisio am brosiect yng Ngogledd Iwerddon?</strong></p>
-      <p><a href="/funding/programmes/awards-for-all-northern-ireland">Bydd angen ichi lawrlwytho ffurflen gais i ymgeisio</a>.</p>
-      <p>Dim ond ymgeiswyr yng Nghymru neu'r Alban all ymgeisio drwy ein ffurflen ar-lein newydd ar hyn o bryd. Rydym yn gweithio ar wneud hwn yn hygyrch i weddill y DU.</p>
     newApplication:
       title: Cais newydd
       body: Gallwch greu cais ariannu newydd am %s yma

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1519,14 +1519,6 @@ applyNext:
     title: Start an application for National Lottery Awards for All
     intro: A quick and simple way to get small National Lottery grants of between £300 and £10,000
     callToAction: Start a new application
-  locationMessage: >
-      <p>Welcome to our new online application for National Lottery Awards for All.</p>
-      <p><strong>Applying for a project in Wales or Scotland?</strong></p>
-      <p>Great - you’re in the right place. You’ll need to <a href="/user/register">create a new account</a> to apply. Unless you’ve already created an account for our new online application form.</p>
-      <p><strong>Applying for a project in England?</strong></p>
-      <p><a href="https://apply.tnlcommunityfund.org.uk">You'll need to use this form instead</a>.</p>
-      <p><strong>Applying for a project in Northern Ireland?</strong></p>
-      <p><a href="/funding/programmes/awards-for-all-northern-ireland">You'll need to download an application form to apply</a>.</p>
   dashboard:
     title: Your applications
     introduction: >
@@ -1549,12 +1541,6 @@ applyNext:
         You might want to look at some helpful advice and tips about <a href="/funding/under10k">applying for funding on our website</a>.
     decisionMessage: We aim to let you know our decision in about %s weeks. If you have any questions,
       <a href="/contact">contact a member of our advice team</a>.
-    locationMessage: >
-      <p><strong>Applying for a project in England?</strong></p>
-      <p><a href="https://apply.tnlcommunityfund.org.uk">You'll need to use this form instead</a>.</p>
-      <p><strong>Applying for a project in Northern Ireland?</strong></p>
-      <p><a href="/funding/programmes/awards-for-all-northern-ireland">You'll need to download an application form to apply</a>.</p>
-      <p>Only applicants in Wales or Scotland can apply through our new online form at the moment. We're working on making this available for the rest of the UK.</p>
     newApplication:
       title: New application
       body: You can create a new funding application for %s here

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -73,32 +73,6 @@ module.exports = function({
     }
 
     function stepProjectCountry() {
-        /**
-         * We are rolling out this form on a per-country basis
-         * so we need to show a message to direct applicants to the old form
-         * if they are applying for a country we don't support yet
-         */
-        const countryNoticeMessage = {
-            title: localise({
-                en: `Applying for a project in England?`,
-                cy: `Ymgeisio am brosiect yn Lloegr?`
-            }),
-            body: localise({
-                en: `
-                    <p><a href="https://apply.tnlcommunityfund.org.uk">You'll need to use this form instead</a>.</p>
-                    <p><strong>Applying for a project in Northern Ireland?</strong></p>
-                    <p><a href="/funding/programmes/awards-for-all-northern-ireland">You'll need to download an application form to apply</a>.</p>
-                    <p>Only applicants in Wales or Scotland can apply through our new online form at the moment. We're working on making this available for the rest of the UK.</p>
-                `,
-                cy: `
-                    <p><a href="https://apply.tnlcommunityfund.org.uk">Byddwch angen defnyddio’r ffurflen hon yn lle</a>.</p>
-                    <p><strong>Ymgeisio am brosiect yng Ngogledd Iwerddon?</strong></p>
-                    <p><a href="funding/programmes/awards-for-all-northern-ireland">Byddwch angen lawrlwytho ffurflen gais i ymgeisio</a>.</p>
-                    <p>Dim ond ymgeiswyr yng Nghymru neu'r Alban all ymgeisio drwy ein ffurflen ar-lein newydd ar hyn o bryd. Rydym yn gweithio ar wneud hwn yn hygyrch i weddill y DU.</p>
-                `
-            })
-        };
-
         return {
             title: localise({ en: 'Project country', cy: 'Gwlad y prosiect' }),
             noValidate: true,
@@ -110,8 +84,7 @@ module.exports = function({
                     }),
                     fields: [fields.projectCountry]
                 }
-            ],
-            message: countryNoticeMessage
+            ]
         };
     }
 

--- a/controllers/apply/form-router-next/views/dashboard.njk
+++ b/controllers/apply/form-router-next/views/dashboard.njk
@@ -107,14 +107,7 @@
 {% block content %}
     <main role="main" id="content">
         <section class="content-box u-inner-wide-only">
-
             {{ userNavigation(userNavigationLinks) }}
-
-            {% if formId === 'awards-for-all' %}
-                <div class="message message--info message--minor" role="alert">
-                    {{  copy.dashboard.locationMessage | safe }}
-                </div>
-            {% endif %}
 
             {{ userStatus(user) }}
 

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -14,14 +14,7 @@
             {{ userNavigation(userNavigationLinks) }}
 
             {{ formHeaderWithData(formTitle, form.summary.title) }}
-
-            {% if step.message %}
-                <div class="message message--info message--minor" role="alert">
-                    <p><strong>{{ step.message.title | safe }}</strong></p>
-                    <p>{{ step.message.body | safe }}</p>
-                </div>
-            {% endif %}
-
+            
             <form action=""
                   method="post"
                   class="js-form-warn-unsaved js-session-form js-apply-{{ formId }}"

--- a/controllers/apply/lib/validate-model.js
+++ b/controllers/apply/lib/validate-model.js
@@ -66,10 +66,6 @@ module.exports = function validateModel(formModel) {
         fieldsets: Joi.array()
             .items(fieldsetSchema)
             .required(),
-        message: Joi.object({
-            title: Joi.string().required(),
-            body: Joi.string().required()
-        }).optional(),
         preFlightCheck: Joi.func().optional(),
         isMultipart: Joi.boolean().optional()
     });

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -5,11 +5,6 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
-
-            <div class="message message--info message--minor" role="alert">
-                {{ __('applyNext.locationMessage') | safe }}
-            </div>
-
             <h1 class="t--underline">{{ title }}</h1>
      
             {% if alertMessage %}

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -5,11 +5,6 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
-
-            <div class="message message--info message--minor" role="alert">
-                {{ __('applyNext.locationMessage') | safe }}
-            </div>
-
             <h1 class="t--underline">{{ title }}</h1>
 
             {% if alertMessage %}


### PR DESCRIPTION
- Remove form messaging. Northern Ireland do not use the old online form so we can remove all messaging with limited impact.
- Add `england` to `allowedCountries`