### PR TITLE
Bin cleanup

### DIFF
--- a/bin/.eslintrc.js
+++ b/bin/.eslintrc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    rules: {
+        'no-console': 'off'
+    }
+};

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 'use strict';
-/* eslint-disable no-console */
 require('dotenv').config();
 const config = require('config');
 
 const has = require('lodash/has');
 
 if (!has(process.env, 'TEST_URL') || !has(process.env, 'PROD_URL')) {
-    console.log('Error: TEST_URL and PROD_URL environment variables must be defined');
+    console.log(
+        'Error: TEST_URL and PROD_URL environment variables must be defined'
+    );
     process.exit(1);
 }
 
@@ -143,9 +144,7 @@ function getCommitsToBeDeployed() {
 
         // first commit this returns will be the one currently on TEST
         // @TODO what if we're deploying an older build? no way to save its commit ID in AWS
-        let commitList = `https://api.github.com/repos/${CONF.githubAccount}/${CONF.githubRepo}/commits?sha=${
-            ids.test
-        }&per_page=100`;
+        let commitList = `https://api.github.com/repos/${CONF.githubAccount}/${CONF.githubRepo}/commits?sha=${ids.test}&per_page=100`;
 
         // now get commits made before the one currently on TEST
         return rp
@@ -201,27 +200,37 @@ function verifyCommitsToDeploy() {
             .then(commits => {
                 const commitStr = [
                     'This deployment will push the following commits live:',
-                    commits.map(info => `- ${info.sha.slice(0, 12)} ${info.commit.message}`).join('\n')
+                    commits
+                        .map(
+                            info =>
+                                `- ${info.sha.slice(0, 12)} ${
+                                    info.commit.message
+                                }`
+                        )
+                        .join('\n')
                 ].join('\n');
 
                 console.log(commitStr);
 
                 prompt.start();
 
-                prompt.get({
-                    description: `Are you sure you want to push the above commits live?`,
-                    name: 'yesno',
-                    type: 'string',
-                    pattern: /y[es]*|n[o]?/,
-                    message: 'Please answer the question properly',
-                    required: true
-                }, (err, result) => {
-                    if (['y', 'yes'].indexOf(result.yesno) !== -1) {
-                        resolve(commitStr);
-                    } else {
-                        reject('Bailing out!');
+                prompt.get(
+                    {
+                        description: `Are you sure you want to push the above commits live?`,
+                        name: 'yesno',
+                        type: 'string',
+                        pattern: /y[es]*|n[o]?/,
+                        message: 'Please answer the question properly',
+                        required: true
+                    },
+                    (err, result) => {
+                        if (['y', 'yes'].indexOf(result.yesno) !== -1) {
+                            resolve(commitStr);
+                        } else {
+                            reject('Bailing out!');
+                        }
                     }
-                });
+                );
             })
             .catch(err => {
                 reject(err);
@@ -231,7 +240,9 @@ function verifyCommitsToDeploy() {
 
 // trigger the deploy itself
 function pushOutDeploy(env, id) {
-    console.log(`Attempting to deploy revision ${id} to environment ${env}, please wait…`);
+    console.log(
+        `Attempting to deploy revision ${id} to environment ${env}, please wait…`
+    );
 
     const deployParams = createDeploymentConf(id);
 
@@ -239,7 +250,9 @@ function pushOutDeploy(env, id) {
         .createDeployment(deployParams)
         .promise()
         .then(() => {
-            console.log('Deployment started, check Slack or the AWS console to monitor the deployment.');
+            console.log(
+                'Deployment started, check Slack or the AWS console to monitor the deployment.'
+            );
         })
         .catch(err => {
             console.error('Error creating deployment', {

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -4,8 +4,6 @@ const { forEach } = require('lodash');
 const config = require('config');
 const fs = require('fs');
 const path = require('path');
-const util = require('util');
-const writeFile = util.promisify(fs.writeFile);
 
 const { generateBehaviours } = require('../common/cloudfront');
 
@@ -14,21 +12,31 @@ const cloudfrontDistributions = config.get('aws.cloudfrontDistributions');
 /**
  * For each CloudFront distribution generate a config and store it
  */
-forEach(cloudfrontDistributions, async (distribution, distributionName) => {
+forEach(cloudfrontDistributions, function(distribution, distributionName) {
     const behaviours = generateBehaviours(distribution.origins);
 
-    try {
-        const filePath = path.join(
-            __dirname,
-            `../config/cloudfront/${distributionName}.json`
-        );
-        await writeFile(filePath, JSON.stringify(behaviours, null, 2), 'utf8');
-        console.log(
-            `[${distributionName}] Cloudfront configuration with ${
-                behaviours.CacheBehaviors.Items.length
-            } behaviours saved at ${path.relative(process.cwd(), filePath)}.`
-        );
-    } catch (error) {
-        console.error('Error saving config', error);
-    }
+    const filePath = path.join(
+        __dirname,
+        `../config/cloudfront/${distributionName}.json`
+    );
+
+    fs.writeFile(
+        filePath,
+        JSON.stringify(behaviours, null, 2),
+        'utf8',
+        function(err) {
+            if (err) {
+                console.error('Error saving config', err);
+            } else {
+                console.log(
+                    `[${distributionName}] Cloudfront configuration with ${
+                        behaviours.CacheBehaviors.Items.length
+                    } behaviours saved at ${path.relative(
+                        process.cwd(),
+                        filePath
+                    )}.`
+                );
+            }
+        }
+    );
 });

--- a/bin/generate-cloudfront-config
+++ b/bin/generate-cloudfront-config
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-/* eslint-disable no-console */
 const { forEach } = require('lodash');
 const config = require('config');
 const fs = require('fs');
@@ -19,7 +18,10 @@ forEach(cloudfrontDistributions, async (distribution, distributionName) => {
     const behaviours = generateBehaviours(distribution.origins);
 
     try {
-        const filePath = path.join(__dirname, `../config/cloudfront/${distributionName}.json`);
+        const filePath = path.join(
+            __dirname,
+            `../config/cloudfront/${distributionName}.json`
+        );
         await writeFile(filePath, JSON.stringify(behaviours, null, 2), 'utf8');
         console.log(
             `[${distributionName}] Cloudfront configuration with ${

--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -60,7 +60,10 @@ function getParametersForEnvironment(environment) {
                 {
                     Key: 'Path',
                     Option: 'Recursive',
-                    Values: ['/Web/Global', environment === 'production' ? '/Web/Prod' : '/Web/Test']
+                    Values: [
+                        '/Web/Global',
+                        environment === 'production' ? '/Web/Prod' : '/Web/Test'
+                    ]
                 }
             ]
         };
@@ -75,21 +78,34 @@ function getParametersForEnvironment(environment) {
                 .then(results => flatten(results))
                 .then(allParameters => {
                     if (parameterNames.length !== allParameters.length) {
-                        throw new Error("Number of results doesn't match the amount requested");
+                        throw new Error(
+                            "Number of results doesn't match the amount requested"
+                        );
                     }
 
-                    const [rawGlobalParameters, rawEnvironmentParameters] = partition(allParameters, parameter => {
+                    const [
+                        rawGlobalParameters,
+                        rawEnvironmentParameters
+                    ] = partition(allParameters, parameter => {
                         return /^\/Web\/Global/.test(parameter.Name);
                     });
 
-                    const globalParameters = rawGlobalParameters.map(normaliseParameterName);
-                    const environmentParameters = rawEnvironmentParameters.map(normaliseParameterName);
+                    const globalParameters = rawGlobalParameters.map(
+                        normaliseParameterName
+                    );
+                    const environmentParameters = rawEnvironmentParameters.map(
+                        normaliseParameterName
+                    );
 
                     /**
                      * Take union of /Web/Global and /Web/$Environment parameters
                      * Favour environment specific parameters over global ones
                      */
-                    const combinedParameters = unionBy(environmentParameters, globalParameters, 'Name');
+                    const combinedParameters = unionBy(
+                        environmentParameters,
+                        globalParameters,
+                        'Name'
+                    );
                     resolve(combinedParameters);
                 });
         });

--- a/bin/hash-rev
+++ b/bin/hash-rev
@@ -1,31 +1,29 @@
 #!/usr/bin/env node
 'use strict';
 const fs = require('fs');
-const util = require('util');
 const { execSync } = require('child_process');
-const writeFile = util.promisify(fs.writeFile);
 
 const commitHash = execSync('git rev-parse --short=12 HEAD')
     .toString()
     .trim();
 
-(async () => {
-    try {
-        execSync(`cp -r ./public/build/latest ./public/build/${commitHash}`);
+execSync(`cp -r ./public/build/latest ./public/build/${commitHash}`);
 
-        await writeFile(
-            './config/assets.json',
-            JSON.stringify(
-                {
-                    version: commitHash
-                },
-                null,
-                4
-            )
-        );
-
-        console.log('✔ Assets hash revved');
-    } catch (error) {
-        console.error('Error hash revving asset files', error);
+fs.writeFile(
+    './config/assets.json',
+    JSON.stringify(
+        {
+            version: commitHash
+        },
+        null,
+        4
+    ),
+    'utf8',
+    function(err) {
+        if (err) {
+            console.error('Error hash revving asset files', err);
+        } else {
+            console.log('✔ Assets hash revved');
+        }
     }
-})();
+);

--- a/bin/multi-test
+++ b/bin/multi-test
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-function runTest() {
-    npx cypress run --spec "cypress/integration/awards-for-all.js" --browser chrome
-}
-
-runTest & runTest & runTest & runTest & runTest

--- a/bin/start-test-server
+++ b/bin/start-test-server
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-export DB_CONNECTION_URI=sqlite://:memory;
-export PORT=8090;
-export TEST_SERVER=true;
-
-npm run start

--- a/bin/update-cloudfront
+++ b/bin/update-cloudfront
@@ -27,7 +27,9 @@ const argv = require('yargs')
 const IS_LIVE = argv.l;
 
 if (!has(process.env, 'TEST_URL') || !has(process.env, 'PROD_URL')) {
-    console.log('Error: TEST_URL and PROD_URL environment variables must be defined');
+    console.log(
+        'Error: TEST_URL and PROD_URL environment variables must be defined'
+    );
     process.exit(1);
 }
 
@@ -77,7 +79,9 @@ if (customConfig) {
                 routesParams.ref = argv.c;
             }
 
-            console.log(`Fetching "${configFilename}" config file for commit ${routesParams.ref}`);
+            console.log(
+                `Fetching "${configFilename}" config file for commit ${routesParams.ref}`
+            );
 
             // fetch the routes file details
             rp({
@@ -90,7 +94,9 @@ if (customConfig) {
                 .then(response => {
                     let json = JSON.parse(response);
                     let filePath = json.download_url;
-                    console.log(`Got the file data, downloading content from ${filePath}...`);
+                    console.log(
+                        `Got the file data, downloading content from ${filePath}...`
+                    );
 
                     // now fetch the file content itself
                     rp({
@@ -101,15 +107,21 @@ if (customConfig) {
                             beginUpdate(JSON.parse(fileContent));
                         })
                         .catch(err => {
-                            console.log(`Error getting "${configFilename}" config file content`, {
-                                error: err
-                            });
+                            console.log(
+                                `Error getting "${configFilename}" config file content`,
+                                {
+                                    error: err
+                                }
+                            );
                         });
                 })
                 .catch(err => {
-                    console.log(`Error getting "${configFilename}" config file data`, {
-                        error: err
-                    });
+                    console.log(
+                        `Error getting "${configFilename}" config file data`,
+                        {
+                            error: err
+                        }
+                    );
                 });
         })
         .catch(() => {
@@ -120,10 +132,16 @@ if (customConfig) {
 function storeBackup(existingConfig) {
     try {
         const timestamp = moment().format('YYYY-MM-DD-HH-mm-ss');
-        const confPath = path.join(__dirname, `../config/cloudfront/backup/${timestamp}.json`);
+        const confPath = path.join(
+            __dirname,
+            `../config/cloudfront/backup/${timestamp}.json`
+        );
         const backup = {
-            DefaultCacheBehavior: existingConfig.Distribution.DistributionConfig.DefaultCacheBehavior,
-            CacheBehaviors: existingConfig.Distribution.DistributionConfig.CacheBehaviors
+            DefaultCacheBehavior:
+                existingConfig.Distribution.DistributionConfig
+                    .DefaultCacheBehavior,
+            CacheBehaviors:
+                existingConfig.Distribution.DistributionConfig.CacheBehaviors
         };
         fs.writeFileSync(confPath, JSON.stringify(backup, null, 4));
         console.log('A copy of the existing config was saved in ' + confPath);
@@ -146,11 +164,15 @@ function listChanges(pathConfigs) {
 
 function beginUpdate(savedConfig) {
     // create AWS SDK instance
-    AWS.config.credentials = new AWS.SharedIniFileCredentials({ profile: 'default' });
+    AWS.config.credentials = new AWS.SharedIniFileCredentials({
+        profile: 'default'
+    });
     const cloudfront = new AWS.CloudFront();
 
     // decide which config to use (pass --live to this script to use live)
-    const cloudfrontDistribution = IS_LIVE ? cloudfrontDistributions.live : cloudfrontDistributions.test;
+    const cloudfrontDistribution = IS_LIVE
+        ? cloudfrontDistributions.live
+        : cloudfrontDistributions.test;
 
     // get existing cloudfront config
     const getDistributionConfig = cloudfront
@@ -186,23 +208,37 @@ function beginUpdate(savedConfig) {
 
             // verify what's being changed
             const paths = {
-                before: existingConfig.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls),
-                after: newConfigToWrite.Distribution.DistributionConfig.CacheBehaviors.Items.map(getUrls)
+                before: existingConfig.Distribution.DistributionConfig.CacheBehaviors.Items.map(
+                    getUrls
+                ),
+                after: newConfigToWrite.Distribution.DistributionConfig.CacheBehaviors.Items.map(
+                    getUrls
+                )
             };
 
-            const pathsAdded = filter(paths.after, obj => !find(paths.before, obj));
-            const pathsRemoved = filter(paths.before, obj => !find(paths.after, obj));
+            const pathsAdded = filter(
+                paths.after,
+                obj => !find(paths.before, obj)
+            );
+            const pathsRemoved = filter(
+                paths.before,
+                obj => !find(paths.after, obj)
+            );
             // warn users about changes
             console.log(
                 'There are currently ' +
-                    existingConfig.Distribution.DistributionConfig.CacheBehaviors.Quantity +
+                    existingConfig.Distribution.DistributionConfig
+                        .CacheBehaviors.Quantity +
                     ' items in the existing behaviours, and ' +
-                    newConfigToWrite.Distribution.DistributionConfig.CacheBehaviors.Quantity +
+                    newConfigToWrite.Distribution.DistributionConfig
+                        .CacheBehaviors.Quantity +
                     ' in this one.'
             );
 
             if (pathsRemoved.length) {
-                console.log('The following paths will be removed from Cloudfront:');
+                console.log(
+                    'The following paths will be removed from Cloudfront:'
+                );
                 listChanges(pathsRemoved);
             }
 
@@ -233,7 +269,9 @@ function beginUpdate(savedConfig) {
                     // try to update the distribution
                     let updateDistributionConfig = cloudfront
                         .updateDistribution({
-                            DistributionConfig: newConfigToWrite.Distribution.DistributionConfig,
+                            DistributionConfig:
+                                newConfigToWrite.Distribution
+                                    .DistributionConfig,
                             Id: cloudfrontDistribution.distributionId,
                             IfMatch: etag
                         })
@@ -244,14 +282,19 @@ function beginUpdate(savedConfig) {
                         .then(data => {
                             // the update worked
                             console.log(data);
-                            console.log('CloudFront was successfully updated with the new configuration!');
+                            console.log(
+                                'CloudFront was successfully updated with the new configuration!'
+                            );
                         })
                         .catch(updateError => {
                             // failed to update config
                             console.log(JSON.stringify(newConfigToWrite));
-                            console.error('There was an error uploading this config', {
-                                error: updateError
-                            });
+                            console.error(
+                                'There was an error uploading this config',
+                                {
+                                    error: updateError
+                                }
+                            );
                         });
                 } else {
                     console.log('Bailing out!');

--- a/bin/www
+++ b/bin/www
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 const http = require('http');
-const config = require('config');
 
 const logger = require('../common/logger').child({
     service: 'www'
@@ -10,7 +9,7 @@ const logger = require('../common/logger').child({
 const app = require('../server');
 const { sequelize } = require('../db/models');
 
-logger.debug(`App environment: ${config.util.getEnv('NODE_ENV')}`);
+logger.debug(`App environment: ${process.env.NODE_ENV || 'development'}`);
 
 /**
  * Normalize a port into a number, string, or false.

--- a/bin/www
+++ b/bin/www
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 const http = require('http');
+const config = require('config');
 
 const logger = require('../common/logger').child({
     service: 'www'
@@ -9,7 +10,7 @@ const logger = require('../common/logger').child({
 const app = require('../server');
 const { sequelize } = require('../db/models');
 
-logger.debug(`App environment: ${process.env.NODE_ENV || 'development'}`);
+logger.debug(`App environment: ${config.util.getEnv('NODE_ENV')}`);
 
 /**
  * Normalize a port into a number, string, or false.

--- a/bin/www
+++ b/bin/www
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 'use strict';
-/* eslint-disable no-console */
 const http = require('http');
 const config = require('config');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "start-dev": "nodemon --inspect ./bin/www",
-    "start-test": "DB_CONNECTION_URI=sqlite://:memory && PORT=8090 && TEST_SERVER=true && npm run start",
+    "start-test": "DB_CONNECTION_URI=sqlite://:memory PORT=8090 TEST_SERVER=true npm run start",
     "lint": "eslint . bin/* --ext .js,.vue",
     "format": "prettier --write **/*.{js,scss,vue}",
     "test-unit": "jest --maxWorkers=4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "start-dev": "nodemon --inspect ./bin/www",
-    "start-test": "./bin/start-test-server",
+    "start-test": "DB_CONNECTION_URI=sqlite://:memory && PORT=8090 && TEST_SERVER=true && npm run start",
     "lint": "eslint . --ext .js,.vue",
     "format": "prettier --write **/*.{js,scss,vue}",
     "test-unit": "jest --maxWorkers=4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node ./bin/www",
     "start-dev": "nodemon --inspect ./bin/www",
     "start-test": "DB_CONNECTION_URI=sqlite://:memory && PORT=8090 && TEST_SERVER=true && npm run start",
-    "lint": "eslint . --ext .js,.vue",
+    "lint": "eslint . bin/* --ext .js,.vue",
     "format": "prettier --write **/*.{js,scss,vue}",
     "test-unit": "jest --maxWorkers=4",
     "test": "npm run lint && npm run test-unit",


### PR DESCRIPTION
Clean up `bin/`. `start-test-server` is simple enough that we can inline it into a npm script leaving the bin directory solely for executable node scripts; meaning we can lint this directory too.

Removes some awkwardness with `util.promisify` in favour of standard callback style and runs a prettier autoformat on all of `bin`