### PR TITLE
Allow special Funding pages (logo/merchandise) to render sub-templates

### DIFF
--- a/controllers/materials/views/materials.njk
+++ b/controllers/materials/views/materials.njk
@@ -2,7 +2,7 @@
 {% from "components/icons.njk" import iconClose %}
 {% from "./materials-fields.njk" import textInput, radios with context %}
 
-{% extends "controllers/common/views/information-page.njk" %}
+{% extends "controllers/common/views/cms-page.njk" %}
 
 {% macro textField(field) %}
     {{ textInput(

--- a/controllers/routes.js
+++ b/controllers/routes.js
@@ -133,12 +133,25 @@ let funding = {
 // Add Funding subpages in non-prod environments
 // @TODO progress to production when ready
 if (isNotProduction) {
-    funding.pages.push({
-        path: '/*',
-        router: basicContent({
-            cmsPage: true
-        })
-    });
+    funding.pages.push(
+        {
+            path: `/managing-your-grant/promoting-your-project/order-free-plaques-stickers-bunting-and-more`,
+            router: require('./materials')
+        },
+        {
+            path: `/managing-your-grant/promoting-your-project/download-our-logo-to-tell-people-about-your-national-lottery-funding`,
+            router: basicContent({
+                lang: 'funding.guidance.logos',
+                customTemplate: 'static-pages/logos'
+            })
+        },
+        {
+            path: '/*',
+            router: basicContent({
+                cmsPage: true
+            })
+        }
+    );
 }
 
 /**

--- a/views/static-pages/logos.njk
+++ b/views/static-pages/logos.njk
@@ -3,7 +3,7 @@
 {% from "components/content-tabs/macro.njk" import contentTabs %}
 {% from "components/icons.njk" import iconClose %}
 
-{% extends "controllers/common/views/information-page.njk" %}
+{% extends "controllers/common/views/cms-page.njk" %}
 
 {% set customSegmentLinks = [{
     "title": copy.downloadsTitle


### PR DESCRIPTION
This adds the eventual URL paths for the Logo/Merch pages to the routes so they correctly render their additional logic (eg. logo selection / material order form). 

The dependent change for this is to add the "primary content" for these pages (eg. the paragraphs appearing before the custom code) as Flexible Content to the *old* versions of the pages once this PR is live, as otherwise this content will disappear when these pages start using the new "CMS page" template (which only supports flex content, not segments etc). I can coordinate this when we deploy.