### PR TITLE
converting last save time to BST

### DIFF
--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -6,7 +6,7 @@ const includes = require('lodash/includes');
 const omit = require('lodash/omit');
 const Sentry = require('@sentry/node');
 const crypto = require('crypto');
-const moment = require('moment');
+const moment = require('moment-timezone');
 
 const logger = require('../../../common/logger');
 const { sanitiseRequestBody } = require('../../../common/sanitise');
@@ -115,7 +115,10 @@ module.exports = function(formId, formBuilder) {
 
         return {
             dateTime: moment(lastUpdatedAt).toISOString(true),
-            calendarTime: moment(lastUpdatedAt).locale(locale).calendar(),
+            calendarTime: moment(lastUpdatedAt)
+                .tz('Europe/London')
+                .locale(locale)
+                .calendar(),
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lodash": "4.17.15",
     "mime-types": "2.1.24",
     "moment": "^2.18.1",
+    "moment-timezone": "0.5.26",
     "mysql2": "1.6.5",
     "nodemailer": "^4.1.0",
     "nunjucks": "^3.1.3",


### PR DESCRIPTION
As the prod db is using a different timezone, using `moment-timezone` to convert the last save time to standard BST.

As my local db would not show the timezone change, its worth testing it on test server.