### PR TITLE
Add missing explanatory text to standard organisation type question

### DIFF
--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -543,6 +543,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 en: 'What type of organisation are you?',
                 cy: 'Pa fath o sefydliad ydych chi?'
             }),
+            explanation: localise({
+                en: `If you're both a charity and a company—just pick ‘Not-for-profit company’ below.`,
+                cy: `Os ydych yn elusen ac yn gwmni—dewiswch ‘Cwmni di-elw’ isod.`
+            }),
             options: [
                 {
                     value: 'unregistered-vco',


### PR DESCRIPTION
Add missing explanatory text to standard organisation type question. I don't know if we should actually be trying to _share_ this code yet, so for the time being I've just copied the text.