### PR TITLE
Only track expiry warnings once

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -12,6 +12,7 @@ const expiryCheckIntervalSeconds = 30;
 const warningShownSecondsRemaining = 10 * 60;
 
 const showWarnings = window.AppConfig.apply.enableSessionExpiryWarning;
+let hasShownWarning = false;
 
 function handleBeforeUnload(e) {
     // Message cannot be customised in Chrome 51+
@@ -233,6 +234,7 @@ function handleSessionExpiration() {
 
     function clearSessionExpiryWarningTimer() {
         window.clearInterval(sessionInterval);
+        hasShownWarning = false;
     }
 
     function sessionTimeoutCheck() {
@@ -250,10 +252,13 @@ function handleSessionExpiration() {
             }
         } else if (expiryTimeRemaining <= warningShownSecondsRemaining) {
             // The user has a few minutes remaining before logout
-            trackEvent('Session', 'Warning', 'Timeout almost reached');
-            tagHotjarRecording(['App: User shown session expiry warning']);
-            if (showWarnings) {
-                modal.triggerModal('apply-expiry-pending');
+            if (!hasShownWarning) {
+                trackEvent('Session', 'Warning', 'Timeout almost reached');
+                tagHotjarRecording(['App: User shown session expiry warning']);
+                if (showWarnings) {
+                    modal.triggerModal('apply-expiry-pending');
+                }
+                hasShownWarning = true;
             }
         }
     }
@@ -310,6 +315,5 @@ function init() {
 }
 
 export default {
-    init,
-    removeBeforeUnload
+    init
 };


### PR DESCRIPTION
Spotted a big jump in analytics events for session expiry warnings (eg. 10 mins to go) being shown:

![image](https://user-images.githubusercontent.com/394376/69865214-842b9880-1298-11ea-82ea-b0cc2f5c6bb1.png)

... realised it's because the code checks every 30 seconds whether your session is within 10 mins of expiring, but when this threshold is crossed it _keeps_ checking... and showing the modal/logging it in analytics. If a user let the session run out for 2 hours we'd see ~20 analytics events for "Timeout almost reached" (because the timer runs every 30 seconds, so the 10 minute countdown would log 2 events per minute). 

This change adds a check to make sure we only log the timeout once (and reset the check if the user restarts the session).
