### PR TITLE
Enable animated save button in non-test environments

### DIFF
--- a/assets/js/vue-apps/form-components/save-button.js
+++ b/assets/js/vue-apps/form-components/save-button.js
@@ -53,11 +53,8 @@ function animateSaveButtons() {
 }
 
 function init() {
-    // Launch this feature in non-prod envs (for now) and don't add extra delays for automated tests
-    if (
-        window.AppConfig.environment !== 'production' &&
-        !window.AppConfig.isTestServer
-    ) {
+    // Don't add extra delays for automated tests
+    if (!window.AppConfig.isTestServer) {
         animateSaveButtons();
     }
 }


### PR DESCRIPTION
Launch the animated save button everywhere (except automated tests). Fairly confident now we've kicked the tyres on this for a week, and keen to see what feedback we get when it's live.