### PR TITLE
Safari address-lookup dropdown fix

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -159,7 +159,7 @@ export default {
                                 result['line_2'],
                                 result['post_town'],
                                 result['county']
-                            ]).join(', ');
+                            ]).join(', ');                            
                             return { value: result.udprn, label: label };
                         });
                     } else {
@@ -349,7 +349,7 @@ export default {
                     @focus="selectFocused"
                     @keydown="selectKeyed"
                     @change="selectChanged"
-                    @click="selectClicked"
+                    @mousedown="selectClicked"
                     data-hj-suppress
                 >
                     <option disabled value="">

--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -159,7 +159,7 @@ export default {
                                 result['line_2'],
                                 result['post_town'],
                                 result['county']
-                            ]).join(', ');                            
+                            ]).join(', ');
                             return { value: result.udprn, label: label };
                         });
                     } else {


### PR DESCRIPTION
Webkit has had a ~10 year old issue of `click` event not working on `select`. This suggests that it is still not fixed!

Replaced the `@click` with the `@mousedown` event.

One of the links for the bug: https://forum.jquery.com/topic/problem-with-click-on-select-boxes-webkit