### PR TITLE
Add a media object variant for larger screens

### DIFF
--- a/assets/sass/scaffolding/_media.scss
+++ b/assets/sass/scaffolding/_media.scss
@@ -4,7 +4,7 @@
 // The classic Nicole Sullivan original. Image alongside text.
 // Source: https://philipwalton.github.io/solved-by-flexbox/demos/media-object/
 
-.o-media {
+@mixin media-object() {
     display: flex;
     align-items: flex-start;
 
@@ -17,5 +17,22 @@
     }
     .o-media__body {
         flex: 1;
+    }
+}
+
+.o-media {
+    @include media-object();
+}
+
+// A version of the above which only applies in larger layouts
+// Media figures gain space below when used on smaller screens (eg. vertical layout)
+.o-media--constrained {
+    @include mq('medium-minor', 'max') {
+        .o-media__figure {
+            margin-bottom: $spacingUnit;
+        }
+    }
+    @include mq('medium-minor') {
+        @include media-object();
     }
 }

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -900,11 +900,11 @@ module.exports = function({
                 but photos of your bank statements are absolutely fine.
             </strong></p>
             
-            <div class="o-media u-padded u-tone-background-tint u-margin-bottom">
+            <div class="o-media--constrained u-padded u-tone-background-tint u-margin-bottom">
                 <a href="../help/bank-statement" target="_blank">
                     <img src="/assets/images/apply/afa-bank-statement-example-small.png"
                          alt="An example of a bank statement we need from you"
-                         class="o-media__figure-gutter"
+                         class="o-media__figure o-media__figure-gutter"
                          width="300" />
                     <span class="u-visually-hidden">Opens in a new window</span>
                  </a>
@@ -952,11 +952,11 @@ module.exports = function({
                 ond mae lluniau o’ch cyfriflenni banc yn hollol iawn.
             </strong></p>
             
-            <div class="o-media u-padded u-tone-background-tint u-margin-bottom">
+            <div class="o-media--constrained u-padded u-tone-background-tint u-margin-bottom">
                 <a href="../help/bank-statement" target="_blank">
                     <img src="/assets/images/apply/afa-bank-statement-example-small-welsh.jpg"
                          alt="Enghraifft o gyfriflen banc rydym ei angen gennych"
-                         class="o-media__figure-gutter"
+                         class="o-media__figure o-media__figure-gutter"
                          width="300" />
                     <span class="u-visually-hidden">Yn agor mewn ffenest newydd</span>
                  </a>


### PR DESCRIPTION
Fixes this layout issue by adding a media object variant which only applies to larger screens.

Before:
![image](https://user-images.githubusercontent.com/394376/68297059-f6400180-008d-11ea-8bec-a83e08de81d6.png)

After:
![image](https://user-images.githubusercontent.com/394376/68297103-0821a480-008e-11ea-9223-ff1d05f9838e.png)
