### PR TITLE
Launch flag check

### DIFF
--- a/controllers/apply/dashboard.js
+++ b/controllers/apply/dashboard.js
@@ -13,6 +13,14 @@ const { enrichPending, enrichSubmitted } = require('./lib/enrich-application');
 
 const router = express.Router();
 
+function checkFeatureEnabled(req, res, next) {
+    if (res.locals.enableStandardApplications) {
+        next();
+    } else {
+        res.redirect('/');
+    }
+}
+
 /**
  * Determine the latest application to show and
  * prepare application data for display in the view.
@@ -61,6 +69,7 @@ router.get(
     requireActiveUser,
     injectCopy('applyNext.dashboardNew'),
     injectNavigationLinks,
+    checkFeatureEnabled,
     async function(req, res, next) {
         const { copy } = res.locals;
 
@@ -105,6 +114,7 @@ router.get(
     requireActiveUser,
     injectCopy('applyNext.dashboardNew'),
     injectNavigationLinks,
+    checkFeatureEnabled,
     async function(req, res, next) {
         const { copy } = res.locals;
 

--- a/controllers/apply/form-router-next/dashboard.js
+++ b/controllers/apply/form-router-next/dashboard.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const path = require('path');
 const get = require('lodash/get');
-const features = require('config').get('features');
 
 const {
     PendingApplication,
@@ -14,7 +13,7 @@ module.exports = function(formId, formBuilder) {
     const router = express.Router();
 
     router.route('/').get(async function(req, res, next) {
-        if (features.enableStandardApplications) {
+        if (res.locals.enableStandardApplications) {
             return res.redirect(localify(req.i18n.getLocale())('/apply'));
         }
 

--- a/controllers/apply/form-router-next/delete.js
+++ b/controllers/apply/form-router-next/delete.js
@@ -1,7 +1,6 @@
 'use strict';
 const express = require('express');
 const path = require('path');
-const features = require('config').get('features');
 
 const { PendingApplication } = require('../../../db/models');
 const { localify } = require('../../../common/urls');
@@ -42,7 +41,7 @@ module.exports = function(formId) {
 
                 logger.info('Application deleted', { applicationId });
 
-                if (features.enableStandardApplications) {
+                if (res.locals.enableStandardApplications) {
                     res.redirect(
                         localify(req.i18n.getLocale())(
                             '/apply/all?s=applicationDeleted'

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -58,7 +58,7 @@ function initFormRouter({
         res.locals.user = req.user;
 
         const localeUrl = localify(req.i18n.getLocale());
-        if (features.enableStandardApplications) {
+        if (res.locals.enableStandardApplications) {
             res.locals.userNavigationLinks = [
                 {
                     url: `${req.baseUrl}/summary`,

--- a/controllers/apply/index.js
+++ b/controllers/apply/index.js
@@ -15,17 +15,7 @@ router.use(function(req, res, next) {
     next();
 });
 
-router.use(
-    '/',
-    function(req, res, next) {
-        if (res.locals.enableStandardApplications) {
-            next();
-        } else {
-            res.redirect('/');
-        }
-    },
-    require('./dashboard')
-);
+router.use('/', require('./dashboard'));
 
 router.use('/your-idea', require('./reaching-communities'));
 router.use('/awards-for-all', require('./awards-for-all'));

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -62,7 +62,7 @@ router.use(requireNotStaffAuth, injectCopy('applyNext'), function(
         res.locals.user = req.user;
 
         const localeUrl = localify(req.i18n.getLocale());
-        if (features.enableStandardApplications) {
+        if (res.locals.enableStandardApplications) {
             res.locals.userNavigationLinks = [
                 {
                     url: localeUrl('/apply'),

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -2,7 +2,6 @@
 const path = require('path');
 const express = require('express');
 const passport = require('passport');
-const features = require('config').get('features');
 
 const logger = require('../../common/logger').child({
     service: 'user'
@@ -87,7 +86,7 @@ router
                                 await LoginRateLimiter.clearRateLimit();
                             }
 
-                            if (features.enableStandardApplications) {
+                            if (res.locals.enableStandardApplications) {
                                 redirectUrlWithFallback(req, res, '/apply');
                             } else {
                                 redirectUrlWithFallback(req, res, '/user');


### PR DESCRIPTION
- Moves dashboard check into the routes to avoid applying to the _whole_ apply section 🙈 
- Always check `enableStandardApplications` from `res.locals` rather than `features` to make sure value comes from cookie enabled / run-time value.