### PR TITLE
Launch email expiry

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -38,7 +38,7 @@
   },
   "awardsForAll": {
     "allowedCountries": ["england", "scotland", "wales"],
-    "enableExpiration": false
+    "enableExpiration": true
   },
   "cookies": {
     "session": "blf-alpha-session"

--- a/controllers/apply/form-router-next/lib/application-expiry.js
+++ b/controllers/apply/form-router-next/lib/application-expiry.js
@@ -63,12 +63,9 @@ const sendExpiryEmails = async (req, emailQueue, locale) => {
                     break;
             }
 
-            // const addressToSendTo = appData.isNotProduction
-            //     ? EMAIL_EXPIRY_TEST_ADDRESS
-            //     : emailToSend.PendingApplication.user.username
-
-            // @TODO delete this in favour of the above lines once we're confident it works as expected
-            const addressToSendTo = EMAIL_EXPIRY_TEST_ADDRESS;
+            const addressToSendTo = appData.isNotProduction
+                ? EMAIL_EXPIRY_TEST_ADDRESS
+                : emailToSend.PendingApplication.user.username;
 
             const mailParams = {
                 name: 'application_expiry_afa',

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -18,6 +18,10 @@ const {
     deleteExpiredApplications
 } = require('./form-router-next/lib/application-expiry');
 
+const logger = commonLogger.child({
+    service: 'application-expiry'
+});
+
 // @TODO remove this logic after seeding past application email queue
 const { EXPIRY_EMAIL_REMINDERS } = require('./awards-for-all/constants');
 const {
@@ -51,9 +55,7 @@ router.get('/emails/unsubscribe', async function(req, res) {
             await ApplicationEmailQueue.deleteEmailsForApplication(
                 applicationId
             );
-            commonLogger.info(
-                'User unsubscribed from application expiry emails'
-            );
+            logger.info('User unsubscribed from application expiry emails');
             res.render(
                 path.resolve(
                     __dirname,
@@ -65,7 +67,7 @@ router.get('/emails/unsubscribe', async function(req, res) {
                 }
             );
         } catch (error) {
-            commonLogger.warn('Email unsubscribe token failed', {
+            logger.warn('Email unsubscribe token failed', {
                 token: req.query.token
             });
             res.redirect(req.baseUrl);
@@ -156,6 +158,11 @@ router.post('/handle-expiry', async (req, res) => {
         } else {
             response.expired = [];
         }
+
+        logger.info('application expiries processed', {
+            emailsSent: response.emailQueue.length,
+            expiredAppsDeleted: response.expired.length
+        });
 
         res.json(response);
     } catch (error) {


### PR DESCRIPTION
This adds a few log messages so we can count the number of emails sent / applications expired, and crucially sends expiry emails to the **real** recipient. 