### PR TITLE
Launch standard funding proposal form and new dashboards

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -27,7 +27,7 @@
     "enableRelatedGrants": false,
     "enableSalesforceConnector": true,
     "enableSeeders": false,
-    "enableStandardApplications": false
+    "enableStandardApplications": true
   },
   "awardsForAll": {
     "enableExpiration": true

--- a/config/development.json
+++ b/config/development.json
@@ -2,8 +2,7 @@
   "logLevel": "debug",
   "features": {
     "enableSeeders": true,
-    "enableSalesforceConnector": false,
-    "enableStandardApplications": true
+    "enableSalesforceConnector": false
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland", "scotland", "wales"]

--- a/config/test.json
+++ b/config/test.json
@@ -5,7 +5,6 @@
     }
   },
   "features": {
-    "enableHotjar": true,
-    "enableStandardApplications": true
+    "enableHotjar": true
   }
 }


### PR DESCRIPTION
Does the minimum to launch the standard application flow. There's plenty to clean up after this but we can do that in follow on pull requests.