### PR TITLE
Add some redirects for constantly-requested logo images

### DIFF
--- a/controllers/__snapshots__/aliases.test.js.snap
+++ b/controllers/__snapshots__/aliases.test.js.snap
@@ -6402,5 +6402,85 @@ Array [
     "from": "/welsh/wales/about/customer-service/supplier-zone/contracts-finder",
     "to": "/welsh/about/customer-service/supplier-zone",
   },
+  Object {
+    "from": "/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/england/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/england/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/scotland/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/scotland/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/northernireland/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/northernireland/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/wales/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/wales/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/england/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/england/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/scotland/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/scotland/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/northernireland/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/northernireland/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/wales/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
+  Object {
+    "from": "/welsh/wales/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg",
+    "to": "/welsh/assets/images/logos/tnlcf/monolingual/colour.png",
+  },
 ]
 `;

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -186,7 +186,9 @@ const aliases = {
     '/contact-us': '/contact',
     '/news-and-events': '/news',
     '/research/open-data': '/data#open-data',
-    '/about/customer-service/supplier-zone/contracts-finder': '/about/customer-service/supplier-zone'
+    '/about/customer-service/supplier-zone/contracts-finder': '/about/customer-service/supplier-zone',
+    '/-/media/Images/Logos/JPEGs/hi_big_e_min_blue.jpg': '/assets/images/logos/tnlcf/monolingual/colour.png',
+    '/-/media/Images/Logos/JPEGs/hi_big_e_min_pink.jpg': '/assets/images/logos/tnlcf/monolingual/colour.png'
 };
 
 /**


### PR DESCRIPTION
This has bothered me for ages:

![image](https://user-images.githubusercontent.com/394376/69654670-0fc0e180-106d-11ea-8aef-904fd7a5a110.png)

Autodiscover has been solved by switching off the old domain redirect service (which was forwarding Outlook clients requesting `https://tnlcommunityfund.org.uk/autodiscover/autodiscover.xml` onto `https://www.tnlcommunityfund.org.uk/autodiscover/autodiscover.xml`) but those two logo requests are a huge chunk of our 404 stats and get tons of requests every day:

![image](https://user-images.githubusercontent.com/394376/69654749-37b04500-106d-11ea-89dd-c301843308d6.png)

I can't prove it as the logs don't include referrers, and searching the web for references to these file paths only turns up a few small local blogs/sites which are unlikely to be sending 1000 reqs/day, so my theory is that these images are hotlinked somewhere internally (eg. the intranet or some other tool), which I've asked IT about.

In the meantime, this change redirects them to the current logo so we'll stop seeing so many 404s, and so whatever service is hotlinking them stands a chance of getting an expected response back.