### PR TITLE
Make server notification opt-in

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -53,6 +53,7 @@ function describePortBinding() {
  */
 function startServer() {
     server.listen(port);
+
     server.on('error', function onError(error) {
         if (error.syscall !== 'listen') {
             throw error;
@@ -69,12 +70,18 @@ function startServer() {
                 throw error;
         }
     });
+
     server.on('listening', function() {
         const msg = `App now running on ${describeAddressBinding(
             server.address()
         )}`;
+
         logger.debug(msg);
-        if (NODE_ENV === 'development') {
+
+        if (
+            NODE_ENV === 'development' &&
+            !!process.env.SHOW_RESTART_NOTIFICATION
+        ) {
             require('node-notifier').notify({
                 title: 'blf-alpha',
                 message: msg,


### PR DESCRIPTION
Apologies for the contrary pull request. Finding the restart notification distracting, probably down to the server restart process being faster on my machine. @mattandrews Happy to split the different and make this opt-in via an `env` property?