### PR TITLE
Add temporary warning text to RC form in advance of closure

### DIFF
--- a/controllers/apply/form-router/views/form.njk
+++ b/controllers/apply/form-router/views/form.njk
@@ -20,7 +20,7 @@
                 ) }}
 
                 <div class="message" role="alert">
-                    <h3>We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</h3>
+                    <p class="t3">We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</p>
                     <p>Our new online form makes it easier for you to tell us about your funding proposals - if you're looking for more than £10,000 from us. It launches at 11:00am on 20 November.</p>
                 </div>
 

--- a/controllers/apply/form-router/views/form.njk
+++ b/controllers/apply/form-router/views/form.njk
@@ -19,6 +19,11 @@
                     backUrl = stepProgress.prevStepUrl
                 ) }}
 
+                <div class="message" role="alert">
+                    <h3>We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</h3>
+                    <p>Our new online form makes it easier for you to tell us about your funding proposals - if you're looking for more than £10,000 from us. It launches at 11:00am on 20 November.</p>
+                </div>
+
                 {{ languageServiceMessage(currentLocale = locale) }}
 
                 {{ formErrors(errors = errors, title = copy.errorTitle) }}

--- a/controllers/apply/reaching-communities/startpage.njk
+++ b/controllers/apply/reaching-communities/startpage.njk
@@ -16,6 +16,14 @@
                 <h3>We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</h3>
                 <p>Our new online form makes it easier for you to tell us about your funding proposals - if you're looking for more than £10,000 from us. It launches at 11:00am on 20 November.</p>
             </div>
+            
+            <h2>Find out how we can help you</h2>
+            <p>
+                You can apply for over £10,000 to support communities to take action
+                on the issues that matter to them. Once you submit your idea a local
+                funding officer will aim to contact you within fifteen working days
+                to seek further information or to update you on your idea’s progress.
+            </p>
 
             {{ startButton(startUrl) }}
 

--- a/controllers/apply/reaching-communities/startpage.njk
+++ b/controllers/apply/reaching-communities/startpage.njk
@@ -12,13 +12,10 @@
                 suffix = copy.description | safe
             ) }}
 
-            <h2>Find out how we can help you</h2>
-            <p>
-                You can apply for over £10,000 to support communities to take action
-                on the issues that matter to them. Once you submit your idea a local
-                funding officer will aim to contact you within fifteen working days
-                to seek further information or to update you on your idea’s progress.
-            </p>
+            <div class="message" role="alert">
+                <h3>We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</h3>
+                <p>Our new online form makes it easier for you to tell us about your funding proposals - if you're looking for more than £10,000 from us. It launches at 11:00am on 20 November.</p>
+            </div>
 
             {{ startButton(startUrl) }}
 

--- a/controllers/apply/reaching-communities/startpage.njk
+++ b/controllers/apply/reaching-communities/startpage.njk
@@ -13,7 +13,7 @@
             ) }}
 
             <div class="message" role="alert">
-                <h3>We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</h3>
+                <p class="t3">We're moving to a new online form to tell us about your ideas - from Wednesday 20 November</p>
                 <p>Our new online form makes it easier for you to tell us about your funding proposals - if you're looking for more than £10,000 from us. It launches at 11:00am on 20 November.</p>
             </div>
             


### PR DESCRIPTION
Adds a warning to RC form pages to clarify the form will change.

This is hard-coded which I think is acceptable given we'll shortly delete all of this code, and that it's not used for any other forms.

![image](https://user-images.githubusercontent.com/394376/68857195-3597cf00-06da-11ea-8a4f-d49a46439dd0.png)
![image](https://user-images.githubusercontent.com/394376/68857205-3c264680-06da-11ea-98d4-c0e67312d795.png)
