### PR TITLE
Add country messaging on standard start page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1755,6 +1755,13 @@ applyNext:
 yourFundingProposal:
   startPage:
     title: Before you start
+    applyingForNorthernIreland:
+      title: Applying for a project in Northern Ireland?
+      description: Great - you're in the right place.
+    applyingForWalesScotlandEngland:
+      title: Applying for a project in Wales, Scotland or England?
+      description: >
+        You'll need to look at <a href="/funding/over10k">our programme pages for funding over £10,000</a> to find out how to apply.
     beforeYouStart:
       title: Before you start
       items:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1756,10 +1756,12 @@ yourFundingProposal:
   startPage:
     title: Before you start
     applyingForNorthernIreland:
-      title: Applying for a project in Northern Ireland?
+      title: >
+        <strong>Applying for a project in Northern Ireland?</strong>
       description: Great - you're in the right place.
     applyingForWalesScotlandEngland:
-      title: Applying for a project in Wales, Scotland or England?
+      title: >
+        <strong>Applying for a project in Wales, Scotland or England?</strong>
       description: >
         You'll need to look at <a href="/funding/over10k">our programme pages for funding over £10,000</a> to find out how to apply.
     beforeYouStart:

--- a/controllers/apply/standard-proposal/views/startpage.njk
+++ b/controllers/apply/standard-proposal/views/startpage.njk
@@ -15,6 +15,12 @@
                 prefix = globalCopy.brand.title
             )}}
 
+            <h2>{{ copy.applyingForNorthernIreland.title }}</h2>
+            <p>{{ copy.applyingForNorthernIreland.description }}</p>
+
+            <h2>{{ copy.applyingForWalesScotlandEngland.title }}</h2>
+            <p>{{ copy.applyingForWalesScotlandEngland.description | safe }}</p>
+
             <h2>{{ copy.beforeYouStart.title }}</h2>
 
             <ul>

--- a/controllers/apply/standard-proposal/views/startpage.njk
+++ b/controllers/apply/standard-proposal/views/startpage.njk
@@ -15,11 +15,13 @@
                 prefix = globalCopy.brand.title
             )}}
 
-            <h2>{{ copy.applyingForNorthernIreland.title }}</h2>
-            <p>{{ copy.applyingForNorthernIreland.description }}</p>
+            <div class="message message--info message--minor" role="alert">
+                {{ copy.applyingForNorthernIreland.title | safe }}
+                <p>{{ copy.applyingForNorthernIreland.description }}</p>
 
-            <h2>{{ copy.applyingForWalesScotlandEngland.title }}</h2>
-            <p>{{ copy.applyingForWalesScotlandEngland.description | safe }}</p>
+                {{ copy.applyingForWalesScotlandEngland.title | safe }}
+                <p>{{ copy.applyingForWalesScotlandEngland.description | safe }}</p>
+            </div>
 
             <h2>{{ copy.beforeYouStart.title }}</h2>
 


### PR DESCRIPTION
https://trello.com/c/U07q25m8/919-add-country-messaging-at-the-top-of-your-funding-proposal-form

<img width="1009" alt="Screenshot 2019-11-01 at 14 02 23" src="https://user-images.githubusercontent.com/5576981/68029871-15b2e500-fcb0-11e9-9b2c-7bfd11cfe6b0.png">
