### PR TITLE
Account cleanup

### DIFF
--- a/common/authed.js
+++ b/common/authed.js
@@ -75,7 +75,7 @@ function requireActiveUserWithCallback(cb) {
     return (req, res, next) => requireActiveUser(req, res, next, cb);
 }
 
-function requiredUnactivatedUser(req, res, next) {
+function requireUnactivatedUser(req, res, next) {
     if (
         req.isAuthenticated() &&
         isStaff(req.user) === false &&
@@ -130,7 +130,7 @@ module.exports = {
     requireNoAuth,
     requireUserAuth,
     requireActiveUser,
-    requiredUnactivatedUser,
+    requireUnactivatedUser,
     requireStaffAuth,
     requireNotStaffAuth,
     redirectUrlWithFallback,

--- a/common/authed.js
+++ b/common/authed.js
@@ -75,6 +75,18 @@ function requireActiveUserWithCallback(cb) {
     return (req, res, next) => requireActiveUser(req, res, next, cb);
 }
 
+function requiredUnactivatedUser(req, res, next) {
+    if (
+        req.isAuthenticated() &&
+        isStaff(req.user) === false &&
+        isActivated(req.user) === false
+    ) {
+        redirectUrlWithFallback(req, res, '/user');
+    } else {
+        next();
+    }
+}
+
 /**
  * Required staff auth
  * Middleware to require that the visitor is logged in as a staff user
@@ -91,7 +103,11 @@ function requireStaffAuth(req, res, next) {
             });
         }
     } else {
-        res.redirect(`/user/staff/login?redirectUrl=${encodeURIComponent(req.originalUrl)}`);
+        res.redirect(
+            `/user/staff/login?redirectUrl=${encodeURIComponent(
+                req.originalUrl
+            )}`
+        );
     }
 }
 
@@ -114,6 +130,7 @@ module.exports = {
     requireNoAuth,
     requireUserAuth,
     requireActiveUser,
+    requiredUnactivatedUser,
     requireStaffAuth,
     requireNotStaffAuth,
     redirectUrlWithFallback,

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -5,14 +5,11 @@ const Sentry = require('@sentry/node');
 
 const { Users } = require('../../db/models');
 const {
-    requireUserAuth,
-    redirectUrlWithFallback
+    redirectUrlWithFallback,
+    requiredUnactivatedUser
 } = require('../../common/authed');
 const { injectCopy } = require('../../common/inject-content');
-
-const logger = require('../../common/logger').child({
-    service: 'user'
-});
+const logger = require('../../common/logger').child({ service: 'user' });
 
 const { verifyTokenActivate } = require('./lib/jwt');
 const sendActivationEmail = require('./lib/activation-email');
@@ -24,17 +21,9 @@ function renderTemplate(req, res) {
     res.render(template);
 }
 
-function requireNotActivated(req, res, next) {
-    if (req.user.userData.is_active) {
-        redirectUrlWithFallback(req, res, '/user');
-    } else {
-        next();
-    }
-}
-
 router
     .route('/')
-    .all(requireUserAuth, injectCopy('user.activate'), requireNotActivated)
+    .all(requiredUnactivatedUser, injectCopy('user.activate'))
     .get(async function(req, res) {
         if (req.query.token) {
             try {

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -8,10 +8,7 @@ const {
     requireUserAuth,
     redirectUrlWithFallback
 } = require('../../common/authed');
-const {
-    injectCopy,
-    injectBreadcrumbs
-} = require('../../common/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({
     service: 'user'
@@ -27,20 +24,17 @@ function renderTemplate(req, res) {
     res.render(template);
 }
 
+function requireNotActivated(req, res, next) {
+    if (req.user.userData.is_active) {
+        redirectUrlWithFallback(req, res, '/user');
+    } else {
+        next();
+    }
+}
+
 router
     .route('/')
-    .all(
-        requireUserAuth,
-        injectCopy('user.activate'),
-        injectBreadcrumbs,
-        function(req, res, next) {
-            if (req.user.userData.is_active) {
-                redirectUrlWithFallback(req, res, '/user');
-            } else {
-                next();
-            }
-        }
-    )
+    .all(requireUserAuth, injectCopy('user.activate'), requireNotActivated)
     .get(async function(req, res) {
         if (req.query.token) {
             try {

--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -6,7 +6,7 @@ const Sentry = require('@sentry/node');
 const { Users } = require('../../db/models');
 const {
     redirectUrlWithFallback,
-    requiredUnactivatedUser
+    requireUnactivatedUser
 } = require('../../common/authed');
 const { injectCopy } = require('../../common/inject-content');
 const logger = require('../../common/logger').child({ service: 'user' });
@@ -23,7 +23,7 @@ function renderTemplate(req, res) {
 
 router
     .route('/')
-    .all(requiredUnactivatedUser, injectCopy('user.activate'))
+    .all(requireUnactivatedUser, injectCopy('user.activate'))
     .get(async function(req, res) {
         if (req.query.token) {
             try {

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -13,10 +13,7 @@ const {
     RateLimiter
 } = require('../../common/rate-limiter');
 
-const {
-    injectCopy,
-    injectBreadcrumbs
-} = require('../../common/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback
@@ -45,12 +42,7 @@ function renderRateLimitError(req, res, minutesLeft) {
 
 router
     .route('/')
-    .all(
-        csrfProtection,
-        requireNoAuth,
-        injectCopy('user.login'),
-        injectBreadcrumbs
-    )
+    .all(csrfProtection, requireNoAuth, injectCopy('user.login'))
     .get(function(req, res) {
         if (req.query.s) {
             res.locals.alertMessage = req.i18n.__(

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -1,7 +1,6 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const concat = require('lodash/concat');
 const Sentry = require('@sentry/node');
 
 const { Users } = require('../../db/models');
@@ -13,10 +12,7 @@ const {
     localify
 } = require('../../common/urls');
 const { requireNoAuth } = require('../../common/authed');
-const {
-    injectCopy,
-    injectBreadcrumbs
-} = require('../../common/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 
 const logger = require('../../common/logger').child({
     service: 'user'
@@ -100,9 +96,6 @@ function renderResetForm(req, res, data = null, errors = []) {
 }
 
 function renderResetFormExpired(req, res) {
-    res.locals.breadcrumbs = concat(res.locals.breadcrumbs, {
-        label: 'Reset password'
-    });
     res.render(path.resolve(__dirname, './views/reset-password-expired'));
 }
 
@@ -111,7 +104,7 @@ function renderResetFormExpired(req, res) {
  */
 router
     .route('/forgot')
-    .all(requireNoAuth, injectCopy('user.forgottenPassword'), injectBreadcrumbs)
+    .all(requireNoAuth, injectCopy('user.forgottenPassword'))
     .get(renderForgotForm)
     .post(async function(req, res) {
         const validationResult = validateSchema(
@@ -159,7 +152,7 @@ router
  */
 router
     .route('/reset')
-    .all(injectCopy('user.resetPassword'), injectBreadcrumbs)
+    .all(injectCopy('user.resetPassword'))
     .get(async (req, res) => {
         function token() {
             return req.query.token ? req.query.token : res.locals.token;

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -9,10 +9,7 @@ const { localify } = require('../../common/urls');
 const { sanitise } = require('../../common/sanitise');
 const logger = require('../../common/logger').child({ service: 'user' });
 const { csrfProtection } = require('../../common/cached');
-const {
-    injectCopy,
-    injectBreadcrumbs
-} = require('../../common/inject-content');
+const { injectCopy } = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback
@@ -50,12 +47,7 @@ function renderForm(req, res, data = null, errors = []) {
 
 router
     .route('/')
-    .all(
-        requireNoAuth,
-        csrfProtection,
-        injectCopy('user.register'),
-        injectBreadcrumbs
-    )
+    .all(requireNoAuth, csrfProtection, injectCopy('user.register'))
     .get(renderForm)
     .post(async function handleRegister(req, res, next) {
         const validationResult = validateSchema(

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -56,14 +56,18 @@ router
         );
 
         /**
-         * Generic fallback error
+         * Fallback error
          * Shown when there is an error authenticating or attempting to register with an existing user
          * This messages needs to be generic to avoid exposing the account state.
          */
-        const genericError = req.i18n.__(
-            res.locals.copy.genericError,
-            localify(req.i18n.getLocale())('/user/password/forgot')
-        );
+        const fallbackErrors = [
+            {
+                msg: req.i18n.__(
+                    res.locals.copy.genericError,
+                    localify(req.i18n.getLocale())('/user/password/forgot')
+                )
+            }
+        ];
 
         if (validationResult.isValid) {
             try {
@@ -82,8 +86,12 @@ router
                         );
                     });
 
-                    res.locals.alertMessage = genericError;
-                    renderForm(req, res, validationResult.value);
+                    renderForm(
+                        req,
+                        res,
+                        validationResult.value,
+                        fallbackErrors
+                    );
                 } else {
                     const newUser = await Users.createUser({
                         username: sanitise(username),
@@ -108,8 +116,7 @@ router
             } catch (error) {
                 logger.warn('Registration failed', error);
                 Sentry.captureException(error);
-                res.locals.alertMessage = genericError;
-                renderForm(req, res, validationResult.value);
+                renderForm(req, res, validationResult.value, fallbackErrors);
             }
         } else {
             /**
@@ -119,6 +126,7 @@ router
                 const hasPasswordIssue = validationResult.messages.some(
                     _ => _.param === 'password'
                 );
+
                 if (hasPasswordIssue) {
                     res.locals.hotJarTagList = [
                         'User: Error on password creation'

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -1,5 +1,4 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/form-fields-next/macros.njk" import formErrors, formField with context %}
 
 {% block content %}
@@ -11,13 +10,13 @@
             </div>
 
             <h1 class="t--underline">{{ title }}</h1>
-     
+
             {% if alertMessage %}
                 <div class="message" role="alert">
                     {{ alertMessage }}
                 </div>
             {% endif %}
-     
+
             <form action="" method="post" autocomplete="off">
                 <div class="s-prose u-constrained-wide">
                     {{ copy.introduction | safe }}

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -1,5 +1,4 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/form-fields-next/macros.njk" import formErrors, formField with context %}
 
 {% block content %}

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -11,12 +11,6 @@
 
             <h1 class="t--underline">{{ title }}</h1>
 
-            {% if alertMessage %}
-                <div class="message" role="alert">
-                    {{ alertMessage | safe }}
-                </div>
-            {% endif %}
-
             <form action="" method="post" autocomplete="off">
                 {{ formErrors(
                     title = __('global.misc.errorTitle'),


### PR DESCRIPTION
1. Remove a bunch of unused breadcrumb code from accounts section (we don't show them here)
2. Add an explicit method for requiring an unactivated account
3. Show generic error using common error style, not alert message

![image](https://user-images.githubusercontent.com/123386/67698220-dfb8ec80-f9a1-11e9-9373-504a8f9a36a8.png)
