### PR TITLE
Fix ampersands issue

### DIFF
--- a/controllers/apply/emails/expiry-email.njk
+++ b/controllers/apply/emails/expiry-email.njk
@@ -5,7 +5,7 @@
 
     <p>
         <strong>Your National Lottery Awards for All application isn’t finished yet.</strong><br/>
-        We noticed you started applying{% if projectName %} for {{ projectName }}{% endif %}. But you haven’t finished your application.
+        We noticed you started applying{% if projectName %} for {{ projectName | safe }}{% endif %}. But you haven’t finished your application.
     </p>
 
     <p>

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -55,7 +55,7 @@
         type="{{ field.type }}"
         id="field-{{ field.name }}"
         name="{{ field.name }}"
-        {% if field.value %}value="{{ field.value }}"{% endif %}
+        {% if field.value %}value="{{ field.value | safe }}"{% endif %}
         {% if field.isRequired %}required aria-required="true"{% endif %}
         {# @TODO: Remove in favour of always setting explicit size #}
         {% if not field.attributes.size %}size="{{ field.size | default(40, true) }}"{% endif %}
@@ -73,7 +73,7 @@
         type="text"
         id="field-{{ field.name }}-{{ nameType }}"
         name="{{ field.name }}[{{ nameType }}]"
-        {% if field.value[nameType] %}value="{{ field.value[nameType] }}"{% endif %}
+        {% if field.value[nameType] %}value="{{ field.value[nameType] | safe }}"{% endif %}
         {% if field.isRequired %}required aria-required="true"{% endif %}
         size="40" autocomplete="{{ autocompleteName }}" spellcheck="false"
     />
@@ -215,7 +215,7 @@
         {% if field.isRequired %}required aria-required="true"{% endif %}
         {% if field.attributes %}{% for attr, value in field.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
         {% if settings.showWordCount %} @input="onInput" ref="textarea"{% endif %}
-    >{{ field.value }}</textarea>
+    >{{ field.value | safe }}</textarea>
     {% if settings.showWordCount %}
         <word-count
             :current-text="text"

--- a/views/components/form-header/macro.njk
+++ b/views/components/form-header/macro.njk
@@ -21,7 +21,7 @@
     <div class="form-header u-tone-background-tint u-padded u-flush">
         {% if projectName %}
             <p class="form-header__prefix">{{ formTitle }}</p>
-            <p class="t2 form-header__title u-wrap-words" data-hj-suppress>{{ projectName }}</p>
+            <p class="t2 form-header__title u-wrap-words" data-hj-suppress>{{ projectName | safe }}</p>
         {% else %}
             <p class="t2 form-header__title u-wrap-words">{{ formTitle }}</p>
         {% endif %}


### PR DESCRIPTION
This is to do with how we escape/sanitise strings and then display them again:

![image](https://user-images.githubusercontent.com/394376/67673038-0c084500-f971-11e9-970c-aa84ac4c4da7.png)

This change makes sure we mark text inputs as `safe` when displaying/editing them. Probably doesn't cover all cases (the Vue components, eg. budgets and large textareas) might do some weird things, but this fixes a user-reported error of their project name constantly replacing `&` with `&amp;`.