### PR TITLE
differentiate suggested project duration from max

### DIFF
--- a/controllers/apply/awards-for-all/constants.js
+++ b/controllers/apply/awards-for-all/constants.js
@@ -14,28 +14,24 @@ const FREE_TEXT_MAXLENGTH = {
 const ORG_MIN_AGE = {
     amount: 15,
     unit: 'months',
-    label: {
-        en: '15 months',
-        cy: '15 mis'
-    }
+    label: { en: '15 months', cy: '15 mis' }
 };
 
 const MIN_START_DATE = {
     amount: 18,
     unit: 'weeks',
-    label: {
-        en: '18 weeks',
-        cy: '18 wythnos'
-    }
+    label: { en: '18 weeks', cy: '18 wythnos' }
+};
+
+const SUGGESTED_PROJECT_DURATION = {
+    en: '12 months',
+    cy: '12 mis'
 };
 
 const MAX_PROJECT_DURATION = {
     amount: 15,
     unit: 'months',
-    label: {
-        en: '15 months',
-        cy: '15 mis'
-    }
+    label: { en: '15 months', cy: '15 mis' }
 };
 
 const ORGANISATION_TYPES = {
@@ -143,6 +139,7 @@ module.exports = {
     CONTACT_EXCLUDED_TYPES,
     FILE_LIMITS,
     MAX_BUDGET_TOTAL_GBP,
+    SUGGESTED_PROJECT_DURATION,
     MAX_PROJECT_DURATION,
     MIN_AGE_MAIN_CONTACT,
     MIN_AGE_SENIOR_CONTACT,

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -6,7 +6,7 @@ const {
     MIN_BUDGET_TOTAL_GBP,
     MIN_START_DATE,
     MAX_BUDGET_TOTAL_GBP,
-    MAX_PROJECT_DURATION,
+    SUGGESTED_PROJECT_DURATION,
     ORG_MIN_AGE
 } = require('./constants');
 
@@ -14,7 +14,7 @@ module.exports = function({ locale }) {
     const localise = get(locale);
 
     const minStartDateLabel = localise(MIN_START_DATE.label);
-    const maxProjectDurationLabel = localise(MAX_PROJECT_DURATION.label);
+    const maxProjectDurationLabel = localise(SUGGESTED_PROJECT_DURATION);
     const orgMinAgeLabel = localise(ORG_MIN_AGE.label);
 
     const question1 = {

--- a/controllers/apply/awards-for-all/fields/project-date-range.js
+++ b/controllers/apply/awards-for-all/fields/project-date-range.js
@@ -3,16 +3,17 @@ const get = require('lodash/fp/get');
 const moment = require('moment');
 const { oneLine } = require('common-tags');
 
-const { MAX_PROJECT_DURATION, MIN_START_DATE } = require('../constants');
+const {
+    MAX_PROJECT_DURATION,
+    MIN_START_DATE,
+    SUGGESTED_PROJECT_DURATION
+} = require('../constants');
 const Joi = require('../../lib/joi-extensions');
 
 module.exports = function(locale) {
     const localise = get(locale);
 
-    const minDate = moment().add(
-        MIN_START_DATE.amount,
-        MIN_START_DATE.unit
-    );
+    const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
 
     function formatAfterDate() {
         return minDate
@@ -39,10 +40,10 @@ module.exports = function(locale) {
             </p>
             <p>
                 We usually only fund projects that last
-                ${localise(MAX_PROJECT_DURATION.label)} or less.
+                ${localise(SUGGESTED_PROJECT_DURATION)} or less.
                 So, the end date can't be more than
                 ${localise(
-                    MAX_PROJECT_DURATION.label
+                    SUGGESTED_PROJECT_DURATION
                 )} after the start date.    
             </p>
             <p><strong>If your project is a one-off event</strong></p>
@@ -59,11 +60,11 @@ module.exports = function(locale) {
             <p>
                 Fel arfer, dim ond prosiectau sy’n para 
                 ${localise(
-                    MAX_PROJECT_DURATION.label
+                    SUGGESTED_PROJECT_DURATION
                 )} neu lai rydym yn eu hariannu.
                 Felly, ni all y dyddiad gorffen fod yn hwyrach na 
                 ${localise(
-                    MAX_PROJECT_DURATION.label
+                    SUGGESTED_PROJECT_DURATION
                 )} wedi’r dyddiad cychwyn.    
             </p>
             <p><strong>Os yw eich prosiect yn ddigwyddiad sy’n digwydd unwaith yn unig</strong></p>


### PR DESCRIPTION
Differentiate suggested project duration from max allowed. Shows 12 months in help text but allows up to 15 months.

![image](https://user-images.githubusercontent.com/123386/66310799-f3be8080-e904-11e9-8736-15bd02205e72.png)
