### PR TITLE
Retry transaction if db lock error is thrown

### DIFF
--- a/db/database-config.js
+++ b/db/database-config.js
@@ -10,7 +10,13 @@ const commonConfig = {
             collate: 'utf8mb4_general_ci'
         }
     },
-    pool: { max: 5, min: 1, idle: 10000 }
+    pool: { max: 5, min: 1, idle: 10000 },
+    retry: {
+        match: [
+            'Deadlock found when trying to get lock; try restarting transaction'
+        ],
+        max: 3
+    }
 };
 
 module.exports = {


### PR DESCRIPTION
https://trello.com/c/LZsbXWbs/900-bug-investigate-occasional-database-locks-when-starting-a-new-application

This is one of the solution to the deadlock issue. The other being diving deeper and restructuring our queries around `UPDATE`, `INSERT` & `DELETE` (though in this case, looks like its most probably `INSERT` or `DELETE` while creating new application) so that each query accesses the db in the same order which avoids the deadlock.

References:
https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks.html
https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html

Probably we could see the information about the last deadlock using `SHOW ENGINE INNODB STATUS` ? - https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_deadlock_detect