### PR TITLE
Test cleanup

### DIFF
--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -108,13 +108,6 @@ Array [
 ]
 `;
 
-exports[`finance details required if organisation is over 15 months old 2`] = `
-Array [
-  "Enter a day and month",
-  "Total income must be a real number",
-]
-`;
-
 exports[`full names must not match 1`] = `
 Array [
   "Main contact name must be different from the senior contact's name",
@@ -145,14 +138,5 @@ Array [
   "Select the age group(s) of the people that will benefit from your project",
   "Select the disabled people that will benefit from your project",
   "Select the religion(s) or belief(s) of the people that will benefit from your project",
-]
-`;
-
-exports[`valid basic organisation details required 1`] = `
-Array [
-  "Enter a full UK address",
-  "Enter a month and year",
-  "Enter the full legal name of the organisation",
-  "Select a type of organisation",
 ]
 `;

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -1,13 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Bank details requires valid bank details 1`] = `
-Array [
-  "Enter a sort code",
-  "Enter an account number",
-  "Enter the name of your organisation, as it appears on your bank statement",
-]
-`;
-
 exports[`Contacts contact addresses must not match 1`] = `
 Array [
   "Main contact address must be different from the senior contact's address",
@@ -59,6 +51,9 @@ exports[`empty form 1`] = `
 Array [
   "projectName: Enter a project name",
   "projectCountry: Select a country",
+  "projectLocation: Select a location",
+  "projectLocationDescription: Tell us the towns, villages or wards your beneficiaries live in",
+  "projectPostcode: Enter a real postcode",
   "yourIdeaProject: Tell us about your project",
   "yourIdeaPriorities: Tell us how your project meets at least one of our funding priorities",
   "yourIdeaCommunity: Tell us how your project involves your community",

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`contact addresses must not match 1`] = `
-Array [
-  "Main contact address must be different from the senior contact's address",
-  "Senior contact address must be different from the main contact's address",
-]
-`;
-
 exports[`empty form 1`] = `
 Array [
   "projectName: Enter a project name",
@@ -111,24 +104,35 @@ Array [
 exports[`invalid form 1`] = `
 Array [
   "projectName: Project name must be 80 characters or less",
-  "seniorContactEmail: Email address must be in the correct format, like name@example.com",
-  "mainContactEmail: Main contact email address must be different from the senior contact's email address",
-]
-`;
-
-exports[`project questions must be at least 50 words 1`] = `
-Array [
-  "yourIdeaProject: Answer must be at least 50 words",
-  "yourIdeaPriorities: Answer must be at least 50 words",
-  "yourIdeaCommunity: Answer must be at least 50 words",
-]
-`;
-
-exports[`project questions must not be over word-count 1`] = `
-Array [
+  "projectPostcode: Enter a real postcode",
   "yourIdeaProject: Answer must be no more than 300 words",
   "yourIdeaPriorities: Answer must be no more than 150 words",
   "yourIdeaCommunity: Answer must be no more than 200 words",
+  "projectBudget: Costs you would like us to fund must be less than £10,000",
+  "projectTotalCosts: Total cost must be the same as or higher than the amount you’re asking us to fund",
+  "mainContactName: Main contact name must be different from the senior contact's name",
+  "mainContactDateOfBirth: Must be at least 16 years old",
+  "mainContactAddress: Main contact address must be different from the senior contact's address",
+  "mainContactAddressHistory: Enter a full UK address",
+  "mainContactPhone: Enter a real UK telephone number",
+  "seniorContactRole: Senior contact role is not valid",
+  "seniorContactName: Senior contact name must be different from the main contact's name",
+  "seniorContactDateOfBirth: Must be at least 18 years old",
+  "seniorContactAddress: Senior contact address must be different from the main contact's address",
+  "seniorContactAddressHistory: Enter a full UK address",
+  "mainContactEmail: Main contact email address must be different from the senior contact's email address",
+  "seniorContactPhone: Enter a real UK telephone number",
+  "projectDateRange: Date you end the project must be after the start date",
+]
+`;
+
+exports[`invalid form 2`] = `
+Array [
+  "Main contact name must be different from the senior contact's name",
+  "Enter a real UK telephone number",
+  "Senior contact role is not valid",
+  "Main contact email address must be different from the senior contact's email address",
+  "Date you end the project must be after the start date",
 ]
 `;
 

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -140,3 +140,19 @@ Object {
   "sectionsComplete": 0,
 }
 `;
