### PR TITLE
Force integer input for budget (eg. disallow commas/periods)

### DIFF
--- a/assets/js/vue-apps/form-components/budget-input.vue
+++ b/assets/js/vue-apps/form-components/budget-input.vue
@@ -93,6 +93,13 @@ export default {
                 this.budgetRows.length > 1 &&
                 index !== this.budgetRows.length - 1
             );
+        },
+        onlyNumber($event) {
+            let keyCode = $event.keyCode ? $event.keyCode : $event.which;
+            // disallow commas and periods
+            if (keyCode === 46 || keyCode === 44) {
+                $event.preventDefault();
+            }
         }
     }
 };
@@ -144,6 +151,7 @@ export default {
                             step="1"
                             :max="maxBudget"
                             class="ff-currency__input"
+                            @keypress="onlyNumber($event)"
                         />
                     </div>
                 </div>

--- a/controllers/apply/lib/joi-extensions/budget-items.js
+++ b/controllers/apply/lib/joi-extensions/budget-items.js
@@ -15,7 +15,7 @@ module.exports = function budgetItems(joi) {
                         .max(255)
                         .required(),
                     cost: joi
-                        .number()
+                        .friendlyNumber()
                         .min(1)
                         .integer()
                         .required()


### PR DESCRIPTION
This blocks the input of periods/commas (which is already happening in Chrome but not in Firefox or IE) for the budget tool. Users were confused by this as the current behaviour turns `1,000` into `1` (while leaving `1,000` onscreen).