### PR TITLE
Fix issue with missing permissions

### DIFF
--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -100,10 +100,7 @@ router.post('/handle-expiry/seed', async (req, res) => {
         });
 
         if (emailQueueItems.length > 0) {
-            // Clear out the existing email queue
-            await ApplicationEmailQueue.destroy({
-                truncate: true
-            });
+            // NOTE: clear out the existing email queue before running this
             await ApplicationEmailQueue.createNewQueue(emailQueueItems);
 
             res.json({


### PR DESCRIPTION
Remove truncation of email table in favour of doing it manually, as this failed in TEST as the app user doesn't have permission to `DROP` tables. Good!