### PR TITLE
Forgot password unregistered

### DIFF
--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -135,6 +135,9 @@ router
                         logger.info('Password reset request succeeded');
                         renderForgotForm(req, res);
                     }
+                } else {
+                    logger.info('Password reset request for unregistered user');
+                    renderForgotForm(req, res);
                 }
             } catch (error) {
                 logger.warn('Password reset request failed');

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -342,7 +342,7 @@ it('should be able to reset password while logged out', () => {
     });
 });
 
-it.only('should return forgotten password screen for invalid accounts', () => {
+it('should return forgotten password screen for invalid accounts', () => {
     cy.visit('/user/password/forgot');
 
     cy.findByLabelText('Email address', { exact: false }).type(
@@ -355,6 +355,10 @@ it.only('should return forgotten password screen for invalid accounts', () => {
     cy.get('.form-actions').within(() => {
         cy.findByText('Reset password').click();
     });
+
+    cy.findByText('Password reset requested', { exact: false }).should(
+        'be.visible'
+    );
 });
 
 it('should allow survey API responses', () => {

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -342,6 +342,21 @@ it('should be able to reset password while logged out', () => {
     });
 });
 
+it.only('should return forgotten password screen for invalid accounts', () => {
+    cy.visit('/user/password/forgot');
+
+    cy.findByLabelText('Email address', { exact: false }).type(
+        'not.registered@example.com',
+        {
+            delay: 0
+        }
+    );
+
+    cy.get('.form-actions').within(() => {
+        cy.findByText('Reset password').click();
+    });
+});
+
 it('should allow survey API responses', () => {
     const dataYes = {
         choice: 'yes',

--- a/lambda/lambda-expiry.js
+++ b/lambda/lambda-expiry.js
@@ -1,4 +1,5 @@
 'use strict';
+/* eslint-disable no-console */
 const querystring = require('querystring');
 const https = require('https');
 


### PR DESCRIPTION
Identified a bug where forgotten password requests for _unregistered_ users would hang. Steps to reproduce:

- Go to https://www.tnlcommunityfund.org.uk/user/password/forgot
- Enter an unregistered email address

Expected behaviour is that a placebo version of the forgotten password confirmation screen should be shown.

Added a cypress test for unregistered accounts to confirm the bug and implemented a fix.