### PR TITLE
Run cypress in chrome in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
 
 dist: xenial
 
+addons:
+  chrome: stable
+
 # Defaults
 language: node_js
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --write **/*.{js,scss,vue}",
     "test-unit": "jest --maxWorkers=4",
     "test": "npm run lint && npm run test-unit",
-    "test-integration": "npm run start-test & wait-on http://localhost:8090 && npx cypress run",
+    "test-integration": "npm run start-test & wait-on http://localhost:8090 && npx cypress run --browser chrome",
     "clean": "del-cli $npm_package_config_dist_root/* ./config/assets.json",
     "build-css-style": "node-sass assets/sass/style.scss --output $npm_package_config_dist_css --source-map $npm_package_config_dist_css && postcss $npm_package_config_dist_css/style.css --replace --map",
     "build-css-emails": "node-sass assets/sass/emails.scss | postcss --no-map -u autoprefixer > $npm_package_config_dist_css/emails.css",


### PR DESCRIPTION
~Early test run suggests this might speed things up—and be closer to real-world—compared to running in Electron. Going to run the build a few more times to confirm though.~

Update: This seems to reliably shave between 30-60 seconds off the build.