### PR TITLE
Consider ContentVersion step optional

### DIFF
--- a/controllers/apply/form-router-next/submission.js
+++ b/controllers/apply/form-router-next/submission.js
@@ -117,7 +117,7 @@ module.exports = function(
                                 applicationId: currentApplication.id,
                                 filename: field.value.filename
                             }).then(versionData => {
-                                return salesforce.contentsVersion({
+                                return salesforce.contentVersion({
                                     recordId: salesforceRecordId,
                                     attachmentName: `${
                                         field.name

--- a/controllers/apply/form-router-next/submission.js
+++ b/controllers/apply/form-router-next/submission.js
@@ -9,9 +9,7 @@ const {
 } = require('../../../db/models');
 
 const appData = require('../../../common/appData');
-const logger = require('../../../common/logger').child({
-    service: 'salesforce'
-});
+const commonLogger = require('../../../common/logger');
 
 const salesforceService = require('./lib/salesforce');
 const { buildMultipartData } = require('./lib/file-uploads');
@@ -24,6 +22,11 @@ module.exports = function(
     enableSalesforceConnector
 ) {
     const router = express.Router();
+
+    const logger = commonLogger.child({
+        service: 'salesforce',
+        formId: formId
+    });
 
     /**
      * Route: Submission
@@ -48,9 +51,7 @@ module.exports = function(
                     data: currentApplicationData
                 });
 
-                logger.info('Submission successful', {
-                    formId: formId
-                });
+                logger.info('Submission successful');
 
                 res.render(path.resolve(__dirname, './views/confirmation'), {
                     title: confirmation.title,
@@ -61,9 +62,7 @@ module.exports = function(
         }
 
         try {
-            logger.info('Submission started', {
-                formId: formId
-            });
+            logger.info('Submission started');
 
             /**
              * Increment submission attempts
@@ -99,9 +98,7 @@ module.exports = function(
                     salesforceFormData
                 );
 
-                logger.info('FormData record created', {
-                    formId: formId
-                });
+                logger.info('FormData record created');
 
                 /**
                  * We can consider an application "submitted" once the
@@ -133,14 +130,11 @@ module.exports = function(
                     await Promise.all(contentVersionPromises);
                 } catch (error) {
                     logger.error('Error creating ContentVersion', error, {
-                        formId: formId,
                         applicationId: currentApplication.id
                     });
                 }
             } else {
-                logger.debug(`Skipped salesforce submission`, {
-                    formId: formId
-                });
+                logger.debug(`Skipped salesforce submission`);
             }
 
             /**

--- a/controllers/apply/form-router-next/submission.js
+++ b/controllers/apply/form-router-next/submission.js
@@ -133,7 +133,8 @@ module.exports = function(
                     await Promise.all(contentVersionPromises);
                 } catch (error) {
                     logger.error('Error creating ContentVersion', error, {
-                        formId: formId
+                        formId: formId,
+                        applicationId: currentApplication.id
                     });
                 }
             } else {


### PR DESCRIPTION
Follow on from https://github.com/biglotteryfund/blf-alpha/pull/2668

We can consider an application "submitted" once the main FormData record has been created. Consider ContentVersion step optional but log an error for investigation if upload fails

💭 welcome if this is preferable to considering a failure attaching the bank statement a hard failure.