### PR TITLE
Fix some oft-repeated CSP warnings for services we support

### DIFF
--- a/common/__snapshots__/csp-directives.test.js.snap
+++ b/common/__snapshots__/csp-directives.test.js.snap
@@ -176,6 +176,7 @@ Object {
     "stats.g.doubleclick.net",
     "via.placeholder.com",
     "biglotteryfund-assets.imgix.net",
+    "i.ytimg.com",
     "https://insights.hotjar.com",
     "http://static.hotjar.com",
     "https://static.hotjar.com",

--- a/common/csp-directives.js
+++ b/common/csp-directives.js
@@ -50,7 +50,11 @@ module.exports = function cspDirectives() {
             'biglotteryfund-assets.imgix.net',
             'i.ytimg.com'
         ]),
-        fontSrc: concat(defaultSrc, ['data:', 'use.typekit.net']),
+        fontSrc: concat(defaultSrc, [
+            'data:',
+            'use.typekit.net',
+            'fonts.googleapis.com'
+        ]),
         styleSrc: concat(defaultSrc, [
             "'unsafe-inline'",
             '*.typekit.net',

--- a/common/csp-directives.js
+++ b/common/csp-directives.js
@@ -47,10 +47,15 @@ module.exports = function cspDirectives() {
             'localhost',
             'stats.g.doubleclick.net',
             'via.placeholder.com',
-            'biglotteryfund-assets.imgix.net'
+            'biglotteryfund-assets.imgix.net',
+            'i.ytimg.com'
         ]),
         fontSrc: concat(defaultSrc, ['data:', 'use.typekit.net']),
-        styleSrc: concat(defaultSrc, ["'unsafe-inline'", '*.typekit.net']),
+        styleSrc: concat(defaultSrc, [
+            "'unsafe-inline'",
+            '*.typekit.net',
+            'fonts.googleapis.com'
+        ]),
         scriptSrc: concat(defaultSrc, ["'unsafe-eval'", "'unsafe-inline'"]),
         childSrc: concat(defaultSrc, ['www.google.com']),
         connectSrc: defaultSrc,

--- a/common/csp-directives.js
+++ b/common/csp-directives.js
@@ -50,16 +50,8 @@ module.exports = function cspDirectives() {
             'biglotteryfund-assets.imgix.net',
             'i.ytimg.com'
         ]),
-        fontSrc: concat(defaultSrc, [
-            'data:',
-            'use.typekit.net',
-            'fonts.googleapis.com'
-        ]),
-        styleSrc: concat(defaultSrc, [
-            "'unsafe-inline'",
-            '*.typekit.net',
-            'fonts.googleapis.com'
-        ]),
+        fontSrc: concat(defaultSrc, ['data:', 'use.typekit.net']),
+        styleSrc: concat(defaultSrc, ["'unsafe-inline'", '*.typekit.net']),
         scriptSrc: concat(defaultSrc, ["'unsafe-eval'", "'unsafe-inline'"]),
         childSrc: concat(defaultSrc, ['www.google.com']),
         connectSrc: defaultSrc,


### PR DESCRIPTION
Fixes some regular noise in the error logs for domains we should be supporting:

![image](https://user-images.githubusercontent.com/394376/67491393-cac01e80-f66c-11e9-93f2-3a2b40d0c167.png)

![image](https://user-images.githubusercontent.com/394376/67491487-ecb9a100-f66c-11e9-8ca0-118abf5fcd45.png)
