### PR TITLE
Add a £1bn max amount to currency field

### DIFF
--- a/controllers/apply/lib/field-types/currency.js
+++ b/controllers/apply/lib/field-types/currency.js
@@ -18,9 +18,11 @@ class CurrencyField extends Field {
 
     defaultSchema() {
         const minAmount = this.minAmount || 0;
+        const maxAmount = this.maxAmount || 1000000000;
         const baseSchema = Joi.friendlyNumber()
             .integer()
-            .min(minAmount);
+            .min(minAmount)
+            .max(maxAmount);
 
         if (this.isRequired) {
             return baseSchema.required();


### PR DESCRIPTION
This feels a little better than having _no_ max limit. Set a default max limit of 1 billion, and no specific error message so you get the default in if you enter a number that is far too high (as some testers did entering 1.2 pentillion). Is this a bad idea?

![image](https://user-images.githubusercontent.com/123386/67878216-dc089f80-fb32-11e9-836d-ef40609e3ef9.png)
