### PR TITLE
Fix apply charts

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -386,6 +386,9 @@ router.get('/:applicationId', async (req, res, next) => {
             now: new Date(),
             country: country,
             countryTitle: countryTitle,
+            countryColour: country
+                ? getColourForCountry(titleCase(country))
+                : null,
             dataStudioUrl: dataStudioUrl,
             feedback: feedback
         });

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -158,11 +158,13 @@
                             type: 'bar',
                             data: {
                                 {% if country %}
+                                    {% set barColour = countryColour if countryColour else '#e5007d' %}
                                     datasets: [{
                                         label: '{{ appType.title }}',
                                         data: {{ appType.data.appsPerDay | dump(2) | safe }},
-                                        borderColor: '#e5007d',
-                                        fill: '#e5007d'
+                                        borderColor: '{{ barColour }}',
+                                        fill: '{{ barColour }}',
+                                        backgroundColor: '{{ barColour }}'
                                     }]
                                 {% else %}
                                     datasets: [

--- a/controllers/tools/views/applications.njk
+++ b/controllers/tools/views/applications.njk
@@ -10,7 +10,7 @@
 
 {% set countries = [
     {
-        'value': 'uk',
+        'value': '',
         'label': 'UK-wide'
     },
     {


### PR DESCRIPTION
Individual country charts were rendering like this:

![image](https://user-images.githubusercontent.com/394376/69229578-94979100-0b7d-11ea-8df7-7ba8642590b0.png)

(I think because we changed the bar format which now expects a `backgroundColor` rather than a `fill`)

I updated it so individual countries always use the same shades as in the combined chart, eg:

![image](https://user-images.githubusercontent.com/394376/69229629-b5f87d00-0b7d-11ea-95fb-80c7a17c1b46.png)

Also fixed an issue with the UK-wide country option which should really be a blank string.