### PR TITLE
Block deleted apps

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1305,6 +1305,10 @@ applyNext:
         Os ydych yn siŵr eich bod eisiau dileu eich cais, gallwch barhau isod.
       </p>
     success: Mae eich cais wedi’i ddileu’n llwyddiannus
+  expired:
+    title: Roedd rhaid i ni ddileu’r cais hwn
+    summary: Mae wedi bod dros 3 mis ers i chi ei ddechrau. Rydym felly wedi gorfod dileu’r cais hwn i gadw eich data’n ddiogel.
+    message: Cafodd eich cais ei ddileu ar %s. Os ydych yn dal i fod eisiau ymgeisio, bydd angen i chi ddechrau cais newydd.
   questions:
     printLink: Argraffu’r cwestiynau hyn
     downloadLink: Lawrlwytho ‘r cwestiynau hyn (PDF)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1588,6 +1588,10 @@ applyNext:
         If you're sure you want to delete your application, then you can proceed below.
       </p>
     success: Your application was successfully deleted
+  expired:
+    title: We've had to delete this application
+    summary: It's been over 3 months since you started it. So we've had to delete this application to keep your data safe.
+    message: Your application expired on %s. If you still want to apply, you'll need to start a new application.
   questions:
     printLink: Print these questions
     downloadLink: Download these questions (PDF)

