### PR TITLE
Misc quick fixes

### DIFF
--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -67,6 +67,7 @@ module.exports = function(formId, formBuilder) {
                                         section: section.slug,
                                         step: stepNumber,
                                         errorType: item.type,
+                                        joiErrorType: item.joiType,
                                         applicationId: anonymisedId
                                     });
                                 });

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -29,7 +29,7 @@ if (isNotProduction) {
     router.use('/get-advice', require('./get-advice'));
 }
 
-router.get('/emails/unsubscribe', require('./unsubscribe'));
-router.post('/handle-expiry', require('./expiry'));
+router.use('/emails/unsubscribe', require('./unsubscribe'));
+router.use('/handle-expiry', require('./expiry'));
 
 module.exports = router;

--- a/controllers/apply/lib/normalise-errors.js
+++ b/controllers/apply/lib/normalise-errors.js
@@ -68,6 +68,7 @@ module.exports = function normaliseErrors({
             return {
                 param: name,
                 type: match.type,
+                joiType: detail.type,
                 msg: match.message,
                 field: formField
             };

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -26,10 +26,7 @@ function getChildrenLayoutMode(content) {
         );
         if (childPageDisplay === 'grid' && !missingTrailImages) {
             childrenLayoutMode = 'grid';
-        } else if (
-            !childPageDisplay ||
-            childPageDisplay === 'none'
-        ) {
+        } else if (!childPageDisplay || childPageDisplay === 'none') {
             childrenLayoutMode = false;
         }
     }
@@ -100,6 +97,10 @@ function basicContent({
         injectBreadcrumbs,
         (req, res, next) => {
             const { content } = res.locals;
+
+            if (!content) {
+                return next();
+            }
 
             /**
              * Determine template to render:

--- a/controllers/user/lib/jwt.js
+++ b/controllers/user/lib/jwt.js
@@ -14,7 +14,7 @@ function signTokenActivate(userId, dateOfActivationAttempt) {
     };
 
     return jwt.sign(payload, JWT_SIGNING_TOKEN, {
-        expiresIn: '1h' // Short-lived token
+        expiresIn: '3h' // Short-lived token
     });
 }
 
@@ -54,7 +54,7 @@ function verifyTokenActivate(token, userId) {
 function signTokenPasswordReset(userId) {
     const payload = { data: { userId: userId, reason: 'resetpassword' } };
     return jwt.sign(payload, JWT_SIGNING_TOKEN, {
-        expiresIn: '1h' // Short-lived token
+        expiresIn: '3h' // Short-lived token
     });
 }
 


### PR DESCRIPTION
Few things in here:

- Stop letting the site render 500 errors for CMS pages that don't resolve (seeing lots of noise in Sentry for this since merging the Funding section changes)

- Boost token expiry time to 3 hours after seeing lots of errors for expiries 

- Add the Joi error type to logs help diagnose some tricky validation errors with the budget field (though testing this locally I can't get the Joi type to differ from "our" type, but worth a punt I guess)