### PR TITLE
Fixup findAllByForm query to include formId

### DIFF
--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -77,17 +77,12 @@ class PendingApplication extends Model {
         });
     }
 
-    static findAllByForm(formId, dateRange = {}) {
-        let whereClause = {
-            formId: { [Op.eq]: formId }
-        };
-        if (dateRange.start && dateRange.end) {
-            whereClause = {
-                createdAt: { [Op.between]: [dateRange.start, dateRange.end] }
-            };
-        }
+    static findAllByForm(formId, dateRange) {
         return this.findAll({
-            where: whereClause,
+            where: {
+                formId: { [Op.eq]: formId },
+                createdAt: { [Op.between]: [dateRange.start, dateRange.end] }
+            },
             order: [['createdAt', 'ASC']]
         });
     }
@@ -294,17 +289,12 @@ class SubmittedApplication extends Model {
         });
     }
 
-    static findAllByForm(formId, dateRange = {}) {
-        let whereClause = {
-            formId: { [Op.eq]: formId }
-        };
-        if (dateRange.start && dateRange.end) {
-            whereClause = {
-                createdAt: { [Op.between]: [dateRange.start, dateRange.end] }
-            };
-        }
+    static findAllByForm(formId, dateRange) {
         return this.findAll({
-            where: whereClause,
+            where: {
+                formId: { [Op.eq]: formId },
+                createdAt: { [Op.between]: [dateRange.start, dateRange.end] }
+            },
             order: [['createdAt', 'ASC']]
         });
     }


### PR DESCRIPTION
Extracts query fix from https://github.com/biglotteryfund/blf-alpha/pull/2614 so we can get this out now and give ourselves more time to get the standard dashboard working. Fixes the issue where the `formId` was not included in the query which will cause the awards for all dashboard to report incorrectly once the standard form goes live.