### PR TITLE
New Dashboard Redirects

### DIFF
--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -50,24 +50,45 @@ function initFormRouter({
 
         res.locals.user = req.user;
 
-        res.locals.userNavigationLinks = [
-            {
-                url: `${req.baseUrl}/summary`,
-                label: res.locals.copy.navigation.summary
-            },
-            {
-                url: req.baseUrl,
-                label: res.locals.copy.navigation.applications
-            },
-            {
-                url: localify(req.i18n.getLocale())('/user'),
-                label: res.locals.copy.navigation.account
-            },
-            {
-                url: localify(req.i18n.getLocale())('/user/logout'),
-                label: res.locals.copy.navigation.logOut
-            }
-        ];
+        if (features.enableNewApplicationDashboards) {
+            res.locals.userNavigationLinks = [
+                {
+                    url: `${req.baseUrl}/summary`,
+                    label: res.locals.copy.navigation.summary
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/apply'),
+                    label: 'Latest application'
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/apply/all'),
+                    label: 'All applications'
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/user'),
+                    label: 'Account'
+                }
+            ];
+        } else {
+            res.locals.userNavigationLinks = [
+                {
+                    url: `${req.baseUrl}/summary`,
+                    label: res.locals.copy.navigation.summary
+                },
+                {
+                    url: req.baseUrl,
+                    label: res.locals.copy.navigation.applications
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/user'),
+                    label: res.locals.copy.navigation.account
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/user/logout'),
+                    label: res.locals.copy.navigation.logOut
+                }
+            ];
+        }
 
         next();
     }

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -18,6 +18,8 @@ router.use(function(req, res, next) {
 
 if (features.enableNewApplicationDashboards) {
     router.use('/', require('./dashboard'));
+    router.get('/awards-for-all', (req, res) => res.redirect(req.baseUrl));
+    router.get('/get-advice', (req, res) => res.redirect(req.baseUrl));
 } else {
     router.get('/', (req, res) => res.redirect('/'));
 }

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -64,20 +64,37 @@ router.use(requireNotStaffAuth, injectCopy('applyNext'), function(
     if (req.user) {
         res.locals.user = req.user;
 
-        res.locals.userNavigationLinks = [
-            {
-                url: localify(req.i18n.getLocale())('/apply/awards-for-all'),
-                label: res.locals.copy.navigation.applications
-            },
-            {
-                url: localify(req.i18n.getLocale())('/user'),
-                label: res.locals.copy.navigation.account
-            },
-            {
-                url: localify(req.i18n.getLocale())('/user/logout'),
-                label: res.locals.copy.navigation.logOut
-            }
-        ];
+        if (features.enableNewApplicationDashboards) {
+            res.locals.userNavigationLinks = [
+                {
+                    url: localify(req.i18n.getLocale())('/apply'),
+                    label: 'Latest application'
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/apply/all'),
+                    label: 'All applications'
+                },
+                {
+                    url: req.baseUrl,
+                    label: 'Account'
+                }
+            ];
+        } else {
+            res.locals.userNavigationLinks = [
+                {
+                    url: localify(req.i18n.getLocale())('/apply/awards-for-all'),
+                    label: res.locals.copy.navigation.applications
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/user'),
+                    label: res.locals.copy.navigation.account
+                },
+                {
+                    url: localify(req.i18n.getLocale())('/user/logout'),
+                    label: res.locals.copy.navigation.logOut
+                }
+            ];
+        }
     }
 
     next();

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const express = require('express');
 const passport = require('passport');
+const features = require('config').get('features');
 
 const logger = require('../../common/logger').child({
     service: 'user'
@@ -93,7 +94,12 @@ router
                             if (LoginRateLimiter.hasConsumedPoints()) {
                                 await LoginRateLimiter.clearRateLimit();
                             }
-                            redirectUrlWithFallback(req, res, '/apply');
+
+                            if (features.enableNewApplicationDashboards) {
+                                redirectUrlWithFallback(req, res, '/apply');
+                            } else {
+                                redirectUrlWithFallback(req, res, '/user');
+                            }
                         }
                     });
                 } else {

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -93,7 +93,7 @@ router
                             if (LoginRateLimiter.hasConsumedPoints()) {
                                 await LoginRateLimiter.clearRateLimit();
                             }
-                            redirectUrlWithFallback(req, res, '/user');
+                            redirectUrlWithFallback(req, res, '/apply');
                         }
                     });
                 } else {

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -153,7 +153,7 @@ it('log in and log out', function() {
     cy.seedUser().then(newUser => {
         logIn(newUser.username, newUser.password);
 
-        cy.get('.user-nav__links').within(() => {
+        cy.get('.global-header__navigation-secondary').within(() => {
             cy.findByText('Log out', { exact: false }).click();
         });
 
@@ -293,6 +293,11 @@ function submitPasswordReset(newPassword, oldPassword = null) {
 it('should be able to log in and update account details', () => {
     cy.seedUser().then(user => {
         logIn(user.username, user.password);
+
+        cy.get('.user-nav__links').within(() => {
+            cy.findByText('Account').click();
+        });
+
         const newPassword = generateAccountPassword();
         submitPasswordReset(newPassword, user.password);
 
@@ -502,7 +507,7 @@ it('should submit full awards for all application', () => {
     }
 
     function startApplication() {
-        cy.findByText('Start new application').click();
+        cy.findByText('Start a new application').click();
         times(5, function() {
             cy.findByLabelText('Yes').click();
             cy.findByText('Continue').click();
@@ -1105,7 +1110,7 @@ it('should complete get advice form', () => {
 
         acceptCookieConsent();
 
-        cy.findAllByText('Start new application').click();
+        cy.findAllByText('Get advice on your idea').click();
 
         cy.get('.form-actions').within(() => {
             cy.findAllByText('Get advice on your idea').click();


### PR DESCRIPTION
- Old dashboard screens redirect to the new dashboard screen
- Successfully logging in takes you to `/apply` and not account anymore
- navigation links change based on a `enableNewApplicationDashboards` flag
- Fixed tests for all the above