### PR TITLE
data-hj-whitelist only applies to inputs

### DIFF
--- a/assets/js/vue-apps/form-components/word-count.vue
+++ b/assets/js/vue-apps/form-components/word-count.vue
@@ -77,7 +77,6 @@ export default {
         aria-live="polite"
         aria-atomic="true"
         data-testid="word-count"
-        data-hj-whitelist
     >
         <span class="word-count__counter" v-html="currentCountMessage"></span>
         <span class="word-count__message" v-html="helpMessage"></span>

--- a/controllers/errors/views/error.njk
+++ b/controllers/errors/views/error.njk
@@ -6,7 +6,7 @@
     <main role="main">
         {{ hero(title, fallbackHeroImage) }}
 
-        <div class="nudge-up" data-hj-whitelist>
+        <div class="nudge-up">
             {% call contentBox() %}
                 <h2>Error {{ status }}</h2>
 


### PR DESCRIPTION
According to hotjar docs `data-hj-whitelist` only applies to inputs. Numeric blacklisting is handled via an account level setting so is a global config.