### PR TITLE
Breadcrumb cleanup

### DIFF
--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -2,7 +2,6 @@
 const moment = require('moment');
 const Sentry = require('@sentry/node');
 const get = require('lodash/fp/get');
-const getOr = require('lodash/fp/getOr');
 
 const contentApi = require('./content-api');
 const checkPreviewMode = require('./check-preview-mode');
@@ -91,23 +90,6 @@ function injectCopy(lang) {
     };
 }
 
-function injectBreadcrumbs(req, res, next) {
-    const breadcrumbs = getOr([], 'breadcrumbs')(res.locals);
-
-    const getTitle = get('title');
-    const injectedTitle = res.locals.title || getTitle(res.locals.content);
-
-    if (injectedTitle) {
-        breadcrumbs.push({
-            label: injectedTitle
-        });
-    }
-
-    res.locals.breadcrumbs = breadcrumbs;
-
-    next();
-}
-
 async function injectListingContent(req, res, next) {
     try {
         const entry = await contentApi.getListingPage({
@@ -147,7 +129,6 @@ async function injectFlexibleContent(req, res, next) {
 }
 
 module.exports = {
-    injectBreadcrumbs,
     injectCopy,
     injectFlexibleContent,
     injectHeroImage,

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -1,9 +1,9 @@
 'use strict';
-const { flatten, get, getOr } = require('lodash/fp');
 const moment = require('moment');
 const Sentry = require('@sentry/node');
+const get = require('lodash/fp/get');
+const getOr = require('lodash/fp/getOr');
 
-const { localify } = require('./urls');
 const contentApi = require('./content-api');
 const checkPreviewMode = require('./check-preview-mode');
 
@@ -92,17 +92,7 @@ function injectCopy(lang) {
 }
 
 function injectBreadcrumbs(req, res, next) {
-    const locale = req.i18n.getLocale();
-
     const breadcrumbs = getOr([], 'breadcrumbs')(res.locals);
-
-    const ancestors = res.locals.customAncestors || [];
-    ancestors.forEach(ancestor => {
-        breadcrumbs.push({
-            label: ancestor.title,
-            url: localify(locale)(`/${ancestor.path}`)
-        });
-    });
 
     const getTitle = get('title');
     const injectedTitle = res.locals.title || getTitle(res.locals.content);

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -100,9 +100,7 @@ function injectBreadcrumbs(req, res, next) {
             url: res.locals.sectionUrl
         };
 
-        const ancestors =
-            res.locals.customAncestors ||
-            getOr([], 'ancestors')(res.locals.content);
+        const ancestors = res.locals.customAncestors || [];
         const ancestorCrumbs = ancestors.map(ancestor => {
             return {
                 label: ancestor.title,

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -94,33 +94,26 @@ function injectCopy(lang) {
 function injectBreadcrumbs(req, res, next) {
     const locale = req.i18n.getLocale();
 
-    if (res.locals.sectionTitle && res.locals.sectionUrl) {
-        const topLevelCrumb = {
-            label: res.locals.sectionTitle,
-            url: res.locals.sectionUrl
-        };
+    const breadcrumbs = getOr([], 'breadcrumbs')(res.locals);
 
-        const ancestors = res.locals.customAncestors || [];
-        const ancestorCrumbs = ancestors.map(ancestor => {
-            return {
-                label: ancestor.title,
-                url: localify(locale)(`/${ancestor.path}`)
-            };
+    const ancestors = res.locals.customAncestors || [];
+    ancestors.forEach(ancestor => {
+        breadcrumbs.push({
+            label: ancestor.title,
+            url: localify(locale)(`/${ancestor.path}`)
         });
+    });
 
-        const breadcrumbs = flatten([topLevelCrumb, ancestorCrumbs]);
+    const getTitle = get('title');
+    const injectedTitle = res.locals.title || getTitle(res.locals.content);
 
-        const getTitle = get('title');
-        const injectedTitle = res.locals.title || getTitle(res.locals.content);
-
-        if (injectedTitle) {
-            breadcrumbs.push({
-                label: injectedTitle
-            });
-        }
-
-        res.locals.breadcrumbs = breadcrumbs;
+    if (injectedTitle) {
+        breadcrumbs.push({
+            label: injectedTitle
+        });
     }
+
+    res.locals.breadcrumbs = breadcrumbs;
 
     next();
 }

--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -3,9 +3,9 @@ const path = require('path');
 const express = require('express');
 const Sentry = require('@sentry/node');
 const isEmpty = require('lodash/isEmpty');
+const getOr = require('lodash/fp/getOr');
 
 const {
-    injectBreadcrumbs,
     injectCopy,
     injectFlexibleContent,
     injectHeroImage,
@@ -23,48 +23,46 @@ function staticPage({
 } = {}) {
     const router = express.Router();
 
-    router.get(
-        '/',
-        injectHeroImage(heroSlug),
-        injectCopy(lang),
-        injectBreadcrumbs,
-        async function(req, res, next) {
-            const { copy } = res.locals;
+    router.get('/', injectHeroImage(heroSlug), injectCopy(lang), async function(
+        req,
+        res,
+        next
+    ) {
+        const { copy } = res.locals;
 
-            function shouldRedirectLang() {
-                return (
-                    (disableLanguageLink === true || isEmpty(copy)) &&
-                    isWelsh(req.originalUrl)
-                );
-            }
-
-            if (shouldRedirectLang()) {
-                next();
-            } else {
-                /**
-                 * Inject project stories if we've been provided any slugs to fetch
-                 */
-                let stories;
-                if (projectStorySlugs.length > 0) {
-                    try {
-                        stories = await contentApi.getProjectStories({
-                            locale: req.i18n.getLocale(),
-                            slugs: projectStorySlugs
-                        });
-                    } catch (error) {
-                        Sentry.captureException(error);
-                    }
-                }
-
-                res.render(template, {
-                    title: copy.title,
-                    description: copy.description || false,
-                    isBilingual: disableLanguageLink === false,
-                    stories: stories
-                });
-            }
+        function shouldRedirectLang() {
+            return (
+                (disableLanguageLink === true || isEmpty(copy)) &&
+                isWelsh(req.originalUrl)
+            );
         }
-    );
+
+        if (shouldRedirectLang()) {
+            next();
+        } else {
+            /**
+             * Inject project stories if we've been provided any slugs to fetch
+             */
+            let stories;
+            if (projectStorySlugs.length > 0) {
+                try {
+                    stories = await contentApi.getProjectStories({
+                        locale: req.i18n.getLocale(),
+                        slugs: projectStorySlugs
+                    });
+                } catch (error) {
+                    Sentry.captureException(error);
+                }
+            }
+
+            res.render(template, {
+                title: copy.title,
+                description: copy.description || false,
+                isBilingual: disableLanguageLink === false,
+                stories: stories
+            });
+        }
+    });
 
     return router;
 }
@@ -93,43 +91,53 @@ function basicContent({
 } = {}) {
     const router = express.Router();
 
-    router.get(
-        '/',
-        injectCopy(lang),
-        injectListingContent,
-        injectBreadcrumbs,
-        (req, res, next) => {
-            const { content } = res.locals;
+    router.get('/', injectCopy(lang), injectListingContent, function(
+        req,
+        res,
+        next
+    ) {
+        const { content } = res.locals;
 
-            if (!content) {
-                return next();
-            }
-
-            /**
-             * Determine template to render:
-             * 1. If using a custom template defer to that
-             * 2. If using the new CMS page style, use that template
-             * 2. If the response has child pages then render a listing page
-             * 3. Otherwise, render an information page
-             */
-            if (customTemplate) {
-                res.render(customTemplate);
-            } else if (cmsPage) {
-                res.render(path.resolve(__dirname, './views/cms-page'));
-            } else if (content.children) {
-                // @TODO: Deprecate these templates in favour of CMS pages (above)
-                renderListingPage(res, content);
-            } else if (
-                content.introduction ||
-                content.segments.length > 0 ||
-                content.flexibleContent.length > 0
-            ) {
-                res.render(path.resolve(__dirname, './views/information-page'));
-            } else {
-                next();
-            }
+        if (!content) {
+            return next();
         }
-    );
+
+        const ancestors = getOr([], 'ancestors')(content);
+        ancestors.forEach(function(ancestor) {
+            res.locals.breadcrumbs.push({
+                label: ancestor.title,
+                url: ancestor.linkUrl
+            });
+        });
+
+        res.locals.breadcrumbs.push({
+            label: content.title
+        });
+
+        /**
+         * Determine template to render:
+         * 1. If using a custom template defer to that
+         * 2. If using the new CMS page style, use that template
+         * 2. If the response has child pages then render a listing page
+         * 3. Otherwise, render an information page
+         */
+        if (customTemplate) {
+            res.render(customTemplate);
+        } else if (cmsPage) {
+            res.render(path.resolve(__dirname, './views/cms-page'));
+        } else if (content.children) {
+            // @TODO: Deprecate these templates in favour of CMS pages (above)
+            renderListingPage(res, content);
+        } else if (
+            content.introduction ||
+            content.segments.length > 0 ||
+            content.flexibleContent.length > 0
+        ) {
+            res.render(path.resolve(__dirname, './views/information-page'));
+        } else {
+            next();
+        }
+    });
 
     return router;
 }
@@ -137,23 +145,29 @@ function basicContent({
 function flexibleContent() {
     const router = express.Router();
 
-    router.get(
-        '/',
-        injectFlexibleContent,
-        injectBreadcrumbs,
-        (req, res, next) => {
-            if (res.locals.content) {
-                res.render(
-                    path.resolve(__dirname, './views/flexible-content'),
-                    {
-                        flexibleContent: res.locals.content.flexibleContent
-                    }
-                );
-            } else {
-                next();
-            }
+    router.get('/', injectFlexibleContent, function(req, res, next) {
+        const { content } = res.locals;
+
+        if (content) {
+            const ancestors = getOr([], 'ancestors')(content);
+            ancestors.forEach(function(ancestor) {
+                res.locals.breadcrumbs.push({
+                    label: ancestor.title,
+                    url: ancestor.linkUrl
+                });
+            });
+
+            res.locals.breadcrumbs.push({
+                label: content.title
+            });
+
+            res.render(path.resolve(__dirname, './views/flexible-content'), {
+                flexibleContent: content.flexibleContent
+            });
+        } else {
+            next();
         }
-    );
+    });
 
     return router;
 }
@@ -167,7 +181,7 @@ function renderFlexibleContentChild(req, res, entry) {
               },
               { label: res.locals.title }
           ])
-        : res.locals.breadcrumbs.concat([{ label: res.locals.title }]);
+        : res.locals.breadcrumbs.concat({ label: res.locals.title });
 
     res.render(path.resolve(__dirname, './views/flexible-content'), {
         breadcrumbs: breadcrumbs,

--- a/controllers/digital-fund/assistance.js
+++ b/controllers/digital-fund/assistance.js
@@ -16,7 +16,7 @@ function render(req, res, formData = null, errors = []) {
     const title = res.locals.copy.assistance.title;
     res.render(path.resolve(__dirname, './views/assistance'), {
         title: title,
-        breadcrumbs: res.locals.breadcrumbs.concat([{ label: title }]),
+        breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
         formData: formData,
         errors: errors
     });

--- a/controllers/digital-fund/index.js
+++ b/controllers/digital-fund/index.js
@@ -12,9 +12,10 @@ router.use(
 );
 
 router.use((req, res, next) => {
-    res.locals.breadcrumbs = res.locals.breadcrumbs.concat([
-        { label: res.locals.title, url: req.baseUrl }
-    ]);
+    res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
+        label: res.locals.title,
+        url: req.baseUrl
+    });
     next();
 });
 
@@ -26,7 +27,7 @@ router.get('/eligibility', (req, res) => {
     const title = res.locals.copy.fullEligiblity.title;
     res.render(path.resolve(__dirname, './views/full-eligibility'), {
         title: title,
-        breadcrumbs: res.locals.breadcrumbs.concat([{ label: title }])
+        breadcrumbs: res.locals.breadcrumbs.concat({ label: title })
     });
 });
 
@@ -34,9 +35,9 @@ router.get('/strand-1', function(req, res) {
     res.render(path.resolve(__dirname, './views/strand'), {
         title: res.locals.copy.strand1.title,
         currentStrand: 'strand1',
-        breadcrumbs: res.locals.breadcrumbs.concat([
-            { label: res.locals.copy.strand1.shortTitle }
-        ])
+        breadcrumbs: res.locals.breadcrumbs.concat({
+            label: res.locals.copy.strand1.shortTitle
+        })
     });
 });
 
@@ -44,9 +45,9 @@ router.get('/strand-2', function(req, res) {
     res.render(path.resolve(__dirname, './views/strand'), {
         title: res.locals.copy.strand2.title,
         currentStrand: 'strand2',
-        breadcrumbs: res.locals.breadcrumbs.concat([
-            { label: res.locals.copy.strand2.shortTitle }
-        ])
+        breadcrumbs: res.locals.breadcrumbs.concat({
+            label: res.locals.copy.strand2.shortTitle
+        })
     });
 });
 

--- a/controllers/grants/index.js
+++ b/controllers/grants/index.js
@@ -1,5 +1,5 @@
 'use strict';
-const { concat, clone, pick, isEmpty, get } = require('lodash');
+const { clone, pick, isEmpty, get } = require('lodash');
 const path = require('path');
 const config = require('config');
 const Sentry = require('@sentry/node');
@@ -8,7 +8,6 @@ const nunjucks = require('nunjucks');
 const querystring = require('querystring');
 
 const {
-    injectBreadcrumbs,
     injectCopy,
     injectHeroImage,
     setHeroLocals
@@ -20,17 +19,13 @@ const grantsService = require('./grants-service');
 
 const router = express.Router();
 
-router.use(
-    sMaxAge(604800 /* 7 days in seconds */),
-    injectBreadcrumbs,
-    (req, res, next) => {
-        res.locals.breadcrumbs = concat(res.locals.breadcrumbs, {
-            label: req.i18n.__('funding.pastGrants.search.title'),
-            url: req.baseUrl
-        });
-        next();
-    }
-);
+router.use(sMaxAge(604800 /* 7 days in seconds */), function(req, res, next) {
+    res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
+        label: req.i18n.__('funding.pastGrants.search.title'),
+        url: req.baseUrl
+    });
+    next();
+});
 
 function buildPagination(req, paginationMeta, currentQuery = {}) {
     if (paginationMeta && paginationMeta.totalPages > 1) {
@@ -266,7 +261,7 @@ router.get(
                         recipientLocalAuthorities: data.facets.localAuthorities,
                         totalAwarded: data.meta.totalAwarded.toLocaleString(),
                         totalResults: data.meta.totalResults.toLocaleString(),
-                        breadcrumbs: concat(res.locals.breadcrumbs, {
+                        breadcrumbs: res.locals.breadcrumbs.concat({
                             label: organisation.name
                         }),
                         pagination: buildPagination(req, data.meta.pagination)
@@ -326,7 +321,7 @@ router.get(
                     grant: grant,
                     projectStory: projectStory,
                     fundingProgramme: fundingProgramme,
-                    breadcrumbs: concat(res.locals.breadcrumbs, {
+                    breadcrumbs: res.locals.breadcrumbs.concat({
                         label: data.result.title
                     })
                 });

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -5,7 +5,6 @@ const { pick, clone } = require('lodash');
 
 const contentApi = require('../../common/content-api');
 const {
-    injectBreadcrumbs,
     injectCopy,
     injectHeroImage,
     setCommonLocals
@@ -76,7 +75,7 @@ router.get(
     }
 );
 
-router.get('/:slug', injectBreadcrumbs, async function(req, res, next) {
+router.get('/:slug', async function(req, res, next) {
     try {
         const entry = await contentApi.getResearch({
             slug: req.params.slug,

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -148,9 +148,9 @@ router.get(
                 return /\d/.test(firstLetter) ? '#' : firstLetter;
             });
 
-            const breadcrumbs = res.locals.breadcrumbs.concat([
-                { label: res.locals.title }
-            ]);
+            const breadcrumbs = res.locals.breadcrumbs.concat({
+                label: res.locals.title
+            });
 
             const regionsCopy = req.i18n.__('global.regions');
             const locations = {
@@ -217,9 +217,9 @@ router.get('/:slug/:child_slug?', async (req, res, next) => {
              */
             res.render(path.resolve(__dirname, './views/programme'), {
                 entry: entry,
-                breadcrumbs: res.locals.breadcrumbs.concat([
-                    { label: res.locals.title }
-                ])
+                breadcrumbs: res.locals.breadcrumbs.concat({
+                    label: res.locals.title
+                })
             });
         } else if (get(entry, 'isArchived') === true) {
             /**
@@ -228,9 +228,9 @@ router.get('/:slug/:child_slug?', async (req, res, next) => {
             res.render(path.resolve(__dirname, './views/archived-programme'), {
                 entry: entry,
                 archiveUrl: buildArchiveUrl(entry.legacyPath),
-                breadcrumbs: res.locals.breadcrumbs.concat([
-                    { label: res.locals.title }
-                ])
+                breadcrumbs: res.locals.breadcrumbs.concat({
+                    label: res.locals.title
+                })
             });
         } else {
             next();

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -6,11 +6,11 @@ const get = require('lodash/get');
 const groupBy = require('lodash/groupBy');
 
 const {
-    injectBreadcrumbs,
     injectCopy,
     injectHeroImage,
     setCommonLocals
 } = require('../../common/inject-content');
+const { localify } = require('../../common/urls');
 const { buildArchiveUrl } = require('../../common/archived');
 const { getValidLocation, programmeFilters } = require('./helpers');
 const { sMaxAge } = require('../../common/cached');
@@ -20,12 +20,11 @@ const { basicContent, renderFlexibleContentChild } = require('../common');
 
 const router = express.Router();
 
-router.use(injectBreadcrumbs, (req, res, next) => {
-    const routerCrumb = {
+router.use(function(req, res, next) {
+    res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
         label: req.i18n.__('funding.programmes.title'),
         url: req.baseUrl
-    };
-    res.locals.breadcrumbs = res.locals.breadcrumbs.concat([routerCrumb]);
+    });
     next();
 });
 
@@ -248,12 +247,12 @@ router.get('/:slug/:child_slug?', async (req, res, next) => {
 router.use(
     '/building-better-opportunities/*',
     (req, res, next) => {
-        res.locals.customAncestors = [
-            {
-                title: 'Building Better Opportunities',
-                path: 'funding/programmes/building-better-opportunities'
-            }
-        ];
+        res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
+            label: 'Building Better Opportunities',
+            url: localify(req.i18n.getLocale())(
+                `/funding/programmes/building-better-opportunities`
+            )
+        });
         next();
     },
     basicContent()

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -4,7 +4,6 @@ const express = require('express');
 const compact = require('lodash/compact');
 
 const {
-    injectBreadcrumbs,
     injectListingContent,
     setCommonLocals
 } = require('../../common/inject-content');
@@ -14,13 +13,11 @@ const { renderFlexibleContentChild } = require('../common');
 
 const router = express.Router();
 
-router.use(injectBreadcrumbs, (req, res, next) => {
-    res.locals.breadcrumbs = res.locals.breadcrumbs.concat([
-        {
-            label: req.i18n.__('funding.strategics.title'),
-            url: req.baseUrl
-        }
-    ]);
+router.use(function(req, res, next) {
+    res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
+        label: req.i18n.__('funding.strategics.title'),
+        url: req.baseUrl
+    });
     next();
 });
 

--- a/controllers/tools/feedback.js
+++ b/controllers/tools/feedback.js
@@ -15,7 +15,7 @@ async function render(req, res) {
 
     res.render(path.resolve(__dirname, './views/feedback'), {
         title: title,
-        breadcrumbs: res.locals.breadcrumbs.concat([{ label: title }]),
+        breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
         feedback
     });
 }

--- a/controllers/tools/users.js
+++ b/controllers/tools/users.js
@@ -65,7 +65,7 @@ router.get('/', async (req, res, next) => {
         const title = 'User accounts summary';
         res.render(path.resolve(__dirname, './views/users'), {
             title: title,
-            breadcrumbs: res.locals.breadcrumbs.concat([{ label: title }]),
+            breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
             chartData: chartData(allUsers.rows),
             totalUsers: allUsers.count,
             totalActiveUsers: active.length,

--- a/server.js
+++ b/server.js
@@ -230,8 +230,17 @@ forEach(routes, function(section, sectionId) {
      * Used for determining top-level section for navigation and breadcrumbs
      */
     router.use(function(req, res, next) {
-        res.locals.sectionTitle = req.i18n.__(`global.nav.${sectionId}`);
-        res.locals.sectionUrl = localify(req.i18n.getLocale())(req.baseUrl);
+        const sectionTitle = req.i18n.__(`global.nav.${sectionId}`);
+        const sectionUrl = localify(req.i18n.getLocale())(req.baseUrl);
+
+        res.locals.sectionTitle = sectionTitle;
+        res.locals.sectionUrl = sectionUrl;
+
+        /**
+         * Set top-level breadcrumb for current section
+         */
+        res.locals.breadcrumbs = [{ label: sectionTitle, url: sectionUrl }];
+
         next();
     });
 


### PR DESCRIPTION
- Removes `ancestors` from content check (no longer included by CMS)
- Remove single use of `customAncestors`
- Sets section breadcrumbs up front rather than at a distance in `injectBreadcrumbs`

We only show breadcrumbs if there is more than one item in the list so this is pretty safe. The only renaming code in `injectBreadcrumbs` is adding the title which can be—and often is—better handled in individual routers. So eventually we can remove `injectBreadcrumbs` in favour but leaving that for a future PR.