### PR TITLE
Remove redirects/references to BLF domain

### DIFF
--- a/assets/js/helpers/features.js
+++ b/assets/js/helpers/features.js
@@ -23,12 +23,10 @@ export const isDoNotTrack =
 
 /* Disable analytics outside of the real domain to avoid polluting data. */
 function shouldBlockAnalytics() {
-    return (
-        window.AppConfig.environment === 'production' &&
-        ['www.biglotteryfund.org.uk', 'www.tnlcommunityfund.org.uk'].indexOf(
-            window.location.hostname
-        ) === -1
-    );
+    const isProduction = window.AppConfig.environment === 'production';
+    const isProdDomain =
+        window.location.hostname === 'www.tnlcommunityfund.org.uk';
+    return !isProduction && !isProdDomain;
 }
 
 export const FEATURES = [

--- a/controllers/domain-redirect.js
+++ b/controllers/domain-redirect.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = function(req, res, next) {
-    if (req.get('host') === 'www.biglotteryfund.org.uk') {
-        res.redirect(301, `https://www.tnlcommunityfund.org.uk${req.originalUrl}`);
+    if (req.get('host') === 'apply.tnlcommunityfund.org.uk') {
+        res.redirect(301, `https://www.tnlcommunityfund.org.uk/apply`);
     } else {
         next();
     }

--- a/controllers/domain-redirect.test.js
+++ b/controllers/domain-redirect.test.js
@@ -10,7 +10,7 @@ describe('domain redirect', () => {
             method: 'GET',
             url: '/some/example/url/',
             headers: {
-                'Host': 'www.biglotteryfund.org.uk',
+                'Host': 'apply.tnlcommunityfund.org.uk',
                 'X-Forwarded-Proto': 'https'
             }
         });

--- a/controllers/robots.js
+++ b/controllers/robots.js
@@ -1,5 +1,5 @@
 'use strict';
-const { includes, concat } = require('lodash');
+const { concat } = require('lodash');
 const express = require('express');
 
 const { getAbsoluteUrl } = require('../common/urls');
@@ -9,11 +9,7 @@ const { noStore } = require('../common/cached');
 const router = express.Router();
 
 router.get('/', noStore, (req, res) => {
-    const shouldIndex =
-        includes(
-            ['www.biglotteryfund.org.uk', 'www.tnlcommunityfund.org.uk'],
-            req.get('host')
-        ) === true;
+    const shouldIndex = req.get('host') === 'apply.tnlcommunityfund.org.uk';
 
     // Merge archived paths with internal / deliberately excluded URLs
     const disallowList = concat(

--- a/server.js
+++ b/server.js
@@ -66,7 +66,7 @@ i18n.expressBind(app, {
 
 /**
  * Old domain redirect
- * Redirect requests from www.biglotteryfund.org.uk
+ * Redirect requests from apply.tnlcommunityfund.org.uk
  */
 app.use(require('./controllers/domain-redirect'));
 


### PR DESCRIPTION
```
$ dig -type CNAME www.biglotteryfund.org.uk

;; ANSWER SECTION:
www.biglotteryfund.org.uk. 0	IN	CNAME	d1dat5w75fqn9b.cloudfront.net.
```

The above domain now points to its own Cloudfront distribution, which redirects it to the Redirectotron server, which in turn redirects it to https://www.tnlcommunityfund.org.uk meaning the site will never be served directly on www.biglotteryfund.org.uk (and it hasn't been for a while). 

This change removes checks for `www.biglotteryfund.org.uk` in code (eg. to ensure we don't block robots/analytics for that domain – this has been redundant for almost a year now) but it also redirects `apply.tnlcommunityfund.org.uk` to the production domain as we now have DNS changes  to serve that via the main app.