### PR TITLE
Add modal dialog with session expiry warnings

### DIFF
--- a/assets/js/common/index.js
+++ b/assets/js/common/index.js
@@ -3,6 +3,7 @@ import fitvids from 'fitvids';
 import tabs from './tabs';
 import forms from './forms';
 import session from './session';
+import modal from './modal';
 
 /**
  * Common modules that are run across the site.
@@ -18,6 +19,8 @@ export const init = () => {
         }
     );
 
+    // Modal init must come first to allow other modules to use them
+    modal.init();
     tabs.init();
     forms.init();
     session.init();

--- a/assets/js/common/modal.js
+++ b/assets/js/common/modal.js
@@ -1,17 +1,19 @@
 // Original source:
 // https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+// See https://github.com/alphagov/govuk-design-system-backlog/issues/30 for more
 
 import forEach from 'lodash/forEach';
-
-const modalStartedAttr = 'data-modal-started';
 
 function ModalDialogue() {}
 
 ModalDialogue.prototype.start = function($module) {
     this.$module = $module;
-    this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box');
+    this.$dialogBox = this.$module.querySelector('.js-modal-dialog');
     this.$closeButton = this.$module.querySelector(
-        '.gem-c-modal-dialogue__close-button'
+        '.js-modal-dialog-close-button--main'
+    );
+    this.$allCloseButtons = this.$module.querySelectorAll(
+        '.js-modal-dialog-close-button'
     );
     this.$body = document.querySelector('body');
 
@@ -20,7 +22,7 @@ ModalDialogue.prototype.start = function($module) {
     this.$module.focusDialog = this.handleFocusDialog.bind(this);
     this.$module.boundKeyDown = this.handleKeyDown.bind(this);
 
-    var $triggerElement = document.querySelector(
+    const $triggerElement = document.querySelector(
         '[data-toggle="modal"][data-target="' + this.$module.id + '"]'
     );
 
@@ -28,8 +30,10 @@ ModalDialogue.prototype.start = function($module) {
         $triggerElement.addEventListener('click', this.$module.open);
     }
 
-    if (this.$closeButton) {
-        this.$closeButton.addEventListener('click', this.$module.close);
+    if (this.$allCloseButtons) {
+        forEach(this.$allCloseButtons, el => {
+            el.addEventListener('click', this.$module.close);
+        });
     }
 };
 
@@ -38,8 +42,7 @@ ModalDialogue.prototype.handleOpen = function(event) {
         event.preventDefault();
     }
 
-    this.$body.classList.add('app-o-template__body--modal');
-    this.$body.classList.add('app-o-template__body--blur');
+    this.$body.classList.add('is-modal');
     this.$focusedElementBeforeOpen = document.activeElement;
     this.$module.style.display = 'block';
     this.$dialogBox.focus();
@@ -52,8 +55,7 @@ ModalDialogue.prototype.handleClose = function(event) {
         event.preventDefault();
     }
 
-    this.$body.classList.remove('app-o-template__body--modal');
-    this.$body.classList.remove('app-o-template__body--blur');
+    this.$body.classList.remove('is-modal');
     this.$module.style.display = 'none';
     this.$focusedElementBeforeOpen.focus();
 
@@ -67,10 +69,11 @@ ModalDialogue.prototype.handleFocusDialog = function() {
 // while open, prevent tabbing to outside the dialogue
 // and listen for ESC key to close the dialogue
 ModalDialogue.prototype.handleKeyDown = function(event) {
-    var KEY_TAB = 9;
-    var KEY_ESC = 27;
+    const KEY_TAB = 9;
+    const KEY_ESC = 27;
 
     switch (event.keyCode) {
+        // @TODO in modals without close buttons it's possible to tab into the document below
         case KEY_TAB:
             if (event.shiftKey) {
                 if (document.activeElement === this.$dialogBox) {
@@ -86,7 +89,9 @@ ModalDialogue.prototype.handleKeyDown = function(event) {
 
             break;
         case KEY_ESC:
-            this.$module.close();
+            if (this.$closeButton) {
+                this.$module.close();
+            }
             break;
         default:
             break;
@@ -94,6 +99,7 @@ ModalDialogue.prototype.handleKeyDown = function(event) {
 };
 
 function init() {
+    const modalStartedAttr = 'data-modal-started';
     const modalElements = document.querySelectorAll('[data-modal]');
     forEach(modalElements, el => {
         const started = el.getAttribute(modalStartedAttr);

--- a/assets/js/common/modal.js
+++ b/assets/js/common/modal.js
@@ -1,0 +1,118 @@
+// Original source:
+// https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/modal-dialogue.js
+
+import forEach from 'lodash/forEach';
+
+const modalStartedAttr = 'data-modal-started';
+
+function ModalDialogue() {}
+
+ModalDialogue.prototype.start = function($module) {
+    this.$module = $module;
+    this.$dialogBox = this.$module.querySelector('.gem-c-modal-dialogue__box');
+    this.$closeButton = this.$module.querySelector(
+        '.gem-c-modal-dialogue__close-button'
+    );
+    this.$body = document.querySelector('body');
+
+    this.$module.open = this.handleOpen.bind(this);
+    this.$module.close = this.handleClose.bind(this);
+    this.$module.focusDialog = this.handleFocusDialog.bind(this);
+    this.$module.boundKeyDown = this.handleKeyDown.bind(this);
+
+    var $triggerElement = document.querySelector(
+        '[data-toggle="modal"][data-target="' + this.$module.id + '"]'
+    );
+
+    if ($triggerElement) {
+        $triggerElement.addEventListener('click', this.$module.open);
+    }
+
+    if (this.$closeButton) {
+        this.$closeButton.addEventListener('click', this.$module.close);
+    }
+};
+
+ModalDialogue.prototype.handleOpen = function(event) {
+    if (event) {
+        event.preventDefault();
+    }
+
+    this.$body.classList.add('app-o-template__body--modal');
+    this.$body.classList.add('app-o-template__body--blur');
+    this.$focusedElementBeforeOpen = document.activeElement;
+    this.$module.style.display = 'block';
+    this.$dialogBox.focus();
+
+    document.addEventListener('keydown', this.$module.boundKeyDown, true);
+};
+
+ModalDialogue.prototype.handleClose = function(event) {
+    if (event) {
+        event.preventDefault();
+    }
+
+    this.$body.classList.remove('app-o-template__body--modal');
+    this.$body.classList.remove('app-o-template__body--blur');
+    this.$module.style.display = 'none';
+    this.$focusedElementBeforeOpen.focus();
+
+    document.removeEventListener('keydown', this.$module.boundKeyDown, true);
+};
+
+ModalDialogue.prototype.handleFocusDialog = function() {
+    this.$dialogBox.focus();
+};
+
+// while open, prevent tabbing to outside the dialogue
+// and listen for ESC key to close the dialogue
+ModalDialogue.prototype.handleKeyDown = function(event) {
+    var KEY_TAB = 9;
+    var KEY_ESC = 27;
+
+    switch (event.keyCode) {
+        case KEY_TAB:
+            if (event.shiftKey) {
+                if (document.activeElement === this.$dialogBox) {
+                    event.preventDefault();
+                    this.$closeButton.focus();
+                }
+            } else {
+                if (document.activeElement === this.$closeButton) {
+                    event.preventDefault();
+                    this.$dialogBox.focus();
+                }
+            }
+
+            break;
+        case KEY_ESC:
+            this.$module.close();
+            break;
+        default:
+            break;
+    }
+};
+
+function init() {
+    const modalElements = document.querySelectorAll('[data-modal]');
+    forEach(modalElements, el => {
+        const started = el.getAttribute(modalStartedAttr);
+        if (!started) {
+            const modal = new ModalDialogue();
+            modal.start(el);
+            el.setAttribute(modalStartedAttr, true);
+        }
+    });
+}
+
+function triggerModal(id) {
+    const modal = document.getElementById(id);
+    if (modal && modal.open) {
+        modal.open();
+    }
+}
+
+export default {
+    init,
+    triggerModal
+};

--- a/assets/js/common/modal.js
+++ b/assets/js/common/modal.js
@@ -42,9 +42,18 @@ ModalDialogue.prototype.handleOpen = function(event) {
         event.preventDefault();
     }
 
+    // Close any currently-open modal
+    const currentOpenModal = this.$body.querySelector(
+        '[data-modal-open="true"]'
+    );
+    if (currentOpenModal) {
+        currentOpenModal.close();
+    }
+
     this.$body.classList.add('is-modal');
     this.$focusedElementBeforeOpen = document.activeElement;
     this.$module.style.display = 'block';
+    this.$module.setAttribute('data-modal-open', true);
     this.$dialogBox.focus();
 
     document.addEventListener('keydown', this.$module.boundKeyDown, true);
@@ -57,6 +66,7 @@ ModalDialogue.prototype.handleClose = function(event) {
 
     this.$body.classList.remove('is-modal');
     this.$module.style.display = 'none';
+    this.$module.removeAttribute('data-modal-open');
     this.$focusedElementBeforeOpen.focus();
 
     document.removeEventListener('keydown', this.$module.boundKeyDown, true);
@@ -112,7 +122,6 @@ function init() {
 }
 
 function triggerModal(id) {
-    // @TODO handle hiding other modals if present
     const modal = document.getElementById(id);
     if (modal && modal.open) {
         modal.open();

--- a/assets/js/common/modal.js
+++ b/assets/js/common/modal.js
@@ -112,6 +112,7 @@ function init() {
 }
 
 function triggerModal(id) {
+    // @TODO handle hiding other modals if present
     const modal = document.getElementById(id);
     if (modal && modal.open) {
         modal.open();

--- a/assets/js/common/modal.js
+++ b/assets/js/common/modal.js
@@ -82,16 +82,25 @@ ModalDialogue.prototype.handleKeyDown = function(event) {
     const KEY_TAB = 9;
     const KEY_ESC = 27;
 
+    const focusableModalElements = this.$module.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    // Some modals don't have close buttons so we need to find the last focusable element in the modal
+    // to keep tab keypresses within the modal and not the (hidden) document underneath
+    const lastFocusableElement = this.$closeButton
+        ? this.$closeButton
+        : focusableModalElements[focusableModalElements.length - 1];
+
     switch (event.keyCode) {
-        // @TODO in modals without close buttons it's possible to tab into the document below
         case KEY_TAB:
             if (event.shiftKey) {
                 if (document.activeElement === this.$dialogBox) {
                     event.preventDefault();
-                    this.$closeButton.focus();
+                    lastFocusableElement.focus();
                 }
             } else {
-                if (document.activeElement === this.$closeButton) {
+                if (document.activeElement === lastFocusableElement) {
                     event.preventDefault();
                     this.$dialogBox.focus();
                 }
@@ -121,6 +130,7 @@ function init() {
     });
 }
 
+// Allow triggering a modal via JavaScript if you know its ID
 function triggerModal(id) {
     const modal = document.getElementById(id);
     if (modal && modal.open) {

--- a/assets/js/common/session.js
+++ b/assets/js/common/session.js
@@ -11,6 +11,8 @@ const expiryCheckIntervalSeconds = 30;
 // Note: if changing this, the accompanying copy will need to change too
 const warningShownSecondsRemaining = 10 * 60;
 
+const showWarnings = window.AppConfig.apply.enableSessionExpiryWarning;
+
 function handleSessionExpiration() {
     let sessionInterval;
     let isAuthenticated = true;
@@ -34,11 +36,15 @@ function handleSessionExpiration() {
             isAuthenticated = false;
             clearSessionExpiryWarningTimer();
             trackEvent('Session', 'Warning', 'Timeout reached');
-            modal.triggerModal('apply-expiry-expired');
+            if (showWarnings) {
+                modal.triggerModal('apply-expiry-expired');
+            }
         } else if (expiryTimeRemaining <= warningShownSecondsRemaining) {
             // The user has a few minutes remaining before logout
             trackEvent('Session', 'Warning', 'Timeout almost reached');
-            modal.triggerModal('apply-expiry-pending');
+            if (showWarnings) {
+                modal.triggerModal('apply-expiry-pending');
+            }
         }
     }
 

--- a/assets/js/common/session.js
+++ b/assets/js/common/session.js
@@ -1,9 +1,15 @@
 import $ from 'jquery';
 import debounce from 'lodash/debounce';
-import { trackEvent } from '../helpers/metrics';
 
-const expiryCheckIntervalSeconds = 30; // The interval we'll check timeouts in
-const warningShownSecondsRemaining = 5 * 60; // The time before logout we'll show a warning at
+import { trackEvent } from '../helpers/metrics';
+import modal from './modal';
+
+// The interval we'll check timeouts in
+const expiryCheckIntervalSeconds = 30;
+
+// The time before logout we'll show a warning at
+// Note: if changing this, the accompanying copy will need to change too
+const warningShownSecondsRemaining = 10 * 60;
 
 function handleSessionExpiration() {
     let sessionInterval;
@@ -28,9 +34,11 @@ function handleSessionExpiration() {
             isAuthenticated = false;
             clearSessionExpiryWarningTimer();
             trackEvent('Session', 'Warning', 'Timeout reached');
+            modal.triggerModal('apply-expiry-expired');
         } else if (expiryTimeRemaining <= warningShownSecondsRemaining) {
             // The user has a few minutes remaining before logout
             trackEvent('Session', 'Warning', 'Timeout almost reached');
+            modal.triggerModal('apply-expiry-pending');
         }
     }
 

--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -818,6 +818,11 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
     padding: 1em 0;
     margin-bottom: $spacingUnit / 2;
 
+    &.form-actions--constrained {
+        margin-bottom: 0;
+        padding-bottom: 0;
+    }
+
     > .btn {
         display: inline-block;
         vertical-align: middle;

--- a/assets/sass/components/_modal.scss
+++ b/assets/sass/components/_modal.scss
@@ -1,0 +1,121 @@
+$govuk-modal-margin: 20px;
+$govuk-modal-close-button-size: 44px;
+$govuk-modal-z-index: 1000;
+
+.gem-c-modal-dialogue {
+    display: none;
+    position: fixed;
+    z-index: $govuk-modal-z-index;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow-x: hidden;
+    overflow-y: scroll;
+    outline: 0;
+}
+
+.gem-c-modal-dialogue__box {
+    display: block;
+    position: fixed;
+    background: white;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    border: 0;
+
+    @include mq('medium') {
+        position: relative;
+        top: inherit;
+        right: inherit;
+        bottom: inherit;
+        left: inherit;
+        width: auto;
+        max-width: 700px;
+        height: auto;
+        margin: 20px;
+        border: 1px solid black;
+    }
+}
+
+.gem-c-modal-dialogue__box--wide {
+    @include mq('medium') {
+        max-width: 900px
+    }
+
+    @include mq('medium', 'max') {
+        margin: $govuk-modal-margin;
+    }
+}
+
+.gem-c-modal-dialogue__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: .8;
+    background: black;
+    pointer-events: none;
+    touch-action: none;
+}
+
+.app-o-template__body--modal {
+    overflow: hidden;
+}
+
+.app-o-template__body--blur {
+    .global-container {
+        filter: blur(2px);
+    }
+}
+
+.gem-c-modal-dialogue__header {
+    padding: 8px;
+    color: white;
+    background: black;
+}
+
+.gem-c-modal-dialogue__logotype-crown {
+    fill: currentColor;
+    vertical-align: middle;
+}
+
+.gem-c-modal-dialogue__logotype-crown-fallback-image {
+    width: 30px;
+    height: 26px;
+    border: 0;
+    vertical-align: middle;
+}
+
+.gem-c-modal-dialogue__content {
+    padding: 8px;
+    background: white;
+}
+
+.gem-c-modal-dialogue__close-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: $govuk-modal-close-button-size;
+    height: $govuk-modal-close-button-size;
+    border: 0;
+    color: white;
+    background: none;
+    cursor: pointer;
+
+    &:focus,
+    &:hover {
+        outline: none;
+        color: black;
+        background: yellow;
+    }
+}

--- a/assets/sass/components/_modal.scss
+++ b/assets/sass/components/_modal.scss
@@ -1,11 +1,12 @@
-$govuk-modal-margin: 20px;
-$govuk-modal-close-button-size: 44px;
-$govuk-modal-z-index: 1000;
+$close-button-size: $spacingUnit * 2;
+$inputOutlineWidth: 3px;
+$inputOutlineColour: get-color('border', 'outline');
+$inputOutline: $inputOutlineWidth solid $inputOutlineColour;
 
-.gem-c-modal-dialogue {
+.modal-dialog {
     display: none;
     position: fixed;
-    z-index: $govuk-modal-z-index;
+    z-index: 1000;
     top: 0;
     left: 0;
     width: 100%;
@@ -15,7 +16,7 @@ $govuk-modal-z-index: 1000;
     outline: 0;
 }
 
-.gem-c-modal-dialogue__box {
+.modal-dialog__box {
     display: block;
     position: fixed;
     background: white;
@@ -30,31 +31,25 @@ $govuk-modal-z-index: 1000;
     overflow-y: auto;
     border: 0;
 
+    &:focus {
+        outline: $inputOutline;
+    }
+
     @include mq('medium') {
         position: relative;
-        top: inherit;
+        top: 25%;
         right: inherit;
-        bottom: inherit;
         left: inherit;
         width: auto;
-        max-width: 700px;
         height: auto;
-        margin: 20px;
+        max-width: 700px;
+        margin-left: auto;
+        margin-right: auto;
         border: 1px solid black;
     }
 }
 
-.gem-c-modal-dialogue__box--wide {
-    @include mq('medium') {
-        max-width: 900px
-    }
-
-    @include mq('medium', 'max') {
-        margin: $govuk-modal-margin;
-    }
-}
-
-.gem-c-modal-dialogue__overlay {
+.modal-dialog__overlay {
     position: fixed;
     top: 0;
     right: 0;
@@ -68,54 +63,47 @@ $govuk-modal-z-index: 1000;
     touch-action: none;
 }
 
-.app-o-template__body--modal {
+body.is-modal {
     overflow: hidden;
-}
-
-.app-o-template__body--blur {
     .global-container {
         filter: blur(2px);
     }
 }
 
-.gem-c-modal-dialogue__header {
-    padding: 8px;
+.modal-dialog__header {
+    padding: $spacingUnit;
     color: white;
     background: black;
 }
 
-.gem-c-modal-dialogue__logotype-crown {
-    fill: currentColor;
-    vertical-align: middle;
-}
-
-.gem-c-modal-dialogue__logotype-crown-fallback-image {
-    width: 30px;
-    height: 26px;
-    border: 0;
-    vertical-align: middle;
-}
-
-.gem-c-modal-dialogue__content {
-    padding: 8px;
+.modal-dialog__content {
+    padding: $spacingUnit;
     background: white;
 }
 
-.gem-c-modal-dialogue__close-button {
+.modal-dialog__close-button {
     position: absolute;
-    top: 0;
-    right: 0;
-    width: $govuk-modal-close-button-size;
-    height: $govuk-modal-close-button-size;
+    top: $spacingUnit / 2;
+    right: $spacingUnit / 2;
+    width: $close-button-size;
+    height: $close-button-size;
     border: 0;
-    color: white;
+    color: black;
     background: none;
     cursor: pointer;
 
-    &:focus,
-    &:hover {
+    @include on-interact() {
         outline: none;
         color: black;
-        background: yellow;
+        background: #dfdfdf;
+        outline: $inputOutline;
+    }
+
+    // Invert the button colours if placed on a title
+    .modal-dialog--title & {
+        color: white;
+        @include on-interact() {
+            color: black;
+        }
     }
 }

--- a/assets/sass/components/_modal.scss
+++ b/assets/sass/components/_modal.scss
@@ -71,9 +71,7 @@ body.is-modal {
 }
 
 .modal-dialog__header {
-    padding: $spacingUnit;
-    color: white;
-    background: black;
+    padding: $spacingUnit $spacingUnit 0 $spacingUnit;
 }
 
 .modal-dialog__content {
@@ -97,13 +95,5 @@ body.is-modal {
         color: black;
         background: #dfdfdf;
         outline: $inputOutline;
-    }
-
-    // Invert the button colours if placed on a title
-    .modal-dialog--title & {
-        color: white;
-        @include on-interact() {
-            color: black;
-        }
     }
 }

--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -53,6 +53,7 @@
 @import 'components/cards';
 @import 'components/data';
 @import 'components/media';
+@import 'components/modal';
 @import 'components/applications';
 @import 'components/programmes';
 @import 'components/past-grants';

--- a/config/default.json
+++ b/config/default.json
@@ -29,7 +29,8 @@
     "enableSeeders": false
   },
   "awardsForAll": {
-    "enableExpiration": true
+    "enableExpiration": true,
+    "enableSessionExpiryWarning": true
   },
   "standardFundingProposal": {
     "allowedCountries": ["northern-ireland"]

--- a/config/default.json
+++ b/config/default.json
@@ -26,11 +26,11 @@
     "enableHotjar": false,
     "enableRelatedGrants": false,
     "enableSalesforceConnector": true,
-    "enableSeeders": false
+    "enableSeeders": false,
+    "enableSessionExpiryWarning": true
   },
   "awardsForAll": {
-    "enableExpiration": true,
-    "enableSessionExpiryWarning": true
+    "enableExpiration": true
   },
   "standardFundingProposal": {
     "allowedCountries": ["northern-ireland"]

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1412,6 +1412,23 @@ applyNext:
     promptLabel: "Oes gennych funud sbâr i roi adborth i ni?"
     fieldLabel: "Sut oedd eich profiad o'r broses hon?"
     helpText: "Mae hwn yn gwbl ddienw ac nid yw'n ffurfio rhan o'ch cyflwyniad. Peidiwch â chynnwys unrhyw fanylion am eich syniad, dim ond sut brofiad yr oedd."
+  expirationWarnings:
+    pending:
+      title: Rydych ar fin colli eich gwaith
+      body: >
+        <p>Byddwn yn eich allgofnodi os nad dydych yn ymateb o fewn 10 munud.</p>
+        <p>Rydym yn gwneud hyn i gadw eich gwybodaeth yn ddiogel.</p>
+      actions:
+        continue: Parhau i weithio
+        logOut: Allgofnodi
+    expired:
+      title: Mae’n ddrwg gennym, roedd rhaid i ni eich allgofnodi
+      body: >
+        <p>Nid ydych wedi bod yn llenwi’r ffurflen hwn am dros ddwy awr. Felly roedd rhaid i ni eich allgofnodi i gadw eich gwybodaeth bersonol yn ddiogel.</p>
+        <p>Ac mae gwaith nad ydych wedi’i arbed bellach wedi diflannu.</p>
+      actions:
+        logInAgain: Mewngofnodi eto
+        visitHomepage: Ymweld â’n tudalen gartref
   common:
     delete: Dileu
     exit: Gadael

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1692,6 +1692,23 @@ applyNext:
     promptLabel: "Can you spare a minute to give us some feedback?"
     fieldLabel: "How was your experience of this process?"
     helpText: "This is completely anonymous and doesn't form part of your submission. Don't include any details about your idea, just tell us how you found the experience."
+  expirationWarnings:
+    pending:
+      title: You’re about to lose your work
+      body: >
+        <p>We’ll log you out if you don’t respond in ten minutes.</p>
+        <p>We do this to keep your information secure.</p>
+      actions:
+        continue: Continue working
+        logOut: Log out
+    expired:
+      title: Sorry, we’ve had to log you out
+      body: >
+        <p>You’ve not been filling in this form for over two hours. So we’ve had to log you out to keep your personal information safe.</p>
+        <p>Any work you haven’t saved is gone now.</p>
+      actions:
+        logInAgain: Log in again
+        visitHomepage: Visit our homepage
   #  @TODO: Move other common text to common:
   common:
     delete: Delete

--- a/config/production.json
+++ b/config/production.json
@@ -7,9 +7,7 @@
   "hotjarId": 828894,
   "googleAnalyticsCode": "UA-637620-2",
   "features": {
-    "enableHotjar": true
-  },
-  "awardsForAll": {
+    "enableHotjar": true,
     "enableSessionExpiryWarning": false
   }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -8,5 +8,8 @@
   "googleAnalyticsCode": "UA-637620-2",
   "features": {
     "enableHotjar": true
+  },
+  "awardsForAll": {
+    "enableSessionExpiryWarning": false
   }
 }

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -122,25 +122,25 @@
         {{ __('applyNext.expirationWarnings.pending.body') | safe }}
         <div class="form-actions form-actions--constrained">
             <button type="button" class="btn btn--small js-modal-dialog-close-button">
-                {{ __('applyNext.expirationWarnings.pending.actions.continue') }}
+                {{ copy.expirationWarnings.pending.actions.continue }}
             </button>
             <a href="{{ localify('/user/logout') }}" class="btn btn--small btn--outline">
-                {{ __('applyNext.expirationWarnings.pending.actions.logOut') }}
+                {{ copy.expirationWarnings.pending.actions.logOut }}
             </a>
         </div>
     {% endcall %}
 
     {% call modal('apply-expiry-expired',
-            title = __('applyNext.expirationWarnings.expired.title'),
+            title = copy.expirationWarnings.expired.title,
             closeButton = false
         ) %}
-        {{ __('applyNext.expirationWarnings.expired.body') | safe }}
+        {{ copy.expirationWarnings.expired.body | safe }}
         <div class="form-actions form-actions--constrained">
             <a href="{{ localify('/user/login') }}" class="btn btn--small">
-                {{ __('applyNext.expirationWarnings.expired.actions.logInAgain') }}
+                {{ copy.expirationWarnings.expired.actions.logInAgain }}
             </a>
             <a href="{{ localify('/') }}" class="btn btn--small btn--outline">
-                {{ __('applyNext.expirationWarnings.expired.actions.visitHomepage') }}
+                {{ copy.expirationWarnings.expired.actions.visitHomepage }}
             </a>
         </div>
     {% endcall %}

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -2,6 +2,7 @@
 {% from "components/form-fields-next/macros.njk" import formErrors, formField with context %}
 {% from "components/form-header/macro.njk" import formHeaderWithData with context %}
 {% from "components/icons.njk" import iconBin, iconTick %}
+{% from "components/modal/macro.njk" import modal %}
 
 
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
@@ -107,4 +108,41 @@
             </form>
         </div>
     </main>
+{% endblock %}
+
+
+{% block modals %}
+
+    {#
+        The IDs of these modals are references in session.js (client-side file)
+        and must be changed there if changed here.
+    #}
+
+    {% call modal('apply-expiry-pending', title = __('applyNext.expirationWarnings.pending.title')) %}
+        {{ __('applyNext.expirationWarnings.pending.body') | safe }}
+        <div class="form-actions">
+            <button type="button" class="btn btn--small js-modal-dialog-close-button">
+                {{ __('applyNext.expirationWarnings.pending.actions.continue') }}
+            </button>
+            <a href="{{ localify('/user/logout') }}" class="btn btn--small btn--outline">
+                {{ __('applyNext.expirationWarnings.pending.actions.logOut') }}
+            </a>
+        </div>
+    {% endcall %}
+
+    {% call modal('apply-expiry-expired',
+            title = __('applyNext.expirationWarnings.expired.title'),
+            closeButton = false
+        ) %}
+        {{ __('applyNext.expirationWarnings.expired.body') | safe }}
+        <div class="form-actions u-no-margin">
+            <a href="{{ localify('/user/login') }}" class="btn btn--small">
+                {{ __('applyNext.expirationWarnings.expired.actions.logInAgain') }}
+            </a>
+            <a href="{{ localify('/') }}" class="btn btn--small btn--outline">
+                {{ __('applyNext.expirationWarnings.expired.actions.visitHomepage') }}
+            </a>
+        </div>
+    {% endcall %}
+
 {% endblock %}

--- a/controllers/apply/form-router-next/views/step.njk
+++ b/controllers/apply/form-router-next/views/step.njk
@@ -120,7 +120,7 @@
 
     {% call modal('apply-expiry-pending', title = __('applyNext.expirationWarnings.pending.title')) %}
         {{ __('applyNext.expirationWarnings.pending.body') | safe }}
-        <div class="form-actions">
+        <div class="form-actions form-actions--constrained">
             <button type="button" class="btn btn--small js-modal-dialog-close-button">
                 {{ __('applyNext.expirationWarnings.pending.actions.continue') }}
             </button>
@@ -135,7 +135,7 @@
             closeButton = false
         ) %}
         {{ __('applyNext.expirationWarnings.expired.body') | safe }}
-        <div class="form-actions u-no-margin">
+        <div class="form-actions form-actions--constrained">
             <a href="{{ localify('/user/login') }}" class="btn btn--small">
                 {{ __('applyNext.expirationWarnings.expired.actions.logInAgain') }}
             </a>

--- a/views/components/modal/macro.njk
+++ b/views/components/modal/macro.njk
@@ -12,7 +12,9 @@
             </div>
             {% if closeButton %}
                 <button class="modal-dialog__close-button js-modal-dialog-close-button js-modal-dialog-close-button--main"
-                        aria-label="Close modal dialogue">&times;</button>
+                        aria-label="Close dialogue">
+                    &times;
+                </button>
             {% endif %}
         </dialog>
     </div>

--- a/views/components/modal/macro.njk
+++ b/views/components/modal/macro.njk
@@ -1,0 +1,19 @@
+{% macro modal(id = false, title = false, closeButton = true) %}
+    <div class="modal-dialog{% if title %} modal-dialog--title{% endif %}" data-modal id="{{ id }}">
+        <div class="modal-dialog__overlay"></div>
+        <dialog class="modal-dialog__box js-modal-dialog" aria-modal="true" role="dialogue" tabindex="0">
+            {% if title %}
+                <div class="modal-dialog__header t3">
+                    {{ title | safe }}
+                </div>
+            {% endif %}
+            <div class="modal-dialog__content s-prose">
+                {{ caller() }}
+            </div>
+            {% if closeButton %}
+                <button class="modal-dialog__close-button js-modal-dialog-close-button js-modal-dialog-close-button--main"
+                        aria-label="Close modal dialogue">&times;</button>
+            {% endif %}
+        </dialog>
+    </div>
+{% endmacro %}

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -8,7 +8,10 @@
         isTestServer: {% if appData.isTestServer %}true{% else %}false{% endif %},
         locale: '{{ locale }}',
         localePrefix: '{{ localePrefix }}',
-        sessionExpirySeconds: {{ appData.config.get('session.expiryInSeconds') }}
+        sessionExpirySeconds: {{ appData.config.get('session.expiryInSeconds') }},
+        apply: {
+            enableSessionExpiryWarning: {{ appData.config.get('awardsForAll.enableSessionExpiryWarning') }}
+        }
     };
 
     var docEl = document.documentElement;

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -10,7 +10,7 @@
         localePrefix: '{{ localePrefix }}',
         sessionExpirySeconds: {{ appData.config.get('session.expiryInSeconds') }},
         apply: {
-            enableSessionExpiryWarning: {{ appData.config.get('awardsForAll.enableSessionExpiryWarning') }}
+            enableSessionExpiryWarning: {{ appData.config.get('features.enableSessionExpiryWarning') }}
         }
     };
 

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -45,6 +45,8 @@
             {% include "includes/global-footer.njk" %}
         </div>
 
+        {% block modals %}{% endblock %}
+
         {% include "includes/metaFooterJS.njk" %}
     </body>
 </html>


### PR DESCRIPTION
This uses the GDS in-progress modal component ([sourced here](https://github.com/alphagov/govuk-design-system-backlog/issues/30) - demo [here](https://components.publishing.service.gov.uk/component-guide/modal_dialogue)) to add an accessible modal to the site. 

We can use these anywhere on the site by adding the following to a page:

```
{% block modals %}
    {% call modal('your-id-here, title = 'Some title here') %}
        <p>Your content goes here</p>
    {% endcall %}
{% endblock %}
```

... and then a trigger can open the modal like so:

    <button data-toggle="modal" data-target="your-id-here">Show modal</button>

Or directly in JavaScript via:

    import modal from './modal';
    modal.triggerModal('your-id-here');

This change adds the session expiry warnings like so – you'll see this message when you have 10 minutes remaining:

![image](https://user-images.githubusercontent.com/394376/69138322-584d2d80-0ab6-11ea-8e18-5dfa0218dfdd.png)

Followed by this unclosable dialog when the total session (two hours) has expired:

![image](https://user-images.githubusercontent.com/394376/69138360-6a2ed080-0ab6-11ea-91ba-7e01441b5be0.png)

For now I'm only enabling this on non-prod environments so we can test it and confirm it works as expected.
