### PR TITLE
No application panel when using new dashboards

### DIFF
--- a/common/locals.js
+++ b/common/locals.js
@@ -48,6 +48,8 @@ module.exports = function(req, res, next) {
     res.locals.enableSiteSurvey = true;
     res.locals.hotjarId = features.enableHotjar && config.get('hotjarId');
     res.locals.enableGlobalHeaderLogin = features.enableGlobalHeaderLogin;
+    res.locals.enableNewApplicationDashboards =
+        features.enableNewApplicationDashboards;
 
     /**
      * Global copy

--- a/controllers/user/views/dashboard.njk
+++ b/controllers/user/views/dashboard.njk
@@ -11,34 +11,47 @@
 
             {{ userStatus(user) }}
 
-            <div class="content-sidebar">
-                <div class="content-sidebar__primary">
-                    <h1 class="t--underline">{{ title }}</h1>
+            {% if enableNewApplicationDashboards %}
+                <h1 class="t--underline">{{ title }}</h1>
 
-                    {% if alertMessage %}
-                        <div class="message" role="alert">
-                            {{ alertMessage }}
+                {% if alertMessage %}
+                    <div class="message" role="alert">
+                        {{ alertMessage }}
+                    </div>
+                {% endif %}
+
+                <div class="u-margin-bottom">
+                    {{ sectionLinks(copy.sectionLinks) }}
+                </div>
+            {% else %}
+                <div class="content-sidebar">
+                    <div class="content-sidebar__primary">
+                        <h1 class="t--underline">{{ title }}</h1>
+
+                        {% if alertMessage %}
+                            <div class="message" role="alert">
+                                {{ alertMessage }}
+                            </div>
+                        {% endif %}
+
+                        <div class="u-margin-bottom">
+                            {{ sectionLinks(copy.sectionLinks) }}
                         </div>
-                    {% endif %}
+                    </div>
 
-                    <div class="u-margin-bottom">
-                        {{ sectionLinks(copy.sectionLinks) }}
+                    <div class="content-sidebar__secondary content-sidebar__secondary--major">
+                        <div class="u-padded u-tone-background-tint">
+                            <h2>{{ __('applyNext.startApplication.title') | safe }}</h2>
+                            <p>{{ __('applyNext.startApplication.intro') }}</p>
+                            <p>
+                                <a class="btn btn--small" href="{{ localify("/apply/awards-for-all/start") }}">
+                                    {{ __('applyNext.startApplication.callToAction') }}
+                                </a>
+                            </p>
+                        </div>
                     </div>
                 </div>
-
-                <div class="content-sidebar__secondary content-sidebar__secondary--major">
-                    <div class="u-padded u-tone-background-tint">
-                        <h2>{{ __('applyNext.startApplication.title') | safe }}</h2>
-                        <p>{{ __('applyNext.startApplication.intro') }}</p>
-                        <p>
-                            <a class="btn btn--small" href="{{ localify("/apply/awards-for-all/start") }}">
-                                {{ __('applyNext.startApplication.callToAction') }}
-                            </a>
-                        </p>
-                    </div>
-                </div>
-            </div>
-
+            {% endif %}
         </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
With the new dashboard screens the account section becomes secondary, so we don't need to show the awards for all panel here.

**With new dashboards enabled**

![image](https://user-images.githubusercontent.com/123386/67384566-4b0d5380-f589-11e9-92e2-e1ab319d81d4.png)


**Without**

![image](https://user-images.githubusercontent.com/123386/67384619-67a98b80-f589-11e9-8921-07d3692eb713.png)
