### PR TITLE
Fix broken filter controls for insight document search

### DIFF
--- a/controllers/insights/views/insights-documents.njk
+++ b/controllers/insights/views/insights-documents.njk
@@ -256,7 +256,7 @@
                                                 'value': ''
                                             }), entriesMeta.programmes) %}
                                                 <option value="{{ option.value }}"
-                                                    {% if field.value === entriesMeta.activeProgramme.value %} selected{% endif %}>
+                                                    {% if option.value === entriesMeta.activeProgramme.value %} selected{% endif %}>
                                                     {{ option.label }}
                                                 </option>
                                             {% endfor %}
@@ -274,7 +274,7 @@
                                                 'value': ''
                                             }), entriesMeta.portfolios) %}
                                                 <option value="{{ option.value }}"
-                                                    {% if field.value === entriesMeta.activePortfolio.value %} selected{% endif %}>
+                                                    {% if option.value === entriesMeta.activePortfolio.value %} selected{% endif %}>
                                                     {{ option.label }}
                                                 </option>
                                             {% endfor %}
@@ -296,7 +296,7 @@
                                                         <input
                                                             type="radio"
                                                             id="field-doctype-{{ loop.index }}"
-                                                            name="{{ field.name }}"
+                                                            name="doctype"
                                                             value="{{ option.value }}"
                                                             {% if entriesMeta.activeDocType.value === option.value %}checked{% endif %}
                                                         />


### PR DESCRIPTION
[Insight documents search](https://www.tnlcommunityfund.org.uk/insights/documents) wasn't properly preserving selected filters and looks like this whenever you select an item:

![image](https://user-images.githubusercontent.com/394376/70451868-10f70300-1a9e-11ea-9f53-bc29df9e5829.png)
(eg. the final items are always selected)

![image](https://user-images.githubusercontent.com/394376/70451887-1bb19800-1a9e-11ea-9594-d1352283cc86.png)
(document types weren't working at all either)

