### PR TITLE
Fix postcode lookup bug

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -100,7 +100,8 @@ export default {
             return (
                 this.candidates.length === 0 &&
                 this.postcode &&
-                this.currentState !== states.NotRequired
+                (this.currentState !== states.NotRequired &&
+                    this.currentState !== states.EnteringManually)
             );
         },
         getAddressFromId(udprn) {


### PR DESCRIPTION
Fixes this bug:
![postcode-bug-v2](https://user-images.githubusercontent.com/394376/66202047-b8217d80-e69c-11e9-91d3-9c31e0298390.gif)

(eg. entering a postcode but not looking it up, and then using manual entry)

The `alert()` logic didn't account for this scenario and it sounds like it crops up when browser autofill does something unexpected.