### PR TITLE
Retained token for subsequent pwd reset requests

### DIFF
--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -243,13 +243,11 @@ router
             }
         } else {
             // Handle an unauthorised user who submitted the form with a token
-
-            // Retaining token in body for subsequent requests
-            req.body.token
-            ? req.session.token = req.body.token
-            : req.body.token = req.session.token;
-
             const { token } = req.body;
+
+            // Retaining token for subsequent requests
+            res.locals.token = token;
+
             if (!token) {
                 redirectForLocale(req, res, '/user/login');
             } else {

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -243,6 +243,12 @@ router
             }
         } else {
             // Handle an unauthorised user who submitted the form with a token
+
+            // Retaining token in body for subsequent requests
+            req.body.token
+            ? req.session.token = req.body.token
+            : req.body.token = req.session.token;
+
             const { token } = req.body;
             if (!token) {
                 redirectForLocale(req, res, '/user/login');


### PR DESCRIPTION
After some long testing, found an issue - any subsequent requests after the first will not have token within the `req.body` and hence will be treated as an unauthorized request. This update will fix that.

https://trello.com/c/BhLy1R1r/903-check-for-continued-password-reset-bugs