### PR TITLE
Translate bilingual expiry emails

### DIFF
--- a/controllers/apply/emails/expiry-email.njk
+++ b/controllers/apply/emails/expiry-email.njk
@@ -1,6 +1,16 @@
 {% extends "views/layouts/emails.njk" %}
 
 {% block content %}
+
+    {% if isBilingual %}
+        <p>
+            <strong>
+                Bilingual message – please scroll down for Welsh.<br />
+                Neges ddwyieithog – y Gymraeg i’w weld isod.
+            </strong>
+        </p>
+    {% endif %}
+
     <p>Hello,</p>
 
     <p>
@@ -9,7 +19,7 @@
     </p>
 
     <p>
-        <strong>You have until {{ expiryDate }} to finish your application.</strong><br/>
+        <strong>You have until {{ expiryDate.en }} to finish your application.</strong><br/>
         If you don’t complete your application before that time, we’ll delete it - so that we can keep your data safe.
     </p>
 
@@ -20,7 +30,7 @@
 
     <p>
         <strong>If you don’t want more reminders from us</strong><br/>
-        You can <a href="{{ unsubscribeLink }}">tell us to stop sending emails</a> that remind you about your application.
+        You can <a href="{{ unsubscribeLink.en }}">tell us to stop sending emails</a> that remind you about your application.
     </p>
 
     <p>
@@ -29,7 +39,53 @@
     </p>
 
     <p>
-        <strong>Best wishes,</strong><br/>
-        <strong>The National Lottery Awards for All Team</strong>
+        <strong>
+            Best wishes,<br/>
+            The National Lottery Awards for All Team
+        </strong>
     </p>
+
+
+    {% if isBilingual %}
+        <p>
+            <br />
+            --
+            <br />
+        </p>
+
+        <p>Helo,</p>
+
+        <p>
+            <strong>Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi’i gwblhau eto.</strong><br />
+            Fe sylweddolom eich bod wedi dechrau ymgeisio{% if projectName %} am {{ projectName | safe }}{% endif %}. Ond nid ydych wedi cwblhau eich cais.
+        </p>
+
+        <p>
+            <strong>Mae gennych tan {{ expiryDate.cy }} i orffen eich cais.</strong><br />
+            Os nad ydych yn cwblhau eich cais cyn hynny, byddwn yn ei ddileu – felly gallwn gadw eich data yn ddiogel.
+        </p>
+
+        <p>
+            <strong>I orffen eich cais</strong><br />
+            <a href="https://www.tnlcommunityfund.org.uk/welsh/apply/awards-for-all/edit/{{ application.id }}?s=expiryEmail">Mewngofnodwch i'ch cyfrif ac ateb gweddill y cwestiynau</a>.
+        </p>
+
+        <p>
+            <strong>Os nad ydych eisiau mwy o nodiadau atgoffa gennym</strong><br />
+            <a href="{{ unsubscribeLink.cy }}">Gallwch ddweud wrthym i stopio anfon e-byst  sy’n eich atgoffa am eich cais</a>.
+        </p>
+
+        <p>
+            <strong>Os oes gennych unrhyw gwestiynau</strong><br />
+            Gallwch ffonio {{ countryPhoneNumber }}. Neu e-bostiwch cymru@cronfagymunedolylg.org.uk. Byddwn yn hapus i’ch helpu.
+        </p>
+
+        <p>
+            <strong>
+                Cofion,<br />
+                Tîm Arian i Bawb y Loteri Genedlaethol
+            </strong>
+        </p>
+    {% endif %}
+
 {% endblock %}

--- a/controllers/apply/emails/expiry-email.njk
+++ b/controllers/apply/emails/expiry-email.njk
@@ -47,11 +47,7 @@
 
 
     {% if isBilingual %}
-        <p>
-            <br />
-            --
-            <br />
-        </p>
+        <hr />
 
         <p>Helo,</p>
 

--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -150,10 +150,8 @@ async function sendExpiryEmails(req, emailQueue) {
                     templateData: {
                         isBilingual: isBilingual,
                         projectName: getAppData('projectName'),
-                        countryPhoneNumber: getPhoneFor(
-                            getAppData('projectCountry')
-                        ),
-                        countryEmail: getEmailFor(getAppData('projectCountry')),
+                        countryPhoneNumber: getPhoneFor(projectCountry),
+                        countryEmail: getEmailFor(projectCountry),
                         application: emailToSend.PendingApplication,
                         unsubscribeLink: unsubscribeUrl,
                         expiryDate: expiryDates

--- a/controllers/apply/form-router-next/views/unsubscribed.njk
+++ b/controllers/apply/form-router-next/views/unsubscribed.njk
@@ -7,7 +7,7 @@
             <div class="s-prose">
                 <h1>{{ title }}</h1>
                 <div class="message" role="alert">{{ message | safe }}</div>
-                <p><a class="btn" href="/">{{ __('global.misc.back') | capitalize }}</a></p>
+                <p><a class="btn" href="{{ localify('/') }}">{{ __('global.misc.back') | capitalize }}</a></p>
             </div>
         </div>
     </main>

--- a/controllers/apply/unsubscribe.js
+++ b/controllers/apply/unsubscribe.js
@@ -49,9 +49,15 @@ router.get('/', async function(req, res) {
                     './form-router-next/views/unsubscribed'
                 ),
                 {
-                    title: 'Unsubscription successful',
-                    message: `We will no longer email you about your application's expiration.`
-                }
+                    en: {
+                        title: 'Unsubscription successful',
+                        message: `We will no longer email you about your application's expiration.`
+                    },
+                    cy: {
+                        title: 'Tanysgrifiad llwyddiannus',
+                        message: `Ni fyddwn yn eich e-bostio rhagor am derfyn amser eich cais.`
+                    }
+                }[req.i18n.getLocale()]
             );
         } catch (error) {
             logger.warn('Email unsubscribe token failed', {

--- a/views/layouts/emails.njk
+++ b/views/layouts/emails.njk
@@ -9,7 +9,7 @@
     </head>
     <body>
         <div class="logo">
-            {% if locale === 'cy' %}
+            {% if locale === 'cy' or isBilingual %}
                 <img src="https://www.tnlcommunityfund.org.uk/assets/images/site-logo-bilingual-email.jpg" alt="Cronfa Gymunedol y Loteri Genedlaethol logo" />
             {% else %}
                 <img src="https://www.tnlcommunityfund.org.uk/assets/images/site-logo-email.jpg" alt="The National Lottery Community Fund logo" />


### PR DESCRIPTION
This was a bit fiddlier than usual as there's no `locale` for this endpoint (just gets called by a robot... an English-speaking one) so we have to default to bilingual for applicants in Wales.