### PR TITLE
Boost radio buttons

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -179,7 +179,9 @@
    ========================================================================= */
 
 $inputPadding: 6px 12px;
-$inputOutline: 3px solid get-color('border', 'outline');
+$inputOutlineWidth: 3px;
+$inputOutlineColour: get-color('border', 'outline');
+$inputOutline: $inputOutlineWidth solid $inputOutlineColour;
 
 /**
  * Field labels
@@ -302,73 +304,95 @@ $inputOutline: 3px solid get-color('border', 'outline');
             }
         }
 
+        // Radio button component
+        //
+        // Styles taken from https://design-system.service.gov.uk/components/radios/
+
+        $radioRadius: 32px;
+        $radioBorder: 2px;
+        $radioTotalSize: $radioRadius + ($radioBorder * 2);
+        $labelOffset: $radioRadius + 10px;
+
         &.ff-choice__option--radio {
             position: relative;
-            min-height: 40px;
             display: block;
-            clear: left;
-            margin-top: 20px;
+            min-height: $radioRadius;
+            margin-top: $spacingUnit;
 
+            // Hide the real radio input by making it transparent
             input[type='radio'] {
                 cursor: pointer;
                 position: absolute;
                 z-index: 1;
-                top: -2px;
-                left: -2px;
-                width: 44px;
-                height: 44px;
+                top: -#{$radioBorder / 2};
+                left: -#{$radioBorder / 2};
+                width: $radioTotalSize;
+                height: $radioTotalSize;
                 margin: 0;
                 opacity: 0;
+
+                // Focus state for radio input
+                // (eg. outline the radio button)
                 &:focus+.ff-choice__label:before {
-                    border-width:4px;
-                    box-shadow:0 0 0 4px #fd0
+                    border-width: $radioBorder * 2;
+                    box-shadow: 0 0 0 $inputOutlineWidth $inputOutlineColour;
                 }
+
+                // Checked state for radio input
+                // (eg. show the filled circle)
                 &:checked+.ff-choice__label:after {
-                    opacity:1
+                    opacity: 1
                 }
+
+                // Disabled state for radio input
+                // (eg. normal cursor and faded input)
                 &:disabled,
                 &:disabled+.ff-choice__label {
-                    cursor:default
+                    cursor: default;
                 }
+
                 &:disabled+.ff-choice__label {
-                    opacity:.5
+                    opacity: .5;
                 }
+            }
+
+            .ff-choice__label,
+            .ff-choice__caption {
+                padding-left: $labelOffset;
             }
 
             .ff-choice__label {
                 display: inline-block;
-                padding: 6px 0px 0px 50px;
+                vertical-align: middle;
 
-
+                // Draw an outline for a radio button
                 &:before {
                     content: "";
                     position: absolute;
                     top: 0;
                     left: 0;
-                    width: 40px;
-                    height: 40px;
-                    border: 2px solid currentColor;
+                    width: $radioRadius;
+                    height: $radioRadius;
+                    border: $radioBorder solid currentColor;
                     border-radius: 50%;
                     background: transparent;
                 }
 
+                // Draw a filled-in circle for a checked radio button
                 &:after {
                     content: "";
                     position: absolute;
-                    top: 10px;
-                    left: 10px;
+                    top: #{$radioRadius / 4};
+                    left: #{$radioRadius / 4};
                     width: 0;
                     height: 0;
-                    border: 10px solid currentColor;
+                    border: #{$radioRadius / 4} solid currentColor;
                     border-radius: 50%;
                     opacity: 0;
                     background: currentColor;
                 }
             }
 
-            .ff-choice__caption {
-                padding-left: 50px;
-            }
         }
 
     }

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -301,6 +301,76 @@ $inputOutline: 3px solid get-color('border', 'outline');
                 top: -2px;
             }
         }
+
+        &.ff-choice__option--radio {
+            position: relative;
+            min-height: 40px;
+            display: block;
+            clear: left;
+            margin-top: 20px;
+
+            input[type='radio'] {
+                cursor: pointer;
+                position: absolute;
+                z-index: 1;
+                top: -2px;
+                left: -2px;
+                width: 44px;
+                height: 44px;
+                margin: 0;
+                opacity: 0;
+                &:focus+.ff-choice__label:before {
+                    border-width:4px;
+                    box-shadow:0 0 0 4px #fd0
+                }
+                &:checked+.ff-choice__label:after {
+                    opacity:1
+                }
+                &:disabled,
+                &:disabled+.ff-choice__label {
+                    cursor:default
+                }
+                &:disabled+.ff-choice__label {
+                    opacity:.5
+                }
+            }
+
+            .ff-choice__label {
+                display: inline-block;
+                padding: 6px 0px 0px 50px;
+
+
+                &:before {
+                    content: "";
+                    position: absolute;
+                    top: 0;
+                    left: 0;
+                    width: 40px;
+                    height: 40px;
+                    border: 2px solid currentColor;
+                    border-radius: 50%;
+                    background: transparent;
+                }
+
+                &:after {
+                    content: "";
+                    position: absolute;
+                    top: 10px;
+                    left: 10px;
+                    width: 0;
+                    height: 0;
+                    border: 10px solid currentColor;
+                    border-radius: 50%;
+                    opacity: 0;
+                    background: currentColor;
+                }
+            }
+
+            .ff-choice__caption {
+                padding-left: 50px;
+            }
+        }
+
     }
     .ff-choice__input,
     .ff-choice__label {

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -313,14 +313,15 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
         $radioTotalSize: $radioRadius + ($radioBorder * 2);
         $labelOffset: $radioRadius + 10px;
 
-        &.ff-choice__option--radio {
+        &.ff-choice__option--radio,
+        &.ff-choice__option--checkbox {
             position: relative;
             display: block;
             min-height: $radioRadius;
             margin-top: $spacingUnit;
 
             // Hide the real radio input by making it transparent
-            input[type='radio'] {
+            input {
                 cursor: pointer;
                 position: absolute;
                 z-index: 1;
@@ -354,6 +355,7 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
                 &:disabled+.ff-choice__label {
                     opacity: .5;
                 }
+
             }
 
             .ff-choice__label,
@@ -394,6 +396,32 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
             }
 
         }
+
+        &.ff-choice__option--checkbox {
+
+            // Disable rounded corners for checkboxes
+            .ff-choice__label:before {
+                border-radius: 0;
+            }
+
+            // Draw a tick for selected checkboxes
+            $tickScale: floor($radioRadius / 3);
+            .ff-choice__label:after {
+                border-radius: 0;
+                top: $tickScale;
+                left: $tickScale / 2;
+                width:  $tickScale * 2;
+                height: $tickScale;
+                transform: rotate(-45deg);
+                border: solid;
+                border-width: 0 0 $tickScale / 2 $tickScale / 2;
+                border-top-color: transparent;
+                opacity: 0;
+                background: transparent;
+            }
+        }
+
+
 
     }
     .ff-choice__input,

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -271,25 +271,21 @@
                     <ul class="ff-choice__list">
                         {% for option in optgroup.options %}
                             {% set fieldId = 'field-' + field.name + '-' + optgroupIdx + '-' + loop.index %}
-                            <li class="ff-choice__option{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
-                                <div class="ff-choice__input">
-                                    <input
-                                        type="checkbox"
-                                        id="{{ fieldId }}"
-                                        name="{{ field.name }}"
-                                        value="{{ option.value }}"
-                                        {% if field.value.length and field.value.indexOf(option.value) > -1 %}checked{% endif %}
-                                        {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
-                                    />
-                                </div>
-                                <div>
-                                    <label class="ff-choice__label" for="{{ fieldId }}">
-                                        {{ option.label }}
-                                    </label>
-                                    {% if option.explanation %}
-                                        <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
-                                    {% endif %}
-                                </div>
+                            <li class="ff-choice__option ff-choice__option--checkbox{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
+                                <input
+                                    type="checkbox"
+                                    id="{{ fieldId }}"
+                                    name="{{ field.name }}"
+                                    value="{{ option.value }}"
+                                    {% if field.value.length and field.value.indexOf(option.value) > -1 %}checked{% endif %}
+                                    {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+                                />
+                                <label class="ff-choice__label" for="{{ fieldId }}">
+                                    {{ option.label }}
+                                </label>
+                                {% if option.explanation %}
+                                    <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
+                                {% endif %}
                             </li>
                         {% endfor %}
                     </ul>
@@ -298,25 +294,21 @@
         {% else %}
             <ul class="ff-choice__list">
                 {% for option in field.options %}
-                    <li class="ff-choice__option{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
-                        <div class="ff-choice__input">
-                            <input
-                                type="checkbox"
-                                id="field-{{ field.name }}-{{ loop.index }}"
-                                name="{{ field.name }}"
-                                value="{{ option.value }}"
-                                {% if field.value.length and field.value.indexOf(option.value) > -1 %}checked{% endif %}
-                                {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
-                            />
-                        </div>
-                        <div>
-                            <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
-                                {{ option.label }}
-                            </label>
-                            {% if option.explanation %}
-                                <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
-                            {% endif %}
-                        </div>
+                    <li class="ff-choice__option ff-choice__option--checkbox{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
+                        <input
+                            type="checkbox"
+                            id="field-{{ field.name }}-{{ loop.index }}"
+                            name="{{ field.name }}"
+                            value="{{ option.value }}"
+                            {% if field.value.length and field.value.indexOf(option.value) > -1 %}checked{% endif %}
+                            {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+                        />
+                        <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
+                            {{ option.label }}
+                        </label>
+                        {% if option.explanation %}
+                            <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
+                        {% endif %}
                     </li>
                 {% endfor %}
             </ul>

--- a/views/components/form-fields-next/macros.njk
+++ b/views/components/form-fields-next/macros.njk
@@ -332,26 +332,22 @@
         {{ explanationFor(field) }}
         <ul class="ff-choice__list">
             {% for option in field.options %}
-                <li class="ff-choice__option{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
-                    <div class="ff-choice__input">
-                        <input
-                            type="radio"
-                            id="field-{{ field.name }}-{{ loop.index }}"
-                            name="{{ field.name }}"
-                            value="{{ option.value }}"
-                            {% if field.isRequired %}required aria-required="true"{% endif %}
-                            {% if field.value[0] === option.value or field.value === option.value %}checked{% endif %}
-                            {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
-                        />
-                    </div>
-                    <div>
-                        <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
-                            {{ option.label }}
-                        </label>
-                        {% if option.explanation %}
-                            <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
-                        {% endif %}
-                    </div>
+                <li class="ff-choice__option ff-choice__option--radio{% if option.attributes.disabled %} ff-choice__option--disabled{% endif %}">
+                    <input
+                        type="radio"
+                        id="field-{{ field.name }}-{{ loop.index }}"
+                        name="{{ field.name }}"
+                        value="{{ option.value }}"
+                        {% if field.isRequired %}required aria-required="true"{% endif %}
+                        {% if field.value[0] === option.value or field.value === option.value %}checked{% endif %}
+                        {% if option.attributes %}{% for attr, value in option.attributes %} {{ attr }}="{{ value }}"{% endfor %}{% endif %}
+                    />
+                    <label class="ff-choice__label" for="field-{{ field.name }}-{{ loop.index }}">
+                        {{ option.label }}
+                    </label>
+                    {% if option.explanation %}
+                        <small class="ff-choice__caption">{{ option.explanation | safe }}</small>
+                    {% endif %}
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
Use GDS-style radio buttons ([as defined here](https://design-system.service.gov.uk/components/radios/)) to make ours easier to click:

### Before:
![image](https://user-images.githubusercontent.com/394376/68869418-0771b980-06f1-11ea-8abf-cf3f60d38391.png)

### After:
![image](https://user-images.githubusercontent.com/394376/68869427-0c366d80-06f1-11ea-9393-012dee70da71.png)

CSS is taken directly from GDS, then modified a bit (eg. uses variables to allow changing the button sizes, uses our default highlight colour etc).

Main change is the HTML structure for the radios themselves as much of the (CSS) logic here depends upon the input/radio being siblings.