### PR TITLE
🐛 Fix incorrect option value on standard form

### DIFF
--- a/controllers/apply/lib/field-types/radio.js
+++ b/controllers/apply/lib/field-types/radio.js
@@ -1,5 +1,6 @@
 'use strict';
 const find = require('lodash/fp/find');
+const uniq = require('lodash/uniq');
 const castArray = require('lodash/castArray');
 const Joi = require('../joi-extensions');
 
@@ -12,6 +13,11 @@ class RadioField extends Field {
         const options = props.options || [];
         if (options.length === 0) {
             throw Error('Must provide options');
+        }
+
+        const values = options.map(option => option.value);
+        if (values.length !== uniq(values).length) {
+            throw new Error('Options must contain unique values');
         }
 
         this.options = options;

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -596,7 +596,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     })
                 },
                 {
-                    value: 'unregistered-vco',
+                    value: 'unincorporated-registered-charity',
                     label: localise({
                         en: `Registered charity (unincorporated)`,
                         cy: `Elusen gofrestredig (anghorfforedig)`


### PR DESCRIPTION
One of the values for the organisation type field on the standard form is incorrect, using a duplicate value for `unregistered-vco` instead of `unincorporated-registered-charity`.

Added a guard in the radio field type first to throw an error if option values are not unique and then updated the value.