### PR TITLE
Tools date filter

### DIFF
--- a/assets/sass/components/_tools.scss
+++ b/assets/sass/components/_tools.scss
@@ -5,7 +5,6 @@
 .tools-filter-form {
     display: flex;
     flex-flow: row wrap;
-    align-items: flex-end;
 
     .tools-filter-form__item {
         flex: 0 0 auto;
@@ -18,6 +17,7 @@
     }
 
     .tools-filter-form__actions {
+        align-self: flex-end;
         margin-bottom: 5px;
     }
 }

--- a/assets/sass/components/_tools.scss
+++ b/assets/sass/components/_tools.scss
@@ -1,0 +1,23 @@
+/* =========================================================================
+   Tools specific components
+   ========================================================================= */
+
+.tools-filter-form {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-end;
+
+    .tools-filter-form__item {
+        flex: 0 0 auto;
+        margin-right: $spacingUnit;
+        padding-bottom: $spacingUnit / 2;
+
+        &:last-of-type {
+            margin-right: 0;
+        }
+    }
+
+    .tools-filter-form__actions {
+        margin-bottom: 5px;
+    }
+}

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -65,6 +65,7 @@
 @import 'components/logos';
 @import 'components/social';
 @import 'components/user';
+@import 'components/tools';
 @import 'components/global-header';
 @import 'components/global-footer';
 

