### PR TITLE
Add additional guards for unique option values

### DIFF
--- a/controllers/apply/lib/field-types/checkbox.js
+++ b/controllers/apply/lib/field-types/checkbox.js
@@ -1,7 +1,6 @@
 'use strict';
 const castArray = require('lodash/castArray');
-const filter = require('lodash/filter');
-const includes = require('lodash/includes');
+const uniq = require('lodash/uniq');
 const Joi = require('../joi-extensions');
 
 const Field = require('./field');
@@ -15,6 +14,11 @@ class CheckboxField extends Field {
         const options = props.options || [];
         if (options.length === 0) {
             throw new Error('Must provide options');
+        }
+
+        const values = options.map(option => option.value);
+        if (values.length !== uniq(values).length) {
+            throw new Error('Options must contain unique values');
         }
 
         this.options = options;
@@ -39,8 +43,8 @@ class CheckboxField extends Field {
         if (this.value) {
             const choices = castArray(this.value);
 
-            const matches = filter(this.options, option =>
-                includes(choices, option.value)
+            const matches = this.options.filter(option =>
+                choices.includes(option.value)
             );
 
             return matches.length > 0

--- a/controllers/apply/lib/field-types/checkbox.test.js
+++ b/controllers/apply/lib/field-types/checkbox.test.js
@@ -2,11 +2,11 @@
 'use strict';
 const CheckboxField = require('./checkbox');
 
-test('CheckboxField', function() {
+test('checkbox field', function() {
     const field = new CheckboxField({
         locale: 'en',
         name: 'example',
-        label: 'Checkbox field',
+        label: 'Example field',
         options: [
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' },
@@ -24,4 +24,19 @@ test('CheckboxField', function() {
     expect(field.validate().error.message).toEqual(
         expect.stringContaining('must be one of')
     );
+});
+
+test('checkbox field options must contain unique values', function() {
+    expect(() => {
+        new CheckboxField({
+            locale: 'en',
+            name: 'example',
+            label: 'Example field',
+            options: [
+                { label: 'Option 1', value: 'duplicate-value' },
+                { label: 'Option 2', value: 'duplicate-value' },
+                { label: 'Option 3', value: 'option-3' }
+            ]
+        });
+    }).toThrowError('Options must contain unique values');
 });

--- a/controllers/apply/lib/field-types/radio.test.js
+++ b/controllers/apply/lib/field-types/radio.test.js
@@ -2,11 +2,11 @@
 'use strict';
 const RadioField = require('./radio');
 
-test('RadioField', function() {
+test('radio field', function() {
     const field = new RadioField({
         locale: 'en',
         name: 'example',
-        label: 'Radio field',
+        label: 'Example field',
         options: [
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' }
@@ -23,4 +23,19 @@ test('RadioField', function() {
     expect(field.validate().error.message).toEqual(
         expect.stringContaining('must be one of')
     );
+});
+
+test('radio field options must contain unique values', function() {
+    expect(() => {
+        new RadioField({
+            locale: 'en',
+            name: 'example',
+            label: 'Example field',
+            options: [
+                { label: 'Option 1', value: 'duplicate-value' },
+                { label: 'Option 2', value: 'duplicate-value' },
+                { label: 'Option 3', value: 'option-3' }
+            ]
+        });
+    }).toThrowError('Options must contain unique values');
 });

--- a/controllers/apply/lib/field-types/select.test.js
+++ b/controllers/apply/lib/field-types/select.test.js
@@ -2,11 +2,11 @@
 'use strict';
 const SelectField = require('./select');
 
-test('SelectField', function() {
+test('select field', function() {
     const field = new SelectField({
         locale: 'en',
         name: 'example',
-        label: 'Checkbox field',
+        label: 'Example field',
         options: [
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' },
@@ -24,4 +24,62 @@ test('SelectField', function() {
     expect(field.validate().error.message).toEqual(
         expect.stringContaining('must be one of')
     );
+});
+
+test('select field supports optgroups', function() {
+    const field = new SelectField({
+        locale: 'en',
+        name: 'example',
+        label: 'Example field',
+        defaultOption: 'Select an option',
+        optgroups: [
+            {
+                label: 'Group 1',
+                options: [{ label: 'Option 1', value: 'option-1' }]
+            },
+            {
+                label: 'Group 2',
+                options: [{ label: 'Option 2', value: 'option-2' }]
+            }
+        ]
+    });
+
+    expect(field.normalisedOptions).toEqual([
+        { label: 'Option 1', value: 'option-1' },
+        { label: 'Option 2', value: 'option-2' }
+    ]);
+});
+
+test('select field options must contain unique values', function() {
+    expect(() => {
+        new SelectField({
+            locale: 'en',
+            name: 'example',
+            label: 'Example field',
+            options: [
+                { label: 'Option 1', value: 'duplicate-value' },
+                { label: 'Option 2', value: 'duplicate-value' },
+                { label: 'Option 3', value: 'option-3' }
+            ]
+        });
+    }).toThrowError('Options must contain unique values');
+
+    expect(() => {
+        new SelectField({
+            locale: 'en',
+            name: 'example',
+            label: 'Example field',
+            defaultOption: 'Select an option',
+            optgroups: [
+                {
+                    label: 'Group 1',
+                    options: [{ label: 'Option 1', value: 'duplicate-value' }]
+                },
+                {
+                    label: 'Group 2',
+                    options: [{ label: 'Option 2', value: 'duplicate-value' }]
+                }
+            ]
+        });
+    }).toThrowError('Options must contain unique values');
 });


### PR DESCRIPTION
Expands guards for unique values to radio options in https://github.com/biglotteryfund/blf-alpha/pull/2793 to checkbox and select fields. Adds unit tests to confirm this works for both plain options and opt-groups in selects too.