### PR TITLE
Require locale for field types

### DIFF
--- a/controllers/apply/awards-for-all/fields/bank-account-number.js
+++ b/controllers/apply/awards-for-all/fields/bank-account-number.js
@@ -8,6 +8,7 @@ module.exports = function(locale) {
     const localise = get(locale);
 
     return new Field({
+        locale: locale,
         name: 'bankAccountNumber',
         label: localise({ en: 'Account number', cy: 'Rhif cyfrif' }),
         explanation: localise({ en: 'eg. 12345678', cy: 'e.e. 12345678' }),

--- a/controllers/apply/awards-for-all/fields/bank-sort-code.js
+++ b/controllers/apply/awards-for-all/fields/bank-sort-code.js
@@ -8,6 +8,7 @@ module.exports = function(locale) {
     const localise = get(locale);
 
     return new Field({
+        locale: locale,
         name: 'bankSortCode',
         label: localise({ en: 'Sort code', cy: 'Cod didoli' }),
         explanation: localise({ en: 'eg. 123456', cy: 'e.e. 123456' }),

--- a/controllers/apply/awards-for-all/fields/bank-statement.js
+++ b/controllers/apply/awards-for-all/fields/bank-statement.js
@@ -7,6 +7,7 @@ module.exports = function(locale) {
     const localise = get(locale);
 
     return new FileField({
+        locale: locale,
         name: 'bankStatement',
         label: localise({
             en: 'Upload a bank statement',

--- a/controllers/apply/awards-for-all/fields/project-start-date.js
+++ b/controllers/apply/awards-for-all/fields/project-start-date.js
@@ -19,8 +19,8 @@ module.exports = function(locale) {
         .format('DD MM YYYY');
 
     return new DateField({
+        locale: locale,
         name: 'projectStartDate',
-
         label: localise({
             en: `When would you like to start your project?`,
             cy: `Pryd hoffech ddechrau eich prosiect?`

--- a/controllers/apply/lib/field-types/address.test.js
+++ b/controllers/apply/lib/field-types/address.test.js
@@ -4,6 +4,7 @@ const AddressField = require('./address');
 
 test('AddressField', function() {
     const field = new AddressField({
+        locale: 'en',
         name: 'example',
         label: 'Address field'
     });

--- a/controllers/apply/lib/field-types/checkbox.test.js
+++ b/controllers/apply/lib/field-types/checkbox.test.js
@@ -4,6 +4,7 @@ const CheckboxField = require('./checkbox');
 
 test('CheckboxField', function() {
     const field = new CheckboxField({
+        locale: 'en',
         name: 'example',
         label: 'Checkbox field',
         options: [

--- a/controllers/apply/lib/field-types/currency.test.js
+++ b/controllers/apply/lib/field-types/currency.test.js
@@ -4,6 +4,7 @@ const CurrencyField = require('./currency');
 
 test('CurrencyField', function() {
     const field = new CurrencyField({
+        locale: 'en',
         name: 'example',
         label: 'Currency field'
     });

--- a/controllers/apply/lib/field-types/date.test.js
+++ b/controllers/apply/lib/field-types/date.test.js
@@ -4,6 +4,7 @@ const DateField = require('./date');
 
 test('DateField', function() {
     const field = new DateField({
+        locale: 'en',
         name: 'example',
         label: 'Date field'
     });

--- a/controllers/apply/lib/field-types/email.test.js
+++ b/controllers/apply/lib/field-types/email.test.js
@@ -4,6 +4,7 @@ const EmailField = require('./email');
 
 test('EmailField', function() {
     const field = new EmailField({
+        locale: 'en',
         name: 'example',
         label: 'Email field'
     });

--- a/controllers/apply/lib/field-types/field.js
+++ b/controllers/apply/lib/field-types/field.js
@@ -4,17 +4,21 @@ const Joi = require('../joi-extensions');
 
 class Field {
     constructor(props) {
-        this.locale = props.locale || 'en';
-
-        // Used to switch on non-class type fields
-        // @TODO: Remove this after fully migrating to field types
-        this._isClass = true;
-
         if (props.name) {
             this.name = props.name;
         } else {
             throw new Error('Must provide name');
         }
+
+        if (props.locale) {
+            this.locale = props.locale;
+        } else {
+            throw new Error(`Must provide locale for ${props.name}`);
+        }
+
+        // Used to switch on non-class type fields
+        // @TODO: Remove this after fully migrating to field types
+        this._isClass = true;
 
         const label = props.label ? props.label : this.defaultLabel();
         if (label) {

--- a/controllers/apply/lib/field-types/field.test.js
+++ b/controllers/apply/lib/field-types/field.test.js
@@ -5,6 +5,7 @@ const Joi = require('../joi-extensions');
 
 test('field base type', function() {
     const field = new Field({
+        locale: 'en',
         name: 'example',
         label: 'Text field'
     });
@@ -18,6 +19,7 @@ test('field base type', function() {
 
 test('optional default field', function() {
     const optionalField = new Field({
+        locale: 'en',
         name: 'example',
         label: 'Optional text field',
         isRequired: false
@@ -44,6 +46,7 @@ test('field extension', function() {
     }
 
     const minimalField = new CustomField({
+        locale: 'en',
         name: 'example'
     });
 
@@ -59,6 +62,7 @@ test('field extension', function() {
     );
 
     const fieldWithProps = new CustomField({
+        locale: 'en',
         name: 'example',
         label: 'Custom label'
     });

--- a/controllers/apply/lib/field-types/file.test.js
+++ b/controllers/apply/lib/field-types/file.test.js
@@ -4,6 +4,7 @@ const FileField = require('./file');
 
 test('FileField', function() {
     const field = new FileField({
+        locale: 'en',
         name: 'example',
         label: 'File field'
     });

--- a/controllers/apply/lib/field-types/name.test.js
+++ b/controllers/apply/lib/field-types/name.test.js
@@ -4,6 +4,7 @@ const NameField = require('./name');
 
 test('NameField', function() {
     const field = new NameField({
+        locale: 'en',
         name: 'example',
         label: 'Name field'
     });

--- a/controllers/apply/lib/field-types/phone.test.js
+++ b/controllers/apply/lib/field-types/phone.test.js
@@ -4,6 +4,7 @@ const PhoneField = require('./phone');
 
 test('PhoneField', function() {
     const field = new PhoneField({
+        locale: 'en',
         name: 'example',
         label: 'Email field'
     });

--- a/controllers/apply/lib/field-types/radio.test.js
+++ b/controllers/apply/lib/field-types/radio.test.js
@@ -4,6 +4,7 @@ const RadioField = require('./radio');
 
 test('RadioField', function() {
     const field = new RadioField({
+        locale: 'en',
         name: 'example',
         label: 'Radio field',
         options: [

--- a/controllers/apply/lib/field-types/select.test.js
+++ b/controllers/apply/lib/field-types/select.test.js
@@ -4,6 +4,7 @@ const SelectField = require('./select');
 
 test('SelectField', function() {
     const field = new SelectField({
+        locale: 'en',
         name: 'example',
         label: 'Checkbox field',
         options: [

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -9,6 +9,7 @@ test('TextareaField', function() {
     const maxWords = 150;
 
     const field = new TextareaField({
+        locale: 'en',
         name: 'example',
         label: 'Textarea field',
         minWords: minWords,
@@ -36,6 +37,7 @@ test('TextareaField', function() {
     );
 
     const optionalField = new TextareaField({
+        locale: 'en',
         name: 'example',
         isRequired: false,
         label: 'Radio field',

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -30,6 +30,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
     function fieldProjectName() {
         const maxLength = 80;
         return new Field({
+            locale: locale,
             name: 'projectName',
             label: localise({
                 en: 'What is the name of your project?',
@@ -430,6 +431,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
     function fieldYourIdeaActivities() {
         return new TextareaField({
+            locale: locale,
             name: 'yourIdeaActivities',
             label: localise({
                 en: 'How does your idea fit in with other local activities?',


### PR DESCRIPTION
Throws an error if no locale is provided to a field type. We were defaulting this to `en` which kept tests leaner but made it possible to omit the locale on field definitions.

Seem to have only been missing on:

- Some standard proposal fields. Not a big deal as this isn't translated yet anyway.
- Bank fields added in https://github.com/biglotteryfund/blf-alpha/pull/2779. Not gone live yet
- `projectStartDate` this does affect production. Result would be some of the common date error messages not being translated
