### PR TITLE
Strategic programme cleanup

### DIFF
--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -220,24 +220,6 @@ async function injectStrategicProgramme(req, res, next) {
     }
 }
 
-async function injectStrategicProgrammes(req, res, next) {
-    try {
-        res.locals.strategicProgrammes = await contentApi.getStrategicProgrammes(
-            {
-                locale: req.i18n.getLocale(),
-                requestParams: req.query
-            }
-        );
-        next();
-    } catch (error) {
-        if (error.statusCode >= 500) {
-            next(error);
-        } else {
-            next();
-        }
-    }
-}
-
 async function injectResearch(req, res, next) {
     try {
         const research = await contentApi.getResearch({
@@ -324,7 +306,6 @@ module.exports = {
     injectResearch,
     injectResearchEntry,
     injectStrategicProgramme,
-    injectStrategicProgrammes,
     setCommonLocals,
     setHeroLocals
 };

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -194,32 +194,6 @@ async function injectFundingProgramme(req, res, next) {
     }
 }
 
-async function injectStrategicProgramme(req, res, next) {
-    try {
-        // Assumes a parameter of :slug and :childPageSlug? in the request
-        const { slug, childPageSlug } = req.params;
-        if (slug) {
-            const querySlug = childPageSlug ? `${slug}/${childPageSlug}` : slug;
-
-            const entry = await contentApi.getStrategicProgrammes({
-                slug: querySlug,
-                locale: req.i18n.getLocale(),
-                requestParams: req.query
-            });
-
-            res.locals.strategicProgramme = entry;
-            setCommonLocals({ res, entry });
-        }
-        next();
-    } catch (error) {
-        if (error.statusCode >= 500) {
-            next(error);
-        } else {
-            next();
-        }
-    }
-}
-
 async function injectResearch(req, res, next) {
     try {
         const research = await contentApi.getResearch({
@@ -305,7 +279,6 @@ module.exports = {
     injectOurPeople,
     injectResearch,
     injectResearchEntry,
-    injectStrategicProgramme,
     setCommonLocals,
     setHeroLocals
 };

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -1,8 +1,7 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const get = require('lodash/get');
-const set = require('lodash/set');
+const compact = require('lodash/compact');
 
 const {
     injectBreadcrumbs,
@@ -40,69 +39,50 @@ router.get('/', injectListingContent, async function(req, res, next) {
     }
 });
 
-async function injectStrategicProgramme(req, res, next) {
+router.get('/:slug/:child_slug?', async function(req, res, next) {
     try {
-        // Assumes a parameter of :slug and :childPageSlug? in the request
-        const { slug, childPageSlug } = req.params;
-        if (slug) {
-            const querySlug = childPageSlug ? `${slug}/${childPageSlug}` : slug;
+        const entry = await contentApi.getStrategicProgrammes({
+            slug: compact([req.params.slug, req.params.child_slug]).join('/'),
+            locale: req.i18n.getLocale(),
+            requestParams: req.query
+        });
 
-            const entry = await contentApi.getStrategicProgrammes({
-                slug: querySlug,
-                locale: req.i18n.getLocale(),
-                requestParams: req.query
+        setCommonLocals({ res, entry });
+
+        /**
+         * Render a plain content page if specified,
+         * otherwise render a standard Strategic page
+         */
+        if (entry.entryType === 'contentPage') {
+            const breadcrumbs = entry.parent
+                ? res.locals.breadcrumbs.concat([
+                      {
+                          label: entry.parent.title,
+                          url: entry.parent.linkUrl
+                      },
+                      { label: res.locals.title }
+                  ])
+                : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
+
+            res.render(
+                path.resolve(__dirname, '../common/views/flexible-content'),
+                {
+                    breadcrumbs: breadcrumbs,
+                    flexibleContent: entry.content
+                }
+            );
+        } else if (entry) {
+            res.render(path.resolve(__dirname, './views/strategic-programme'), {
+                strategicProgramme: entry,
+                breadcrumbs: res.locals.breadcrumbs.concat({
+                    label: res.locals.title
+                })
             });
-
-            res.locals.strategicProgramme = entry;
-            setCommonLocals({ res, entry });
-        }
-        next();
-    } catch (error) {
-        if (error.statusCode >= 500) {
-            next(error);
         } else {
             next();
         }
-    }
-}
-
-router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
-    req,
-    res,
-    next
-) {
-    const { strategicProgramme } = res.locals;
-    // Render a plain content page if specified
-    if (get(strategicProgramme, 'entryType') === 'contentPage') {
-        setCommonLocals({ res, entry: strategicProgramme });
-        set(res.locals, 'content.flexibleContent', strategicProgramme.content);
-
-        const breadcrumbs = strategicProgramme.parent
-            ? res.locals.breadcrumbs.concat([
-                  {
-                      label: strategicProgramme.parent.title,
-                      url: strategicProgramme.parent.linkUrl
-                  },
-                  { label: res.locals.title }
-              ])
-            : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
-
-        res.render(
-            path.resolve(__dirname, '../common/views/flexible-content'),
-            {
-                breadcrumbs: breadcrumbs,
-                flexibleContent: strategicProgramme.content
-            }
-        );
-    } else if (strategicProgramme) {
-        // Render a standard Strategic page
-        res.render(path.resolve(__dirname, './views/strategic-programme'), {
-            breadcrumbs: res.locals.breadcrumbs.concat({
-                label: res.locals.title
-            })
-        });
-    } else {
-        next();
+    } catch (error) {
+        next(error);
     }
 });
 

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -7,9 +7,9 @@ const {
     injectBreadcrumbs,
     injectListingContent,
     injectStrategicProgramme,
-    injectStrategicProgrammes,
     setCommonLocals
 } = require('../../common/inject-content');
+const contentApi = require('../../common/content-api');
 
 const router = express.Router();
 
@@ -22,11 +22,21 @@ router.use(injectBreadcrumbs, (req, res, next) => {
     next();
 });
 
-router.get('/', injectListingContent, injectStrategicProgrammes, function(
-    req,
-    res
-) {
-    res.render(path.resolve(__dirname, './views/strategic-investments'));
+router.get('/', injectListingContent, async function(req, res, next) {
+    try {
+        res.render(path.resolve(__dirname, './views/strategic-investments'), {
+            strategicProgrammes: await contentApi.getStrategicProgrammes({
+                locale: req.i18n.getLocale(),
+                requestParams: req.query
+            })
+        });
+    } catch (error) {
+        if (error.statusCode >= 500) {
+            next(error);
+        } else {
+            next();
+        }
+    }
 });
 
 router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -1,12 +1,12 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const { get, set, startsWith } = require('lodash');
+const get = require('lodash/get');
+const set = require('lodash/set');
 
 const {
     injectBreadcrumbs,
     injectListingContent,
-    injectStrategicProgramme,
     setCommonLocals
 } = require('../../common/inject-content');
 const contentApi = require('../../common/content-api');
@@ -40,51 +40,67 @@ router.get('/', injectListingContent, async function(req, res, next) {
     }
 });
 
+async function injectStrategicProgramme(req, res, next) {
+    try {
+        // Assumes a parameter of :slug and :childPageSlug? in the request
+        const { slug, childPageSlug } = req.params;
+        if (slug) {
+            const querySlug = childPageSlug ? `${slug}/${childPageSlug}` : slug;
+
+            const entry = await contentApi.getStrategicProgrammes({
+                slug: querySlug,
+                locale: req.i18n.getLocale(),
+                requestParams: req.query
+            });
+
+            res.locals.strategicProgramme = entry;
+            setCommonLocals({ res, entry });
+        }
+        next();
+    } catch (error) {
+        if (error.statusCode >= 500) {
+            next(error);
+        } else {
+            next();
+        }
+    }
+}
+
 router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
     req,
     res,
     next
 ) {
-    const { currentPath, strategicProgramme } = res.locals;
-    /* Only render if not using an external path */
-    if (
-        strategicProgramme &&
-        startsWith(currentPath, strategicProgramme.linkUrl)
-    ) {
-        // Render a plain content page if specified
-        if (get(strategicProgramme, 'entryType') === 'contentPage') {
-            setCommonLocals({ res, entry: strategicProgramme });
-            set(
-                res.locals,
-                'content.flexibleContent',
-                strategicProgramme.content
-            );
+    const { strategicProgramme } = res.locals;
+    // Render a plain content page if specified
+    if (get(strategicProgramme, 'entryType') === 'contentPage') {
+        setCommonLocals({ res, entry: strategicProgramme });
+        set(res.locals, 'content.flexibleContent', strategicProgramme.content);
 
-            const breadcrumbs = strategicProgramme.parent
-                ? res.locals.breadcrumbs.concat([
-                      {
-                          label: strategicProgramme.parent.title,
-                          url: strategicProgramme.parent.linkUrl
-                      },
-                      { label: res.locals.title }
-                  ])
-                : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
+        const breadcrumbs = strategicProgramme.parent
+            ? res.locals.breadcrumbs.concat([
+                  {
+                      label: strategicProgramme.parent.title,
+                      url: strategicProgramme.parent.linkUrl
+                  },
+                  { label: res.locals.title }
+              ])
+            : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
 
-            res.render(
-                path.resolve(__dirname, '../common/views/flexible-content'),
-                {
-                    breadcrumbs: breadcrumbs,
-                    flexibleContent: strategicProgramme.content
-                }
-            );
-        } else {
-            // Render a standard Strategic page
-            res.render(path.resolve(__dirname, './views/strategic-programme'), {
-                breadcrumbs: res.locals.breadcrumbs.concat({
-                    label: res.locals.title
-                })
-            });
-        }
+        res.render(
+            path.resolve(__dirname, '../common/views/flexible-content'),
+            {
+                breadcrumbs: breadcrumbs,
+                flexibleContent: strategicProgramme.content
+            }
+        );
+    } else if (strategicProgramme) {
+        // Render a standard Strategic page
+        res.render(path.resolve(__dirname, './views/strategic-programme'), {
+            breadcrumbs: res.locals.breadcrumbs.concat({
+                label: res.locals.title
+            })
+        });
     } else {
         next();
     }

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const { concat, get, set, startsWith } = require('lodash');
+const { get, set, startsWith } = require('lodash');
 
 const {
     injectBreadcrumbs,
@@ -14,11 +14,12 @@ const contentApi = require('../../common/content-api');
 const router = express.Router();
 
 router.use(injectBreadcrumbs, (req, res, next) => {
-    const routerCrumb = {
-        label: req.i18n.__('funding.strategics.title'),
-        url: req.baseUrl
-    };
-    res.locals.breadcrumbs = concat(res.locals.breadcrumbs, [routerCrumb]);
+    res.locals.breadcrumbs = res.locals.breadcrumbs.concat([
+        {
+            label: req.i18n.__('funding.strategics.title'),
+            url: req.baseUrl
+        }
+    ]);
     next();
 });
 
@@ -58,22 +59,16 @@ router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
                 'content.flexibleContent',
                 strategicProgramme.content
             );
-            let breadcrumbs;
 
-            if (strategicProgramme.parent) {
-                const parentProgrammeCrumb = {
-                    label: strategicProgramme.parent.title,
-                    url: strategicProgramme.parent.linkUrl
-                };
-                breadcrumbs = concat(res.locals.breadcrumbs, [
-                    parentProgrammeCrumb,
-                    { label: res.locals.title }
-                ]);
-            } else {
-                breadcrumbs = concat(res.locals.breadcrumbs, [
-                    { label: res.locals.title }
-                ]);
-            }
+            const breadcrumbs = strategicProgramme.parent
+                ? res.locals.breadcrumbs.concat([
+                      {
+                          label: strategicProgramme.parent.title,
+                          url: strategicProgramme.parent.linkUrl
+                      },
+                      { label: res.locals.title }
+                  ])
+                : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
 
             res.render(
                 path.resolve(__dirname, '../common/views/flexible-content'),
@@ -85,7 +80,7 @@ router.get('/:slug/:childPageSlug?', injectStrategicProgramme, function(
         } else {
             // Render a standard Strategic page
             res.render(path.resolve(__dirname, './views/strategic-programme'), {
-                breadcrumbs: concat(res.locals.breadcrumbs, {
+                breadcrumbs: res.locals.breadcrumbs.concat({
                     label: res.locals.title
                 })
             });


### PR DESCRIPTION
Cleans up a bunch of old logic related to supporting legacy strategic programme pages and inlines some `inject*` methods to make the whole router flow much simpler.