### PR TITLE
Inject copy cleanup

### DIFF
--- a/controllers/apply/dashboard.js
+++ b/controllers/apply/dashboard.js
@@ -7,7 +7,6 @@ const isEmpty = require('lodash/isEmpty');
 const { localify } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
 const { requireActiveUser } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
 const { PendingApplication, SubmittedApplication } = require('../../db/models');
 const { enrichPending, enrichSubmitted } = require('./lib/enrich-application');
 
@@ -59,10 +58,9 @@ router.get(
     '/',
     noStore,
     requireActiveUser,
-    injectCopy('applyNext.dashboardNew'),
     injectNavigationLinks,
     async function(req, res, next) {
-        const { copy } = res.locals;
+        const copy = req.i18n.__('applyNext.dashboardNew');
 
         try {
             /**
@@ -88,6 +86,7 @@ router.get(
             ]);
 
             res.render(path.resolve(__dirname, './views/dashboard'), {
+                copy: copy,
                 title: copy.latest.title,
                 latestApplication: latestApplication,
                 hasPendingSimpleApplication: !isEmpty(pendingSimple),
@@ -103,10 +102,9 @@ router.get(
     '/all',
     noStore,
     requireActiveUser,
-    injectCopy('applyNext.dashboardNew'),
     injectNavigationLinks,
     async function(req, res, next) {
-        const { copy } = res.locals;
+        const copy = req.i18n.__('applyNext.dashboardNew');
 
         try {
             const [
@@ -123,6 +121,7 @@ router.get(
             }
 
             res.render(path.resolve(__dirname, './views/dashboard-all'), {
+                copy: copy,
                 title: copy.all.title,
                 pendingApplications: pendingApplications.map(application =>
                     enrichPending(application, req.i18n.getLocale())

--- a/controllers/apply/form-router-next/eligibility.js
+++ b/controllers/apply/form-router-next/eligibility.js
@@ -3,7 +3,6 @@ const express = require('express');
 const path = require('path');
 
 const commonLogger = require('../../../common/logger');
-const { injectCopy } = require('../../../common/inject-content');
 
 const logger = commonLogger.child({
     service: 'apply'
@@ -32,12 +31,15 @@ module.exports = function(eligibilityBuilder, formId) {
 
     router
         .route('/:step?')
-        .all(injectCopy('applyNext'), function(req, res, next) {
+        .all(function(req, res, next) {
+            const copy = req.i18n.__('applyNext');
+
             const eligibility = eligibilityBuilder({
                 locale: req.i18n.getLocale()
             });
 
-            res.locals.title = res.locals.copy.eligibility.title;
+            res.locals.copy = copy;
+            res.locals.title = copy.eligibility.title;
             res.locals.eligibility = eligibility;
 
             const currentStepNumber = parseInt(req.params.step);

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -19,7 +19,6 @@ const logger = require('../../../common/logger').child({ service: 'apply' });
 const { localify, isWelsh, removeWelsh } = require('../../../common/urls');
 const { noStore } = require('../../../common/cached');
 const { requireActiveUserWithCallback } = require('../../../common/authed');
-const { injectCopy } = require('../../../common/inject-content');
 
 const { getObject } = require('./lib/file-uploads');
 const { generateEmailQueueItems } = require('./lib/emailQueue');
@@ -41,11 +40,14 @@ function initFormRouter({
     }
 
     function setCommonLocals(req, res, next) {
-        res.locals.isBilingual = isBilingual;
-
         if (isBilingual === false && isWelsh(req.originalUrl)) {
             return res.redirect(removeWelsh(req.originalUrl));
         }
+
+        const copy = req.i18n.__('applyNext');
+
+        res.locals.copy = copy;
+        res.locals.isBilingual = isBilingual;
 
         const form = formBuilder({
             locale: req.i18n.getLocale()
@@ -60,19 +62,19 @@ function initFormRouter({
         res.locals.userNavigationLinks = [
             {
                 url: `${req.baseUrl}/summary`,
-                label: req.i18n.__('applyNext.navigation.summary')
+                label: copy.navigation.summary
             },
             {
                 url: res.locals.sectionUrl,
-                label: req.i18n.__('applyNext.navigation.latestApplication')
+                label: copy.navigation.latestApplication
             },
             {
                 url: `${res.locals.sectionUrl}/all`,
-                label: req.i18n.__('applyNext.navigation.allApplications')
+                label: copy.navigation.allApplications
             },
             {
                 url: localify(req.i18n.getLocale())('/user'),
-                label: req.i18n.__('applyNext.navigation.account')
+                label: copy.navigation.account
             }
         ];
 
@@ -153,7 +155,6 @@ function initFormRouter({
             }
         }),
         handleMultipartFormData,
-        injectCopy('applyNext'),
         setCommonLocals,
         csurf()
     );

--- a/controllers/apply/form-router-next/index.js
+++ b/controllers/apply/form-router-next/index.js
@@ -79,6 +79,10 @@ function initFormRouter({
             }
         }),
         function(req, res, next) {
+            /**
+             * Decide if we need to handle multipart/form-data
+             * Populate req.body for multipart forms before CSRF token is needed
+             */
             function needsMultipart() {
                 const contentType = req.headers['content-type'];
                 return (


### PR DESCRIPTION
Been finding that the way we use `injectCopy` leads to a bunch of indirection and setting locals that are either unused or overridden later. We can achieve the same thing with direct `req.i18n.__` calls. Starting with the apply section.