### PR TITLE
Add register panel to login screen

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1066,7 +1066,10 @@ user:
   register:
     title: Creu cyfrif
     actionLabel: Creu cyfrif
-    loginLabel: mewngofnodi
+    loginLabel: Mewngofnodi
+    loginPrompt:
+      title: Gyda chyfrif eisoes?
+      body: Mewngofnodwch yma
     genericError: >
       Roedd problem wrth greu eich cyfrif. Os ydych yn meddwl bod gennych gyfrif eisoes, ceisiwch
       <a href="%s">ailosod eich cyfrinair</a>.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1051,7 +1051,10 @@ user:
     introduction: >
       <p>Mae hon yn ffurflen gais newydd. Os nad ydych wedi mewngofnodi yma eisoes, efallai na fydd gennych gyfrif â ni - a bydd angen <a href="/welsh/user/register">creu cyfrif newydd</a> i ymgeisio.</p>
     actionLabel: Mewngofnodi
-    registerLabel: creu cyfrif
+    registerLabel: Creu cyfrif
+    registerPrompt:
+      title: Heb gyfrif eto?
+      body: Mae ein cyfrif ar-lein yn gwneud llenwi eich cais ariannu yn haws ac yn gyflymach. A dim ond cwpwl funudau mae’n ei gymryd i’w osod.
     forgottenPasswordPrompt: Wedi anghofio eich cyfrinair?
     credentialError: Nid yw eich enw defnyddiwr a chyfrinair yn gywir. Neu efallai nad oes gennych gyfrif, gan fod hwn yn ffurflen gais newydd – ceisiwch <a href="/welsh/user/register">greu cyfrif</a>.
   rateLimited:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1160,7 +1160,10 @@ user:
     introduction: >
       <p>This is a new application form. If you haven't logged in here before, you might not have an account with us - and will need to <a href="/user/register">create a new account</a> to apply.</p>
     actionLabel: Log in
-    registerLabel: create an account
+    registerLabel: Create an account
+    registerPrompt:
+      title: Don't have an account yet?
+      body: Our online account makes filling in your funding applications quicker and easier. And it only takes a couple of minutes to set up.
     forgottenPasswordPrompt: Forgotten your password?
     credentialError: Your username and password aren't quite right. Or you might not have an account, as this is a new application form - try <a href="/user/register">creating an account</a>.
   rateLimited:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1175,7 +1175,10 @@ user:
   register:
     title: Create an account
     actionLabel: Create an account
-    loginLabel: log in
+    loginLabel: Log in
+    loginPrompt:
+      title: Already have an account?
+      body: Log in here
     genericError: >
       There was an error creating your account. If you think you already have an account try
       <a href="%s">resetting your password</a>.

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -61,8 +61,12 @@
 
                 </div>
 
-                <div class="content-sidebar__secondary u-tone-background-tint u-padded">
-                    <h3>Don't have an account?</h3>
+                <div class="content-sidebar__secondary">
+                    <aside class="u-tone-background-tint u-padded u-margin-top-l">
+                        <h3>{{ copy.registerPrompt.title }}</h3>
+                        <p>{{ copy.registerPrompt.body }}</p>
+                        <a class="btn btn--small btn--outline u-block" href="{{ localify('/user/register') }}">{{ copy.registerLabel }}</a>
+                    </aside>
                 </div>
             </div>
         </div>

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -4,54 +4,69 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
-            <h1 class="t--underline">{{ title }}</h1>
 
-            {% if alertMessage %}
-                <div class="message" role="alert">
-                    {{ alertMessage }}
+
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    <h1 class="t--underline">{{ title }}</h1>
+
+                    {% if alertMessage %}
+                        <div class="message" role="alert">
+                            {{ alertMessage }}
+                        </div>
+                    {% endif %}
+
+                    <form action="" method="post" autocomplete="off" novalidate>
+                        <div class="s-prose u-constrained-wide">
+                            {{ copy.introduction | safe }}
+                        </div>
+
+                        {{ formErrors(
+                            title = __('global.misc.errorTitle'),
+                            errors = errors
+                        ) }}
+
+                        {% if csrfToken %}
+                            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                        {% endif %}
+
+                        {{ formField({
+                            type: 'email',
+                            name: 'username',
+                            label: __('user.common.emailAddress'),
+                            isRequired: true,
+                            value: formValues['username']
+                        }, errors = errors) }}
+
+                        {{ formField({
+                            type: 'password',
+                            name: 'password',
+                            label: __('user.common.password'),
+                            isRequired: true
+                        }, errors = errors) }}
+
+                        <p>
+                            <small>
+                                <a href="{{ localify('/user/password/forgot') }}">
+                                    {{ copy.forgottenPasswordPrompt }}
+                                </a>
+                            </small>
+                        </p>
+
+                        <div class="form-actions">
+                            <input type="submit" class="btn" value="{{ copy.actionLabel }}" />
+                        </div>
+
+                    </form>
+
                 </div>
-            {% endif %}
 
-            <form action="" method="post" autocomplete="off" novalidate>
-                <div class="s-prose u-constrained-wide">
-                    {{ copy.introduction | safe }}
+                <div class="content-sidebar__secondary u-tone-background-tint u-padded">
+                    <h3>Don't have an account?</h3>
                 </div>
