### PR TITLE
Replace brittle filter by country code with normalised country

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -106,37 +106,6 @@ function countRequestedAmount(data) {
     return values;
 }
 
-function filterByCountry(country, appType) {
-    return function(item) {
-        if (!country) {
-            return item;
-        } else if (!item.applicationSummary && !item.applicationData) {
-            return false;
-        } else {
-            let appCountry;
-
-            if (appType === 'pending') {
-                appCountry = get(item, 'applicationData.projectCountry');
-            } else {
-                const rowCountry = item.applicationSummary.find(
-                    _ =>
-                        _.label ===
-                            'What country will your project be based in?' ||
-                        _.label === 'Pa wlad fydd eich prosiect wedi’i leoli?'
-                );
-                appCountry = get(rowCountry, 'value');
-            }
-
-            if (appCountry) {
-                const c = appCountry.toLowerCase().replace(' ', '-');
-                return c === country;
-            } else {
-                return false;
-            }
-        }
-    };
-}
-
 function titleCase(str) {
     if (!str) {
         return;
@@ -232,7 +201,9 @@ router.get('/:applicationId', async (req, res, next) => {
                     );
                     return data;
                 })
-                .filter(filterByCountry(country, 'pending'));
+                .filter(function(application) {
+                    return country ? application.country === country : true;
+                });
         });
     }
 
@@ -247,7 +218,9 @@ router.get('/:applicationId', async (req, res, next) => {
                     data.country = data.applicationCountry;
                     return data;
                 })
-                .filter(filterByCountry(country, 'submitted'));
+                .filter(function(application) {
+                    return country ? application.country === country : true;
+                });
         });
     }
 


### PR DESCRIPTION
Fixes an issue where filtering by country didn't work for standard application forms as the filter code was tightly coupled to awards for all.

Tried a bunch of refactoring before realising that we already normalise the application country earlier in the process so can check the computed `country` property.

There's still a bit too much logic that's conditional on the form type that makes me inclined to split this out into two controllers (with a code sharing where it makes sense), but this is the most direct fix for now.