### PR TITLE
Country validation

### DIFF
--- a/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty form 1`] = `
+Array [
+  "Enter a project name",
+  "Tell us all of the locations that you'll be running your project in",
+  "Enter a total cost for your project",
+  "Tell us what you would like to do",
+  "Tell us how your project involves your community",
+  "Tell us how your idea fits in with other local activities",
+  "Enter the full legal name of the organisation",
+  "Enter a full UK address",
+  "Select a type of organisation",
+  "Enter first and last name",
+  "Enter an email address",
+]
+`;
+
 exports[`invalid form 1`] = `
 Array [
   "Enter a project name",

--- a/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
@@ -3,6 +3,7 @@
 exports[`empty form 1`] = `
 Array [
   "Enter a project name",
+  "Select a country",
   "Tell us all of the locations that you'll be running your project in",
   "Enter a total cost for your project",
   "Tell us what you would like to do",

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -148,7 +148,8 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 .items(
                     Joi.string().valid(options().map(option => option.value))
                 )
-                .single(),
+                .single()
+                .required(),
             messages: [
                 {
                     type: 'base',

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -42,6 +42,11 @@ function mockResponse(overrides = {}) {
     return Object.assign(defaults, overrides);
 }
 
+test('empty form', () => {
+    const result = formBuilder().validation;
+    expect(mapMessages(result)).toMatchSnapshot();
+});
+
 test('valid form', () => {
     const data = mockResponse();
     const result = formBuilder({ data }).validation;


### PR DESCRIPTION
`projectCountries` was missing an explicit `.required()` so it is currently possible to miss selecting the country. Added a failing "empty form" test to cover this.