### PR TITLE
Move session check endpoint to above the non-staff requirement

### DIFF
--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -46,6 +46,22 @@ if (features.enableSeeders) {
 }
 
 /**
+ * Session check endpoint
+ *
+ * Used in AJAX calls to determine the user's logged-in state.
+ * Must appear here (eg. before we require non-staff users)
+ */
+router.get('/session', function(req, res) {
+    res.send({
+        expires: req.session.cookie.expires,
+        maxAge: req.session.cookie.maxAge,
+        originalMaxAge: req.session.cookie.originalMaxAge,
+        isExpired: moment(req.session.cookie.expires).isBefore(moment()),
+        isAuthenticated: req.isAuthenticated()
+    });
+});
+
+/**
  * Public user routes
  * Disallow staff from this point on
  */
@@ -93,16 +109,6 @@ router.get('/logout', function(req, res) {
     logger.info('User logout', { service: 'user' });
     req.session.save(() => {
         redirectForLocale(req, res, '/user/login?s=loggedOut');
-    });
-});
-
-router.get('/session', function(req, res) {
-    res.send({
-        expires: req.session.cookie.expires,
-        maxAge: req.session.cookie.maxAge,
-        originalMaxAge: req.session.cookie.originalMaxAge,
-        isExpired: moment(req.session.cookie.expires).isBefore(moment()),
-        isAuthenticated: req.isAuthenticated()
     });
 });
 


### PR DESCRIPTION
Tagging @NikhilNanjappa so he can get some closure from seeing this fixed!

I discovered that the AJAX call to `/user/session` (which happens on every page) was logging out logged-in Staff users. I assumed this was due to `withCredentials` not being set, or some combo of missing headers ( `Access-Control-Allow-Origin` etc).

Turns out that the position of the `/user/session` route was causing this as it comes _after_  the regular-user-only routes, which start:

`router.use(requireNotStaffAuth)...`

... and `requireNotStaffAuth` specifies:

```
if (req.isAuthenticated() && isStaff(req.user)) {
        req.logout();
        ...
```

... so every call to `/user/session` would log out any Staff users who were logged in 💥 

This fix (confirmed on TEST by manually making the change) restores things!