### PR TITLE
Enabling global login on test site as well

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -5,7 +5,8 @@
     }
   },
   "features": {
-    "enableHotjar": true
+    "enableHotjar": true,
+    "enableGlobalHeaderLogin": true
   },
   "awardsForAll": {
     "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]


### PR DESCRIPTION
Building on top of https://github.com/biglotteryfund/blf-alpha/pull/2469 to enable the global login feature on test site as well.