### PR TITLE
Collect metrics for memory usage

### DIFF
--- a/deploy/cloudwatch-agent.json
+++ b/deploy/cloudwatch-agent.json
@@ -2,6 +2,13 @@
   "agent": {
     "run_as_user": "root"
   },
+  "metrics": {
+    "metrics_collected": {
+      "mem": {
+        "measurement": ["mem_used_percent"]
+      }
+    }
+  },
   "logs": {
     "logs_collected": {
       "files": {


### PR DESCRIPTION
Bare minimum config to collect memory usage metrics through the CloudWatch agent.