### PR TITLE
explicit log level for winston-cloudwatch

### DIFF
--- a/common/logger.js
+++ b/common/logger.js
@@ -17,6 +17,7 @@ function getTransports() {
     if (enableCloudWatchLogs()) {
         return [
             new WinstonCloudWatch({
+                level: process.env.LOG_LEVEL || config.get('logLevel'),
                 awsRegion: config.get('aws.region'),
                 logGroupName: `/tnlcf/${environment}/app`,
                 logStreamName: `build-${buildNumber}`,


### PR DESCRIPTION
winston-cloudwatch doesn't  seem to respect the global `level` but does have its own `level` property so trying setting that.