### PR TITLE
Upgrade html-to-text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9137,14 +9137,14 @@
       }
     },
     "html-to-text": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-4.0.0.tgz",
-      "integrity": "sha512-QQl5EEd97h6+3crtgBhkEAO6sQnZyDff8DAeJzoSkOc1Dqe1UvTUZER0B+KjBe6fPZqq549l2VUhtracus3ndA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-5.1.1.tgz",
+      "integrity": "sha512-Bci6bD/JIfZSvG4s0gW/9mMKwBRoe/1RWLxUME/d6WUSZCdY7T60bssf/jFf7EYXRyqU4P5xdClVqiYU0/ypdA==",
       "requires": {
-        "he": "^1.0.0",
-        "htmlparser2": "^3.9.2",
-        "lodash": "^4.17.4",
-        "optimist": "^0.6.1"
+        "he": "^1.2.0",
+        "htmlparser2": "^3.10.1",
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0"
       }
     },
     "htmlparser2": {
@@ -13075,6 +13075,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -13083,7 +13084,8 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         }
       }
     },
@@ -18669,7 +18671,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "globby": "10.0.1",
     "google-libphonenumber": "3.2.6",
     "helmet": "3.21.2",
-    "html-to-text": "4.0.0",
+    "html-to-text": "5.1.1",
     "i18n-2": "^0.7.3",
     "jquery": "^3.4.1",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
We had asked dependabot to ignore mail related dependencies, but this one is fairly safe to upgrade. Single breaking change in v5 is the removal of `fromFile` which we don't use.

https://github.com/werk85/node-html-to-text/blob/master/CHANGELOG.md#version-500