### PR TITLE
Restore the form warning when leaving unsaved changes

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -51,12 +51,20 @@ function handleAbandonmentMessage(formEl) {
 function warnOnUnsavedChanges() {
     $('.js-form-warn-unsaved').each(function() {
         const $form = $(this);
+
         const initialState = $form.serialize();
         const formHasErrors = $form.data('form-has-errors');
 
-        $form.submit(function() {
-            window.removeEventListener('beforeunload', handleBeforeUnload);
-        });
+        $form
+            .find('input[type="submit"], button[type="submit"]')
+            .on('click', function() {
+                const targetName = $(this).attr('name');
+                // Only remove the warning if they've clicked the main submit
+                if (['previousBtn', 'nextBtn'].indexOf(targetName) !== -1) {
+                    return;
+                }
+                window.removeEventListener('beforeunload', handleBeforeUnload);
+            });
 
         $(document).ready(() => {
             if (formHasErrors) {


### PR DESCRIPTION
Noticed this wasn't working after the animated save button (eg. events bound to the form's submit method get cancelled, so the code here was never adding those warning listeners).