### PR TITLE
Use a customised name for <details> clicks in HotJar tags

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -167,8 +167,9 @@ function trackSharedSurnameWarning($form, shortId) {
 // Track clicks on details expandos
 function trackDetailsClicks($form, shortId) {
     $('details summary', $form).on('click', function() {
+        const componentLocation = $(this).data('name') || 'Clicky Thing';
         tagHotjarRecording([
-            `Apply: ${shortId}: Summary: User toggles details element`
+            `Apply: ${shortId}: ${componentLocation}: User toggles details element`
         ]);
     });
 }

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -155,7 +155,8 @@
                     assistiveText = 'for "' + secTitle + '" section',
                     extraClasses = 'js-toggleable',
                     isOpen = form.progress.isComplete or section.hasFeaturedErrors,
-                    showInfoIcon = false
+                    showInfoIcon = false,
+                    dataName = 'Summary'
                 ) %}
                     {% for step in section.steps %}
                         {{ stepSummary(

--- a/views/components/details/macro.njk
+++ b/views/components/details/macro.njk
@@ -1,8 +1,8 @@
 {% from "components/icons.njk" import iconInfo %}
 
-{% macro details(title, isOpen = false, showInfoIcon = true, extraClasses, assistiveText = false) %}
+{% macro details(title, isOpen = false, showInfoIcon = true, extraClasses, assistiveText = false, dataName = false) %}
     <details class="o-details u-margin-bottom-s {% if extraClasses %}{{ extraClasses }}{% endif %}"{% if isOpen %} open{% endif %}>
-        <summary class="o-details__summary">
+        <summary class="o-details__summary"{% if dataName %} data-name="{{ dataName }}"{% endif %}>
             {% if showInfoIcon %}{{ iconInfo() }}{% endif %}
             {{ title }}
             {% if assistiveText %}<span class="u-visually-hidden">{{ assistiveText }}</span>{% endif %}

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -203,7 +203,7 @@
     </label>
 
     {% if field.labelDetails %}
-        {% call details(field.labelDetails.summary) %}
+        {% call details(field.labelDetails.summary, dataName = field.name) %}
             <div class="ff-help s-prose">{{ field.labelDetails.content | safe }}</div>
         {% endcall %}
     {% endif %}


### PR DESCRIPTION
We were using the same HotJar tag for all clicks on `<details>` elements. This change now uses the field name (if the details element is part of a field) to distinguish between these clicks and ones on the summary screen.