### PR TITLE
Add a min-width to budget amount column to ensure placeholder is visible in Chrome

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -535,6 +535,10 @@ $inputOutline: 3px solid get-color('border', 'outline');
                 flex-grow: 2;
             }
 
+            .ff-budget__row-amount {
+                min-width: 160px;
+            }
+
             .ff-budget-row__action {
                 min-width: 190px;
                 text-align: right;


### PR DESCRIPTION
As reported by @scottoakley!

Before:
![image](https://user-images.githubusercontent.com/394376/68285053-78bcc700-0076-11ea-92f3-5653c767bc11.png)

After:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/394376/68285023-6cd10500-0076-11ea-81de-2673d7be8b14.png">
