### PR TITLE
Fix staff tools

### DIFF
--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -33,7 +33,6 @@
                     <label for="start" class="ff-label">Start date</label>
                     <input class="ff-text"
                            type="date"
-                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
                            max="{{ formatDate(now, "YYYY-MM-DD") }}"
                            value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
                            name="start"
@@ -44,7 +43,6 @@
                     <label for="end" class="ff-label">End date</label>
                     <input class="ff-text"
                            type="date"
-                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
                            max="{{ formatDate(now, "YYYY-MM-DD") }}"
                            value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
                            name="end"

--- a/controllers/tools/views/orders.njk
+++ b/controllers/tools/views/orders.njk
@@ -4,7 +4,7 @@
 {% from "components/data.njk" import statsGrid %}
 
 {% block extraHead %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js" integrity="sha256-N4u5BjTLNwmGul6RgLoESPNqDFVUibVuOYhP4gJgrew=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js" crossorigin="anonymous"></script>
 {% endblock %}
 
 {% macro statBlock(number, caption) %}

--- a/controllers/tools/views/users.njk
+++ b/controllers/tools/views/users.njk
@@ -25,7 +25,6 @@
                     <label for="start" class="ff-label">Start date</label>
                     <input class="ff-text"
                            type="date"
-                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
                            max="{{ formatDate(now, "YYYY-MM-DD") }}"
                            value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
                            name="start"
@@ -36,7 +35,6 @@
                     <label for="end" class="ff-label">End date</label>
                     <input class="ff-text"
                            type="date"
-                           min="{{ formatDate(oldestDate, "YYYY-MM-DD") }}"
                            max="{{ formatDate(now, "YYYY-MM-DD") }}"
                            value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
                            name="end"


### PR DESCRIPTION
The material order chart had stopped showing up due to a SHA256 error (maybe they changed the remote file? We removed the integrity check in all the other places we use this file).

We also had some staff user reports with the AFA dashboard that the date lookups were preventing them going back beyond 16th October 2019. 

The reason for this is because the datepicker uses the oldest date in the dataset as its minimum value... but the dataset defaults to the last 30 days (as opposed to _all_ data), so the oldest date is always today minus 30 days.

The same is true of the user dashboard too, so I've just removed the `min` parameters from both start/end dates. I don't think it's such a big deal if someone is able to choose a date range with no results – that should be quite quickly apparent to them. It's worse if they can't just choose the range they want.