### PR TITLE
Add segment links to CMS pages

### DIFF
--- a/controllers/common/views/cms-page.njk
+++ b/controllers/common/views/cms-page.njk
@@ -23,13 +23,15 @@
 
             {# Flexible content #}
             {% if content.flexibleContent %}
+
                 {% for part in content.flexibleContent %}
                     <section class="content-box u-inner-wide-only"
                              id="{{ flexAnchor + '-' + loop.index }}">
 
-                        {# Show breadcrumbs inside the first item's container #}
+                        {# Show breadcrumbs and links inside the first item's container #}
                         {% if loop.first %}
                             {{ breadcrumbTrail(breadcrumbs) }}
+                            {{ segmentLinks(content.flexibleContent, anchor = flexAnchor) }}
                         {% endif %}
 
                         <div class="s-prose u-constrained-content-wide">


### PR DESCRIPTION
@scottoakley pointed out that these links were missing (on the new CMS Page template) so have re-added them like so (for flex content items with titles):

![image](https://user-images.githubusercontent.com/394376/67407252-24faaa00-f5af-11e9-810e-b3a7ca6d10a3.png)
