### PR TITLE
Fix date errors

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -245,14 +245,28 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     }
 
     function dateOfBirthField(minAge, props) {
+        const exampleDateFormat = '30 02 1980';
         const defaultProps = {
             explanation: localise({
-                en: oneLine`We need their date of birth to help confirm who they are.
-                    And we do check their date of birth. So make sure you've entered it right.
-                    If you don't, it could delay your application.`,
-                cy: oneLine`Rydym angen eu dyddiad geni i helpu cadarnhau pwy ydynt.
-                    Rydym yn gwirio eu dyddiad geni. Felly sicrhewch eich bod wedi ei roi yn gywir.
-                    Os nad ydych, gall oedi eich cais.`
+                en: `
+                    <p>
+                        We need their date of birth to help confirm who they are.
+                        And we do check their date of birth. So make sure you've entered it right.
+                        If you don't, it could delay your application.
+                    </p>
+                    <p>
+                        <strong>For example: ${exampleDateFormat}</strong>
+                    </p>
+                `,
+                cy: `
+                    <p>
+                        Rydym angen eu dyddiad geni i helpu cadarnhau pwy ydynt.
+                        Rydym yn gwirio eu dyddiad geni. Felly sicrhewch eich bod wedi ei roi yn gywir.
+                        Os nad ydych, gall oedi eich cais.
+                    </p>
+                    <p>
+                        <strong>Er enghraifft: ${exampleDateFormat}</strong>
+                    </p>`
             }),
             type: 'date',
             attributes: {
@@ -1276,20 +1290,17 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             ]
         },
         organisationStartDate: fieldOrganisationStartDate(locale),
-        organisationAddress: fieldAddress(
-            locale,
-            {
-                name: 'organisationAddress',
-                label: localise({
-                    en: `What is the main or registered address of your organisation?`,
-                    cy: `Beth yw prif gyfeiriad neu gyfeiriad gofrestredig eich sefydliad?`
-                }),
-                explanation: localise({
-                    en: `<p>Enter the postcode and search for the address, or enter it manually below.`,
-                    cy: `Rhowch y cod post a chwiliwch am y cyfeiriad, neu ei deipio isod.`
-                })
-            }
-        ),
+        organisationAddress: fieldAddress(locale, {
+            name: 'organisationAddress',
+            label: localise({
+                en: `What is the main or registered address of your organisation?`,
+                cy: `Beth yw prif gyfeiriad neu gyfeiriad gofrestredig eich sefydliad?`
+            }),
+            explanation: localise({
+                en: `<p>Enter the postcode and search for the address, or enter it manually below.`,
+                cy: `Rhowch y cod post a chwiliwch am y cyfeiriad, neu ei deipio isod.`
+            })
+        }),
         organisationType: fieldOrganisationType(locale),
         organisationSubTypeStatutoryBody: {
             name: 'organisationSubType',
@@ -1606,17 +1617,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: `A ydynt wedi byw yn eu cyfeiriad cartref am y tair blynedd diwethaf?`
             })
         }),
-        seniorContactEmail: fieldEmail(
-            locale,
-            {
-                name: 'seniorContactEmail',
-                explanation: localise({
-                    en: 'We’ll use this whenever we get in touch about the project',
-                    cy:
-                        'Byddwn yn defnyddio hwn pan fyddwn yn cysylltu ynglŷn â’r prosiect'
-                })
-            }
-        ),
+        seniorContactEmail: fieldEmail(locale, {
+            name: 'seniorContactEmail',
+            explanation: localise({
+                en: 'We’ll use this whenever we get in touch about the project',
+                cy:
+                    'Byddwn yn defnyddio hwn pan fyddwn yn cysylltu ynglŷn â’r prosiect'
+            })
+        }),
         seniorContactPhone: fieldPhone(locale, {
             name: 'seniorContactPhone'
         }),

--- a/controllers/apply/awards-for-all/fields/project-date-range.js
+++ b/controllers/apply/awards-for-all/fields/project-date-range.js
@@ -97,7 +97,7 @@ module.exports = function(locale) {
                 })
             },
             {
-                type: 'datesRange.startDate.invalid',
+                type: 'dateRange.startDate.invalid',
                 message: localise({
                     en: `Date you start the project must be a real date`,
                     cy: `Rhaid i ddyddiad dechrau’r prosiect fod yn un go iawn`

--- a/controllers/apply/awards-for-all/fields/project-date-range.js
+++ b/controllers/apply/awards-for-all/fields/project-date-range.js
@@ -15,12 +15,11 @@ module.exports = function(locale) {
 
     const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
 
-    function formatAfterDate() {
+    function formatAfterDate(format = 'D MMMM YYYY') {
         return minDate
             .clone()
-            .subtract(1, 'days')
             .locale(locale)
-            .format('D MMMM YYYY');
+            .format(format);
     }
 
     return {
@@ -35,7 +34,7 @@ module.exports = function(locale) {
         explanation: localise({
             en: `<p>
                 If you don't know exactly, your dates can be estimates.
-                But you need to start your project after
+                But you need to start your project on or after
                 ${formatAfterDate()}.
             </p>
             <p>
@@ -50,6 +49,9 @@ module.exports = function(locale) {
             <p>
                 Just let us know the date you plan to hold the event
                 in the start and end date boxes below.
+            </p>
+            <p>
+                <strong>For example: ${formatAfterDate('MM DD YYYY')}</strong>
             </p>`,
 
             cy: `<p>
@@ -71,6 +73,9 @@ module.exports = function(locale) {
             <p>
                 Gadewch i ni wybod y dyddiad rydych yn bwriadu cynnal y
                 digwyddiad yn y bocsys dyddiad dechrau a gorffen isod. 
+            </p>
+            <p>
+                <strong>Er enghraifft: ${formatAfterDate('DD MM YYYY')}</strong>
             </p>`
         }),
         type: 'date-range',

--- a/controllers/apply/awards-for-all/fields/project-date-range.js
+++ b/controllers/apply/awards-for-all/fields/project-date-range.js
@@ -56,7 +56,7 @@ module.exports = function(locale) {
 
             cy: `<p>
                 Os nad ydych yn gwybod yn union, gall eich dyddiadau fod yn amcangyfrifon.
-                Ond mae angen i chi ddechrau eich prosiect ar ôl 
+                Ond mae angen i chi ddechrau eich prosiect ar neu ar ôl 
                 ${formatAfterDate()}.
             </p>
             <p>

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -412,6 +412,7 @@ module.exports = function({
                 en: `People who speak Welsh`,
                 cy: `Pobl sy’n siarad Cymraeg`
             }),
+            noValidate: true,
             fieldsets: [
                 {
                     legend: localise({
@@ -435,6 +436,7 @@ module.exports = function({
                 en: `Northern Ireland community`,
                 cy: `Cymuned Gogledd Iwerddon`
             }),
+            noValidate: true,
             fieldsets: [
                 {
                     legend: localise({


### PR DESCRIPTION
Few things here. 

Adds some missing example formats to date fields:

![image](https://user-images.githubusercontent.com/394376/66650177-df8dc280-ec27-11e9-91d2-f8dfb393e282.png)

Simplifies things with "on or after" and a valid date, rather than invalid:
![image](https://user-images.githubusercontent.com/394376/66650157-d3096a00-ec27-11e9-97a1-67a2ead49e45.png)

Fixes a typo which prevented this error from showing up for invalid start dates:

![image](https://user-images.githubusercontent.com/394376/66650169-db61a500-ec27-11e9-9c4e-2cdefc525d3d.png)
