### PR TITLE
Preview mode cleanup

### DIFF
--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = function checkPreviewMode(queryParams) {
+    function isLivePreview() {
+        return queryParams['x-craft-live-preview'] && queryParams['token'];
+    }
+
+    function isShareLink() {
+        return queryParams['x-craft-preview'] && queryParams['token'];
+    }
+
+    return {
+        isPreview: isLivePreview() || isShareLink(),
+        isLivePreview: isLivePreview(),
+        isShareLink: isShareLink()
+    };
+};

--- a/common/preview-auth.js
+++ b/common/preview-auth.js
@@ -6,13 +6,11 @@ const checkPreviewMode = require('./check-preview-mode');
  * Preview mode
  * Staff-auth powered preview mode
  */
-module.exports = (req, res, next) => {
-    const previewMode = checkPreviewMode(req.query);
-    if (previewMode.isPreview) {
+module.exports = function previewAuthMiddleware(req, res, next) {
+    if (checkPreviewMode(req.query).isPreview) {
         res.cacheControl = { noStore: true };
-        res.locals.PREVIEW_MODE = true;
 
-        if (previewMode.isLivePreview) {
+        if (checkPreviewMode(req.query).isLivePreview) {
             // Allow embedding the site via iframe for CMS live preview
             res.removeHeader('X-Frame-Options');
             // Skip staff check for live preview (these URLs are secured via tokens)

--- a/common/preview.js
+++ b/common/preview.js
@@ -1,18 +1,18 @@
 'use strict';
 const { requireStaffAuth } = require('./authed');
+const checkPreviewMode = require('./check-preview-mode');
 
 /**
  * Preview mode
  * Staff-auth powered preview mode
  */
 module.exports = (req, res, next) => {
-    const isLivePreview =
-        req.query['x-craft-live-preview'] && req.query['token'];
-    const isShareLink = req.query['x-craft-preview'] && req.query['token'];
-    if (isLivePreview || isShareLink) {
+    const previewMode = checkPreviewMode(req.query);
+    if (previewMode.isPreview) {
         res.cacheControl = { noStore: true };
         res.locals.PREVIEW_MODE = true;
-        if (isLivePreview) {
+
+        if (previewMode.isLivePreview) {
             // Allow embedding the site via iframe for CMS live preview
             res.removeHeader('X-Frame-Options');
             // Skip staff check for live preview (these URLs are secured via tokens)

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -84,7 +84,7 @@ router.get('/:slug', injectBreadcrumbs, async function(req, res, next) {
             requestParams: req.query
         });
 
-        setCommonLocals({ res, entry });
+        setCommonLocals(req, res, entry);
 
         if (entry) {
             res.render(path.resolve(__dirname, './views/insights-detail'), {

--- a/controllers/our-people/index.js
+++ b/controllers/our-people/index.js
@@ -57,7 +57,7 @@ router.get('/:slug', async function(req, res, next) {
         const entry = find(people, item => item.slug === req.params.slug);
 
         if (entry) {
-            setCommonLocals({ res, entry });
+            setCommonLocals(req, res, entry);
 
             res.render(path.resolve(__dirname, './views/profiles'), {
                 entry: entry,

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -208,7 +208,7 @@ router.get('/:slug/:child_slug?', async (req, res, next) => {
             requestParams: req.query
         });
 
-        setCommonLocals({ res, entry });
+        setCommonLocals(req, res, entry);
 
         if (entry && entry.entryType === 'contentPage') {
             renderFlexibleContentChild(req, res, entry);

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -49,7 +49,7 @@ router.get('/:slug/:child_slug?', async function(req, res, next) {
             requestParams: req.query
         });
 
-        setCommonLocals({ res, entry });
+        setCommonLocals(req, res, entry);
 
         /**
          * Render a plain content page if specified,

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -11,6 +11,7 @@ const {
     injectHeroImage
 } = require('../../common/inject-content');
 const contentApi = require('../../common/content-api');
+const checkPreviewMode = require('../../common/check-preview-mode');
 
 const router = express.Router();
 
@@ -54,6 +55,13 @@ router.get(
         }
     }
 );
+
+function shouldRedirectLinkUrl(req, entry) {
+    return (
+        req.baseUrl + req.path !== entry.linkUrl &&
+        checkPreviewMode(req.query).isPreview === false
+    );
+}
 
 /**
  * Press releases handler
@@ -101,10 +109,7 @@ router.get(
                 );
             } else {
                 const entry = response.result;
-                if (
-                    req.baseUrl + req.path !== entry.linkUrl &&
-                    !res.locals.PREVIEW_MODE
-                ) {
+                if (shouldRedirectLinkUrl(req, entry)) {
                     res.redirect(entry.linkUrl);
                 } else if (entry.articleLink) {
                     res.redirect(entry.articleLink);
@@ -212,10 +217,7 @@ router.get(
                 });
             } else {
                 const entry = response.result;
-                if (
-                    req.baseUrl + req.path !== entry.linkUrl &&
-                    !res.locals.PREVIEW_MODE
-                ) {
+                if (shouldRedirectLinkUrl(req, entry)) {
                     res.redirect(entry.linkUrl);
                 } else if (entry.content.length > 0) {
                     res.locals.isBilingual =

--- a/server.js
+++ b/server.js
@@ -181,7 +181,7 @@ app.use([
     express.urlencoded({ extended: true }),
     require('./common/session')(app),
     require('./common/passport')(),
-    require('./common/preview'),
+    require('./common/preview-auth'),
     require('./common/locals')
 ]);
 

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -17,7 +17,7 @@
 
         <div class="global-container">
             {# Status and announcement banners #}
-            {% if previewStatus.isPreviewOrShareLink %}
+            {% if previewStatus.isPreview %}
                 <aside class="announcement-banner announcement-banner--info">
                     ✋ You are viewing a draft (last updated {{ previewStatus.lastUpdated }}).
                     Please do not share this page. <a href="{{ getCurrentUrl() }}">View original</a>


### PR DESCRIPTION
Spotted whilst working on https://github.com/biglotteryfund/blf-alpha/pull/2560 that we can clean up how we determine preview mode to avoid passing around a `PREVIEW_MODE` local and instead explicitly check if we are in preview mode based on the current query.