### PR TITLE
Activation email

### DIFF
--- a/assets/sass/emails.scss
+++ b/assets/sass/emails.scss
@@ -8,7 +8,7 @@
 
 body {
     padding: 10px;
-    margin: auto;
+    max-width: 800px;
 }
 
 body,
@@ -64,6 +64,11 @@ a {
     img {
         width: 200px;
     }
+}
+
+hr {
+    border: 0;
+    border-top: 1px solid get-color('border', 'base');
 }
 
 .summary {
@@ -167,4 +172,19 @@ table {
             @include wrap-words();
         }
     }
+}
+
+.btn {
+    font-family: font-stack('display');
+    line-height: 1; // so we can calculate padding for the height
+    font-weight: font-weight('display', 'semibold');
+    color: white;
+    background-color: get-color('brand', 'primary');
+    text-decoration: none;
+    border: none;
+    border-radius: 50px;
+    vertical-align: top;
+    display: inline-block;
+    font-size: 18px;
+    padding: $spacingUnit $spacingUnit * 2;
 }

--- a/assets/sass/emails.scss
+++ b/assets/sass/emails.scss
@@ -52,6 +52,10 @@ h6 {
     font-size: 12px;
 }
 
+p {
+    margin: 0 0 1em 0;
+}
+
 a {
     color: get-color('links', 'base');
     font-weight: font-weight('display', 'bold');
@@ -187,4 +191,9 @@ table {
     display: inline-block;
     font-size: 18px;
     padding: $spacingUnit $spacingUnit * 2;
+}
+
+.u-no-margin {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1114,17 +1114,6 @@ user:
         <li>Gwiriwch eich e-byst (dylech fod wedi cael un gennym)</li>
         <li>Cliciwch ar y ddolen yn ein e-bost actifadu</li>
       </ul>
-    email:
-      subject: Actifadu eich cyfrif gwefan Cronfa Gymunedol y Loteri Genedlaethol
-      body: >
-        <h1>Cronfa Gymunedol y Loteri Genedlaethol</h1>
-        <h2>Rydych bron yn barod i ymgeisio i’r Gronfa Gymunedol y Loteri Genedlaethol</h2>
-
-        <p>Rydych wedi creu cyfrif â ni gan ddefnyddio’r cyfeiriad e-bost hwn: %s.</p>
-        <p>Nawr, rydych angen <a href="%s">actifadu eich cyfrif</a> i ddechrau ar eich cais.</p>
-
-        <p>Diolch,</p>
-        <p>Cronfa Gymunedol y Loteri Genedlaethol</p>
     errorMessage: Roedd eich dolen actifadu yn annilys neu wedi dod i ben.
     resendLabel: Anfon dolen actifadu eto
     resendMessage: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1223,17 +1223,6 @@ user:
         <li>Check your emails (you should’ve got one from us)</li>
         <li>Click on the link in our activation email</li>
       </ul>
-    email:
-      subject: Activate your The National Lottery Community Fund website account
-      body: >
-        <h1>The National Lottery Community Fund</h1>
-        <h2>You’re almost ready to apply for the National Lottery Community Fund</h2>
-
-        <p>You set up an account with us, using this email address: %s.</p>
-        <p>Now you just need to <a href="%s">activate your account</a> to start your application.</p>
-
-        <p>Thanks,</p>
-        <p>The National Lottery Community Fund</p>
     errorMessage: Your activation link was invalid or has expired.
     resendLabel: Send activation link again
     resendMessage: >

--- a/controllers/user/lib/activation-email.js
+++ b/controllers/user/lib/activation-email.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const moment = require('moment');
+const get = require('lodash/fp/get');
 
 const { sendHtmlEmail } = require('../../../common/mail');
 const { getAbsoluteUrl, localify } = require('../../../common/urls');
@@ -9,37 +10,40 @@ const { Users } = require('../../../db/models');
 const { signTokenActivate } = require('./jwt');
 
 module.exports = async function sendActivationEmail(req, user) {
-    const dateOfActivationAttempt = moment().unix();
-    const token = signTokenActivate(user.id, dateOfActivationAttempt);
+    const locale = req.i18n.getLocale();
+    const localise = get(locale);
+    const now = moment();
+    const { token, expiresAt } = signTokenActivate(user.id, now);
 
-    const urlPath = localify(req.i18n.getLocale())(
-        `/user/activate?token=${token}`
-    );
-    const activationUrl = getAbsoluteUrl(req, urlPath);
-
-    const emailContent = {
-        subject: req.i18n.__('user.activate.email.subject'),
-        body: req.i18n.__(
-            'user.activate.email.body',
-            user.username,
-            activationUrl
-        )
-    };
+    function localisedAbsoluteUrl(urlPath) {
+        return getAbsoluteUrl(req, localify(locale)(urlPath));
+    }
 
     const mailParams = {
         name: 'user_activate_account',
         sendTo: user.username,
-        subject: emailContent.subject
+        subject: localise({
+            en: 'Please confirm your email address',
+            cy: '@TODO: i18n'
+        })
     };
 
     const email = await sendHtmlEmail(
         {
             template: path.resolve(
                 __dirname,
-                '../views/emails/email-from-locale.njk'
+                '../views/emails/activate-email.njk'
             ),
             templateData: {
-                body: emailContent.body
+                locale: locale,
+                emailAddress: user.username,
+                activationUrl: localisedAbsoluteUrl(
+                    `/user/activate?token=${token}`
+                ),
+                loginUrl: localisedAbsoluteUrl(`/user/login`),
+                expiryDate: expiresAt
+                    .locale(locale)
+                    .format('H:mm [on] dddd Do MMMM')
             }
         },
         mailParams
@@ -47,7 +51,7 @@ module.exports = async function sendActivationEmail(req, user) {
 
     await Users.updateDateOfActivationAttempt({
         id: user.id,
-        dateOfActivationAttempt: dateOfActivationAttempt
+        dateOfActivationAttempt: now.unix()
     });
 
     return {

--- a/controllers/user/lib/activation-email.js
+++ b/controllers/user/lib/activation-email.js
@@ -24,7 +24,7 @@ module.exports = async function sendActivationEmail(req, user) {
         sendTo: user.username,
         subject: localise({
             en: 'Please confirm your email address',
-            cy: '@TODO: i18n'
+            cy: 'Cadarnhewch eich cyfeiriad e-bost'
         })
     };
 

--- a/controllers/user/views/emails/activate-email.njk
+++ b/controllers/user/views/emails/activate-email.njk
@@ -1,0 +1,36 @@
+{% extends "views/layouts/emails.njk" %}
+
+{% block content %}
+    {% if locale === 'cy' %}
+
+    {% else %}
+        <p>Hello,</p>
+
+        <p>
+            Thanks for creating an account.
+            We're looking forward to hearing about your idea to help your community thrive.
+        </p>
+
+        <h2>Before applying for funding—activate your account</h2>
+        <p>This will confirm <strong>{{ emailAddress }}</strong> is your email address.</p>
+
+        <p><a href="{{ activationUrl }}" class="btn">Activate your account</a></p>
+
+        <p><strong>This activation link will expire at {{ expiryDate }}</strong></p>
+
+        <p>
+            If you haven't used it by then, you'll need to
+            <a href="{{ loginUrl }}">log in to your account</a> to request the activation link again.
+            We do this to keep your account secure.
+        </p>
+
+        <p>Thanks,<br/>The National Lottery Community Fund</p>
+
+        <hr />
+
+        <p>
+            Button not working? Paste this link into your browser:
+            <a href="{{ activationUrl }}">{{ activationUrl }}</a>
+        </p>
+    {% endif %}
+{% endblock %}

--- a/controllers/user/views/emails/activate-email.njk
+++ b/controllers/user/views/emails/activate-email.njk
@@ -2,7 +2,34 @@
 
 {% block content %}
     {% if locale === 'cy' %}
+        <p>Helo,</p>
 
+        <p>
+            Diolch am greu cyfrif.
+            Rydym yn edrych ymlaen i glywed am eich syniad i helpu eich cymuned i ffynnu.
+        </p>
+
+        <h2>Cyn i chi ymgeisio am arian—rhaid actifadu eich cyfrif</h2>
+        <p>Bydd hyn yn cadarnhau mae <strong>{{ emailAddress }}</strong> yw eich cyfeiriad e-bost.</p>
+
+        <p><a href="{{ activationUrl }}" class="btn">Actifadu eich cyfrif</a></p>
+
+        <p><strong>Bydd y ddolen actifadu hon yn dod i ben am {{ expiryDate }}</strong></p>
+
+        <p>
+            Os nad ydych wedi’i ddefnyddio erbyn hynny, bydd angen i chi
+            <a href="{{ loginUrl }}">fewngofnodi i’ch cyfrif</a> i ofyn am y ddolen actifadu eto.
+            Rydym yn gwneud hyn i gadw eich cyfrif yn ddiogel.
+        </p>
+
+        <p>Diolch,<br/>Cronfa Gymunedol y Loteri Genedlaethol</p>
+
+        <hr />
+
+        <p>
+            Botwm ddim yn gweithio? Copïwch y ddolen hon i’ch porwr:
+            <a href="{{ activationUrl }}">{{ activationUrl }}</a>
+        </p>
     {% else %}
         <p>Hello,</p>
 

--- a/controllers/user/views/emails/activate-email.njk
+++ b/controllers/user/views/emails/activate-email.njk
@@ -9,13 +9,14 @@
             Rydym yn edrych ymlaen i glywed am eich syniad i helpu eich cymuned i ffynnu.
         </p>
 
-        <h2>Cyn i chi ymgeisio am arian—rhaid actifadu eich cyfrif</h2>
+        <h2 class="u-no-margin">Cyn i chi ymgeisio am arian—rhaid actifadu eich cyfrif</h2>
         <p>Bydd hyn yn cadarnhau mae <strong>{{ emailAddress }}</strong> yw eich cyfeiriad e-bost.</p>
 
         <p><a href="{{ activationUrl }}" class="btn">Actifadu eich cyfrif</a></p>
 
-        <p><strong>Bydd y ddolen actifadu hon yn dod i ben am {{ expiryDate }}</strong></p>
-
+        <p class="u-no-margin">
+            <strong>Bydd y ddolen actifadu hon yn dod i ben am {{ expiryDate }}</strong>
+        </p>
         <p>
             Os nad ydych wedi’i ddefnyddio erbyn hynny, bydd angen i chi
             <a href="{{ loginUrl }}">fewngofnodi i’ch cyfrif</a> i ofyn am y ddolen actifadu eto.
@@ -38,12 +39,12 @@
             We're looking forward to hearing about your idea to help your community thrive.
         </p>
 
-        <h2>Before applying for funding—activate your account</h2>
+        <h2 class="u-no-margin">Before applying for funding—activate your account</h2>
         <p>This will confirm <strong>{{ emailAddress }}</strong> is your email address.</p>
 
         <p><a href="{{ activationUrl }}" class="btn">Activate your account</a></p>
 
-        <p><strong>This activation link will expire at {{ expiryDate }}</strong></p>
+        <p class="u-no-margin"><strong>This activation link will expire at {{ expiryDate }}</strong></p>
 
         <p>
             If you haven't used it by then, you'll need to

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -265,10 +265,7 @@ it('should prevent registrations with invalid passwords', () => {
 it('should register and see activation screen', function() {
     createAccount(generateAccountEmail(), generateAccountPassword());
     cy.checkA11y();
-    cy.get('body').should(
-        'contain',
-        'Activate your account'
-    );
+    cy.get('body').should('contain', 'Activate your account');
 });
 
 it('should email valid users with a token', () => {
@@ -286,7 +283,7 @@ it('should email valid users with a token', () => {
         );
         expect(res.body.mailParams.sendTo).to.equal(username);
         expect(res.body.mailParams.subject).to.equal(
-            'Activate your The National Lottery Community Fund website account'
+            'Please confirm your email address'
         );
     });
 });
@@ -351,10 +348,7 @@ it('should be able to log in and update account details', () => {
             cy.findByText('Update email address').click();
         });
 
-        cy.get('body').should(
-            'contain',
-            'Activate your account'
-        );
+        cy.get('body').should('contain', 'Activate your account');
     });
 });
 


### PR DESCRIPTION
Updates activation email template:

![image](https://user-images.githubusercontent.com/123386/68473865-f7069e00-021b-11ea-93ed-0e09b9cea687.png)

We previously had this text as coming from the locale yaml files. The downside of this is that this required sprintf style substitution which becomes unwieldy when needing to reuse substitutions and pass larger numbers of variables. For the time being I've inlined the text into the template directly.
