### PR TITLE
Add a disclaimer to the Data page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -292,6 +292,7 @@ toplevel:
   data:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau
+    disclaimer: Am ystadegau thematig (e.e. amgylcheddol, iechyd a lles, a.y.y.b.), rydym wedi cyfri prosiectau sy’n cynnwys y themâu hyn, ond nid yn gyfan gwbl.
     openData:
       title: Data am Grantiau
       linkPrefix: Data grantiau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -400,6 +400,7 @@ toplevel:
   data:
     keyStats: Key statistics
     mapTitle: Our Year in Numbers
+    disclaimer: For thematic statistics (eg. environmental, health and wellbeing, etc), we've counted projects which include these themes, but not exclusively.
     openData:
       title: Grant Data
       linkPrefix: Grants data

--- a/controllers/data/views/data.njk
+++ b/controllers/data/views/data.njk
@@ -25,6 +25,8 @@
             <div class="content-box content-box--borderless u-inner-wide-only">
                 <h2 class="t2 t--underline">{{ copy.keyStats }}</h2>
                 {{ statsGrid(dataStats.stats) }}
+
+                <p class="u-text-x-small u-margin-top">{{ copy.disclaimer }}</p>
             </div>
 
             <aside class="map-holder u-border-top-brand-primary u-margin-bottom">


### PR DESCRIPTION
In advance of launching a new page with 2018/19 stats, we've been asked to add this disclaimer.

![image](https://user-images.githubusercontent.com/394376/67694424-32db7100-f99b-11e9-8243-7f319c242fc0.png)
