### PR TITLE
relative time change to calendar time

### DIFF
--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -115,7 +115,7 @@ module.exports = function(formId, formBuilder) {
 
         return {
             dateTime: moment(lastUpdatedAt).toISOString(true),
-            relative: moment(lastUpdatedAt).locale(locale).fromNow(),
+            calendarTime: moment(lastUpdatedAt).locale(locale).calendar(),
         };
     }
 

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -74,7 +74,7 @@
                     </div>
                     <p class="form-actions__secondary form-actions__timestamp">
                         {{ copy.lastSaveTimeText }} - 
-                        <time datetime="{{ lastSaveTime.dateTime }}">{{ lastSaveTime.relative }}</time>
+                        <time datetime="{{ lastSaveTime.dateTime }}">{{ lastSaveTime.calendarTime }}</time>
                     </p>
                 </div>
                 {{ userNavigation(userNavigationLinks, isFooter = true) }}

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -469,7 +469,7 @@ it('should test common pages', () => {
 
 it('should submit full awards for all application', () => {
     function checkLastSaveTime() {
-        cy.get('.form-actions__timestamp').contains('a few seconds ago');
+        cy.get('.form-actions__timestamp').contains('Today');
     }
 
     function submitStep() {


### PR DESCRIPTION
This now basically changes the timestamp on the UI to show calendar time (eg `Today at 10:00 AM`) rather than relative (`few minutes ago`) which could confuse the user.