+
+exports[`project questions must be at least 50 words 1`] = `
+Array [
+  "yourIdeaProject: Answer must be at least 50 words",
+  "yourIdeaPriorities: Answer must be at least 50 words",
+  "yourIdeaCommunity: Answer must be at least 50 words",
+]
+`;
+
+exports[`project questions must not be over wordcount 1`] = `
+Array [
+  "yourIdeaProject: Answer must be no more than 300 words",
+  "yourIdeaPriorities: Answer must be no more than 150 words",
+  "yourIdeaCommunity: Answer must be no more than 200 words",
+]
+`;

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -47,6 +47,13 @@ Array [
 ]
 `;
 
+exports[`contact addresses must not match 1`] = `
+Array [
+  "Main contact address must be different from the senior contact's address",
+  "Senior contact address must be different from the main contact's address",
+]
+`;
+
 exports[`empty form 1`] = `
 Array [
   "projectName: Enter a project name",
@@ -141,6 +148,27 @@ Object {
 }
 `;
 
+exports[`finance details required if organisation is over 15 months old 1`] = `
+Array [
+  "Enter a day and month",
+  "Enter a total income for the year (eg. a whole number with no commas or decimal points)",
+]
+`;
+
+exports[`finance details required if organisation is over 15 months old 2`] = `
+Array [
+  "Enter a day and month",
+  "Total income must be a real number",
+]
+`;
+
+exports[`full names must not match 1`] = `
+Array [
+  "Main contact name must be different from the senior contact's name",
+  "Senior contact name must be different from the main contact's name",
+]
+`;
+
 exports[`project questions must be at least 50 words 1`] = `
 Array [
   "yourIdeaProject: Answer must be at least 50 words",
@@ -149,10 +177,37 @@ Array [
 ]
 `;
 
+exports[`project questions must not be over word-count 1`] = `
+Array [
+  "yourIdeaProject: Answer must be no more than 300 words",
+  "yourIdeaPriorities: Answer must be no more than 150 words",
+  "yourIdeaCommunity: Answer must be no more than 200 words",
+]
+`;
+
 exports[`project questions must not be over wordcount 1`] = `
 Array [
   "yourIdeaProject: Answer must be no more than 300 words",
   "yourIdeaPriorities: Answer must be no more than 150 words",
   "yourIdeaCommunity: Answer must be no more than 200 words",
+]
+`;
+
+exports[`require additional beneficiary questions based on groups 1`] = `
+Array [
+  "Select the age group(s) of the people that will benefit from your project",
+  "Select the disabled people that will benefit from your project",
+  "Select the ethnic background(s) of the people that will benefit from your project",
+  "Select the gender(s) of the people that will benefit from your project",
+  "Select the religion(s) or belief(s) of the people that will benefit from your project",
+]
+`;
+
+exports[`valid basic organisation details required 1`] = `
+Array [
+  "Enter a full UK address",
+  "Enter a month and year",
+  "Enter the full legal name of the organisation",
+  "Select a type of organisation",
 ]
 `;

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -1,52 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Contacts contact addresses must not match 1`] = `
-Array [
-  "Main contact address must be different from the senior contact's address",
-  "Senior contact address must be different from the main contact's address",
-]
-`;
-
-exports[`Contacts full names must not match 1`] = `
-Array [
-  "Main contact name must be different from the senior contact's name",
-  "Senior contact name must be different from the main contact's name",
-]
-`;
-
-exports[`Who will benefit require additional beneficiary questions based on groups 1`] = `
-Array [
-  "Select the age group(s) of the people that will benefit from your project",
-  "Select the disabled people that will benefit from your project",
-  "Select the ethnic background(s) of the people that will benefit from your project",
-  "Select the gender(s) of the people that will benefit from your project",
-  "Select the religion(s) or belief(s) of the people that will benefit from your project",
-]
-`;
-
-exports[`Your organisation finance details required if organisation is over 15 months old 1`] = `
-Array [
-  "Enter a day and month",
-  "Enter a total income for the year (eg. a whole number with no commas or decimal points)",
-]
-`;
-
-exports[`Your organisation finance details required if organisation is over 15 months old 2`] = `
-Array [
-  "Enter a day and month",
-  "Total income must be a real number",
-]
-`;
-
-exports[`Your organisation valid basic organisation details required 1`] = `
-Array [
-  "Enter a full UK address",
-  "Enter a month and year",
-  "Enter the full legal name of the organisation",
-  "Select a type of organisation",
-]
-`;
-
 exports[`contact addresses must not match 1`] = `
 Array [
   "Main contact address must be different from the senior contact's address",
@@ -178,14 +131,6 @@ Array [
 `;
 
 exports[`project questions must not be over word-count 1`] = `
-Array [
-  "yourIdeaProject: Answer must be no more than 300 words",
-  "yourIdeaPriorities: Answer must be no more than 150 words",
-  "yourIdeaCommunity: Answer must be no more than 200 words",
-]
-`;
-
-exports[`project questions must not be over wordcount 1`] = `
 Array [
   "yourIdeaProject: Answer must be no more than 300 words",
   "yourIdeaPriorities: Answer must be no more than 150 words",

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -140,10 +140,10 @@ Array [
 
 exports[`require additional beneficiary questions based on groups 1`] = `
 Array [
-  "Select the age group(s) of the people that will benefit from your project",
-  "Select the disabled people that will benefit from your project",
   "Select the ethnic background(s) of the people that will benefit from your project",
   "Select the gender(s) of the people that will benefit from your project",
+  "Select the age group(s) of the people that will benefit from your project",
+  "Select the disabled people that will benefit from your project",
   "Select the religion(s) or belief(s) of the people that will benefit from your project",
 ]
 `;

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -108,13 +108,6 @@ Array [
 ]
 `;
 
-exports[`full names must not match 1`] = `
-Array [
-  "Main contact name must be different from the senior contact's name",
-  "Senior contact name must be different from the main contact's name",
-]
-`;
-
 exports[`project questions must be at least 50 words 1`] = `
 Array [
   "yourIdeaProject: Answer must be at least 50 words",

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -108,6 +108,14 @@ Array [
 ]
 `;
 
+exports[`invalid form 1`] = `
+Array [
+  "projectName: Project name must be 80 characters or less",
+  "seniorContactEmail: Email address must be in the correct format, like name@example.com",
+  "mainContactEmail: Main contact email address must be different from the senior contact's email address",
+]
+`;
+
 exports[`project questions must be at least 50 words 1`] = `
 Array [
   "yourIdeaProject: Answer must be at least 50 words",

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -305,13 +305,9 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             }),
             type: 'text',
             isRequired: true,
-            schema: Joi.when('projectCountry', {
-                is: Joi.exist(),
-                then: Joi.string()
-                    .max(FREE_TEXT_MAXLENGTH.large)
-                    .required(),
-                otherwise: Joi.any().strip()
-            }),
+            schema: Joi.string()
+                .max(FREE_TEXT_MAXLENGTH.large)
+                .required(),
             messages: [
                 {
                     type: 'base',
@@ -347,13 +343,9 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                 autocomplete: 'postal-code'
             },
             isRequired: true,
-            schema: Joi.when('projectCountry', {
-                is: Joi.exist(),
-                then: Joi.string()
-                    .postcode()
-                    .required(),
-                otherwise: Joi.any().strip()
-            }),
+            schema: Joi.string()
+                .postcode()
+                .required(),
             messages: [
                 {
                     type: 'base',

--- a/controllers/apply/awards-for-all/fields/project-location.js
+++ b/controllers/apply/awards-for-all/fields/project-location.js
@@ -47,17 +47,13 @@ module.exports = function(locale, data) {
         }),
         optgroups: optgroups(),
         isRequired: true,
-        schema: Joi.when('projectCountry', {
-            is: Joi.exist(),
-            then: Joi.string()
-                .valid(
-                    flatMap(optgroups(), group => group.options).map(
-                        option => option.value
-                    )
+        schema: Joi.string()
+            .valid(
+                flatMap(optgroups(), group => group.options).map(
+                    option => option.value
                 )
-                .required(),
-            otherwise: Joi.any().strip()
-        }),
+            )
+            .required(),
         messages: [
             {
                 type: 'base',

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -564,21 +564,21 @@ test.each(['not-for-profit-company', 'community-interest-company'])(
     }
 );
 
-test.each([
-    'unincorporated-registered-charity',
-    'charitable-incorporated-organisation',
-    'not-for-profit-company',
-    'faith-group'
-])('Disallow letter O in charity number for %p', function(organisationType) {
-    assertInvalidByKey({
-        organisationType: organisationType,
+test('disallow letter O in charity number for', function() {
+    const data = mockResponse({
+        organisationType: 'unincorporated-registered-charity',
         charityNumber: 'SCO123'
     });
 
-    assertInvalidByKey({
-        organisationType: organisationType,
-        charityNumber: 'SCo123'
-    });
+    const result = formBuilder({ data }).validation;
+
+    expect(mapMessages(result)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining(
+                'use the number ‘0’ in ‘SC0’ instead of the letter ‘O’'
+            )
+        ])
+    );
 });
 
 test.each([

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -65,6 +65,21 @@ test('empty form', () => {
     expect(form.progress).toMatchSnapshot();
 });
 
+test('invalid form', () => {
+    /**
+     * Used to test common invalid values in favour of individual test cases
+     */
+    const data = mockResponse({
+        projectName: `This name will be too long ${faker.lorem.words(50)}`,
+        seniorContactEmail: 'not@anemail',
+        mainContactEmail: 'not@anemail'
+    });
+
+    const result = formBuilder({ data }).validation;
+
+    expect(mapMessageSummary(result)).toMatchSnapshot();
+});
+
 test('valid form for england', () => {
     const data = mockResponse({
         projectCountry: 'england',

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -1,14 +1,9 @@
 /* eslint-env jest */
 'use strict';
-const includes = require('lodash/includes');
-const map = require('lodash/map');
-const omit = require('lodash/omit');
-const times = require('lodash/times');
 const faker = require('faker');
 const moment = require('moment');
 
 const formBuilder = require('./form');
-
 const validateModel = require('../lib/validate-model');
 
 const {
@@ -29,30 +24,8 @@ function mapMessageSummary(validationResult) {
     });
 }
 
-function mapRawMessages(validationResult) {
-    return validationResult.error.details.map(detail => detail.message);
-}
-
-function messagesByKey(data) {
-    const validationResult = formBuilder({ data }).validation;
-    const matches = validationResult.messages.filter(message => {
-        return includes(Object.keys(data), message.param);
-    });
-
-    return map(matches, 'msg').sort();
-}
-
-function assertMessagesByKey(data, messages) {
-    expect(messagesByKey(data)).toEqual(messages.sort());
-}
-
-function assertValidByKey(data) {
-    const validationResult = formBuilder({ data }).validation;
-    const messagesByKey = validationResult.messages.filter(message => {
-        return includes(Object.keys(data), message.param);
-    });
-
-    expect(messagesByKey).toHaveLength(0);
+function fieldsForSection(form, section) {
+    return form.getCurrentFieldsForStep(section, 0).map(field => field.name);
 }
 
 test('validate model shape', () => {
@@ -65,19 +38,73 @@ test('empty form', () => {
     expect(form.progress).toMatchSnapshot();
 });
 
+/**
+ * Used to test common invalid values in favour of individual test cases
+ * This is much faster as it allows us to snapshot a number of error messages at once
+ * without building a new form model each time
+ */
 test('invalid form', () => {
-    /**
-     * Used to test common invalid values in favour of individual test cases
-     */
+    const matchingName = { firstName: 'Alice', lastName: 'Example' };
+    const matchingAddress = {
+        line1: 'National Lottery Community Fund',
+        line2: 'Apex House',
+        county: 'West Midlands',
+        postcode: 'B15 1TR',
+        townCity: 'BIRMINGHAM'
+    };
+
     const data = mockResponse({
         projectName: `This name will be too long ${faker.lorem.words(50)}`,
-        seniorContactEmail: 'not@anemail',
-        mainContactEmail: 'not@anemail'
+        projectDateRange: {
+            startDate: { day: 31, month: 1, year: 2020 },
+            endDate: { day: 31, month: 1, year: 2019 }
+        },
+        projectPostcode: 'not a postcode',
+        projectBudget: [
+            { item: faker.lorem.words(5), cost: 5000 },
+            { item: faker.lorem.words(5), cost: 5100 }
+        ], // over the limit
+        projectTotalCosts: 1000, // lower than budget
+        yourIdeaProject: faker.lorem.words(301), // over word-count
+        yourIdeaPriorities: faker.lorem.words(151), // over word-count
+        yourIdeaCommunity: faker.lorem.words(201), // over word-count
+        seniorContactName: matchingName,
+        mainContactName: matchingName,
+        seniorContactAddress: matchingAddress,
+        mainContactAddress: matchingAddress,
+        seniorContactRole: 'not-a-real-role',
+        seniorContactAddressHistory: {
+            currentAddressMeetsMinimum: 'no',
+            previousAddress: null // address history required
+        },
+        mainContactAddressHistory: {
+            currentAddressMeetsMinimum: 'no',
+            previousAddress: {
+                line1: faker.address.streetAddress(),
+                townCity: faker.address.city()
+            } // partial address
+        },
+        seniorContactEmail: 'example@example.com',
+        mainContactEmail: 'Example@example.com', // emails must not match (case-insensitive)
+        seniorContactPhone: 'not a phone number',
+        mainContactPhone: 'not a phone number',
+        seniorContactDateOfBirth: mockDateOfBirth(0, 17), // too young,
+        mainContactDateOfBirth: mockDateOfBirth(0, 15) // too young
     });
 
-    const result = formBuilder({ data }).validation;
+    const form = formBuilder({
+        data,
+        flags: { enableNewDateRange: false }
+    });
 
-    expect(mapMessageSummary(result)).toMatchSnapshot();
+    expect(mapMessageSummary(form.validation)).toMatchSnapshot();
+
+    // Check list of featured messages
+    const featuredMessages = form.validation.featuredMessages.map(
+        item => item.msg
+    );
+
+    expect(featuredMessages).toMatchSnapshot();
 });
 
 test('valid form for england', () => {
@@ -400,29 +427,6 @@ test('disallow letter O in charity number', function() {
     );
 });
 
-test('featured messages based on allow list', () => {
-    const data = mockResponse({
-        projectDateRange: {
-            startDate: { day: 31, month: 1, year: 2019 },
-            endDate: { day: 31, month: 1, year: 2019 }
-        },
-        seniorContactRole: 'not-a-real-role'
-    });
-
-    const form = formBuilder({
-        data,
-        flags: { enableNewDateRange: false }
-    });
-
-    const messages = form.validation.featuredMessages.map(item => item.msg);
-
-    expect(messages).toContainEqual(
-        expect.stringMatching(/Date you start the project must be after/)
-    );
-
-    expect(messages).toContainEqual('Senior contact role is not valid');
-});
-
 test('project dates must be within range', () => {
     function validateDateRange(start, end, messages) {
         const data = mockResponse({
@@ -438,8 +442,6 @@ test('project dates must be within range', () => {
             expect.arrayContaining(messages)
         );
     }
-
-    validateDateRange(null, null, ['Enter a project start and end date']);
 
     validateDateRange(
         { day: 1, month: 1, year: 2020 },
@@ -512,79 +514,6 @@ test('support new project date schema', function() {
         startDate: '2021-03-03',
         endDate: '2021-04-03'
     });
-});
-
-test('project postcode must be a valid UK postcode', () => {
-    const data = mockResponse({
-        projectPostcode: 'not a postcode'
-    });
-
-    const result = formBuilder({ data }).validation;
-
-    expect(mapMessages(result)).toEqual(
-        expect.arrayContaining(['Enter a real postcode'])
-    );
-});
-
-test('project questions must be at least 50 words', function() {
-    const data = mockResponse({
-        yourIdeaProject: faker.lorem.words(49),
-        yourIdeaPriorities: faker.lorem.words(49),
-        yourIdeaCommunity: faker.lorem.words(49)
-    });
-
-    expect(
-        mapMessageSummary(formBuilder({ data }).validation)
-    ).toMatchSnapshot();
-});
-
-test('project questions must not be over word-count', () => {
-    const data = mockResponse({
-        yourIdeaProject: faker.lorem.words(301),
-        yourIdeaPriorities: faker.lorem.words(151),
-        yourIdeaCommunity: faker.lorem.words(201)
-    });
-
-    expect(
-        mapMessageSummary(formBuilder({ data }).validation)
-    ).toMatchSnapshot();
-});
-
-test('project costs must be less than £10,000', () => {
-    const data = mockResponse({
-        projectBudget: times(10, () => ({
-            item: faker.lorem.words(5),
-            cost: 1100
-        }))
-    });
-
-    const result = formBuilder({ data }).validation;
-
-    expect(mapMessages(result)).toEqual(
-        expect.arrayContaining([
-            expect.stringContaining('must be less than £10,000')
-        ])
-    );
-});
-
-test('project total costs must be at least value of project budget', () => {
-    const data = mockResponse({
-        projectBudget: times(5, () => ({
-            item: faker.lorem.words(5),
-            cost: 500
-        })),
-        projectTotalCosts: 1000
-    });
-
-    const result = formBuilder({ data }).validation;
-
-    expect(mapMessages(result)).toEqual(
-        expect.arrayContaining([
-            expect.stringContaining(
-                'must be the same as or higher than the amount you’re asking us to fund'
-            )
-        ])
-    );
 });
 
 test('require beneficiary groups when check is "yes"', () => {
@@ -677,276 +606,67 @@ test('finance details required if organisation is over 15 months old', function(
     expect(mapMessages(invalidForm.validation)).toMatchSnapshot();
 });
 
-test('full names must not match', function() {
-    const sameName = { firstName: 'Ann', lastName: 'Example' };
-    const data = mockResponse({
-        seniorContactName: sameName,
-        mainContactName: sameName
-    });
-
-    const result = formBuilder({ data }).validation;
-
-    expect(mapMessages(result)).toEqual(
-        expect.arrayContaining([
-            expect.stringContaining('Main contact name must be different'),
-            expect.stringContaining('Senior contact name must be different')
-        ])
-    );
-});
-
-test('include warning if contact last names match', () => {
-    const lastName = faker.name.lastName();
-    const dataWithMatchingLastNames = mockResponse({
-        seniorContactName: {
-            firstName: faker.name.firstName(),
-            lastName: lastName
-        },
-        mainContactName: {
-            firstName: faker.name.firstName(),
-            lastName: lastName
-        }
-    });
-
-    const form = formBuilder({ data: dataWithMatchingLastNames });
-
-    expect(form.allFields.mainContactName.warnings).toEqual([
-        expect.stringContaining('have the same surname')
-    ]);
-});
-
-test.each(['seniorContactEmail', 'mainContactEmail'])(
-    'email address must be valid for %p',
-    function(fieldName) {
-        assertMessagesByKey(
-            {
-                [fieldName]: 'not@anemail'
-            },
-            [
-                'Email address must be in the correct format, like name@example.com'
-            ]
-        );
-    }
-);
-
-test('email addresses must not match', function() {
-    const form = formBuilder({
-        data: mockResponse({
-            seniorContactEmail: 'example@example.com',
-            mainContactEmail: 'Example@example.com' // Test for case insensitivity
-        })
-    });
-
-    expect(mapMessages(form.validation)).toEqual(
-        expect.arrayContaining([
-            expect.stringContaining(
-                'Main contact email address must be different'
-            )
-        ])
-    );
-});
-
-test.each(['seniorContactPhone', 'mainContactPhone'])(
-    'phone number must be valid for %p',
-    function(fieldName) {
-        assertMessagesByKey(
-            {
-                [fieldName]: 'not a phone number'
-            },
-            ['Enter a real UK telephone number']
-        );
-    }
-);
-
-test.each([
-    ['seniorContactDateOfBirth', 18],
-    ['mainContactDateOfBirth', 16]
-])(`date of birth must be valid for %p`, function(fieldName, minAge) {
-    assertMessagesByKey({ [fieldName]: null }, ['Enter a date of birth']);
-
-    assertMessagesByKey({ [fieldName]: { year: 2000, month: 2, day: 31 } }, [
-        'Enter a real date'
-    ]);
-
-    assertMessagesByKey({ [fieldName]: mockDateOfBirth(0, minAge - 1) }, [
-        `Must be at least ${minAge} years old`
-    ]);
-
-    assertValidByKey({
-        [fieldName]: mockDateOfBirth(minAge, 90)
-    });
-});
-
-test('contact address required by default', () => {
-    const data = omit(mockResponse(), [
-        'mainContactAddress',
-        'seniorContactAddress'
-    ]);
-
-    const validationResult = formBuilder({ data }).validation;
-
-    expect(mapRawMessages(validationResult)).toEqual([
-        '"mainContactAddress" is required',
-        '"seniorContactAddress" is required'
-    ]);
-
-    expect(mapMessages(validationResult)).toEqual(
-        expect.arrayContaining(['Enter a full UK address'])
-    );
-
-    expect(validationResult.isValid).toBeFalsy();
-});
-
 test.each(['school', 'college-or-university', 'statutory-body'])(
     'dates of birth and addresses stripped for %p',
     function(excludedOrgType) {
-        const validForm = formBuilder({
-            data: {
-                organisationType: excludedOrgType,
-                seniorContactDateOfBirth: mockDateOfBirth(18, 90),
-                mainContactDateOfBirth: mockDateOfBirth(16, 90),
-                seniorContactAddress: mockAddress(),
-                seniorContactAddressHistory: {
-                    currentAddressMeetsMinimum: 'yes',
-                    previousAddress: mockAddress()
-                },
-                mainContactAddress: mockAddress(),
-                mainContactAddressHistory: {
-                    currentAddressMeetsMinimum: 'yes',
-                    previousAddress: mockAddress()
-                }
-            }
-        });
-
-        // Should strip even when values are invalid
-        const invalidForm = formBuilder({
-            data: {
-                organisationType: excludedOrgType,
-                seniorContactDateOfBirth: mockDateOfBirth(1, 17),
-                mainContactDateOfBirth: mockDateOfBirth(1, 17),
-                seniorContactAddress: {
-                    line1: faker.address.streetAddress(),
-                    townCity: faker.address.city(),
-                    county: faker.address.county()
-                },
-                mainContactAddress: {
-                    line1: faker.address.streetAddress(),
-                    townCity: faker.address.city(),
-                    county: faker.address.county()
-                }
-            }
-        });
-
-        const expectedData = {
-            organisationType: excludedOrgType
-        };
-
-        assertValidByKey(expectedData);
-
-        expect(validForm.validation.value).toEqual(expectedData);
-
-        expect(invalidForm.validation.value).toEqual(expectedData);
-
-        // Check fields are not shown
-        function checkFieldsForSection(section, expectedFields) {
-            const fields = validForm
-                .getCurrentFieldsForStep(section, 0)
-                .map(field => field.name);
-
-            expect(fields).toEqual(expectedFields);
-        }
-
-        checkFieldsForSection('senior-contact', [
-            'seniorContactRole',
-            'seniorContactName',
-            'seniorContactEmail',
-            'seniorContactPhone',
-            'seniorContactCommunicationNeeds'
-        ]);
-
-        checkFieldsForSection('main-contact', [
-            'mainContactName',
-            'mainContactEmail',
-            'mainContactPhone',
-            'mainContactCommunicationNeeds'
-        ]);
-    }
-);
-
-test.each(['seniorContactAddress', 'mainContactAddress'])(
-    'address is valid for %p',
-    function(fieldName) {
-        const partialAddress = {
-            line1: '3 Embassy Drive',
-            county: 'West Midlands',
-            postcode: 'B15 1TR'
-        };
-
-        const addressWithInvalidPostcode = {
-            ...mockAddress(),
-            ...{ postcode: 'not a postcode' }
-        };
-
-        assertMessagesByKey({ [fieldName]: null }, ['Enter a full UK address']);
-
-        assertMessagesByKey({ [fieldName]: partialAddress }, [
-            'Enter a full UK address'
-        ]);
-
-        assertMessagesByKey({ [fieldName]: addressWithInvalidPostcode }, [
-            'Enter a real postcode'
-        ]);
-    }
-);
-
-test.each(['seniorContactAddressHistory', 'mainContactAddressHistory'])(
-    'address history is valid for %p',
-    function(fieldName) {
-        assertValidByKey({
-            [fieldName]: {
+        const validData = {
+            organisationType: excludedOrgType,
+            seniorContactDateOfBirth: mockDateOfBirth(18, 90),
+            mainContactDateOfBirth: mockDateOfBirth(16, 90),
+            seniorContactAddress: mockAddress(),
+            seniorContactAddressHistory: {
                 currentAddressMeetsMinimum: 'yes',
-                previousAddress: null
-            }
-        });
-
-        assertValidByKey({
-            [fieldName]: {
-                currentAddressMeetsMinimum: 'no',
+                previousAddress: mockAddress()
+            },
+            mainContactAddress: mockAddress(),
+            mainContactAddressHistory: {
+                currentAddressMeetsMinimum: 'yes',
                 previousAddress: mockAddress()
             }
-        });
+        };
 
-        assertMessagesByKey(
-            {
-                [fieldName]: {
-                    currentAddressMeetsMinimum: 'no',
-                    previousAddress: {
-                        line1: faker.address.streetAddress(),
-                        townCity: faker.address.city()
-                    }
-                }
-            },
-            ['Enter a full UK address']
-        );
-    }
-);
-
-test('contact addresses must not match', function() {
-    expect(
-        messagesByKey({
+        const invalidData = {
+            organisationType: excludedOrgType,
+            seniorContactDateOfBirth: mockDateOfBirth(1, 17),
+            mainContactDateOfBirth: mockDateOfBirth(1, 17),
             seniorContactAddress: {
-                line1: 'National Lottery Community Fund',
-                line2: 'Apex House',
-                county: 'West Midlands',
-                postcode: 'B15 1TR',
-                townCity: 'BIRMINGHAM'
+                line1: faker.address.streetAddress(),
+                townCity: faker.address.city(),
+                county: faker.address.county()
             },
             mainContactAddress: {
-                line1: 'National Lottery Community Fund',
-                line2: 'Apex House',
-                county: 'West Midlands',
-                postcode: 'B15 1TR',
-                townCity: 'BIRMINGHAM'
+                line1: faker.address.streetAddress(),
+                townCity: faker.address.city(),
+                county: faker.address.county()
             }
-        })
-    ).toMatchSnapshot();
-});
+        };
+
+        const expected = { organisationType: excludedOrgType };
+
+        const validForm = formBuilder({ data: validData });
+        expect(validForm.validation.value).toEqual(expected);
+
+        // Should strip even when values are invalid
+        const invalidForm = formBuilder({ data: invalidData });
+        expect(invalidForm.validation.value).toEqual(expected);
+
+        const seniorContactFields = fieldsForSection(
+            validForm,
+            'senior-contact'
+        );
+
+        expect(seniorContactFields).not.toContainEqual([
+            'seniorContactDateOfBirth',
+            'seniorContactAddress',
+            'seniorContactAddressHistory'
+        ]);
+
+        const mainContactFields = fieldsForSection(validForm, 'main-contact');
+
+        expect(mainContactFields).not.toContainEqual([
+            'mainContactDateOfBirth',
+            'mainContactAddress',
+            'mainContactAddressHistory'
+        ]);
+    }
+);

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -959,29 +959,3 @@ describe('Contacts', () => {
         ).toMatchSnapshot();
     });
 });
-
-describe('Bank details', () => {
-    test('requires valid bank details', () => {
-        expect(
-            messagesByKey({
-                bankAccountName: null,
-                bankSortCode: null,
-                bankAccountNumber: null
-            })
-        ).toMatchSnapshot();
-    });
-
-    test('valid bank statement upload', () => {
-        assertValidByKey({
-            bankStatement: {
-                filename: 'example.pdf',
-                size: 123,
-                type: 'application/pdf'
-            }
-        });
-
-        assertMessagesByKey({ bankStatement: null }, [
-            'Provide a bank statement'
-        ]);
-    });
-});

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -372,47 +372,41 @@ test('project questions must not be over word-count', () => {
     ).toMatchSnapshot();
 });
 
-function budgetValue(budget, totalCosts = 20000) {
-    return { projectBudget: budget, projectTotalCosts: totalCosts };
-}
-
-test('must provide a valid budget', () => {
-    assertValidByKey(budgetValue(mockBudget()));
-
-    const defaultMessages = ['Enter a project budget'];
-    const tooSmallMessage = ['Enter at least one item'];
-    assertMessagesByKey(budgetValue([]), tooSmallMessage);
-
-    const budgetWithoutCosts = times(5, () => ({
-        item: faker.lorem.words(5)
-    }));
-
-    assertMessagesByKey(budgetValue(budgetWithoutCosts), defaultMessages);
-});
-
 test('project costs must be less than £10,000', () => {
-    const budget = times(10, () => ({
-        item: faker.lorem.words(5),
-        cost: 1100
-    }));
+    const data = mockResponse({
+        projectBudget: times(10, () => ({
+            item: faker.lorem.words(5),
+            cost: 1100
+        }))
+    });
 
-    assertMessagesByKey(budgetValue(budget), [
-        'Costs you would like us to fund must be less than £10,000'
-    ]);
+    const result = formBuilder({ data }).validation;
+
+    expect(mapMessages(result)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining('must be less than £10,000')
+        ])
+    );
 });
 
 test('project total costs must be at least value of project budget', () => {
-    assertValidByKey(budgetValue(mockBudget()));
+    const data = mockResponse({
+        projectBudget: times(5, () => ({
+            item: faker.lorem.words(5),
+            cost: 500
+        })),
+        projectTotalCosts: 1000
+    });
 
-    assertMessagesByKey(budgetValue(mockBudget(), null), [
-        'Enter a total cost for your project'
-    ]);
-    assertMessagesByKey(budgetValue(mockBudget(), Infinity), [
-        'Enter a total cost for your project'
-    ]);
-    assertMessagesByKey(budgetValue(mockBudget(), 1000), [
-        'Total cost must be the same as or higher than the amount you’re asking us to fund'
-    ]);
+    const result = formBuilder({ data }).validation;
+
+    expect(mapMessages(result)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining(
+                'must be the same as or higher than the amount you’re asking us to fund'
+            )
+        ])
+    );
 });
 
 test('require beneficiary groups when check is "yes"', () => {

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -662,21 +662,6 @@ test('finance details required if organisation is over 15 months old', function(
     expect(mapMessages(invalidForm.validation)).toMatchSnapshot();
 });
 
-test.each(['seniorContactName', 'mainContactName'])(
-    'first and last name must be provided for %p',
-    function(fieldName) {
-        assertMessagesByKey(
-            {
-                [fieldName]: {
-                    firstName: null,
-                    lastName: null
-                }
-            },
-            ['Enter first and last name']
-        );
-    }
-);
-
 test('full names must not match', function() {
     expect(
         messagesByKey({

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -372,625 +372,606 @@ test('project questions must not be over word-count', () => {
     ).toMatchSnapshot();
 });
 
-describe('Project budget', () => {
-    function value(budget, totalCosts = 20000) {
-        return { projectBudget: budget, projectTotalCosts: totalCosts };
-    }
+function budgetValue(budget, totalCosts = 20000) {
+    return { projectBudget: budget, projectTotalCosts: totalCosts };
+}
 
-    test('must provide a valid budget', () => {
-        assertValidByKey(value(mockBudget()));
+test('must provide a valid budget', () => {
+    assertValidByKey(budgetValue(mockBudget()));
 
-        const defaultMessages = ['Enter a project budget'];
-        const tooSmallMessage = ['Enter at least one item'];
-        assertMessagesByKey(value([]), tooSmallMessage);
+    const defaultMessages = ['Enter a project budget'];
+    const tooSmallMessage = ['Enter at least one item'];
+    assertMessagesByKey(budgetValue([]), tooSmallMessage);
 
-        const budgetWithoutCosts = times(5, () => ({
-            item: faker.lorem.words(5)
-        }));
+    const budgetWithoutCosts = times(5, () => ({
+        item: faker.lorem.words(5)
+    }));
 
-        assertMessagesByKey(value(budgetWithoutCosts), defaultMessages);
-    });
-
-    test('project costs must be less than £10,000', () => {
-        const budget = times(10, () => ({
-            item: faker.lorem.words(5),
-            cost: 1100
-        }));
-
-        assertMessagesByKey(value(budget), [
-            'Costs you would like us to fund must be less than £10,000'
-        ]);
-    });
-
-    test('project total costs must be at least value of project budget', () => {
-        assertValidByKey(value(mockBudget()));
-
-        assertMessagesByKey(value(mockBudget(), null), [
-            'Enter a total cost for your project'
-        ]);
-        assertMessagesByKey(value(mockBudget(), Infinity), [
-            'Enter a total cost for your project'
-        ]);
-        assertMessagesByKey(value(mockBudget(), 1000), [
-            'Total cost must be the same as or higher than the amount you’re asking us to fund'
-        ]);
-    });
+    assertMessagesByKey(budgetValue(budgetWithoutCosts), defaultMessages);
 });
 
-describe('Who will benefit', () => {
-    test('require beneficiary groups when check is "yes"', () => {
-        assertMessagesByKey(
-            {
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroups: null,
-                beneficiariesGroupsOther: null
-            },
-            [expect.stringContaining('Select the specific group')]
-        );
-    });
+test('project costs must be less than £10,000', () => {
+    const budget = times(10, () => ({
+        item: faker.lorem.words(5),
+        cost: 1100
+    }));
 
-    test('require additional beneficiary questions based on groups', () => {
-        expect(
-            messagesByKey({
-                beneficiariesGroupsCheck: 'yes',
-                beneficiariesGroups: [
-                    'ethnic-background',
-                    'gender',
-                    'age',
-                    'disabled-people',
-                    'religion',
-                    'lgbt',
-                    'caring-responsibilities'
-                ],
-                beneficiariesGroupsOther: null,
-                beneficiariesGroupsEthnicBackground: null,
-                beneficiariesGroupsGender: null,
-                beneficiariesGroupsAge: null,
-                beneficiariesGroupsDisabledPeople: null,
-                beneficiariesGroupsReligion: null,
-                beneficiariesGroupsReligionOther: null
-            })
-        ).toMatchSnapshot();
-    });
+    assertMessagesByKey(budgetValue(budget), [
+        'Costs you would like us to fund must be less than £10,000'
+    ]);
+});
 
-    test('strip beneficiary data when check is "no"', () => {
-        assertValidByKey(mockBeneficiaries('no'));
-        expect(
-            formBuilder({
-                data: mockBeneficiaries('no')
-            }).validation.value
-        ).toEqual({
-            beneficiariesGroupsCheck: 'no'
-        });
-    });
+test('project total costs must be at least value of project budget', () => {
+    assertValidByKey(budgetValue(mockBudget()));
 
-    test('allow only "other" option for beneficiary groups', () => {
-        assertValidByKey(mockBeneficiaries('yes'));
+    assertMessagesByKey(budgetValue(mockBudget(), null), [
+        'Enter a total cost for your project'
+    ]);
+    assertMessagesByKey(budgetValue(mockBudget(), Infinity), [
+        'Enter a total cost for your project'
+    ]);
+    assertMessagesByKey(budgetValue(mockBudget(), 1000), [
+        'Total cost must be the same as or higher than the amount you’re asking us to fund'
+    ]);
+});
 
-        assertValidByKey({
+test('require beneficiary groups when check is "yes"', () => {
+    assertMessagesByKey(
+        {
             beneficiariesGroupsCheck: 'yes',
-            beneficiariesGroupsOther: 'this should be valid',
+            beneficiariesGroups: null,
+            beneficiariesGroupsOther: null
+        },
+        [expect.stringContaining('Select the specific group')]
+    );
+});
+
+test('require additional beneficiary questions based on groups', () => {
+    expect(
+        messagesByKey({
+            beneficiariesGroupsCheck: 'yes',
+            beneficiariesGroups: [
+                'ethnic-background',
+                'gender',
+                'age',
+                'disabled-people',
+                'religion',
+                'lgbt',
+                'caring-responsibilities'
+            ],
+            beneficiariesGroupsOther: null,
             beneficiariesGroupsEthnicBackground: null,
             beneficiariesGroupsGender: null,
             beneficiariesGroupsAge: null,
             beneficiariesGroupsDisabledPeople: null,
             beneficiariesGroupsReligion: null,
             beneficiariesGroupsReligionOther: null
-        });
+        })
+    ).toMatchSnapshot();
+});
 
-        assertValidByKey(mockBeneficiaries('yes'));
+test('strip beneficiary data when check is "no"', () => {
+    assertValidByKey(mockBeneficiaries('no'));
+    expect(
+        formBuilder({
+            data: mockBeneficiaries('no')
+        }).validation.value
+    ).toEqual({
+        beneficiariesGroupsCheck: 'no'
     });
 });
 
-describe('Your organisation', () => {
-    test('valid basic organisation details required', () => {
-        const invalidOrganisationData = {
-            organisationLegalName: null,
-            organisationStartDate: {
-                month: 2
-            },
-            organisationAddress: {
-                line1: '3 Embassy Drive',
-                county: 'West Midlands',
-                postcode: 'B15 1TR'
-            },
-            organisationType: sample([null, 'not-a-valid-option'])
-        };
+test('allow only "other" option for beneficiary groups', () => {
+    assertValidByKey(mockBeneficiaries('yes'));
 
-        expect(messagesByKey(invalidOrganisationData)).toMatchSnapshot();
+    assertValidByKey({
+        beneficiariesGroupsCheck: 'yes',
+        beneficiariesGroupsOther: 'this should be valid',
+        beneficiariesGroupsEthnicBackground: null,
+        beneficiariesGroupsGender: null,
+        beneficiariesGroupsAge: null,
+        beneficiariesGroupsDisabledPeople: null,
+        beneficiariesGroupsReligion: null,
+        beneficiariesGroupsReligionOther: null
     });
 
-    test('finance details required if organisation is over 15 months old', function() {
-        const now = moment();
-        const requiredDate = now.clone().subtract('15', 'months');
+    assertValidByKey(mockBeneficiaries('yes'));
+});
 
-        assertValidByKey({
+test('valid basic organisation details required', () => {
+    const invalidOrganisationData = {
+        organisationLegalName: null,
+        organisationStartDate: {
+            month: 2
+        },
+        organisationAddress: {
+            line1: '3 Embassy Drive',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        },
+        organisationType: sample([null, 'not-a-valid-option'])
+    };
+
+    expect(messagesByKey(invalidOrganisationData)).toMatchSnapshot();
+});
+
+test('finance details required if organisation is over 15 months old', function() {
+    const now = moment();
+    const requiredDate = now.clone().subtract('15', 'months');
+
+    assertValidByKey({
+        organisationStartDate: {
+            month: now.month() + 1,
+            year: now.year()
+        },
+        accountingYearDate: null,
+        totalIncomeYear: null
+    });
+
+    expect(
+        messagesByKey({
             organisationStartDate: {
-                month: now.month() + 1,
-                year: now.year()
+                month: requiredDate.month() + 1,
+                year: requiredDate.year()
             },
             accountingYearDate: null,
             totalIncomeYear: null
+        })
+    ).toMatchSnapshot();
+
+    expect(
+        messagesByKey({
+            organisationStartDate: {
+                month: requiredDate.month() + 1,
+                year: requiredDate.year()
+            },
+            accountingYearDate: {
+                month: 22,
+                year: 2021
+            },
+            totalIncomeYear: Infinity
+        })
+    ).toMatchSnapshot();
+});
+
+test.each(['unregistered-vco', 'statutory-body'])(
+    'no registration numbers required for %p',
+    function(organisationType) {
+        assertValidByKey({
+            organisationType: organisationType,
+            companyNumber: null,
+            charityNumber: null,
+            educationNumber: null
+        });
+    }
+);
+
+test.each(['not-for-profit-company', 'community-interest-company'])(
+    'company number required for %p',
+    function(organisationType) {
+        assertValidByKey({
+            organisationType: organisationType,
+            companyNumber: '12345678'
         });
 
-        expect(
-            messagesByKey({
-                organisationStartDate: {
-                    month: requiredDate.month() + 1,
-                    year: requiredDate.year()
-                },
-                accountingYearDate: null,
-                totalIncomeYear: null
-            })
-        ).toMatchSnapshot();
+        assertMessagesByKey(
+            {
+                organisationType: organisationType,
+                companyNumber: undefined
+            },
+            ['Enter your organisation’s Companies House number']
+        );
+    }
+);
 
-        expect(
-            messagesByKey({
-                organisationStartDate: {
-                    month: requiredDate.month() + 1,
-                    year: requiredDate.year()
-                },
-                accountingYearDate: {
-                    month: 22,
-                    year: 2021
-                },
-                totalIncomeYear: Infinity
-            })
-        ).toMatchSnapshot();
+test.each([
+    'unincorporated-registered-charity',
+    'charitable-incorporated-organisation',
+    'not-for-profit-company',
+    'faith-group'
+])('Disallow letter O in charity number for %p', function(organisationType) {
+    assertInvalidByKey({
+        organisationType: organisationType,
+        charityNumber: 'SCO123'
+    });
+
+    assertInvalidByKey({
+        organisationType: organisationType,
+        charityNumber: 'SCo123'
     });
 });
-describe('Registration numbers', function() {
-    const noRegistrationNumbers = ['unregistered-vco', 'statutory-body'];
 
-    test.each(noRegistrationNumbers)(
-        'no registration numbers required for %p',
-        function(organisationType) {
-            assertValidByKey({
-                organisationType: organisationType,
-                companyNumber: null,
-                charityNumber: null,
-                educationNumber: null
-            });
-        }
+test.each([
+    'unincorporated-registered-charity',
+    'charitable-incorporated-organisation'
+])('charity number required for %p', function(organisationType) {
+    const data = {
+        organisationType: organisationType,
+        charityNumber: '23456789'
+    };
+
+    assertValidByKey(data);
+
+    assertMessagesByKey(
+        {
+            organisationType: organisationType,
+            charityNumber: null
+        },
+        ['Enter your organisation’s charity number']
     );
 
-    test.each(['not-for-profit-company', 'community-interest-company'])(
-        'company number required for %p',
-        function(organisationType) {
-            assertValidByKey({
-                organisationType: organisationType,
-                companyNumber: '12345678'
-            });
+    expect(
+        formBuilder({
+            locale: 'en',
+            data: {
+                organisationType,
+                companyNumber: '12345678',
+                charityNumber: '23456789',
+                educationNumber: '345678'
+            }
+        }).validation.value
+    ).toEqual(data);
+});
 
-            assertMessagesByKey(
-                {
-                    organisationType: organisationType,
-                    companyNumber: undefined
-                },
-                ['Enter your organisation’s Companies House number']
-            );
-        }
-    );
-
-    test.each([
-        'unincorporated-registered-charity',
-        'charitable-incorporated-organisation',
-        'not-for-profit-company',
-        'faith-group'
-    ])('Disallow letter O in charity number for %p', function(
-        organisationType
-    ) {
-        assertInvalidByKey({
-            organisationType: organisationType,
-            charityNumber: 'SCO123'
-        });
-
-        assertInvalidByKey({
-            organisationType: organisationType,
-            charityNumber: 'SCo123'
-        });
-    });
-
-    test.each([
-        'unincorporated-registered-charity',
-        'charitable-incorporated-organisation'
-    ])('charity number required for %p', function(organisationType) {
+test.each(['not-for-profit-company', 'faith-group'])(
+    'charity number optional for %p',
+    function(organisationType) {
         const data = {
             organisationType: organisationType,
             charityNumber: '23456789'
         };
 
         assertValidByKey(data);
+        assertValidByKey({
+            organisationType: organisationType,
+            charityNumber: null
+        });
 
-        assertMessagesByKey(
-            {
-                organisationType: organisationType,
-                charityNumber: null
-            },
-            ['Enter your organisation’s charity number']
-        );
+        assertValidByKey({
+            organisationType: organisationType,
+            charityNumber: ''
+        });
+
+        const fullNumbers = {
+            organisationType,
+            charityNumber: '23456789',
+            educationNumber: '345678'
+        };
 
         expect(
             formBuilder({
                 locale: 'en',
-                data: {
-                    organisationType,
-                    companyNumber: '12345678',
-                    charityNumber: '23456789',
-                    educationNumber: '345678'
-                }
+                data: fullNumbers
             }).validation.value
         ).toEqual(data);
-    });
+    }
+);
 
-    test.each(['not-for-profit-company', 'faith-group'])(
-        'charity number optional for %p',
-        function(organisationType) {
-            const data = {
+test.each(['school', 'college-or-university'])(
+    'education number required for %p',
+    function(organisationType) {
+        assertMessagesByKey(
+            {
                 organisationType: organisationType,
-                charityNumber: '23456789'
-            };
+                educationNumber: undefined
+            },
+            ['Enter your organisation’s Department for Education number']
+        );
 
-            assertValidByKey(data);
-            assertValidByKey({
-                organisationType: organisationType,
-                charityNumber: null
-            });
+        assertValidByKey({
+            organisationType: organisationType,
+            educationNumber: '1160580'
+        });
+    }
+);
 
-            assertValidByKey({
-                organisationType: organisationType,
-                charityNumber: ''
-            });
+test('registration numbers shown based on organisation type', () => {
+    const mappings = {
+        companyNumber: ['not-for-profit-company', 'community-interest-company'],
+        charityNumber: [
+            'unincorporated-registered-charity',
+            'charitable-incorporated-organisation',
+            'not-for-profit-company',
+            'faith-group'
+        ],
+        educationNumber: ['school', 'college-or-university']
+    };
 
-            const fullNumbers = {
-                organisationType,
-                charityNumber: '23456789',
-                educationNumber: '345678'
-            };
+    map(mappings, (types, fieldName) => {
+        types.forEach(type => {
+            const fieldNames = formBuilder({
+                locale: 'en',
+                data: { organisationType: type }
+            })
+                .getCurrentFieldsForStep('organisation', 3)
+                .map(field => field.name);
 
-            expect(
-                formBuilder({
-                    locale: 'en',
-                    data: fullNumbers
-                }).validation.value
-            ).toEqual(data);
-        }
-    );
-
-    test.each(['school', 'college-or-university'])(
-        'education number required for %p',
-        function(organisationType) {
-            assertMessagesByKey(
-                {
-                    organisationType: organisationType,
-                    educationNumber: undefined
-                },
-                ['Enter your organisation’s Department for Education number']
-            );
-
-            assertValidByKey({
-                organisationType: organisationType,
-                educationNumber: '1160580'
-            });
-        }
-    );
-
-    test('registration numbers shown based on organisation type', () => {
-        const mappings = {
-            companyNumber: [
-                'not-for-profit-company',
-                'community-interest-company'
-            ],
-            charityNumber: [
-                'unincorporated-registered-charity',
-                'charitable-incorporated-organisation',
-                'not-for-profit-company',
-                'faith-group'
-            ],
-            educationNumber: ['school', 'college-or-university']
-        };
-
-        map(mappings, (types, fieldName) => {
-            types.forEach(type => {
-                const fieldNames = formBuilder({
-                    locale: 'en',
-                    data: { organisationType: type }
-                })
-                    .getCurrentFieldsForStep('organisation', 3)
-                    .map(field => field.name);
-
-                expect(fieldNames).toContain(fieldName);
-            });
+            expect(fieldNames).toContain(fieldName);
         });
     });
 });
 
-describe('Contacts', () => {
-    test.each(['seniorContactName', 'mainContactName'])(
-        'first and last name must be provided for %p',
-        function(fieldName) {
-            assertMessagesByKey(
-                {
-                    [fieldName]: {
-                        firstName: null,
-                        lastName: null
-                    }
-                },
-                ['Enter first and last name']
-            );
-        }
-    );
-
-    test('full names must not match', function() {
-        expect(
-            messagesByKey({
-                seniorContactName: { firstName: 'Ann', lastName: 'Example' },
-                mainContactName: { firstName: 'Ann', lastName: 'Example' }
-            })
-        ).toMatchSnapshot();
-    });
-
-    test('include warning if contact last names match', () => {
-        const form = formBuilder();
-
-        expect(form.allFields.mainContactName.warnings).toEqual([]);
-
-        const lastName = faker.name.lastName();
-        const formWithMatchingLastNames = formBuilder({
-            data: {
-                seniorContactName: {
-                    firstName: faker.name.firstName(),
-                    lastName: lastName
-                },
-                mainContactName: {
-                    firstName: faker.name.firstName(),
-                    lastName: lastName
-                }
-            }
-        });
-
-        expect(
-            formWithMatchingLastNames.allFields.mainContactName.warnings
-        ).toEqual([expect.stringContaining('have the same surname')]);
-    });
-
-    test.each(['seniorContactEmail', 'mainContactEmail'])(
-        'email address must be valid for %p',
-        function(fieldName) {
-            assertMessagesByKey(
-                {
-                    [fieldName]: 'not@anemail'
-                },
-                [
-                    'Email address must be in the correct format, like name@example.com'
-                ]
-            );
-        }
-    );
-
-    test('email addresses must not match', function() {
-        const form = formBuilder({
-            data: mockResponse({
-                seniorContactEmail: 'example@example.com',
-                mainContactEmail: 'Example@example.com' // Test for case insensitivity
-            })
-        });
-
-        expect(mapMessages(form.validation)).toEqual(
-            expect.arrayContaining([
-                expect.stringContaining(
-                    'Main contact email address must be different'
-                )
-            ])
-        );
-    });
-
-    test.each(['seniorContactPhone', 'mainContactPhone'])(
-        'phone number must be valid for %p',
-        function(fieldName) {
-            assertMessagesByKey(
-                {
-                    [fieldName]: 'not a phone number'
-                },
-                ['Enter a real UK telephone number']
-            );
-        }
-    );
-
-    test.each([
-        ['seniorContactDateOfBirth', 18],
-        ['mainContactDateOfBirth', 16]
-    ])(`date of birth must be valid for %p`, function(fieldName, minAge) {
-        assertMessagesByKey({ [fieldName]: null }, ['Enter a date of birth']);
-
+test.each(['seniorContactName', 'mainContactName'])(
+    'first and last name must be provided for %p',
+    function(fieldName) {
         assertMessagesByKey(
-            { [fieldName]: { year: 2000, month: 2, day: 31 } },
-            ['Enter a real date']
-        );
-
-        assertMessagesByKey({ [fieldName]: mockDateOfBirth(0, minAge - 1) }, [
-            `Must be at least ${minAge} years old`
-        ]);
-
-        assertValidByKey({
-            [fieldName]: mockDateOfBirth(minAge, 90)
-        });
-    });
-
-    test('contact address required by default', () => {
-        const data = omit(mockResponse(), [
-            'mainContactAddress',
-            'seniorContactAddress'
-        ]);
-
-        const validationResult = formBuilder({ data }).validation;
-
-        expect(mapRawMessages(validationResult)).toEqual([
-            '"mainContactAddress" is required',
-            '"seniorContactAddress" is required'
-        ]);
-
-        expect(mapMessages(validationResult)).toEqual(
-            expect.arrayContaining(['Enter a full UK address'])
-        );
-
-        expect(validationResult.isValid).toBeFalsy();
-    });
-
-    test.each(['school', 'college-or-university', 'statutory-body'])(
-        'dates of birth and addresses stripped for %p',
-        function(excludedOrgType) {
-            const validForm = formBuilder({
-                data: {
-                    organisationType: excludedOrgType,
-                    seniorContactDateOfBirth: mockDateOfBirth(18, 90),
-                    mainContactDateOfBirth: mockDateOfBirth(16, 90),
-                    seniorContactAddress: mockAddress(),
-                    seniorContactAddressHistory: {
-                        currentAddressMeetsMinimum: 'yes',
-                        previousAddress: mockAddress()
-                    },
-                    mainContactAddress: mockAddress(),
-                    mainContactAddressHistory: {
-                        currentAddressMeetsMinimum: 'yes',
-                        previousAddress: mockAddress()
-                    }
+            {
+                [fieldName]: {
+                    firstName: null,
+                    lastName: null
                 }
-            });
+            },
+            ['Enter first and last name']
+        );
+    }
+);
 
-            // Should strip even when values are invalid
-            const invalidForm = formBuilder({
-                data: {
-                    organisationType: excludedOrgType,
-                    seniorContactDateOfBirth: mockDateOfBirth(1, 17),
-                    mainContactDateOfBirth: mockDateOfBirth(1, 17),
-                    seniorContactAddress: {
-                        line1: faker.address.streetAddress(),
-                        townCity: faker.address.city(),
-                        county: faker.address.county()
-                    },
-                    mainContactAddress: {
-                        line1: faker.address.streetAddress(),
-                        townCity: faker.address.city(),
-                        county: faker.address.county()
-                    }
-                }
-            });
+test('full names must not match', function() {
+    expect(
+        messagesByKey({
+            seniorContactName: { firstName: 'Ann', lastName: 'Example' },
+            mainContactName: { firstName: 'Ann', lastName: 'Example' }
+        })
+    ).toMatchSnapshot();
+});
 
-            const expectedData = {
-                organisationType: excludedOrgType
-            };
+test('include warning if contact last names match', () => {
+    const form = formBuilder();
 
-            assertValidByKey(expectedData);
+    expect(form.allFields.mainContactName.warnings).toEqual([]);
 
-            expect(validForm.validation.value).toEqual(expectedData);
-
-            expect(invalidForm.validation.value).toEqual(expectedData);
-
-            // Check fields are not shown
-            function checkFieldsForSection(section, expectedFields) {
-                const fields = validForm
-                    .getCurrentFieldsForStep(section, 0)
-                    .map(field => field.name);
-
-                expect(fields).toEqual(expectedFields);
+    const lastName = faker.name.lastName();
+    const formWithMatchingLastNames = formBuilder({
+        data: {
+            seniorContactName: {
+                firstName: faker.name.firstName(),
+                lastName: lastName
+            },
+            mainContactName: {
+                firstName: faker.name.firstName(),
+                lastName: lastName
             }
-
-            checkFieldsForSection('senior-contact', [
-                'seniorContactRole',
-                'seniorContactName',
-                'seniorContactEmail',
-                'seniorContactPhone',
-                'seniorContactCommunicationNeeds'
-            ]);
-
-            checkFieldsForSection('main-contact', [
-                'mainContactName',
-                'mainContactEmail',
-                'mainContactPhone',
-                'mainContactCommunicationNeeds'
-            ]);
         }
+    });
+
+    expect(
+        formWithMatchingLastNames.allFields.mainContactName.warnings
+    ).toEqual([expect.stringContaining('have the same surname')]);
+});
+
+test.each(['seniorContactEmail', 'mainContactEmail'])(
+    'email address must be valid for %p',
+    function(fieldName) {
+        assertMessagesByKey(
+            {
+                [fieldName]: 'not@anemail'
+            },
+            [
+                'Email address must be in the correct format, like name@example.com'
+            ]
+        );
+    }
+);
+
+test('email addresses must not match', function() {
+    const form = formBuilder({
+        data: mockResponse({
+            seniorContactEmail: 'example@example.com',
+            mainContactEmail: 'Example@example.com' // Test for case insensitivity
+        })
+    });
+
+    expect(mapMessages(form.validation)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining(
+                'Main contact email address must be different'
+            )
+        ])
+    );
+});
+
+test.each(['seniorContactPhone', 'mainContactPhone'])(
+    'phone number must be valid for %p',
+    function(fieldName) {
+        assertMessagesByKey(
+            {
+                [fieldName]: 'not a phone number'
+            },
+            ['Enter a real UK telephone number']
+        );
+    }
+);
+
+test.each([
+    ['seniorContactDateOfBirth', 18],
+    ['mainContactDateOfBirth', 16]
+])(`date of birth must be valid for %p`, function(fieldName, minAge) {
+    assertMessagesByKey({ [fieldName]: null }, ['Enter a date of birth']);
+
+    assertMessagesByKey({ [fieldName]: { year: 2000, month: 2, day: 31 } }, [
+        'Enter a real date'
+    ]);
+
+    assertMessagesByKey({ [fieldName]: mockDateOfBirth(0, minAge - 1) }, [
+        `Must be at least ${minAge} years old`
+    ]);
+
+    assertValidByKey({
+        [fieldName]: mockDateOfBirth(minAge, 90)
+    });
+});
+
+test('contact address required by default', () => {
+    const data = omit(mockResponse(), [
+        'mainContactAddress',
+        'seniorContactAddress'
+    ]);
+
+    const validationResult = formBuilder({ data }).validation;
+
+    expect(mapRawMessages(validationResult)).toEqual([
+        '"mainContactAddress" is required',
+        '"seniorContactAddress" is required'
+    ]);
+
+    expect(mapMessages(validationResult)).toEqual(
+        expect.arrayContaining(['Enter a full UK address'])
     );
 
-    test.each(['seniorContactAddress', 'mainContactAddress'])(
-        'address is valid for %p',
-        function(fieldName) {
-            const partialAddress = {
-                line1: '3 Embassy Drive',
-                county: 'West Midlands',
-                postcode: 'B15 1TR'
-            };
+    expect(validationResult.isValid).toBeFalsy();
+});
 
-            const addressWithInvalidPostcode = {
-                ...mockAddress(),
-                ...{ postcode: 'not a postcode' }
-            };
-
-            assertMessagesByKey({ [fieldName]: null }, [
-                'Enter a full UK address'
-            ]);
-
-            assertMessagesByKey({ [fieldName]: partialAddress }, [
-                'Enter a full UK address'
-            ]);
-
-            assertMessagesByKey({ [fieldName]: addressWithInvalidPostcode }, [
-                'Enter a real postcode'
-            ]);
-        }
-    );
-
-    test.each(['seniorContactAddressHistory', 'mainContactAddressHistory'])(
-        'address history is valid for %p',
-        function(fieldName) {
-            assertValidByKey({
-                [fieldName]: {
+test.each(['school', 'college-or-university', 'statutory-body'])(
+    'dates of birth and addresses stripped for %p',
+    function(excludedOrgType) {
+        const validForm = formBuilder({
+            data: {
+                organisationType: excludedOrgType,
+                seniorContactDateOfBirth: mockDateOfBirth(18, 90),
+                mainContactDateOfBirth: mockDateOfBirth(16, 90),
+                seniorContactAddress: mockAddress(),
+                seniorContactAddressHistory: {
                     currentAddressMeetsMinimum: 'yes',
-                    previousAddress: null
-                }
-            });
-
-            assertValidByKey({
-                [fieldName]: {
-                    currentAddressMeetsMinimum: 'no',
+                    previousAddress: mockAddress()
+                },
+                mainContactAddress: mockAddress(),
+                mainContactAddressHistory: {
+                    currentAddressMeetsMinimum: 'yes',
                     previousAddress: mockAddress()
                 }
-            });
+            }
+        });
 
-            assertMessagesByKey(
-                {
-                    [fieldName]: {
-                        currentAddressMeetsMinimum: 'no',
-                        previousAddress: {
-                            line1: faker.address.streetAddress(),
-                            townCity: faker.address.city()
-                        }
-                    }
-                },
-                ['Enter a full UK address']
-            );
-        }
-    );
-
-    test('contact addresses must not match', function() {
-        expect(
-            messagesByKey({
+        // Should strip even when values are invalid
+        const invalidForm = formBuilder({
+            data: {
+                organisationType: excludedOrgType,
+                seniorContactDateOfBirth: mockDateOfBirth(1, 17),
+                mainContactDateOfBirth: mockDateOfBirth(1, 17),
                 seniorContactAddress: {
-                    line1: 'National Lottery Community Fund',
-                    line2: 'Apex House',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR',
-                    townCity: 'BIRMINGHAM'
+                    line1: faker.address.streetAddress(),
+                    townCity: faker.address.city(),
+                    county: faker.address.county()
                 },
                 mainContactAddress: {
-                    line1: 'National Lottery Community Fund',
-                    line2: 'Apex House',
-                    county: 'West Midlands',
-                    postcode: 'B15 1TR',
-                    townCity: 'BIRMINGHAM'
+                    line1: faker.address.streetAddress(),
+                    townCity: faker.address.city(),
+                    county: faker.address.county()
                 }
-            })
-        ).toMatchSnapshot();
-    });
+            }
+        });
+
+        const expectedData = {
+            organisationType: excludedOrgType
+        };
+
+        assertValidByKey(expectedData);
+
+        expect(validForm.validation.value).toEqual(expectedData);
+
+        expect(invalidForm.validation.value).toEqual(expectedData);
+
+        // Check fields are not shown
+        function checkFieldsForSection(section, expectedFields) {
+            const fields = validForm
+                .getCurrentFieldsForStep(section, 0)
+                .map(field => field.name);
+
+            expect(fields).toEqual(expectedFields);
+        }
+
+        checkFieldsForSection('senior-contact', [
+            'seniorContactRole',
+            'seniorContactName',
+            'seniorContactEmail',
+            'seniorContactPhone',
+            'seniorContactCommunicationNeeds'
+        ]);
+
+        checkFieldsForSection('main-contact', [
+            'mainContactName',
+            'mainContactEmail',
+            'mainContactPhone',
+            'mainContactCommunicationNeeds'
+        ]);
+    }
+);
+
+test.each(['seniorContactAddress', 'mainContactAddress'])(
+    'address is valid for %p',
+    function(fieldName) {
+        const partialAddress = {
+            line1: '3 Embassy Drive',
+            county: 'West Midlands',
+            postcode: 'B15 1TR'
+        };
+
+        const addressWithInvalidPostcode = {
+            ...mockAddress(),
+            ...{ postcode: 'not a postcode' }
+        };
+
+        assertMessagesByKey({ [fieldName]: null }, ['Enter a full UK address']);
+
+        assertMessagesByKey({ [fieldName]: partialAddress }, [
+            'Enter a full UK address'
+        ]);
+
+        assertMessagesByKey({ [fieldName]: addressWithInvalidPostcode }, [
+            'Enter a real postcode'
+        ]);
+    }
+);
+
+test.each(['seniorContactAddressHistory', 'mainContactAddressHistory'])(
+    'address history is valid for %p',
+    function(fieldName) {
+        assertValidByKey({
+            [fieldName]: {
+                currentAddressMeetsMinimum: 'yes',
+                previousAddress: null
+            }
+        });
+
+        assertValidByKey({
+            [fieldName]: {
+                currentAddressMeetsMinimum: 'no',
+                previousAddress: mockAddress()
+            }
+        });
+
+        assertMessagesByKey(
+            {
+                [fieldName]: {
+                    currentAddressMeetsMinimum: 'no',
+                    previousAddress: {
+                        line1: faker.address.streetAddress(),
+                        townCity: faker.address.city()
+                    }
+                }
+            },
+            ['Enter a full UK address']
+        );
+    }
+);
+
+test('contact addresses must not match', function() {
+    expect(
+        messagesByKey({
+            seniorContactAddress: {
+                line1: 'National Lottery Community Fund',
+                line2: 'Apex House',
+                county: 'West Midlands',
+                postcode: 'B15 1TR',
+                townCity: 'BIRMINGHAM'
+            },
+            mainContactAddress: {
+                line1: 'National Lottery Community Fund',
+                line2: 'Apex House',
+                county: 'West Midlands',
+                postcode: 'B15 1TR',
+                townCity: 'BIRMINGHAM'
+            }
+        })
+    ).toMatchSnapshot();
 });

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -663,36 +663,40 @@ test('finance details required if organisation is over 15 months old', function(
 });
 
 test('full names must not match', function() {
-    expect(
-        messagesByKey({
-            seniorContactName: { firstName: 'Ann', lastName: 'Example' },
-            mainContactName: { firstName: 'Ann', lastName: 'Example' }
-        })
-    ).toMatchSnapshot();
+    const sameName = { firstName: 'Ann', lastName: 'Example' };
+    const data = mockResponse({
+        seniorContactName: sameName,
+        mainContactName: sameName
+    });
+
+    const result = formBuilder({ data }).validation;
+
+    expect(mapMessages(result)).toEqual(
+        expect.arrayContaining([
+            expect.stringContaining('Main contact name must be different'),
+            expect.stringContaining('Senior contact name must be different')
+        ])
+    );
 });
 
 test('include warning if contact last names match', () => {
-    const form = formBuilder();
-
-    expect(form.allFields.mainContactName.warnings).toEqual([]);
-
     const lastName = faker.name.lastName();
-    const formWithMatchingLastNames = formBuilder({
-        data: {
-            seniorContactName: {
-                firstName: faker.name.firstName(),
-                lastName: lastName
-            },
-            mainContactName: {
-                firstName: faker.name.firstName(),
-                lastName: lastName
-            }
+    const dataWithMatchingLastNames = mockResponse({
+        seniorContactName: {
+            firstName: faker.name.firstName(),
+            lastName: lastName
+        },
+        mainContactName: {
+            firstName: faker.name.firstName(),
+            lastName: lastName
         }
     });
 
-    expect(
-        formWithMatchingLastNames.allFields.mainContactName.warnings
-    ).toEqual([expect.stringContaining('have the same surname')]);
+    const form = formBuilder({ data: dataWithMatchingLastNames });
+
+    expect(form.allFields.mainContactName.warnings).toEqual([
+        expect.stringContaining('have the same surname')
+    ]);
 });
 
 test.each(['seniorContactEmail', 'mainContactEmail'])(

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -136,79 +136,112 @@ test('valid form for northern-ireland', () => {
     );
 });
 
-test.each(
-    Object.entries({
-        'unregistered-vco': {
-            seniorContactRole: 'chair'
-        },
-        'unincorporated-registered-charity': {
-            charityNumber: '12345678',
-            seniorContactRole: 'trustee'
-        },
-        'charitable-incorporated-organisation': {
-            charityNumber: '12345678',
-            seniorContactRole: 'trustee'
-        },
-        'not-for-profit-company': {
-            companyNumber: '12345678',
-            seniorContactRole: 'company-director'
-        },
-        'school': {
-            educationNumber: '345678',
-            seniorContactRole: 'head-teacher'
-        },
-        'college-or-university': {
-            educationNumber: '345678',
-            seniorContactRole: 'chancellor'
-        },
-        'statutory-body': {
-            organisationSubType: 'parish-council',
-            seniorContactRole: 'parish-clerk'
-        },
-        'faith-group': {
-            seniorContactRole: 'religious-leader'
-        }
-    })
-)('valid form for %s', function(organisationType, data) {
-    const form = formBuilder({
-        data: mockResponse({
-            organisationType: organisationType,
-            organisationSubType: data.organisationSubType,
-            companyNumber: data.companyNumber,
-            charityNumber: data.charityNumber,
-            educationNumber: data.educationNumber,
-            seniorContactRole: data.seniorContactRole
-        })
+test('valid form for unregistered-vco', function() {
+    const data = mockResponse({
+        organisationType: 'unregistered-vco',
+        seniorContactRole: 'chair'
     });
 
-    expect(form.validation.isValid).toBeTruthy();
-    expect(form.validation.messages).toHaveLength(0);
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
 
-    expect(form.progress.isComplete).toBeTruthy();
-    expect(form.progress.isPristine).toBeFalsy();
+test('valid form for unincorporated-registered-charity', function() {
+    const data = mockResponse({
+        organisationType: 'unincorporated-registered-charity',
+        charityNumber: '12345678',
+        seniorContactRole: 'trustee'
+    });
 
-    const allSectionsComplete = form.progress.sections.every(
-        section => section.status === 'complete'
-    );
-    expect(allSectionsComplete).toBeTruthy();
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for charitable-incorporated-organisation', function() {
+    const data = mockResponse({
+        organisationType: 'charitable-incorporated-organisation',
+        charityNumber: '12345678',
+        seniorContactRole: 'trustee'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for not-for-profit-company', function() {
+    const data = mockResponse({
+        organisationType: 'not-for-profit-company',
+        companyNumber: '12345678',
+        seniorContactRole: 'company-director'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for school', function() {
+    const data = mockResponse({
+        organisationType: 'school',
+        educationNumber: '345678',
+        seniorContactRole: 'head-teacher'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for college-or-university', function() {
+    const data = mockResponse({
+        organisationType: 'college-or-university',
+        educationNumber: '345678',
+        seniorContactRole: 'chancellor'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for statutory-body', function() {
+    const data = mockResponse({
+        organisationType: 'statutory-body',
+        organisationSubType: 'parish-council',
+        seniorContactRole: 'parish-clerk'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
+});
+
+test('valid form for faith-group', function() {
+    const data = mockResponse({
+        organisationType: 'faith-group',
+        seniorContactRole: 'religious-leader'
+    });
+
+    const form = formBuilder({ data });
+    expect(form.validation.error).toBeNull();
 });
 
 test('featured messages based on allow list', () => {
-    const form = formBuilder({
-        data: {
-            projectDateRange: {
-                startDate: { day: 31, month: 1, year: 2019 },
-                endDate: { day: 31, month: 1, year: 2019 }
-            },
-            seniorContactRole: 'not-a-real-role'
+    const data = mockResponse({
+        projectDateRange: {
+            startDate: { day: 31, month: 1, year: 2019 },
+            endDate: { day: 31, month: 1, year: 2019 }
         },
+        seniorContactRole: 'not-a-real-role'
+    });
+
+    const form = formBuilder({
+        data,
         flags: { enableNewDateRange: false }
     });
 
     const messages = form.validation.featuredMessages.map(item => item.msg);
+
     expect(messages).toContainEqual(
         expect.stringMatching(/Date you start the project must be after/)
     );
+
     expect(messages).toContainEqual('Senior contact role is not valid');
 });
 

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -336,38 +336,40 @@ test('support new project date schema', function() {
     });
 });
 
-describe('Project details', () => {
-    test('project postcode must be a valid UK postcode', () => {
-        const invalidMessages = ['Enter a real postcode'];
-        assertMessagesByKey(
-            {
-                projectCountry: 'scotland',
-                projectPostcode: null
-            },
-            invalidMessages
-        );
-        assertMessagesByKey(
-            {
-                projectCountry: 'scotland',
-                projectPostcode: 'not a postcode'
-            },
-            invalidMessages
-        );
+test('project postcode must be a valid UK postcode', () => {
+    const data = mockResponse({
+        projectPostcode: 'not a postcode'
     });
 
-    test.each([
-        ['yourIdeaProject', 50, 300],
-        ['yourIdeaPriorities', 50, 150],
-        ['yourIdeaCommunity', 50, 200]
-    ])('%p must be within %p and %p words', (fieldName, min, max) => {
-        assertMessagesByKey({ [fieldName]: faker.lorem.words(min - 1) }, [
-            expect.stringMatching(/Answer must be at least/)
-        ]);
+    const result = formBuilder({ data }).validation;
 
-        assertMessagesByKey({ [fieldName]: faker.lorem.words(max + 1) }, [
-            expect.stringMatching(/Answer must be no more than/)
-        ]);
+    expect(mapMessages(result)).toEqual(
+        expect.arrayContaining(['Enter a real postcode'])
+    );
+});
+
+test('project questions must be at least 50 words', function() {
+    const data = mockResponse({
+        yourIdeaProject: faker.lorem.words(49),
+        yourIdeaPriorities: faker.lorem.words(49),
+        yourIdeaCommunity: faker.lorem.words(49)
     });
+
+    expect(
+        mapMessageSummary(formBuilder({ data }).validation)
+    ).toMatchSnapshot();
+});
+
+test('project questions must not be over word-count', () => {
+    const data = mockResponse({
+        yourIdeaProject: faker.lorem.words(301),
+        yourIdeaPriorities: faker.lorem.words(151),
+        yourIdeaCommunity: faker.lorem.words(201)
+    });
+
+    expect(
+        mapMessageSummary(formBuilder({ data }).validation)
+    ).toMatchSnapshot();
 });
 
 describe('Project budget', () => {

--- a/controllers/apply/awards-for-all/mocks.js
+++ b/controllers/apply/awards-for-all/mocks.js
@@ -24,15 +24,6 @@ function mockAddress() {
     };
 }
 
-function mockBudget() {
-    return new Array(5).fill(null).map(() => {
-        return {
-            item: faker.lorem.words(5),
-            cost: faker.random.number({ min: 100, max: 1000 })
-        };
-    });
-}
-
 function mockBeneficiaries(checkAnswer = 'yes') {
     return {
         beneficiariesGroupsCheck: checkAnswer,
@@ -67,7 +58,12 @@ function mockResponse(overrides = {}) {
         yourIdeaProject: faker.lorem.words(random(50, 250)),
         yourIdeaPriorities: faker.lorem.words(random(50, 100)),
         yourIdeaCommunity: faker.lorem.words(random(50, 150)),
-        projectBudget: mockBudget(),
+        projectBudget: new Array(5).fill(null).map(() => {
+            return {
+                item: faker.lorem.words(5),
+                cost: faker.random.number({ min: 100, max: 1000 })
+            };
+        }),
         projectTotalCosts: 20000,
         beneficiariesGroupsCheck: 'yes',
         beneficiariesGroups: [
@@ -147,7 +143,6 @@ function mockResponse(overrides = {}) {
 module.exports = {
     mockAddress,
     mockBeneficiaries,
-    mockBudget,
     mockDateOfBirth,
     mockResponse,
     toDateParts


### PR DESCRIPTION
Updates the awards for all schema tests to try and follow a similar pattern to the standard proposal ones with the goals of:

a) expressing similar tests more concisely and with fewer abstractions
b) increase the speed of running these test as they are by far the longest unit tests

done through a few key changes:

- Introduced a general "invalid form" test which allows us to test common invalid error messages in one go. Relative complexity of the two forms aside this is the main reason the standard form tests are much leaner
- Re-grouped related tests based on either country or organisation type which are the two conditions most other fields change based on
- Reducing the use of abstracted methods so it's clearer to see what the expectations are in a test

results are that:

- are ~300 hundred lines  shorter for the same kind of coverage
- typically run twice as fast. Although these are unit tests so we're only talking 2-3 seconds. Not much difference in CI but is noticeable using a test watcher.