### PR TITLE
Add missing line to summary

### DIFF
--- a/controllers/apply/lib/formatters.js
+++ b/controllers/apply/lib/formatters.js
@@ -49,6 +49,7 @@ function formatMultiChoice(field) {
 function formatAddress(value) {
     return compact([
         value.line1,
+        value.line2,
         value.townCity,
         value.county,
         value.postcode


### PR DESCRIPTION
Saw this user feedback:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/394376/70985102-7efd8480-20b3-11ea-97f9-c30fa7489baf.png">

Easy enough fix and doesn't really make sense to have been excluding this line.
