### PR TITLE
Only show logout/applications links for non-staff users

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -205,7 +205,7 @@ function initHotjarTracking() {
 // Update the Login link to Logout if user signs in
 function updateSecondaryNav() {
     getUserSession().then(response => {
-        if (response.userType === 'user') {
+        if (response.userType !== 'staff') {
             const $accountLink = response.isAuthenticated
                 ? $('.js-toggle-logout')
                 : $('.js-toggle-login');

--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -205,10 +205,12 @@ function initHotjarTracking() {
 // Update the Login link to Logout if user signs in
 function updateSecondaryNav() {
     getUserSession().then(response => {
-        const $accountLink = response.isAuthenticated
-            ? $('.js-toggle-logout')
-            : $('.js-toggle-login');
-        $accountLink.removeClass('js-hidden u-hidden');
+        if (response.userType === 'user') {
+            const $accountLink = response.isAuthenticated
+                ? $('.js-toggle-logout')
+                : $('.js-toggle-login');
+            $accountLink.removeClass('js-hidden u-hidden');
+        }
     });
 }
 

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -65,7 +65,8 @@ router.get('/session', function(req, res) {
                 date: sessionExpiresOn.locale(locale).format('dddd D MMMM YYYY')
             },
             maxAge: req.session.cookie.maxAge,
-            isAuthenticated: req.isAuthenticated()
+            isAuthenticated: req.isAuthenticated(),
+            userType: req.user ? req.user.userType : null
         });
     });
 });


### PR DESCRIPTION
Disables the universal user nav for staff to avoid confusion (eg. redundant "my applications" link).