### PR TITLE
Disambiguate mail logs

### DIFF
--- a/common/mail.js
+++ b/common/mail.js
@@ -221,7 +221,7 @@ function sendEmail({ name, mailConfig, mailTransport = null }) {
         const transport = mailTransport ? mailTransport : createSesTransport();
 
         return transport.sendMail(buildMailOptions(mailConfig)).then(info => {
-            logger.info('Mail sent', { name: name });
+            logger.info(`Mail sent for ${name}`);
             return info;
         });
     }


### PR DESCRIPTION
The current log format for mail sending is hard to work with. Adding the name into the log message makes things easier to disambiguate.