### PR TITLE
Remove express-validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7373,15 +7373,6 @@
         }
       }
     },
-    "express-validator": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-5.3.1.tgz",
-      "integrity": "sha512-g8xkipBF6VxHbO1+ksC7nxUU7+pWif0+OZXjZTybKJ/V0aTVhuCoHbyhIPgSYVldwQLocGExPtB2pE0DqK4jsw==",
-      "requires": {
-        "lodash": "^4.17.10",
-        "validator": "^10.4.0"
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
     "express": "4.17.1",
     "express-cache-controller": "^1.0.1",
     "express-session": "1.17.0",
-    "express-validator": "^5.0.0",
     "faker": "4.1.0",
     "filesize": "5.0.3",
     "fitvids": "^2.1.1",


### PR DESCRIPTION
Hey we did it 🎉 . Reached the point where we no longer need both `joi` and `express-validator`