### PR TITLE
Remove name change banner

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -7,7 +7,6 @@ global:
     facebook: http://www.facebook.com/TNLCommunityFundWales
     instagram: https://www.instagram.com/TNLCommunityFund
     twitter: CronGymYLG
-    nameChange: Rydym wedi newid ein henw o’r Gronfa Loteri Fawr i <strong>Gronfa Gymunedol y Loteri Genedlaethol</strong>.
   regions:
     england: Lloegr
     wales: Cymru

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,6 @@ global:
     facebook: http://www.facebook.com/TNLCommunityFund
     instagram: https://www.instagram.com/TNLCommunityFund
     twitter: TNLComFund
-    nameChange: We have changed our name from the Big Lottery Fund to <strong>The National Lottery Community Fund</strong>.
   regions:
     england: England
     wales: Wales

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -26,13 +26,6 @@
                 <aside class="announcement-banner announcement-banner--info">
                     ✋ This is a test environment. Please do not share this page.
                 </aside>
-            {% else %}
-                <aside class="announcement-banner">
-                    {{ globalCopy.brand.nameChange | safe }}
-                    <a href="{{ localify('/news/press-releases/2019-01-29/national-lottery-good-cause-funders-unveil-new-brand') }}">
-                        {{ __('global.misc.readMore') }}
-                    </a>
-                </aside>
             {% endif %}
 
             {# Cookie consent #}


### PR DESCRIPTION
Big change. @LynseyJReynolds and I did some digging and confirmed that very low numbers of people interact with this banner now, the majority of traffic to the press release is via google and the overall numbers are low. We think we can safely remove this now, particularly as we are about to make the header busier with a global login link.

![image](https://user-images.githubusercontent.com/123386/66401484-20dd6280-e9db-11e9-9705-9d1a392e9aa7.png)
