### PR TITLE
Fix CMS sharing link

### DIFF
--- a/common/authed.js
+++ b/common/authed.js
@@ -91,7 +91,7 @@ function requireStaffAuth(req, res, next) {
             });
         }
     } else {
-        res.redirect(`/user/staff/login?redirectUrl=${req.originalUrl}`);
+        res.redirect(`/user/staff/login?redirectUrl=${encodeURIComponent(req.originalUrl)}`);
     }
 }
 

--- a/controllers/user/staff.js
+++ b/controllers/user/staff.js
@@ -7,7 +7,9 @@ const router = express.Router();
 
 router.get('/interstitial', (req, res) => {
     res.render(path.resolve(__dirname, 'views/interstitial'), {
-        redirectUrl: req.query.redirectUrl ? req.query.redirectUrl : '/tools'
+        redirectUrl: req.query.redirectUrl
+            ? decodeURIComponent(req.query.redirectUrl)
+            : '/tools'
     });
 });
 
@@ -22,7 +24,7 @@ router.get('/login', function(req, res, next) {
     passport.authenticate('azuread-openidconnect', {
         failureRedirect: '/user/staff/error',
         // @ts-ignore
-        customState: req.query.redirectUrl
+        customState: encodeURIComponent(req.query.redirectUrl)
     })(req, res, next);
 });
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -104,14 +104,17 @@ it('should protect access to staff-only tools', () => {
     cy.checkRedirect({
         from:
             '/funding/programmes/national-lottery-awards-for-all-england?x-craft-preview=123&token=abc',
-        to:
-            '/user/staff/login?redirectUrl=/funding/programmes/national-lottery-awards-for-all-england?x-craft-preview=123&token=abc',
+        to: `/user/staff/login?redirectUrl=${encodeURIComponent(
+            '/funding/programmes/national-lottery-awards-for-all-england?x-craft-preview=123&token=abc'
+        )}`,
         status: 302
     });
 
     cy.checkRedirect({
         from: '/tools/survey-results',
-        to: '/user/staff/login?redirectUrl=/tools/survey-results',
+        to: `/user/staff/login?redirectUrl=${encodeURIComponent(
+            '/tools/survey-results'
+        )}`,
         status: 302
     });
 });

--- a/server.js
+++ b/server.js
@@ -183,11 +183,11 @@ app.use([
             }
         }
     }),
-    require('./common/preview'),
     express.json(),
     express.urlencoded({ extended: true }),
     require('./common/session')(app),
     require('./common/passport')(),
+    require('./common/preview'),
     require('./common/locals')
 ]);
 


### PR DESCRIPTION
This makes a change to encode URIs correctly when passing them around in querystrings – the upgraded CMS generates preview URLs that look like `http://localhost:3000/about/our-people/senior-management-team?x-craft-preview=ABC&token=123` which weren't being passed through properly (eg. everything after the `&` was being dropped).

This change also moves the Preview middleware to be initialised after our auth/session code, as otherwise the calls to `req.isAuthenticated()` always returned false.