### PR TITLE
Removed top start button from standard summary page

### DIFF
--- a/controllers/apply/form-router-next/views/summary.njk
+++ b/controllers/apply/form-router-next/views/summary.njk
@@ -195,9 +195,6 @@
                 </div>
             {% else %}
                 <div class="s-prose">{{ copy.summary.introduction | safe }}</div>
-                {% if form.progress.isPristine %}
-                    {{ startButton() }}
-                {% endif %}
             {% endif %}
 
             {% if not expandSections %}

--- a/controllers/apply/form-router-next/views/summary.njk
+++ b/controllers/apply/form-router-next/views/summary.njk
@@ -195,6 +195,9 @@
                 </div>
             {% else %}
                 <div class="s-prose">{{ copy.summary.introduction | safe }}</div>
+                {% if form.progress.isPristine and formId === 'awards-for-all' %}
+                    {{ startButton() }}
+                {% endif %}
             {% endif %}
 
             {% if not expandSections %}


### PR DESCRIPTION
https://trello.com/c/B23hKFUa/927-get-rid-of-start-button-up-top-of-this-page-for-your-funding-proposal-leave-the-start-down-the-bottom