### PR TITLE
Fix absolute URLs when localised

### DIFF
--- a/common/urls.js
+++ b/common/urls.js
@@ -4,6 +4,8 @@ const querystring = require('querystring');
 
 const WELSH_REGEX = /^\/welsh(\/|$)/;
 
+const isAbsoluteUrl = str => str.indexOf('://') !== -1;
+
 /**
  * isWelsh
  * Is the current URL a welsh URL
@@ -34,6 +36,9 @@ function removeWelsh(urlPath) {
  */
 function localify(locale) {
     return function(urlPath) {
+        if (isAbsoluteUrl(urlPath)) {
+            return urlPath;
+        }
         const urlIsWelsh = isWelsh(urlPath);
 
         let newUrlPath = urlPath;

--- a/common/urls.test.js
+++ b/common/urls.test.js
@@ -105,6 +105,9 @@ describe('URL Helpers', () => {
             expect(localify('cy')('/welsh/funding/programmes')).toBe(
                 '/welsh/funding/programmes'
             );
+            expect(localify('cy')('https://www.google.com')).toBe(
+                'https://www.google.com'
+            );
         });
     });
 


### PR DESCRIPTION
I need to add an absolute URL (eg. to CNL25 site) to the homepage, but the `localise()` function gets called on all the paths provided here:

![image](https://user-images.githubusercontent.com/394376/69416286-2e8e4380-0d0e-11ea-8808-85c6234f4e8c.png)

This change means that absolute URLs won't be localised, otherwise you end up with something weird where we try to add `/welsh` to a full URL.
