### PR TITLE
Update Array.find instances to lodash.find

### DIFF
--- a/assets/js/vue-apps/form-components/address-lookup.vue
+++ b/assets/js/vue-apps/form-components/address-lookup.vue
@@ -1,5 +1,6 @@
 <script>
 import $ from 'jquery';
+import find from 'lodash/find';
 import compact from 'lodash/compact';
 
 import AddressLine from './address-line.vue';
@@ -111,7 +112,7 @@ export default {
             );
         },
         getAddressFromId(udprn) {
-            return this.addressData.find(_ => _.udprn === udprn);
+            return find(this.addressData, _ => _.udprn === udprn);
         },
         formatAddress(address) {
             return {

--- a/assets/js/vue-apps/materials.js
+++ b/assets/js/vue-apps/materials.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import find from 'lodash/find';
 import sumBy from 'lodash/sumBy';
 import Vue from 'vue';
 import queryString from 'query-string';
@@ -81,7 +82,8 @@ function init() {
             // look up the quantity of a given item, defaulting to its
             // value when the page was loaded (eg. from session cookie)
             getQuantity: function(productId) {
-                let product = this.orderData.find(
+                let product = find(
+                    this.orderData,
                     o => o.productId === parseInt(productId)
                 );
                 return product ? product.quantity : 0;

--- a/assets/js/vue-apps/past-grants.js
+++ b/assets/js/vue-apps/past-grants.js
@@ -159,7 +159,8 @@ function init(STORAGE_KEY) {
                     }
 
                     // Update the existing one
-                    this.filterSummary.find(
+                    find(
+                        this.filterSummary,
                         i => i.name === payload.name
                     ).label = payload.label;
                 } else {


### PR DESCRIPTION
Now required since removing `polyfill.io` https://github.com/biglotteryfund/blf-alpha/pull/2651 which was masking uses of `Array.find`. Double checked and the other `.find` instances are `jQuery.find` for DOM elements.