### PR TITLE
Updated action-card style

### DIFF
--- a/assets/sass/components/_applications.scss
+++ b/assets/sass/components/_applications.scss
@@ -301,6 +301,7 @@ $statuses: (
    ========================================================================= */
 
 .application-card-new {
+    box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.1);
     max-width: 30em;
     margin-bottom: $spacingUnit / 2;
     padding: 12px;
@@ -309,8 +310,6 @@ $statuses: (
         padding: $spacingUnit;
         padding-right: $spacingUnit * 2;
     }
-
-    box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.1);
 
     .application-card-new__overview {
         margin-bottom: $spacingUnit;

--- a/assets/sass/components/_cards.scss
+++ b/assets/sass/components/_cards.scss
@@ -5,6 +5,7 @@
 /* =========================================================================
    Basic Card
    ========================================================================= */
+
 .card {
     padding: 12px;
     background-color: get-color('background', 'light-neutral');
@@ -32,6 +33,7 @@
 /* =========================================================================
    Media Object Card
    ========================================================================= */
+
 /**
  * Media object card
  * https://philipwalton.github.io/solved-by-flexbox/demos/media-object/
@@ -159,5 +161,28 @@
                 padding: $spacingUnit;
             }
         }
+    }
+}
+
+/* =========================================================================
+   Action Card
+   ========================================================================= */
+
+.action-card {
+    display: flex;
+    flex-flow: column nowrap;
+    flex: 1 1 0%;
+
+    box-shadow: 0 2px 6px 1px rgba(0, 0, 0, 0.1);
+    max-width: 30em;
+    margin-bottom: $spacingUnit / 2;
+    padding: 12px;
+
+    @include mq('medium') {
+        padding: $spacingUnit $spacingUnit * 2 $spacingUnit $spacingUnit;
+    }
+
+    .action-card__footer {
+        margin-top: auto;
     }
 }

--- a/controllers/digital-fund/views/landing.njk
+++ b/controllers/digital-fund/views/landing.njk
@@ -20,19 +20,19 @@
 
                 <div class="flex-grid">
                     <div class="flex-grid__item">
-                        {% call actionCard({
+                        {{ actionCard({
                             title: copy.strand1.title,
+                            description: copy.strand1.introduction,
                             link: {
                                 url: localify('/funding/programmes/digital-fund/strand-1'),
                                 label: copy.aboutStrandLabel
                             }
-                        }) %}
-                            <p>{{ copy.strand1.introduction | safe }}</p>
-                        {% endcall %}
+                        }) }}
                     </div>
                     <div class="flex-grid__item">
                         {% call actionCard({
                             title: copy.strand2.title,
+                            description: copy.strand2.introduction,
                             link: {
                                 url: localify('/funding/programmes/digital-fund/strand-2'),
                                 label: copy.aboutStrandLabel

--- a/controllers/digital-fund/views/strand.njk
+++ b/controllers/digital-fund/views/strand.njk
@@ -4,7 +4,6 @@
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/segment-links/macro.njk" import segmentLinks %}
 {% from "components/step-progress/macro.njk" import stepProgress %}
-{% from "components/action-card/macro.njk" import actionCard %}
 
 {% block content %}
     <main role="main" id="content">

--- a/views/components/action-card/examples.njk
+++ b/views/components/action-card/examples.njk
@@ -2,12 +2,19 @@
 {% from "./macro.njk" import actionCard %}
 
 {% call sgExample('Defaults') %}
-    {% call actionCard({
-        title: 'We want to use digital to change our work',
-        link: { url: '#', label: 'Find out more about this strand' }
-    }) %}
-        <p>Digital Fund Strand 1 offers grants of up to £500,000 and a tailored support package. The aim is to help established charities use digital to take a major leap forward. We expect grants to last from 1 to 4 years.</p>
-    {% endcall %}
+    {{ actionCard({
+        title: 'Funding under £10,000: Start an application',
+        description: "National Lottery Awards for All—A quick way to apply for smaller amounts of funding between £300 and £10,000.",
+        link: { url: '#', label: 'Button label' }
+    }) }}
+{% endcall %}
+
+{% call sgExample('Secondary style') %}
+    {{ actionCard({
+        title: 'Funding under £10,000: Start an application',
+        description: "National Lottery Awards for All—A quick way to apply for smaller amounts of funding between £300 and £10,000.",
+        link: { url: '#', label: 'Button label' }
+    }, isSecondary = true) }}
 {% endcall %}
 
 {% call sgUsage() %}

--- a/views/components/action-card/macro.njk
+++ b/views/components/action-card/macro.njk
@@ -1,14 +1,16 @@
-{% macro actionCard(props) %}
-    <div class="card">
-        <header class="card__header">
-            <h3 class="card__title">{{ props.title }}</h3>
+{% macro actionCard(props, isSecondary = false) %}
+    <div class="action-card">
+        <header class="action-card__header">
+            <h3 class="action-card__title{% if not isSecondary %} u-tone-brand-primary{% endif %}">
+                {{ props.title | widont | safe }}
+            </h3>
         </header>
-        <div class="card__body">
-            {{ caller() }}
+        <div class="action-card__body u-text-medium">
+            <p>{{ props.description | safe }}</p>
         </div>
         {% if props.link.url %}
-            <div class="card__footer">
-                <a href="{{ props.link.url }}" class="btn btn--medium">
+            <div class="action-card__footer">
+                <a href="{{ props.link.url }}" class="btn btn--medium{% if isSecondary %} btn--outline{% endif %}">
                     {{ props.link.label }}
                 </a>
             </div>


### PR DESCRIPTION
Builds off https://github.com/biglotteryfund/blf-alpha/pull/2495

One of the two card styles for the new dashboards is an "action card", we already have a pattern like this which we used for the digital fund pages. Rather than creating a completely new pattern I thought it made sense to repurpose this.

<img width="574" alt="Screenshot 2019-10-17 at 15 11 45" src="https://user-images.githubusercontent.com/123386/67016799-b1f5bd00-f0f0-11e9-9255-45f941df7c70.png">

Side-effect is that is naturally changes the digital fund pages, but I think this makes sense for consistency and is fairly low risk as that fund is closed for applications.

**Before**

![image](https://user-images.githubusercontent.com/123386/67016892-d5b90300-f0f0-11e9-82e8-bba2e4753bf1.png)


**After**

![image](https://user-images.githubusercontent.com/123386/67016930-e10c2e80-f0f0-11e9-91b4-f05429b95dd8.png)

