### PR TITLE
New date range clean

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,8 @@
     "enableSessionExpiryWarning": true
   },
   "awardsForAll": {
-    "enableExpiration": true
+    "enableExpiration": true,
+    "enableNewDateRange": false
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]

--- a/config/development.json
+++ b/config/development.json
@@ -3,5 +3,8 @@
   "features": {
     "enableSeeders": true,
     "enableSalesforceConnector": false
+  },
+  "awardsForAll": {
+    "enableNewDateRange": true
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -6,5 +6,8 @@
   },
   "features": {
     "enableHotjar": true
+  },
+  "awardsForAll": {
+    "enableNewDateRange": true
   }
 }

--- a/controllers/apply/awards-for-all/__snapshots__/enrich.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/enrich.test.js.snap
@@ -39,7 +39,7 @@ Object {
   "overview": Array [
     Object {
       "label": "Project dates",
-      "value": "4 June, 2020–4 June, 2020",
+      "value": "13 April, 2020–6 July, 2020",
     },
     Object {
       "label": "Location",

--- a/controllers/apply/awards-for-all/docs/schema.test.js
+++ b/controllers/apply/awards-for-all/docs/schema.test.js
@@ -3,18 +3,17 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const map = require('lodash/map');
 
 const formBuilder = require('../form');
+
+const form = formBuilder({ flags: { enableNewDateRange: false } });
 
 const docContents = fs.readFileSync(
     path.resolve(__dirname, './schema.md'),
     'utf8'
 );
 
-const form = formBuilder({ locale: 'en' });
-
-test.each(map(form.allFields, 'name'))(
+test.each(Object.keys(form.schema.describe().children))(
     '%s has documentation entry',
     fieldName => {
         const fieldNameRegexp = new RegExp(`### ${fieldName}`);

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 const moment = require('moment');
@@ -23,6 +24,8 @@ const fieldYourIdeaPriorities = require('./fields/your-idea-priorities');
 const fieldYourIdeaProject = require('./fields/your-idea-project');
 const fieldProjectLocation = require('./fields/project-location');
 const fieldProjectDateRange = require('./fields/project-date-range');
+const fieldProjectStartDate = require('./fields/project-start-date');
+const fieldProjectEndDate = require('./fields/project-end-date');
 const fieldCompanyNumber = require('./fields/company-number');
 const fieldCharityNumber = require('./fields/charity-number');
 const fieldEducationNumber = require('./fields/education-number');
@@ -258,7 +261,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         });
     }
 
-    return {
+    const allFields = {
         projectName: {
             name: 'projectName',
             label: localise({
@@ -291,7 +294,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 }
             ]
         },
-        projectDateRange: fieldProjectDateRange(locale),
         projectCountry: fieldProjectCountry(locale),
         projectLocation: fieldProjectLocation(locale, data),
         projectLocationDescription: {
@@ -1784,4 +1786,13 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             isRequired: true
         }
     };
+
+    if (config.get('awardsForAll.enableNewDateRange')) {
+        allFields.projectStartDate = fieldProjectStartDate(locale);
+        allFields.projectEndDate = fieldProjectEndDate(locale);
+    } else {
+        allFields.projectDateRange = fieldProjectDateRange(locale);
+    }
+
+    return allFields;
 };

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1,5 +1,4 @@
 'use strict';
-const config = require('config');
 const flatMap = require('lodash/flatMap');
 const get = require('lodash/fp/get');
 const moment = require('moment');
@@ -48,7 +47,7 @@ const {
     FREE_TEXT_MAXLENGTH
 } = require('./constants');
 
-module.exports = function fieldsFor({ locale, data = {} }) {
+module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
     const localise = get(locale);
 
     function multiChoice(options) {
@@ -1787,7 +1786,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
         }
     };
 
-    if (config.get('awardsForAll.enableNewDateRange')) {
+    if (flags.enableNewDateRange) {
         allFields.projectStartDate = fieldProjectStartDate(locale);
         allFields.projectEndDate = fieldProjectEndDate(locale);
     } else {

--- a/controllers/apply/awards-for-all/fields/project-end-date.js
+++ b/controllers/apply/awards-for-all/fields/project-end-date.js
@@ -15,12 +15,13 @@ module.exports = function(locale) {
         name: 'projectEndDate',
         label: localise({
             en: `When would you like to finish your project?`,
-            cy: ``
+            cy: `Pryd hoffech orffen eich prosiect?`
         }),
         explanation: localise({
             en: oneLine`Your project can finish up to 12 months after it starts.
                 It can even be as short as just one day`,
-            cy: ``
+            cy: oneLine`Gall eich prosiect orffen hyd at 12 mis wedi iddo gychwyn.
+                Gall fod mor fyr ag un diwrnod yn unig.`
         }),
         schema: Joi.dateParts()
             .minDateRef(Joi.ref('projectStartDate'))
@@ -33,8 +34,8 @@ module.exports = function(locale) {
             {
                 type: 'base',
                 message: localise({
-                    en: 'Enter a project end date',
-                    cy: ''
+                    en: `Enter a project end date`,
+                    cy: `Cofnodwch ddyddiad gorffen i’ch prosiect`
                 })
             },
             {

--- a/controllers/apply/awards-for-all/fields/project-end-date.js
+++ b/controllers/apply/awards-for-all/fields/project-end-date.js
@@ -1,0 +1,60 @@
+'use strict';
+const get = require('lodash/fp/get');
+const { oneLine } = require('common-tags');
+
+const Joi = require('../../lib/joi-extensions');
+const DateField = require('../../lib/field-types/date');
+
+const { MAX_PROJECT_DURATION } = require('../constants');
+
+module.exports = function(locale) {
+    const localise = get(locale);
+
+    return new DateField({
+        locale: locale,
+        name: 'projectEndDate',
+        label: localise({
+            en: `When would you like to finish your project?`,
+            cy: ``
+        }),
+        explanation: localise({
+            en: oneLine`Your project can finish up to 12 months after it starts.
+                It can even be as short as just one day`,
+            cy: ``
+        }),
+        schema: Joi.dateParts()
+            .minDateRef(Joi.ref('projectStartDate'))
+            .rangeLimit(Joi.ref('projectStartDate'), {
+                amount: MAX_PROJECT_DURATION.amount,
+                unit: MAX_PROJECT_DURATION.unit
+            })
+            .required(),
+        messages: [
+            {
+                type: 'base',
+                message: localise({
+                    en: 'Enter a project end date',
+                    cy: ''
+                })
+            },
+            {
+                type: 'dateParts.minDateRef',
+                message: localise({
+                    en: `Date you end the project must be after the start date`,
+                    cy: `Rhaid i ddyddiad gorffen y prosiect fod ar ôl y dyddiad dechrau`
+                })
+            },
+            {
+                type: 'dateParts.rangeLimit',
+                message: localise({
+                    en: oneLine`Date you end the project must be within
+                        ${localise(MAX_PROJECT_DURATION.label)}
+                        of the start date.`,
+                    cy: oneLine`Rhaid i ddyddiad gorffen y prosiect fod o fewn
+                        ${localise(MAX_PROJECT_DURATION.label)}
+                        o ddyddiad dechrau’r prosiect.`
+                })
+            }
+        ]
+    });
+};

--- a/controllers/apply/awards-for-all/fields/project-start-date.js
+++ b/controllers/apply/awards-for-all/fields/project-start-date.js
@@ -13,20 +13,26 @@ module.exports = function(locale) {
 
     const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
 
-    function formatAfterDate(format = 'D MMMM YYYY') {
-        return minDate
-            .clone()
-            .locale(locale)
-            .format(format);
-    }
+    const minDateExample = minDate
+        .clone()
+        .locale(locale)
+        .format('DD MM YYYY');
 
     return new DateField({
         name: 'projectStartDate',
 
-        label: 'When would you like to start your project?',
-        explanation: oneLine`Don't worry, this can be an estimate.
-            But your project must start after
-            <strong>${formatAfterDate('DD MM YYYY')}.</strong>`,
+        label: localise({
+            en: `When would you like to start your project?`,
+            cy: `Pryd hoffech ddechrau eich prosiect?`
+        }),
+        explanation: localise({
+            en: oneLine`Don't worry, this can be an estimate.
+                But your project must start after
+                <strong>${minDateExample}.</strong>`,
+            cy: oneLine`Peidiwch a poeni, gall hwn fod yn amcangyfrif.
+                Ond mae angen i’ch prosiect ddechrau ar ôl
+                <strong>${minDateExample}.</strong>`
+        }),
         settings: {
             minYear: minDate.format('YYYY')
         },
@@ -37,15 +43,17 @@ module.exports = function(locale) {
             {
                 type: 'base',
                 message: localise({
-                    en: 'Enter a project start date',
-                    cy: ''
+                    en: `Enter a project start date`,
+                    cy: `Cofnodwch ddyddiad dechrau i’ch prosiect`
                 })
             },
             {
                 type: 'dateParts.minDate',
                 message: localise({
-                    en: `Date you start the project must be on or after ${formatAfterDate()}`,
-                    cy: ``
+                    en: oneLine`Date you start the project must be on or after
+                        ${minDateExample}`,
+                    cy: oneLine`Mae’n rhaid i ddyddiad dechrau eich prosiect
+                        fod ar neu ar ôl ${minDateExample}`
                 })
             }
         ]

--- a/controllers/apply/awards-for-all/fields/project-start-date.js
+++ b/controllers/apply/awards-for-all/fields/project-start-date.js
@@ -1,0 +1,53 @@
+'use strict';
+const get = require('lodash/fp/get');
+const moment = require('moment');
+const { oneLine } = require('common-tags');
+
+const Joi = require('../../lib/joi-extensions');
+const DateField = require('../../lib/field-types/date');
+
+const { MIN_START_DATE } = require('../constants');
+
+module.exports = function(locale) {
+    const localise = get(locale);
+
+    const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
+
+    function formatAfterDate(format = 'D MMMM YYYY') {
+        return minDate
+            .clone()
+            .locale(locale)
+            .format(format);
+    }
+
+    return new DateField({
+        name: 'projectStartDate',
+
+        label: 'When would you like to start your project?',
+        explanation: oneLine`Don't worry, this can be an estimate.
+            But your project must start after
+            <strong>${formatAfterDate('DD MM YYYY')}.</strong>`,
+        settings: {
+            minYear: minDate.format('YYYY')
+        },
+        schema: Joi.dateParts()
+            .minDate(minDate.format('YYYY-MM-DD'))
+            .required(),
+        messages: [
+            {
+                type: 'base',
+                message: localise({
+                    en: 'Enter a project start date',
+                    cy: ''
+                })
+            },
+            {
+                type: 'dateParts.minDate',
+                message: localise({
+                    en: `Date you start the project must be on or after ${formatAfterDate()}`,
+                    cy: ``
+                })
+            }
+        ]
+    });
+};

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -1361,6 +1361,8 @@ module.exports = function({
         allFields: fields,
         featuredErrorsAllowList: [
             { fieldName: 'projectDateRange', includeBase: false },
+            { fieldName: 'projectStartDate', includeBase: false },
+            { fieldName: 'projectEndDate', includeBase: false },
             { fieldName: 'seniorContactRole', includeBase: false },
             { fieldName: 'mainContactName', includeBase: false },
             { fieldName: 'mainContactEmail', includeBase: false },

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const Sentry = require('@sentry/node');
 const clone = require('lodash/clone');
 const concat = require('lodash/concat');
@@ -68,13 +69,17 @@ module.exports = function({
     }
 
     function stepProjectLength() {
+        const stepFields = config.get('awardsForAll.enableNewDateRange')
+            ? [fields.projectStartDate, fields.projectEndDate]
+            : [fields.projectDateRange];
+
         return {
             title: localise({
                 en: 'Project length',
                 cy: 'Hyd y prosiect'
             }),
             noValidate: true,
-            fieldsets: [{ fields: [fields.projectDateRange] }]
+            fieldsets: [{ fields: stepFields }]
         };
     }
 
@@ -1304,10 +1309,22 @@ module.exports = function({
 
         const enriched = clone(data);
 
-        enriched.projectDateRange = {
-            startDate: dateFormat(enriched.projectDateRange.startDate),
-            endDate: dateFormat(enriched.projectDateRange.endDate)
-        };
+        const useNewDateSchema =
+            config.get('awardsForAll.enableNewDateRange') &&
+            has('projectStartDate')(enriched) &&
+            has('projectEndDate')(enriched);
+
+        if (useNewDateSchema) {
+            enriched.projectDateRange = {
+                startDate: dateFormat(enriched.projectStartDate),
+                endDate: dateFormat(enriched.projectEndDate)
+            };
+        } else {
+            enriched.projectDateRange = {
+                startDate: dateFormat(enriched.projectDateRange.startDate),
+                endDate: dateFormat(enriched.projectDateRange.endDate)
+            };
+        }
 
         if (has('mainContactDateOfBirth')(enriched)) {
             enriched.mainContactDateOfBirth = dateFormat(

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -81,7 +81,7 @@ test('validate model shape', () => {
 });
 
 test('empty form', () => {
-    const form = formBuilder();
+    const form = formBuilder({ flags: { enableNewDateRange: false } });
     expect(mapMessageSummary(form.validation)).toMatchSnapshot();
     expect(form.progress).toMatchSnapshot();
 });
@@ -102,7 +102,7 @@ test('valid form for scotland', () => {
         projectLocation: 'east-lothian'
     });
 
-    const form = formBuilder({ data }).validation;
+    const form = formBuilder({ data });
     expect(form.validation.error).toBeNull();
 });
 
@@ -127,21 +127,6 @@ test('valid form for wales', () => {
             'seniorContactLanguagePreference'
         ])
     );
-});
-
-test.only('format form data for salesforce', function() {
-    const data = mockResponse({
-        projectDateRange: {
-            startDate: { day: 3, month: 3, year: 2021 },
-            endDate: { day: 3, month: 3, year: 2021 }
-        }
-    });
-
-    const result = formBuilder({ data: data }).forSalesforce();
-    expect(result.projectDateRange).toEqual({
-        startDate: '2021-03-03',
-        endDate: '2021-03-03'
-    });
 });
 
 test('valid form for northern-ireland', () => {
@@ -226,7 +211,8 @@ test('featured messages based on allow list', () => {
                 endDate: { day: 31, month: 1, year: 2019 }
             },
             seniorContactRole: 'not-a-real-role'
-        }
+        },
+        flags: { enableNewDateRange: false }
     });
 
     const messages = form.validation.featuredMessages.map(item => item.msg);
@@ -242,7 +228,10 @@ test('project dates must be within range', () => {
             projectDateRange: { startDate: start, endDate: end }
         });
 
-        const form = formBuilder({ data });
+        const form = formBuilder({
+            data,
+            flags: { enableNewDateRange: false }
+        });
 
         expect(mapMessages(form.validation)).toEqual(
             expect.arrayContaining(messages)

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -167,10 +167,11 @@ test('featured messages based on allow list', () => {
         }
     });
 
-    expect(form.validation.featuredMessages.map(item => item.msg)).toEqual([
-        expect.stringMatching(/Date you start the project must be after/),
-        expect.stringContaining('Senior contact role is not valid')
-    ]);
+    const messages = form.validation.featuredMessages.map(item => item.msg);
+    expect(messages).toContainEqual(
+        expect.stringMatching(/Date you start the project must be after/)
+    );
+    expect(messages).toContainEqual('Senior contact role is not valid');
 });
 
 describe('Project details', () => {

--- a/controllers/apply/awards-for-all/index.js
+++ b/controllers/apply/awards-for-all/index.js
@@ -1,18 +1,17 @@
 'use strict';
-const features = require('config').get('features');
-
 const { initFormRouter } = require('../form-router');
 
 const formBuilder = require('./form');
 const eligibilityBuilder = require('./eligibility');
 const confirmationBuilder = require('./confirmation');
 const { EXPIRY_EMAIL_REMINDERS } = require('./constants');
+const { transform } = require('./transforms');
 
 module.exports = initFormRouter({
     formId: 'awards-for-all',
     eligibilityBuilder: eligibilityBuilder,
     formBuilder: formBuilder,
     confirmationBuilder: confirmationBuilder,
-    enableSalesforceConnector: features.enableSalesforceConnector,
+    transformFunction: transform,
     expiryEmailPeriods: EXPIRY_EMAIL_REMINDERS
 });

--- a/controllers/apply/awards-for-all/mocks.js
+++ b/controllers/apply/awards-for-all/mocks.js
@@ -2,7 +2,6 @@
 const faker = require('faker');
 const moment = require('moment');
 const random = require('lodash/random');
-const sample = require('lodash/sample');
 
 function toDateParts(dt) {
     return { day: dt.date(), month: dt.month() + 1, year: dt.year() };
@@ -60,10 +59,8 @@ function mockResponse(overrides = {}) {
     const defaults = {
         projectName: faker.lorem.words(5),
         projectCountry: 'england',
-        projectDateRange: {
-            startDate: toDateParts(moment().add(18, 'weeks')),
-            endDate: toDateParts(moment().add(30, 'weeks'))
-        },
+        projectStartDate: toDateParts(moment().add(18, 'weeks')),
+        projectEndDate: toDateParts(moment().add(30, 'weeks')),
         projectLocation: 'derbyshire',
         projectLocationDescription: faker.lorem.sentence(),
         projectPostcode: 'B15 1TR',

--- a/controllers/apply/awards-for-all/mocks.js
+++ b/controllers/apply/awards-for-all/mocks.js
@@ -57,23 +57,14 @@ function mockBeneficiaries(checkAnswer = 'yes') {
 }
 
 function mockResponse(overrides = {}) {
-    const projectCountry =
-        overrides.projectCountry ||
-        sample(['england', 'scotland', 'wales', 'northern-ireland']);
-
     const defaults = {
         projectName: faker.lorem.words(5),
-        projectCountry: projectCountry,
+        projectCountry: 'england',
         projectDateRange: {
             startDate: toDateParts(moment().add(18, 'weeks')),
             endDate: toDateParts(moment().add(30, 'weeks'))
         },
-        projectLocation: {
-            'england': 'derbyshire',
-            'scotland': 'east-lothian',
-            'wales': 'caerphilly',
-            'northern-ireland': 'mid-ulster'
-        }[projectCountry],
+        projectLocation: 'derbyshire',
         projectLocationDescription: faker.lorem.sentence(),
         projectPostcode: 'B15 1TR',
         yourIdeaProject: faker.lorem.words(random(50, 250)),
@@ -98,11 +89,6 @@ function mockResponse(overrides = {}) {
         beneficiariesGroupsDisabledPeople: ['sensory'],
         beneficiariesGroupsReligion: ['sikh'],
         beneficiariesGroupsReligionOther: undefined,
-        beneficiariesWelshLanguage: projectCountry === 'wales' ? 'all' : null,
-        beneficiariesNorthernIrelandCommunity:
-            projectCountry === 'northern-ireland'
-                ? 'both-catholic-and-protestant'
-                : null,
         organisationLegalName: faker.company.companyName(),
         organisationTradingName: faker.company.companyName(),
         organisationStartDate: { month: 9, year: 1986 },
@@ -126,8 +112,6 @@ function mockResponse(overrides = {}) {
         },
         mainContactEmail: faker.internet.exampleEmail(),
         mainContactPhone: '0345 4 10 20 30',
-        mainContactLanguagePreference:
-            projectCountry === 'wales' ? 'welsh' : null,
         mainContactCommunicationNeeds: '',
         seniorContactName: {
             firstName: faker.name.firstName(),
@@ -142,8 +126,6 @@ function mockResponse(overrides = {}) {
         },
         seniorContactEmail: faker.internet.exampleEmail(),
         seniorContactPhone: '020 7211 1888',
-        seniorContactLanguagePreference:
-            projectCountry === 'wales' ? 'welsh' : null,
         seniorContactCommunicationNeeds: '',
         bankAccountName: faker.company.companyName(),
         bankSortCode: '308087',
@@ -162,7 +144,7 @@ function mockResponse(overrides = {}) {
         termsPersonPosition: faker.name.jobTitle()
     };
 
-    return Object.assign(defaults, overrides);
+    return Object.assign({}, defaults, overrides);
 }
 
 module.exports = {

--- a/controllers/apply/awards-for-all/transforms.js
+++ b/controllers/apply/awards-for-all/transforms.js
@@ -1,0 +1,42 @@
+'use strict';
+const config = require('config');
+const has = require('lodash/fp/has');
+const get = require('lodash/fp/get');
+const Sentry = require('@sentry/node');
+
+const logger = require('../../../common/logger').child({
+    service: 'transform'
+});
+
+function transformProjectDateRange(applicationData) {
+    if (has('projectDateRange')(applicationData)) {
+        logger.info('Transforming projectDateRange');
+
+        try {
+            const oldDateRange = get('projectDateRange')(applicationData);
+            applicationData.projectStartDate = oldDateRange.startDate;
+            applicationData.projectEndDate = oldDateRange.endDate;
+            delete applicationData['projectDateRange'];
+        } catch (err) {
+            logger.error('Failed to transform projectDateRange');
+            Sentry.captureException(err);
+        }
+    }
+
+    return applicationData;
+}
+
+function transform(applicationData) {
+    // Add additional transforms here
+    if (config.get('awardsForAll.enableNewDateRange') === true) {
+        return transformProjectDateRange(applicationData);
+    } else {
+        return applicationData;
+    }
+}
+
+module.exports = {
+    transform,
+    // Export for tests
+    transformProjectDateRange
+};

--- a/controllers/apply/awards-for-all/transforms.test.js
+++ b/controllers/apply/awards-for-all/transforms.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+'use strict';
+
+const { mockResponse } = require('./mocks');
+const { transformProjectDateRange } = require('./transforms');
+
+test('should transform project date range', function() {
+    const startDate = { day: 27, month: 3, year: 2020 };
+    const endDate = { day: 19, month: 6, year: 2020 };
+
+    const original = mockResponse({
+        projectDateRange: { startDate: startDate, endDate: endDate }
+    });
+
+    expect(original).toHaveProperty('projectDateRange');
+    expect(original.projectDateRange.startDate).toEqual(startDate);
+    expect(original.projectDateRange.endDate).toEqual(endDate);
+
+    const result = transformProjectDateRange(
+        mockResponse({
+            projectDateRange: { startDate: startDate, endDate: endDate }
+        })
+    );
+
+    expect(result.projectStartDate).toEqual(startDate);
+    expect(result.projectEndDate).toEqual(endDate);
+    expect(result).not.toHaveProperty('projectDateRange');
+    expect(true).toBeTruthy();
+});

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -30,7 +30,7 @@ function initFormRouter({
     startTemplate = null,
     eligibilityBuilder = null,
     confirmationBuilder,
-    enableSalesforceConnector = true,
+    transformFunction = null,
     expiryEmailPeriods = null,
     isBilingual = true
 }) {
@@ -306,6 +306,10 @@ function initFormRouter({
                     res.locals.currentApplication = currentApplication;
                     res.locals.currentApplicationData = currentApplicationData;
 
+                    res.locals.currentApplicationData = transformFunction
+                        ? transformFunction(currentApplicationData)
+                        : currentApplicationData;
+
                     res.locals.currentApplicationStatus = get(
                         currentApplication,
                         'status'
@@ -340,8 +344,7 @@ function initFormRouter({
             formId,
             formBuilder,
             confirmationBuilder,
-            currentlyEditingSessionKey,
-            enableSalesforceConnector
+            currentlyEditingSessionKey
         )
     );
 

--- a/controllers/apply/form-router/submission.js
+++ b/controllers/apply/form-router/submission.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const express = require('express');
 const path = require('path');
 const unset = require('lodash/unset');
@@ -18,8 +19,7 @@ module.exports = function(
     formId,
     formBuilder,
     confirmationBuilder,
-    currentlyEditingSessionKey,
-    enableSalesforceConnector
+    currentlyEditingSessionKey
 ) {
     const router = express.Router();
 
@@ -92,7 +92,10 @@ module.exports = function(
             /**
              * Store submission in salesforce if enabled
              */
-            if (enableSalesforceConnector === true && !appData.isTestServer) {
+            if (
+                config.get('features.enableSalesforceConnector') === true &&
+                !appData.isTestServer
+            ) {
                 const salesforce = await salesforceService.authorise();
                 salesforceRecordId = await salesforce.submitFormData(
                     salesforceFormData

--- a/controllers/apply/lib/field-types/index.js
+++ b/controllers/apply/lib/field-types/index.js
@@ -9,6 +9,7 @@ module.exports = {
     RadioField: require('./radio'),
     CheckboxField: require('./checkbox'),
     SelectField: require('./select'),
+    DateField: require('./date'),
     AddressField: require('./address'),
     NameField: require('./name')
 };

--- a/controllers/apply/standard-proposal/index.js
+++ b/controllers/apply/standard-proposal/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const features = require('config').get('features');
 
 const { initFormRouter } = require('../form-router');
 
@@ -12,6 +11,5 @@ module.exports = initFormRouter({
     formBuilder: formBuilder,
     startTemplate: path.resolve(__dirname, './views/startpage.njk'),
     confirmationBuilder: confirmationBuilder,
-    enableSalesforceConnector: features.enableSalesforceConnector,
     isBilingual: false
 });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -575,13 +575,13 @@ it('should submit full awards for all application', () => {
             cy.findByLabelText('Year').type(momentInstance.year());
         }
 
-        cy.findByText('Start date')
+        cy.findByText('When would you like to start your project?')
             .parent()
             .within(() => {
                 fillDateParts(mock.projectDateRange.startDate);
             });
 
-        cy.findByText('End date')
+        cy.findByText('When would you like to finish your project?')
             .parent()
             .within(() => {
                 fillDateParts(mock.projectDateRange.endDate);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start-dev": "nodemon --inspect ./bin/www",
     "start-test": "DB_CONNECTION_URI=sqlite://:memory PORT=8090 TEST_SERVER=true npm run start",
     "lint": "eslint . bin/* --ext .js,.vue",
-    "format": "prettier --write **/*.{js,scss,vue}",
+    "format": "prettier --write '{*,**/*}.{js,vue,scss,md}'",
     "test-unit": "jest --maxWorkers=4",
     "test": "npm run lint && npm run test-unit",
     "test-integration": "npm run start-test & wait-on http://localhost:8090 && npx cypress run --browser chrome",

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -145,7 +145,7 @@
 {% macro inputDate(field, includeYear = true, includeDay = true) %}
     <fieldset class="ff-date" id="field-{{ field.name }}">
         <legend class="ff-label ff-date__legend">
-            {{ field.label }}
+            {{ labelFor(field)  }}
         </legend>
         {{ explanationFor(field) }}
         {{ dayMonthYearInputs(


### PR DESCRIPTION
Clean version of https://github.com/biglotteryfund/blf-alpha/pull/2713

Enabled behind a flag in development only.

![image](https://user-images.githubusercontent.com/123386/69352254-82e4e500-0c74-11ea-8d99-dbd9e5fe2f8e.png)

Splits the project start and end date into two fields. Results in a nicer user experience and can be modelled using the regular date field and will allow us to remove the custom extension and macros for the combined date range field. However, it needs a step where data in the old schema format is translated into the new one.
