### PR TITLE
Tweak expiry metadata

### DIFF
--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -166,9 +166,11 @@ async function sendExpiryEmails(req, emailQueue) {
                 if (enableExpiration) {
                     returnObj.emailSent = true;
 
-                    const dbStatus = (await ApplicationEmailQueue.updateStatusToSent(
-                        emailToSend.id
-                    ))[0];
+                    const dbStatus = (
+                        await ApplicationEmailQueue.updateStatusToSent(
+                            emailToSend.id
+                        )
+                    )[0];
 
                     if (dbStatus === 1) {
                         returnObj.dbUpdated = true;
@@ -201,7 +203,8 @@ async function deleteExpiredApplications(expiredApplications) {
 
             expiredApplications.forEach(application => {
                 logger.info(`Deleting expired application`, {
-                    formId: application.formId
+                    formId: application.formId,
+                    applicationStatus: application.currentProgressState
                 });
             });
 

--- a/controllers/apply/form-router/lib/emailQueue.js
+++ b/controllers/apply/form-router/lib/emailQueue.js
@@ -5,6 +5,7 @@ function generateEmailQueueItems(application, expiryEmailPeriods) {
     return expiryEmailPeriods.map(emailConfig => {
         return {
             applicationId: application.id,
+            userId: application.userId,
             emailType: emailConfig.emailType,
             dateToSend: moment(application.expiresAt)
                 .subtract(

--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -373,6 +373,17 @@ class ApplicationEmailQueue extends Model {
             },
 
             /**
+             * User model reference
+             * (optional as it was added after the model was created)
+             * Intended to allow looking up a user's deleted applications
+             * after the application itself was deleted
+             */
+            userId: {
+                type: DataTypes.INTEGER,
+                allowNull: true
+            },
+
+            /**
              * Email type
              * e.g. AFA_ONE_MONTH, GET_ADVICE_ONE_WEEK etc
              */

--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -115,7 +115,7 @@ class PendingApplication extends Model {
 
     static findExpiredApplications() {
         return this.findAll({
-            attributes: ['id', 'formId'],
+            attributes: ['id', 'formId', 'currentProgressState'],
             where: {
                 expiresAt: {
                     [Op.lte]: moment().toDate()


### PR DESCRIPTION
Two things here:

1. Log in Datadog the application status (eg. `PENDING`, `COMPLETE` etc) when we delete expired apps. This will give us some (potentially painful) data on what state these apps are in at expiry time.

2. Log the `userId` in the email queue table. This is to aid debugging in the case where a customer gets in touch after their application has expired but we can't prove it was deleted as we don't know its application ID.