### PR TITLE
Track clicks on email expiry prompts

### DIFF
--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -238,6 +238,14 @@ function initFormRouter({
      * Route: Edit application
      */
     router.get('/edit/:applicationId', function(req, res) {
+        // If this link includes a source (s) parameter, track it
+        // eg. to analyse usage of expiry reminder emails
+        if (get(req.query, 's') === 'expiryEmail') {
+            commonLogger.info('User clicked edit link on expiry email', {
+                service: 'apply',
+                formId: formId
+            });
+        }
         redirectCurrentlyEditing(req, res, req.params.applicationId);
     });
 

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -240,7 +240,7 @@ function initFormRouter({
     router.get('/edit/:applicationId', function(req, res) {
         // If this link includes a source (s) parameter, track it
         // eg. to analyse usage of expiry reminder emails
-        if (get(req.query, 's') === 'expiryEmail') {
+        if (req.query.s === 'expiryEmail') {
             commonLogger.info('User clicked edit link on expiry email', {
                 service: 'apply',
                 formId: formId

--- a/controllers/apply/form-router-next/views/expiry-email.njk
+++ b/controllers/apply/form-router-next/views/expiry-email.njk
@@ -15,7 +15,7 @@
 
     <p>
         <strong>To finish your application</strong><br/>
-        <a href="https://www.tnlcommunityfund.org.uk/apply/awards-for-all/">Log in to your account</a> and answer the rest of the questions.
+        <a href="https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/{{ application.id }}?s=expiryEmail">Log in to your account</a> and answer the rest of the questions.
     </p>
 
     <p>


### PR DESCRIPTION
We can link users directly to their expiring application in the emails, and also track when they click on these links so we have some idea of how effective these reminders are. Confirmed this works as expected locally.