### PR TITLE
Remove oldestDate, unused but causing error on no results

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -382,7 +382,6 @@ router.get('/:applicationId', async (req, res, next) => {
             applicationData: applicationData,
             statistics: statistics,
             dateRange: dateRange,
-            oldestDate: getOldestDate(submittedApplications),
             now: new Date(),
             country: country,
             countryTitle: countryTitle,


### PR DESCRIPTION
This code was causing an error if there were no results for a query as `getOldestDate` assumed a populated set of results. Partially fixed by https://github.com/biglotteryfund/blf-alpha/pull/2702 but it turns out we don't even use this code in the template anymore so it can go.