-
-                {{ formErrors(
-                    title = __('global.misc.errorTitle'),
-                    errors = errors
-                ) }}
-
-                {% if csrfToken %}
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                {% endif %}
-
-                {{ formField({
-                    type: 'email',
-                    name: 'username',
-                    label: __('user.common.emailAddress'),
-                    isRequired: true,
-                    value: formValues['username']
-                }, errors = errors) }}
-
-                {{ formField({
-                    type: 'password',
-                    name: 'password',
-                    label: __('user.common.password'),
-                    isRequired: true
-                }, errors = errors) }}
-
-                <div class="form-actions">
-                    <input type="submit" class="btn" value="{{ copy.actionLabel }}" />
-                    {{ __('global.misc.or') }}
-                    <a href="{{ localify('/user/register') }}">{{ copy.registerLabel }}</a>
-                </div>
-
-                <p><small><a href="{{ localify('/user/password/forgot') }}">
-                    {{ copy.forgottenPasswordPrompt }}
-                </a></small></p>
-            </form>
+            </div>
         </div>
+
     </main>
 {% endblock %}
 

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -62,11 +62,11 @@
                 </div>
 
                 <div class="content-sidebar__secondary">
-                    <aside class="u-tone-background-tint u-padded u-margin-top-l">
+                    <div class="u-tone-background-tint u-padded u-margin-top-l">
                         <h3>{{ copy.registerPrompt.title }}</h3>
                         <p>{{ copy.registerPrompt.body }}</p>
                         <a class="btn btn--small btn--outline u-block" href="{{ localify('/user/register') }}">{{ copy.registerLabel }}</a>
-                    </aside>
+                    </div>
                 </div>
             </div>
         </div>

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -4,48 +4,59 @@
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
-            <h1 class="t--underline">{{ title }}</h1>
 
-            <form action="" method="post" autocomplete="off" novalidate>
-                {{ formErrors(
-                    title = __('global.misc.errorTitle'),
-                    errors = errors
-                ) }}
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    <h1 class="t--underline">{{ title }}</h1>
 
-                {% if csrfToken %}
-                    <input type="hidden" name="_csrf" value="{{ csrfToken }}">
-                {% endif %}
+                    <form action="" method="post" autocomplete="off" novalidate>
+                        {{ formErrors(
+                            title = __('global.misc.errorTitle'),
+                            errors = errors
+                        ) }}
 
-                {{ formField({
-                    type: 'email',
-                    name: 'username',
-                    label: __('user.common.emailAddress'),
-                    isRequired: true,
-                    value: formValues['username']
-                }, errors = errors) }}
+                        {% if csrfToken %}
+                            <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+                        {% endif %}
 
-                {{ formField({
-                    type: 'password',
-                    name: 'password',
-                    label: __('user.common.password'),
-                    explanation: __('user.common.passwordRequirements'),
-                    isRequired: true
-                }, errors = errors) }}
+                        {{ formField({
+                            type: 'email',
+                            name: 'username',
+                            label: __('user.common.emailAddress'),
+                            isRequired: true,
+                            value: formValues['username']
+                        }, errors = errors) }}
 
-                {{ formField({
-                    type: 'password',
-                    name: 'passwordConfirmation',
-                    label: __('user.common.passwordConfirmation.label'),
-                    explanation: __('user.common.passwordConfirmation.explanation'),
-                    isRequired: true
-                }, errors = errors) }}
+                        {{ formField({
+                            type: 'password',
+                            name: 'password',
+                            label: __('user.common.password'),
+                            explanation: __('user.common.passwordRequirements'),
+                            isRequired: true
+                        }, errors = errors) }}
 
-                <div class="form-actions">
-                    <input type="submit" class="btn" value="{{ copy.actionLabel }}" />
-                    {{ __('global.misc.or') }}
-                    <a href="{{ localify('/user/login') }}">{{ copy.loginLabel }}</a>
+                        {{ formField({
+                            type: 'password',
+                            name: 'passwordConfirmation',
+                            label: __('user.common.passwordConfirmation.label'),
+                            explanation: __('user.common.passwordConfirmation.explanation'),
+                            isRequired: true
+                        }, errors = errors) }}
+
+                        <div class="form-actions">
+                            <input type="submit" class="btn" value="{{ copy.actionLabel }}" />
+                        </div>
+                    </form>
                 </div>
-            </form>
+
+                <div class="content-sidebar__secondary">
+                    <div class="u-tone-background-tint u-padded u-margin-top-l">
+                        <h3>{{ copy.loginPrompt.title }}</h3>
+                        <p>{{ copy.loginPrompt.body }}</p>
+                        <a class="btn btn--small btn--outline u-block" href="{{ localify('/user/login') }}">{{ copy.loginLabel }}</a>
+                    </div>
+                </div>
+            </div>
         </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
Simplifies the login screen to hopefully reduce confusion of people clicking "create an account" and hoping/assuming it will preserve the details they typed.

## Before

![image](https://user-images.githubusercontent.com/394376/70041740-99186c80-15b5-11ea-80de-fcec1c9a1ce8.png)

## After

![image](https://user-images.githubusercontent.com/394376/70041705-8736c980-15b5-11ea-8d34-cba5498f75d3.png)
