### PR TITLE
Show the correct error for non-integer budget items

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -495,6 +495,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                         })
                     },
                     {
+                        type: 'number.integer',
+                        key: 'cost',
+                        message: localise({
+                            en: 'Use whole numbers only, eg. 360',
+                            cy: 'Defnyddiwch rifau cyflawn yn unig, e.e. 360'
+                        })
+                    },
+                    {
                         type: 'array.min',
                         message: localise({
                             en: 'Enter at least one item',


### PR DESCRIPTION
We didn't handle this error and a fair amount of users were seeing the generic "base" error, which didn't help them figure out what was wrong (eg. using decimals in the budget component).