--- a/controllers/apply/awards-for-all/__snapshots__/enrich.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/enrich.test.js.snap
@@ -9,6 +9,7 @@ Object {
   "expiresAt": "2020-03-04T12:00:00.000Z",
   "formId": "awards-for-all",
   "id": "some-uuid",
+  "isExpired": false,
   "overview": Array [
     Object {
       "label": "Project dates",

--- a/controllers/apply/awards-for-all/enrich.js
+++ b/controllers/apply/awards-for-all/enrich.js
@@ -76,6 +76,7 @@ function enrichPending(application, locale = 'en') {
         formId: application.formId,
         createdAt: application.createdAt,
         expiresAt: application.expiresAt,
+        isExpired: application.isExpired,
         updatedAt: application.updatedAt,
         progress: form.progress,
         editUrl: `/apply/awards-for-all/edit/${application.id}`,

--- a/controllers/apply/awards-for-all/enrich.test.js
+++ b/controllers/apply/awards-for-all/enrich.test.js
@@ -13,6 +13,7 @@ test('enrich pending applications', function() {
         formId: 'awards-for-all',
         createdAt: '2020-03-04T12:00:00.000Z',
         expiresAt: '2020-03-04T12:00:00.000Z',
+        isExpired: false,
         updatedAt: '2020-03-04T12:00:00.000Z',
         applicationData: mockResponse({
             projectName: 'Example project',

--- a/controllers/apply/contacts-next/enrich.js
+++ b/controllers/apply/contacts-next/enrich.js
@@ -74,6 +74,7 @@ function enrichPending(application, locale = 'en') {
         formId: application.formId,
         createdAt: application.createdAt,
         expiresAt: application.expiresAt,
+        isExpired: application.isExpired,
         updatedAt: application.updatedAt,
         progress: form.progress,
         editUrl: `/apply/contacts-next/edit/${application.id}`,

--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -127,7 +127,7 @@ async function sendExpiryEmails(req, emailQueue) {
                 emailToSend.PendingApplication.id
             );
 
-            const dateFormat = 'D MMMM, YYYY';
+            const dateFormat = 'D MMMM, YYYY HH:mm:ss';
             const expiresOn = moment(emailToSend.PendingApplication.expiresAt);
 
             const expiryDates = {

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -315,6 +315,16 @@ function initFormRouter({
                         'status'
                     );
 
+                    if (currentApplication.isExpired) {
+                        return res.render(
+                            path.resolve(__dirname, './views/expired'),
+                            {
+                                title: res.locals.copy.expired.title,
+                                csrfToken: req.csrfToken()
+                            }
+                        );
+                    }
+
                     next();
                 } else {
                     res.redirect(req.baseUrl);

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -315,16 +315,6 @@ function initFormRouter({
                         'status'
                     );
 
-                    if (currentApplication.isExpired) {
-                        return res.render(
-                            path.resolve(__dirname, './views/expired'),
-                            {
-                                title: res.locals.copy.expired.title,
-                                csrfToken: req.csrfToken()
-                            }
-                        );
-                    }
-
                     next();
                 } else {
                     res.redirect(req.baseUrl);
@@ -337,6 +327,21 @@ function initFormRouter({
             }
         } else {
             res.redirect(req.baseUrl);
+        }
+    });
+
+    /**
+     * Block access to expired applications
+     * We should prevent access to anything that's pending deletion to avoid user confusion and lost data
+     */
+    router.use((req, res, next) => {
+        if (res.locals.currentApplication.isExpired) {
+            return res.render(path.resolve(__dirname, './views/expired'), {
+                title: res.locals.copy.expired.title,
+                csrfToken: req.csrfToken()
+            });
+        } else {
+            next();
         }
     });
 

--- a/controllers/apply/form-router/views/delete.njk
+++ b/controllers/apply/form-router/views/delete.njk
@@ -1,13 +1,15 @@
 {% extends "layouts/main.njk" %}
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
+{% from "components/form-header/macro.njk" import formHeaderWithData with context %}
 
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner u-inner-wide-only">
             {{ userNavigation(userNavigationLinks) }}
 
+            {{ formHeaderWithData(formTitle) }}
+            
             <div class="form-header">
-                <p class="form-header__prefix">{{ formTitle }}</p>
                 <h1 class="form-header__title">{{ title }}</h1>
             </div>
 

--- a/controllers/apply/form-router/views/expired.njk
+++ b/controllers/apply/form-router/views/expired.njk
@@ -1,0 +1,22 @@
+{% extends "layouts/main.njk" %}
+{% from "components/user-navigation/macro.njk" import userNavigation with context %}
+{% from "components/form-header/macro.njk" import formHeaderWithData with context %}
+
+
+{% block content %}
+    <main role="main" id="content">
+        <div class="content-box u-inner u-inner-wide-only">
+            {{ userNavigation(userNavigationLinks) }}
+
+            {{ formHeaderWithData(formTitle) }}
+
+            <div class="form-header">
+                <h1 class="form-header__title">{{ title }}</h1>
+            </div>
+            <div class="s-prose u-constrained-wide">
+                <p>{{ copy.expired.summary }}</p>
+                <p>{{ __('applyNext.expired.message', formatDate(currentApplication.expiresAt)) }}</p>
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/controllers/apply/standard-proposal/__snapshots__/enrich.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/enrich.test.js.snap
@@ -9,6 +9,7 @@ Object {
   "expiresAt": "2020-03-04T23:00:00.000Z",
   "formId": "standard-enquiry",
   "id": "some-uuid",
+  "isExpired": false,
   "overview": Array [
     Object {
       "label": "Project length",

--- a/controllers/apply/standard-proposal/enrich.js
+++ b/controllers/apply/standard-proposal/enrich.js
@@ -53,6 +53,7 @@ function enrichPending(application, locale = 'en') {
         formId: application.formId,
         createdAt: application.createdAt,
         expiresAt: application.expiresAt,
+        isExpired: application.isExpired,
         updatedAt: application.updatedAt,
         progress: form.progress,
         editUrl: `/apply/your-funding-proposal/edit/${application.id}`,

--- a/controllers/apply/standard-proposal/enrich.test.js
+++ b/controllers/apply/standard-proposal/enrich.test.js
@@ -9,6 +9,7 @@ test('enrich pending applications', function() {
         formId: 'standard-enquiry',
         createdAt: '2020-03-04T23:00:00.000Z',
         expiresAt: '2020-03-04T23:00:00.000Z',
+        isExpired: false,
         updatedAt: '2020-03-04T23:00:00.000Z',
         applicationData: mockResponse()
     });

--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -196,6 +196,10 @@ class PendingApplication extends Model {
             }
         });
     }
+
+    get isExpired() {
+        return moment(this.expiresAt).isBefore(moment());
+    }
 }
 
 class SubmittedApplication extends Model {

--- a/views/components/application-card/macro.njk
+++ b/views/components/application-card/macro.njk
@@ -1,9 +1,11 @@
 {% macro applicationCard(props, headingLevel = '3') %}
     {% set cardCopy = __('applyNext.applicationCards') %}
     <article class="application-card">
+
         <header class="application-card__header">
             <h{{ headingLevel }} class="application-card__title u-tone-brand-primary" data-hj-suppress>
-                {% if props.editUrl %}<a href="{{ localify(props.editUrl) }}" class="u-link-unstyled">{% endif %}
+                {% set shouldLink = props.editUrl and not props.isExpired %}
+                {% if shouldLink %}<a href="{{ localify(props.editUrl) }}" class="u-link-unstyled">{% endif %}
                     {% if props.projectName %}
                         {{ props.projectName | widont | safe }}
                     {% else %}
@@ -17,81 +19,94 @@
                         </span>
                     {% endif %}
 
-                {% if props.editUrl %}</a>{% endif %}
+                {% if shouldLink %}</a>{% endif %}
             </h{{ headingLevel }}>
-            <p class="application-card__amount">
-                <strong>{{ cardCopy.amountRequested }}</strong>:
-                <span class="o-pill" data-hj-suppress>
-                    {{ props.amountRequested }}
-                </span>
-            </p>
+
+            {% if not props.isExpired %}
+                <p class="application-card__amount">
+                    <strong>{{ cardCopy.amountRequested }}</strong>:
+                    <span class="o-pill" data-hj-suppress>
+                        {{ props.amountRequested }}
+                    </span>
+                </p>
+            {% endif %}
         </header>
 
-        <dl class="application-card__overview u-text-small">
-            {% for item in props.overview %}
-                <dt>{{ item.label }}</dt>
-                <dd data-hj-suppress>{% if item.value %}{{ item.value }}{% else %}{{ cardCopy.notYetCompleted }}{% endif %}</dd>
-            {% endfor %}
-        </dl>
+        {% if props.isExpired %}
+            <p><strong>{{ __('applyNext.expired.title') }}</strong></p>
+            <p>{{ __('applyNext.expired.summary') }}</p>
+            <div class="application-card__status u-text-small u-margin-bottom">
+                {{ __('applyNext.expired.message', formatDate(props.expiresAt)) }}
+            </div>
+        {% else %}
 
-        <div class="application-card__status u-text-small u-margin-bottom">
-            {% if props.type === 'submitted' %}
-                <p>
-                    <strong>{{ cardCopy.status }}</strong>:
-                    {{ cardCopy.submitted }} {{ formatCalendarTime(props.submittedAt) }}
-                </p>
-            {% else %}
-                <p>
-                    <strong>{{ cardCopy.status }}</strong>:
-                    {{ __(
-                        cardCopy.sectionsCompleted,
-                        props.progress.sectionsComplete,
-                        props.progress.sections.length
-                    ) }}
-                </p>
+            <dl class="application-card__overview u-text-small">
+                {% for item in props.overview %}
+                    <dt>{{ item.label }}</dt>
+                    <dd data-hj-suppress>{% if item.value %}{{ item.value }}{% else %}{{ cardCopy.notYetCompleted }}{% endif %}</dd>
+                {% endfor %}
+            </dl>
 
-                <ol class="status-bar">
-                    {% for section in props.progress.sections %}
-                        <li class="status-bar__step status-bar__step--{{ section.status }}">
-                            <span class="u-visually-hidden">
-                                {{ section.label }} - {{ section.statusLabel }}
-                            </span>
-                        </li>
-                    {% endfor %}
-                </ol>
+            <div class="application-card__status u-text-small u-margin-bottom">
+                {% if props.type === 'submitted' %}
+                    <p>
+                        <strong>{{ cardCopy.status }}</strong>:
+                        {{ cardCopy.submitted }} {{ formatCalendarTime(props.submittedAt) }}
+                    </p>
+                {% else %}
+                    <p>
+                        <strong>{{ cardCopy.status }}</strong>:
+                        {{ __(
+                            cardCopy.sectionsCompleted,
+                            props.progress.sectionsComplete,
+                            props.progress.sections.length
+                        ) }}
+                    </p>
 
-                <p>{{ cardCopy.lastUpdated }}: {{ formatCalendarTime(props.updatedAt) }}</p>
-            {% endif %}
-        </div>
+                    <ol class="status-bar">
+                        {% for section in props.progress.sections %}
+                            <li class="status-bar__step status-bar__step--{{ section.status }}">
+                                <span class="u-visually-hidden">
+                                    {{ section.label }} - {{ section.statusLabel }}
+                                </span>
+                            </li>
+                        {% endfor %}
+                    </ol>
 
-        {% if props.editUrl %}
-            <div class="application-card__actions">
-                <a href="{{ localify(props.editUrl) }}"
-                   class="btn btn--small">
-                    {{ cardCopy.continue }}
-                    <span class="u-visually-hidden">
-                        — {{ props.projectName or props.untitledName }}
-                        {%- if not props.projectName %}
-                            {{ __(
-                                cardCopy.createdAt,
-                                formatDate(props.createdAt, "DD/MM/YY"),
-                                formatDate(props.createdAt, "h:mma")
-                            ) }}
-                        {%- endif %}
-                    </span>
-                </a>
-                {% if props.deleteUrl %}
-                    <a class="u-text-medium" href="{{ props.deleteUrl }}">
-                        {{ cardCopy.delete }}
-                    </a>
+                    <p>{{ cardCopy.lastUpdated }}: {{ formatCalendarTime(props.updatedAt) }}</p>
                 {% endif %}
             </div>
+
+            {% if props.editUrl %}
+                <div class="application-card__actions">
+                    <a href="{{ localify(props.editUrl) }}"
+                       class="btn btn--small">
+                        {{ cardCopy.continue }}
+                        <span class="u-visually-hidden">
+                            — {{ props.projectName or props.untitledName }}
+                            {%- if not props.projectName %}
+                                {{ __(
+                                    cardCopy.createdAt,
+                                    formatDate(props.createdAt, "DD/MM/YY"),
+                                    formatDate(props.createdAt, "h:mma")
+                                ) }}
+                            {%- endif %}
+                        </span>
+                    </a>
+                    {% if props.deleteUrl %}
+                        <a class="u-text-medium" href="{{ props.deleteUrl }}">
+                            {{ cardCopy.delete }}
+                        </a>
+                    {% endif %}
+                </div>
+            {% endif %}
+
+            {% if props.expiresAt %}
+                <div class="application-card__meta u-text-small">
+                    {{ __(cardCopy.expiresAt, formatDate(props.expiresAt)) | safe }}
+                </div>
+            {% endif %}
         {% endif %}
 
-        {% if props.expiresAt %}
-            <div class="application-card__meta u-text-small">
-                {{ __(cardCopy.expiresAt, formatDate(props.expiresAt)) | safe }}
-            </div>
-        {% endif %}
     </article>
 {% endmacro %}


### PR DESCRIPTION
Dashboards will now show this message for any application whose `expiryDate` is in the past:

![image](https://user-images.githubusercontent.com/394376/71105949-50b49d80-21b6-11ea-81be-14c48b71e83f.png)

If they somehow managed to still get into the application itself, they'll always see this:

![image](https://user-images.githubusercontent.com/394376/71105971-5ca05f80-21b6-11ea-8344-099a8c494cb0.png)

This change also includes the expiry **time** as well as date, eg. the actual date stored in the database. This removes the confusion when someone could still edit their application when it was scheduled to be deleted and might go at any minute.

Now, if we tell someone their application expires at 11am, they can edit it until then, but it will be deleted at the next Lambda run (eg. 4pm currently) and they won't be able to access it from 11am onwards.