### PR TITLE
Submitted statuses

### DIFF
--- a/controllers/apply/lib/from-date-parts.js
+++ b/controllers/apply/lib/from-date-parts.js
@@ -1,12 +1,17 @@
 'use strict';
-const { toInteger } = require('lodash');
+const toInteger = require('lodash/toInteger');
+const isString = require('lodash/isString');
 const moment = require('moment');
 
-module.exports = function fromDateParts(parts) {
-    return moment({
-        year: toInteger(parts.year),
-        // month is 0 indexed when constructing a date object
-        month: toInteger(parts.month) - 1,
-        day: toInteger(parts.day)
-    });
+module.exports = function fromDateParts(value) {
+    if (isString(value)) {
+        return moment(value);
+    } else {
+        return moment({
+            year: toInteger(value.year),
+            // month is 0 indexed when constructing a date object
+            month: toInteger(value.month) - 1,
+            day: toInteger(value.day)
+        });
+    }
 };

--- a/controllers/apply/lib/from-date-parts.test.js
+++ b/controllers/apply/lib/from-date-parts.test.js
@@ -7,3 +7,9 @@ test('constructs moment instance from date parts', () => {
     expect(dt.isValid()).toBe(true);
     expect(dt.format('YYYY-MM-DD')).toBe('2020-06-01');
 });
+
+test('retains value if a plain date string is passed', function() {
+    const dt = fromDateParts('2020-06-01');
+    expect(dt.isValid()).toBe(true);
+    expect(dt.format('YYYY-MM-DD')).toBe('2020-06-01');
+});

--- a/views/components/application-card/macro.njk
+++ b/views/components/application-card/macro.njk
@@ -2,14 +2,14 @@
     {% set cardCopy = __('applyNext.applicationCards') %}
     <article class="application-card">
         <header class="application-card__header">
-            <h{{ headingLevel }} class="application-card__title u-tone-brand-primary">
+            <h{{ headingLevel }} class="application-card__title u-tone-brand-primary" data-hj-suppress>
                 {% if props.editUrl %}<a href="{{ localify(props.editUrl) }}" class="u-link-unstyled">{% endif %}
                     {{ props.projectName | widont | safe }}
                 {% if props.editUrl %}</a>{% endif %}
             </h{{ headingLevel }}>
             <p class="application-card__amount">
                 <strong>{{ cardCopy.amountRequested }}</strong>:
-                <span class="o-pill">
+                <span class="o-pill" data-hj-suppress>
                     {{ props.amountRequested }}
                 </span>
             </p>
@@ -18,7 +18,7 @@
         <dl class="application-card__overview u-text-small">
             {% for item in props.overview %}
                 <dt>{{ item.label }}</dt>
-                <dd>{% if item.value %}{{ item.value }}{% else %}{{ cardCopy.notYetCompleted }}{% endif %}</dd>
+                <dd data-hj-suppress>{% if item.value %}{{ item.value }}{% else %}{{ cardCopy.notYetCompleted }}{% endif %}</dd>
             {% endfor %}
         </dl>
 


### PR DESCRIPTION
Earl spotted a bug where for submitted awards for all applications we'd show the project dates as "not yet completed". This is because we flatten dates to ISO strings when submitting to salesforce and we were assuming it was always stored as parts. The simplest way I could think of handling this was to pass through in `fromDateParts`, which the formatter uses, if we are passed a string.

**Before**

<img width="488" alt="Screenshot 2019-11-05 at 15 52 44" src="https://user-images.githubusercontent.com/123386/68223406-a48f6c80-ffe4-11e9-9e11-4d1bec6a2413.png">

**After**

<img width="500" alt="Screenshot 2019-11-05 at 15 52 25" src="https://user-images.githubusercontent.com/123386/68223418-a9542080-ffe4-11e9-9f29-f39cbe7a7b15.png">

Also, realised we are best to add some `data-hj-suppress` lines to the new application cards.