### PR TITLE
Tweak submission failed error

### DIFF
--- a/controllers/apply/form-router/submission.js
+++ b/controllers/apply/form-router/submission.js
@@ -167,7 +167,7 @@ module.exports = function(
 
             renderConfirmation();
         } catch (error) {
-            logger.error('Submission failed', error);
+            logger.error('Submission failed');
 
             /**
              * Salesforce submission failed,
@@ -181,11 +181,9 @@ module.exports = function(
                 if (response.status !== 'OK') {
                     logger.info(`Salesforce status ${response.status}`);
                 }
+            } catch (e) {} // eslint-disable-line no-empty
 
-                next(error);
-            } catch (statusError) {
-                next(error);
-            }
+            next(error);
         }
     });
 


### PR DESCRIPTION
The submission failed error was appearing in Datadog with the error stack appended e.g. `Submission failed500 - …` causing the errors not to show up reliably on the dashboard. 

As we get the full stack trace in a much more readable format in Sentry we can limit the log line to just tell us that the submission failed and defer to Sentry for the full stack trace.