### PR TITLE
Bank check next previous

### DIFF
--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const express = require('express');
+const has = require('lodash/has');
 const findIndex = require('lodash/findIndex');
 const includes = require('lodash/includes');
 const omit = require('lodash/omit');
@@ -157,7 +158,7 @@ module.exports = function(formId, formBuilder) {
             );
 
             function isPaginationLinks() {
-                return req.body.previousBtn || req.body.nextBtn;
+                return has(req.body, 'previousBtn') || has(req.body, 'nextBtn');
             }
 
             function shouldRenderErrors() {
@@ -222,7 +223,7 @@ module.exports = function(formId, formBuilder) {
                      * Run any pre-flight checks for this steps
                      * eg. custom validations which don't run in Joi
                      */
-                    if (step.preFlightCheck) {
+                    if (step.preFlightCheck && isPaginationLinks() === false) {
                         try {
                             await step.preFlightCheck(dataToStore);
                         } catch (errors) {

--- a/controllers/apply/form-router-next/steps.js
+++ b/controllers/apply/form-router-next/steps.js
@@ -156,11 +156,12 @@ module.exports = function(formId, formBuilder) {
                 stepFields.map(f => f.name).includes(item.param)
             );
 
+            function isPaginationLinks() {
+                return req.body.previousBtn || req.body.nextBtn;
+            }
+
             function shouldRenderErrors() {
-                return (
-                    errorsForStep.length > 0 &&
-                    !(req.body.previousBtn || req.body.nextBtn)
-                );
+                return errorsForStep.length > 0 && !isPaginationLinks();
             }
 
             function determineRedirectUrl() {


### PR DESCRIPTION
Building on from https://github.com/biglotteryfund/blf-alpha/pull/2539 don't run pre-flight checks if using next/previous links. Fixes issue where those links don't work on the bank statement screen