### PR TITLE
Add new Funding section

### DIFF
--- a/assets/sass/scaffolding/_grid.scss
+++ b/assets/sass/scaffolding/_grid.scss
@@ -13,8 +13,12 @@ $flexGridSpacing: $spacingUnit;
  */
 .flex-grid {
     @include reset-list();
-    // Overrides constrained content containers
-    max-width: 100% !important;
+
+    .u-constrained-content-wide & {
+        // Overrides constrained content containers
+        // eg. grids within flexible content areas
+        max-width: 100% !important;
+    }
 
     @include mq('medium-minor') {
         display: flex;

--- a/controllers/common/basicContent.test.js
+++ b/controllers/common/basicContent.test.js
@@ -1,0 +1,103 @@
+/* eslint-env jest */
+'use strict';
+const { getChildrenLayoutMode } = require('./index');
+
+describe('CMS page templates', () => {
+    it('should work out feasible child page layout mode', () => {
+        const pageGrid = {
+            title: 'foo',
+            childPageDisplay: 'grid',
+            children: [
+                {
+                    title: 'bar',
+                    trailImage: 'bar.jpg'
+                },
+                {
+                    title: 'baz',
+                    trailImage: 'baz.jpg'
+                }
+            ]
+        };
+
+        expect(getChildrenLayoutMode(pageGrid)).toEqual('grid');
+
+        const pageGridMissingImages = {
+            title: 'foo',
+            childPageDisplay: 'grid',
+            children: [
+                {
+                    title: 'bar',
+                    trailImage: 'bar.jpg'
+                },
+                {
+                    title: 'baz',
+                    trailImage: 'baz.jpg'
+                },
+                {
+                    title: 'test'
+                }
+            ]
+        };
+
+        expect(getChildrenLayoutMode(pageGridMissingImages)).toEqual('list');
+
+        const pageList = {
+            title: 'foo',
+            childPageDisplay: 'list',
+            children: [
+                {
+                    title: 'bar',
+                    trailImage: 'bar.jpg'
+                },
+                {
+                    title: 'baz',
+                    trailImage: 'baz.jpg'
+                },
+                {
+                    title: 'test'
+                }
+            ]
+        };
+
+        expect(getChildrenLayoutMode(pageList)).toEqual('list');
+
+        const pageNone = {
+            title: 'foo',
+            childPageDisplay: 'none',
+            children: [
+                {
+                    title: 'bar',
+                    trailImage: 'bar.jpg'
+                },
+                {
+                    title: 'baz',
+                    trailImage: 'baz.jpg'
+                },
+                {
+                    title: 'test'
+                }
+            ]
+        };
+
+        expect(getChildrenLayoutMode(pageNone)).toEqual(false);
+
+        const pageUnspecified = {
+            title: 'foo',
+            children: [
+                {
+                    title: 'bar',
+                    trailImage: 'bar.jpg'
+                },
+                {
+                    title: 'baz',
+                    trailImage: 'baz.jpg'
+                },
+                {
+                    title: 'test'
+                }
+            ]
+        };
+
+        expect(getChildrenLayoutMode(pageUnspecified)).toEqual(false);
+    });
+});

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -79,44 +79,33 @@ function basicContent({ lang = null, customTemplate = null } = {}) {
                 /**
                  * Determine template to render:
                  * 1. If using a custom template defer to that
-                 * 2. If the response has child pages then render a listing page
-                 * 3. Otherwise, render an information page
+                 * 2. Otherwise, render a "CMS page" which handles child pages and content alike
                  */
                 if (customTemplate) {
                     res.render(customTemplate);
-                } else if (content.children) {
-                    // What layout mode should we use? (eg. do all of the children have an image?)
-                    const missingTrailImages = content.children.some(
-                        page => !page.trailImage
-                    );
-                    const childrenLayoutMode = missingTrailImages
-                        ? 'plain'
-                        : 'heroes';
-                    if (missingTrailImages) {
-                        content.children = content.children.map(page => {
-                            return {
-                                href: page.linkUrl,
-                                label: page.trailText || page.title
-                            };
-                        });
-                    }
-                    res.render(
-                        path.resolve(__dirname, './views/listing-page'),
-                        {
-                            childrenLayoutMode: childrenLayoutMode
-                        }
-                    );
-                } else if (
-                    content.introduction ||
-                    content.segments.length > 0 ||
-                    content.flexibleContent.length > 0
-                ) {
-                    // ↑ information pages must have at least an introduction or some content segments
-                    res.render(
-                        path.resolve(__dirname, './views/information-page')
-                    );
                 } else {
-                    next();
+                    let childrenLayoutMode = false;
+                    if (content.children) {
+                        // What layout mode should we use? (eg. do all of the children have an image?)
+                        const missingTrailImages = content.children.some(
+                            page => !page.trailImage
+                        );
+                        childrenLayoutMode = missingTrailImages
+                            ? 'plain'
+                            : 'heroes';
+                        if (missingTrailImages) {
+                            content.children = content.children.map(page => {
+                                return {
+                                    href: page.linkUrl,
+                                    label: page.trailText || page.title
+                                };
+                            });
+                        }
+                    }
+
+                    res.render(path.resolve(__dirname, './views/cms-page'), {
+                        childrenLayoutMode: childrenLayoutMode
+                    });
                 }
             } else {
                 next();

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -84,23 +84,36 @@ function basicContent({ lang = null, customTemplate = null } = {}) {
                 if (customTemplate) {
                     res.render(customTemplate);
                 } else {
-                    let childrenLayoutMode = false;
+                    let childrenLayoutMode = 'list';
+                    const childPageDisplay = content.childPageDisplay;
+
+                    // This page should show a grid of child images
+                    // but do they all have images we can use?
                     if (content.children) {
-                        // What layout mode should we use? (eg. do all of the children have an image?)
                         const missingTrailImages = content.children.some(
                             page => !page.trailImage
                         );
-                        childrenLayoutMode = missingTrailImages
-                            ? 'plain'
-                            : 'heroes';
-                        if (missingTrailImages) {
-                            content.children = content.children.map(page => {
-                                return {
-                                    href: page.linkUrl,
-                                    label: page.trailText || page.title
-                                };
-                            });
+                        if (
+                            childPageDisplay === 'grid' &&
+                            !missingTrailImages
+                        ) {
+                            childrenLayoutMode = 'grid';
+                        } else if (
+                            !childPageDisplay ||
+                            childPageDisplay === 'none'
+                        ) {
+                            childrenLayoutMode = false;
                         }
+                    }
+
+                    // Reformat the child pages for plain-text links
+                    if (content.children && childrenLayoutMode === 'list') {
+                        content.children = content.children.map(page => {
+                            return {
+                                href: page.linkUrl,
+                                label: page.trailText || page.title
+                            };
+                        });
                     }
 
                     res.render(path.resolve(__dirname, './views/cms-page'), {

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const express = require('express');
-const { isEmpty } = require('lodash');
+const { isEmpty, get } = require('lodash');
 const path = require('path');
 const Sentry = require('@sentry/node');
 
@@ -13,6 +13,28 @@ const {
 } = require('../../common/inject-content');
 const { isWelsh } = require('../../common/urls');
 const contentApi = require('../../common/content-api');
+
+function getChildrenLayoutMode(content) {
+    let childrenLayoutMode = 'list';
+    const childPageDisplay = get(content, 'childPageDisplay');
+
+    // This page should show a grid of child images
+    // but do they all have images we can use?
+    if (content.children) {
+        const missingTrailImages = content.children.some(
+            page => !page.trailImage
+        );
+        if (childPageDisplay === 'grid' && !missingTrailImages) {
+            childrenLayoutMode = 'grid';
+        } else if (
+            !childPageDisplay ||
+            childPageDisplay === 'none'
+        ) {
+            childrenLayoutMode = false;
+        }
+    }
+    return childrenLayoutMode;
+}
 
 function staticPage({
     lang = null,
@@ -64,7 +86,11 @@ function staticPage({
     return router;
 }
 
-function basicContent({ lang = null, customTemplate = null } = {}) {
+function basicContent({
+    lang = null,
+    customTemplate = null,
+    cmsPage = false
+} = {}) {
     const router = express.Router();
 
     router.get(
@@ -75,51 +101,59 @@ function basicContent({ lang = null, customTemplate = null } = {}) {
         (req, res, next) => {
             const { content } = res.locals;
 
-            if (content) {
-                /**
-                 * Determine template to render:
-                 * 1. If using a custom template defer to that
-                 * 2. Otherwise, render a "CMS page" which handles child pages and content alike
-                 */
-                if (customTemplate) {
-                    res.render(customTemplate);
-                } else {
-                    let childrenLayoutMode = 'list';
-                    const childPageDisplay = content.childPageDisplay;
+            /**
+             * Determine template to render:
+             * 1. If using a custom template defer to that
+             * 2. If using the new CMS page style, use that template
+             * 2. If the response has child pages then render a listing page
+             * 3. Otherwise, render an information page
+             */
+            if (customTemplate) {
+                res.render(customTemplate);
+            } else if (cmsPage) {
+                const childrenLayoutMode = getChildrenLayoutMode(content);
 
-                    // This page should show a grid of child images
-                    // but do they all have images we can use?
-                    if (content.children) {
-                        const missingTrailImages = content.children.some(
-                            page => !page.trailImage
-                        );
-                        if (
-                            childPageDisplay === 'grid' &&
-                            !missingTrailImages
-                        ) {
-                            childrenLayoutMode = 'grid';
-                        } else if (
-                            !childPageDisplay ||
-                            childPageDisplay === 'none'
-                        ) {
-                            childrenLayoutMode = false;
-                        }
-                    }
-
-                    // Reformat the child pages for plain-text links
-                    if (content.children && childrenLayoutMode === 'list') {
-                        content.children = content.children.map(page => {
-                            return {
-                                href: page.linkUrl,
-                                label: page.trailText || page.title
-                            };
-                        });
-                    }
-
-                    res.render(path.resolve(__dirname, './views/cms-page'), {
-                        childrenLayoutMode: childrenLayoutMode
+                // Reformat the child pages for plain-text links
+                if (content.children && childrenLayoutMode === 'list') {
+                    content.children = content.children.map(page => {
+                        return {
+                            href: page.linkUrl,
+                            label: page.trailText || page.title
+                        };
                     });
                 }
+
+                res.render(path.resolve(__dirname, './views/cms-page'), {
+                    childrenLayoutMode: childrenLayoutMode
+                });
+            } else if (content.children) {
+                // @TODO eventually deprecate these templates in favour of CMS pages (above)
+
+                // What layout mode should we use? (eg. do all of the children have an image?)
+                const missingTrailImages = content.children.some(
+                    page => !page.trailImage
+                );
+                const childrenLayoutMode = missingTrailImages
+                    ? 'plain'
+                    : 'heroes';
+                if (missingTrailImages) {
+                    content.children = content.children.map(page => {
+                        return {
+                            href: page.linkUrl,
+                            label: page.trailText || page.title
+                        };
+                    });
+                }
+                res.render(path.resolve(__dirname, './views/listing-page'), {
+                    childrenLayoutMode: childrenLayoutMode
+                });
+            } else if (
+                content.introduction ||
+                content.segments.length > 0 ||
+                content.flexibleContent.length > 0
+            ) {
+                // ↑ information pages must have at least an introduction or some content segments
+                res.render(path.resolve(__dirname, './views/information-page'));
             } else {
                 next();
             }
@@ -156,5 +190,6 @@ function flexibleContent() {
 module.exports = {
     basicContent,
     flexibleContent,
-    staticPage
+    staticPage,
+    getChildrenLayoutMode
 };

--- a/controllers/common/views/cms-page.njk
+++ b/controllers/common/views/cms-page.njk
@@ -1,0 +1,120 @@
+{% from "components/hero.njk" import hero with context %}
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/content-box/macro.njk" import contentBox %}
+{% from "components/segment-links/macro.njk" import segmentLinks %}
+{% from "components/segment/macro.njk" import segment %}
+{% from "components/flexible-content/macro.njk" import flexibleContentPart %}
+{% from "components/miniature-hero/macro.njk" import miniatureHero %}
+{% from "components/section-links/macro.njk" import sectionLinks %}
+
+{% extends "layouts/main.njk" %}
+{% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
+
+{% set flexAnchor = 'item' %}
+
+{% block content %}
+
+    {% if pageHero.image %}
+        {{ hero(title, pageHero.image) }}
+    {% endif %}
+
+
+    <main role="main" id="content" {% if pageHero.image %}class="nudge-up"{% endif %}>
+        {% block contentPrimary %}
+
+            {% if content.introduction %}
+                <section class="content-box u-inner-wide-only">
+                    {{ breadcrumbTrail(breadcrumbs) }}
+
+                    <div class="s-prose u-constrained-content-wide">
+                        {% if not pageHero.image %}
+                            <h1>{{ content.title }}</h1>
+                        {% endif %}
+                        {{ content.introduction | safe }}
+                    </div>
+                    {% if not childrenLayoutMode %}
+                        {% if content.segments.length > 0 %}
+                            {{ segmentLinks(content.segments) }}
+                        {% endif %}
+                        {% if content.flexibleContent %}
+                            {{ segmentLinks(content.flexibleContent, anchor = flexAnchor) }}
+                        {% endif %}
+                    {% endif %}
+                </section>
+            {% endif %}
+
+            {# Content segments #}
+            {% if content.segments.length > 0 %}
+                <div class="u-inner-wide-only u-constrained-content-wide">
+                    {% for contentSegment in content.segments %}
+                        {% call segment(
+                            id = 'segment-' + loop.index,
+                            title = contentSegment.title,
+                            imagePath = contentSegment.photo
+                        ) %}
+                            {{ contentSegment.content | safe }}
+                        {% endcall %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            {# Flexible content #}
+            {% if content.flexibleContent %}
+                {% for part in content.flexibleContent %}
+                    <section class="content-box u-inner-wide-only"
+                             id="{{ flexAnchor + '-' + loop.index }}">
+
+                        {# Show breadcrumbs inside the first item's container if they weren't already shown #}
+                        {% if loop.first and not content.introduction %}
+                            {{ breadcrumbTrail(breadcrumbs) }}
+                        {% endif %}
+
+                        <div class="s-prose u-constrained-content-wide">
+                            {{ flexibleContentPart(part) }}
+                        </div>
+
+                        {# Show links to the child pages inside the first item if it's a single-item list #}
+                        {% if loop.last and
+                            childrenLayoutMode === 'plain' and
+                            content.children.length > 0 and
+                            content.flexibleContent.length === 1 %}
+                            {{ sectionLinks(content.children) }}
+                        {% endif %}
+                    </section>
+                {% endfor %}
+            {% endif %}
+
+        {% endblock %}
+
+
+        {% if content.children.length > 0 %}
+            {% if childrenLayoutMode === 'heroes' %}
+                <section class="u-inner">
+                    <ul class="flex-grid">
+                        {% for page in content.children %}
+                            <li class="flex-grid__item">
+                                {{ miniatureHero({
+                                    "title": page.trailText | default(page.title, true),
+                                    "linkUrl": page.linkUrl,
+                                    "image": { "url": page.trailImage if page.trailImage else page.photo }
+                                }, isLarge = true) }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
+            {% elseif childrenLayoutMode === 'plain' and content.flexibleContent.length > 1 %}
+                {# Show the child page links if they weren't shown above (eg. multi-item flexible content #}
+                <section class="content-box u-inner-wide-only">
+                    {{ sectionLinks(content.children) }}
+                </section>
+            {% endif %}
+        {% endif %}
+
+        {% if content.outro %}
+            {% call contentBox() %}
+                {{ content.outro | safe }}
+            {% endcall %}
+        {% endif %}
+
+    </main>
+{% endblock %}

--- a/controllers/common/views/cms-page.njk
+++ b/controllers/common/views/cms-page.njk
@@ -18,7 +18,6 @@
         {{ hero(title, pageHero.image) }}
     {% endif %}
 
-
     <main role="main" id="content" {% if pageHero.image %}class="nudge-up"{% endif %}>
         {% block contentPrimary %}
 
@@ -75,7 +74,7 @@
 
                         {# Show links to the child pages inside the first item if it's a single-item list #}
                         {% if loop.last and
-                            childrenLayoutMode === 'plain' and
+                            childrenLayoutMode === 'list' and
                             content.children.length > 0 and
                             content.flexibleContent.length === 1 %}
                             {{ sectionLinks(content.children) }}
@@ -88,7 +87,7 @@
 
 
         {% if content.children.length > 0 %}
-            {% if childrenLayoutMode === 'heroes' %}
+            {% if childrenLayoutMode === 'grid' %}
                 <section class="u-inner">
                     <ul class="flex-grid">
                         {% for page in content.children %}
@@ -102,7 +101,7 @@
                         {% endfor %}
                     </ul>
                 </section>
-            {% elseif childrenLayoutMode === 'plain' and content.flexibleContent.length > 1 %}
+            {% elseif childrenLayoutMode === 'list' and content.flexibleContent.length > 1 %}
                 {# Show the child page links if they weren't shown above (eg. multi-item flexible content #}
                 <section class="content-box u-inner-wide-only">
                     {{ sectionLinks(content.children) }}

--- a/controllers/common/views/cms-page.njk
+++ b/controllers/common/views/cms-page.njk
@@ -21,50 +21,14 @@
     <main role="main" id="content" {% if pageHero.image %}class="nudge-up"{% endif %}>
         {% block contentPrimary %}
 
-            {% if content.introduction %}
-                <section class="content-box u-inner-wide-only">
-                    {{ breadcrumbTrail(breadcrumbs) }}
-
-                    <div class="s-prose u-constrained-content-wide">
-                        {% if not pageHero.image %}
-                            <h1>{{ content.title }}</h1>
-                        {% endif %}
-                        {{ content.introduction | safe }}
-                    </div>
-                    {% if not childrenLayoutMode %}
-                        {% if content.segments.length > 0 %}
-                            {{ segmentLinks(content.segments) }}
-                        {% endif %}
-                        {% if content.flexibleContent %}
-                            {{ segmentLinks(content.flexibleContent, anchor = flexAnchor) }}
-                        {% endif %}
-                    {% endif %}
-                </section>
-            {% endif %}
-
-            {# Content segments #}
-            {% if content.segments.length > 0 %}
-                <div class="u-inner-wide-only u-constrained-content-wide">
-                    {% for contentSegment in content.segments %}
-                        {% call segment(
-                            id = 'segment-' + loop.index,
-                            title = contentSegment.title,
-                            imagePath = contentSegment.photo
-                        ) %}
-                            {{ contentSegment.content | safe }}
-                        {% endcall %}
-                    {% endfor %}
-                </div>
-            {% endif %}
-
             {# Flexible content #}
             {% if content.flexibleContent %}
                 {% for part in content.flexibleContent %}
                     <section class="content-box u-inner-wide-only"
                              id="{{ flexAnchor + '-' + loop.index }}">
 
-                        {# Show breadcrumbs inside the first item's container if they weren't already shown #}
-                        {% if loop.first and not content.introduction %}
+                        {# Show breadcrumbs inside the first item's container #}
+                        {% if loop.first %}
                             {{ breadcrumbTrail(breadcrumbs) }}
                         {% endif %}
 

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -130,7 +130,9 @@ const funding = {
         isNotProduction
             ? {
                   path: '/*',
-                  router: basicContent()
+                  router: basicContent({
+                      cmsPage: true
+                  })
               }
             : {}
     ]

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { basicContent, flexibleContent, staticPage } = require('./common');
+const { isNotProduction } = require('../common/appData');
 
 /**
  * @typedef {object} Section
@@ -125,7 +126,13 @@ const funding = {
         {
             path: '/funding-guidance/*',
             router: basicContent()
-        }
+        },
+        isNotProduction
+            ? {
+                  path: '/*',
+                  router: basicContent()
+              }
+            : {}
     ]
 };
 


### PR DESCRIPTION
This pairs with https://github.com/biglotteryfund/craft-dev/pull/194 and handles all URLs under `/funding/*` (besides existing ones). The goal is to revamp the entire Funding section and make the URLs a bit nicer at the same time (eg. drop redundant stuff like `/funding-guidance/`).

The main change here is merging two same-but-different templates: "listing pages" (eg. grids of child pages) and "information pages" (content). This leads to some slightly thorny template code in the combined "CMS page" template (eg. to allow for the different use cases and to display children pages, if required, in different ways) but I think this represents a direction of working for the CMS into 2020 – eg. generic templates for **all** CMS-powered pages (ideally!) which support showing children in different ways.

At the moment this new section is non-PROD environments only while we prepare the content, but when we're ready we can switch it on then manually start linking to it.

Things we might want to do in future: make the entire `/funding` landing page driven dynamically off its child pages in this section – though this would involve making it possible to add child "pages" which just link to other non-CMS URLs (eg. grant search).

Thoughts welcome!