--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -344,6 +344,11 @@ router.get('/:applicationId', async (req, res, next) => {
         const submittedApplications = appTypes.find(_ => _.id === 'submitted')
             .applications;
 
+        const oldestSubmittedApplication = minBy(
+            submittedApplications,
+            response => response.createdAt
+        );
+
         const statistics = {
             appDurations: measureTimeTaken(submittedApplications),
             wordCount: measureWordCounts(submittedApplications),
@@ -397,6 +402,8 @@ router.get('/:applicationId', async (req, res, next) => {
             applicationData: applicationData,
             statistics: statistics,
             dateRange: dateRange,
+            oldestDate: moment(oldestSubmittedApplication.createdAt).toDate(),
+            now: new Date(),
             country: country,
             countryTitle: countryTitle,
             dataStudioUrl: dataStudioUrl,

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -122,7 +122,10 @@ router.get('/', async function(req, res, next) {
             }
         };
 
+        const title = 'Material orders';
         res.render(path.resolve(__dirname, './views/orders'), {
+            title: title,
+            breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
             data: orderData,
             oldestOrderDate: moment(oldestOrder.createdAt).toDate(),
             dateRange: dateRange,

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -95,7 +95,15 @@ function summariseOrders(orders) {
 
 router.get('/', async function(req, res, next) {
     try {
-        const dateRange = getDateRange(req.query.start, req.query.end);
+        let dateRange = getDateRange(req.query.start, req.query.end);
+        if (!dateRange) {
+            dateRange = {
+                start: moment()
+                    .subtract(30, 'days')
+                    .toDate(),
+                end: moment().toDate()
+            };
+        }
 
         const [materials, oldestOrder, orderData] = await Promise.all([
             contentApi.getMerchandise({ locale: 'en', showAll: true }),
@@ -128,6 +136,7 @@ router.get('/', async function(req, res, next) {
             breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
             data: orderData,
             oldestOrderDate: moment(oldestOrder.createdAt).toDate(),
+            now: new Date(),
             dateRange: dateRange,
             materials: materials
         });

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -10,40 +10,6 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.js" integrity="sha256-cpdGuiwvKhwkQY18xx0CNJBb9AhGOYKsAz6ea7LaB30=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.css" integrity="sha256-DnG3ryf8FsLvOmNjwO9S4+Fpju6QECDbhLbWCtpn7Bc=" crossorigin="anonymous" />
-    <script>
-        $(function() {
-            $('.js-datepicker-trigger')
-                .daterangepicker({
-                    maxDate: new Date(),
-                })
-                .on('apply.daterangepicker', function(event, picker) {
-                    const s = picker.startDate.format('YYYY-MM-DD');
-                    const e = picker.endDate.format('YYYY-MM-DD');
-                    const existingSearch = window.location.search;
-                    const dateQuery = `start=${s}&end=${e}`;
-                    window.location = existingSearch ? `${existingSearch}&${dateQuery}` : `?${dateQuery}`;
-                });
-
-            $('.js-country').change(function() {
-                const c = $(this).val();
-                window.location = (c === 'uk') ? '?' : `?country=${c}`;
-            })
-        });
-    </script>
-    <style>
-        .datepicker {
-            font-size: 14px;
-            vertical-align: middle;
-        }
-        .country-picker label,
-        .country-picker select {
-            font-size: 14px;
-        }
-
-        .country-picker label {
-            font-weight: bold;
-        }
-    </style>
 {% endblock %}
 
 {% block content %}
@@ -60,47 +26,43 @@
                 {%- endif -%}
             </h1>
 
-            <h2>
-                Date range:
-                {{ formatDate(dateRange.start) }} &mdash;
-                {{ formatDate(dateRange.end) }}
-                <a class="js-datepicker-trigger datepicker" href="javascript://">Change dates?</a>
-                {% if dateRange %}
-                    <a class="datepicker" href="?">or Reset dates?</a>
-                {% endif %}
-            </h2>
+            <p>
+                <strong>Date range</strong>: {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
+                (<a href="?">Reset dates</a>)
+            </p>
+
+            <form action="" method="get" class="tools-filter-form">
+
+                <div class="tools-filter-form__item">
+                    <label for="start" class="ff-label">Start date</label>
+                    <input class="ff-text"
+                           type="date"
+                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
+                           name="start"
+                           id="start"
+                    >
+                </div>
+                <div class="tools-filter-form__item">
+                    <label for="end" class="ff-label">End date</label>
+                    <input class="ff-text"
+                           type="date"
+                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
+                           name="end"
+                           id="end"
+                    >
+                </div>
+
+                <div class="tools-filter-form__item tools-filter-form__actions">
+                    <input class="btn btn--small" type="submit" value="Filter by date"/>
+                </div>
+            </form>
 
             <form class="country-picker u-margin-bottom-l u-margin-top">
-                <label>Choose a country:</label>
-                {% set countries = [
-                    {
-                        'value': 'uk',
-                        'label': 'UK-wide'
-                    },
-                    {
-                        'value': 'england',
-                        'label': 'England'
-                    },
-                    {
-                        'value': 'northern-ireland',
-                        'label': 'Northern Ireland'
-                    },
-                    {
-                        'value': 'scotland',
-                        'label': 'Scotland'
-                    },
-                    {
-                        'value': 'wales',
-                        'label': 'Wales'
-                    }
-                ] %}
-                <select class="js-country">
-                    {% for c in countries %}
-                        <option value="{{ c.value }}"{% if c.value === country %} selected="selected"{% endif %}>
-                            {{ c.label }}
-                        </option>
-                    {% endfor %}
-                </select>
+
             </form>
 
             {% for appType in applicationData %}

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -6,10 +6,6 @@
 
 {% block extraHead %}
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js" integrity="sha256-CutOzxCRucUsn6C6TcEYsauvvYilEniTXldPa6/wu0k=" crossorigin="anonymous"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.js" integrity="sha256-cpdGuiwvKhwkQY18xx0CNJBb9AhGOYKsAz6ea7LaB30=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.css" integrity="sha256-DnG3ryf8FsLvOmNjwO9S4+Fpju6QECDbhLbWCtpn7Bc=" crossorigin="anonymous" />
 {% endblock %}
 
 {% block content %}

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -4,11 +4,7 @@
 {% from "components/data.njk" import statsGrid %}
 
 {% block extraHead %}
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js" integrity="sha256-CutOzxCRucUsn6C6TcEYsauvvYilEniTXldPa6/wu0k=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.js" integrity="sha256-cpdGuiwvKhwkQY18xx0CNJBb9AhGOYKsAz6ea7LaB30=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.css" integrity="sha256-DnG3ryf8FsLvOmNjwO9S4+Fpju6QECDbhLbWCtpn7Bc=" crossorigin="anonymous" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
 {% endblock %}
 
 {% macro statBlock(number, caption) %}
@@ -171,7 +167,6 @@
                     </tbody>
                 </table>
             </div>
-
 
             <script>
                 var ctx = document.getElementById('js-chart');

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -9,27 +9,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js" integrity="sha256-CutOzxCRucUsn6C6TcEYsauvvYilEniTXldPa6/wu0k=" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.js" integrity="sha256-cpdGuiwvKhwkQY18xx0CNJBb9AhGOYKsAz6ea7LaB30=" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.3/daterangepicker.min.css" integrity="sha256-DnG3ryf8FsLvOmNjwO9S4+Fpju6QECDbhLbWCtpn7Bc=" crossorigin="anonymous" />
-    <script>
-        $(function() {
-            $('.js-datepicker-trigger')
-                .daterangepicker({
-                    minDate: new Date("{{ oldestOrderDate }}"),
-                    maxDate: new Date(),
-                })
-                .on('apply.daterangepicker', function(event, picker) {
-                    const s = picker.startDate.format('YYYY-MM-DD');
-                    const e = picker.endDate.format('YYYY-MM-DD');
-                    window.location = `?start=${s}&end=${e}`;
-                });
-        });
-    </script>
-
-    <style>
-        .datepicker {
-            font-size: 14px;
-            vertical-align: middle;
-        }
-    </style>
 {% endblock %}
 
 {% macro statBlock(number, caption) %}
@@ -50,18 +29,37 @@
         </h1>
 
         <p>
-            {% if dateRange %}
-                {{ formatDate(dateRange.start) }} &mdash;
-                {{ formatDate(dateRange.end) }}
-            {% else %}
-                in the last five months
-            {% endif %}
-
-            <a class="js-datepicker-trigger datepicker" href="javascript://">Change dates?</a>
-            {% if dateRange %}
-                <a class="datepicker" href="?">or Reset dates?</a>
-            {% endif %}
+            {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
+            (<a href="?">Reset dates</a>)
         </p>
+
+        <form action="" method="get" class="tools-filter-form">
+            <div class="tools-filter-form__item">
+                <label for="start" class="ff-label">Start date</label>
+                <input class="ff-text"
+                       type="date"
+                       min="{{ formatDate(oldestOrderDate, "YYYY-MM-DD") }}"
+                       max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                       value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
+                       name="start"
+                       id="start"
+                >
+            </div>
+            <div class="tools-filter-form__item">
+                <label for="end" class="ff-label">End date</label>
+                <input class="ff-text"
+                       type="date"
+                       min="{{ formatDate(oldestOrderDate, "YYYY-MM-DD") }}"
+                       max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                       value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
+                       name="end"
+                       id="end"
+                >
+            </div>
+            <div class="tools-filter-form__item tools-filter-form__actions">
+                <input class="btn btn--small" type="submit" value="Filter by date"/>
+            </div>
+        </form>
 
         {% if data.orders.length > 0 %}
             <div class="u-margin-bottom-l">

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -23,6 +23,7 @@
                 });
         });
     </script>
+
     <style>
         .datepicker {
             font-size: 14px;
@@ -165,7 +166,7 @@
                     <tbody>
                     {% for item in data.grantAmounts %}
                         <tr>
-                            <th>{{ item.code }}</th>
+                            <td>{{ item.code }}</td>
                             <td>{{ item.count }}</td>
                         </tr>
                     {% endfor %}

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -3,8 +3,6 @@
 {% from "components/staff-status/macro.njk" import staffStatus with context %}
 {% from "components/data.njk" import statsGrid %}
 
-{% block title %}Material orders{% endblock %}
-
 {% block extraHead %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>


### PR DESCRIPTION
Reworks the tools date pickers to use native `input[type=date]`. Given these are internal tools browser support is good enough for this use case and allows us to do the simplest thing to support date filters rather than loading in a bunch of extra libraries.

<img width="987" alt="Screenshot 2019-11-11 at 12 50 50" src="https://user-images.githubusercontent.com/123386/68589996-55828500-0485-11ea-9310-793045c34bdc.png">
<img width="982" alt="Screenshot 2019-11-11 at 13 08 37" src="https://user-images.githubusercontent.com/123386/68589997-561b1b80-0485-11ea-8315-cc9ce6077588.png">
