### PR TITLE
Fixup logic for requireUnactivatedUser

### DIFF
--- a/common/authed.js
+++ b/common/authed.js
@@ -81,9 +81,9 @@ function requireUnactivatedUser(req, res, next) {
         isStaff(req.user) === false &&
         isActivated(req.user) === false
     ) {
-        redirectUrlWithFallback(req, res, '/user');
-    } else {
         next();
+    } else {
+        redirectUrlWithFallback(req, res, '/user');
     }
 }
 


### PR DESCRIPTION
Check for `requireUnactivatedUser` was the wrong way around. Introduced in https://github.com/biglotteryfund/blf-alpha/pull/2577