### PR TITLE
Add static error page

### DIFF
--- a/public/html/error.html
+++ b/public/html/error.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html>
+<head>
+    <title>#CelebrateNationalLottery25</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
+
+    <link rel="stylesheet" href="https://use.typekit.net/yyc1dgh.css">
+
+    <style>
+        body {
+            font-family: 'caecilia-sans-text', 'Trebuchet MS', sans-serif;
+        }
+        main {
+            margin: 6em auto;
+            max-width: 700px;
+            display: block;
+        }
+        article {
+            border: 1px solid hsla(0,0%,79.2%,.5);
+            border-top: 4px solid #e5007d;
+            padding: 20px;
+        }
+        h1 {
+            margin-top: 0;
+        }
+        p {
+            margin: 2em auto;
+        }
+        img {
+            margin: 2em 0;
+            display: block;
+        }
+    </style>
+</head>
+<body>
+
+<main>
+
+    <img src="../images/site-logo-bilingual.svg" alt="The National Lottery Community Fund logo" width="250" />
+
+    <article>
+        <h1>The National Lottery Community Fund</h1>
+        <h2>Error</h2>
+
+        <p>We're sorry, we are unable to show you this page at the moment. You can visit us on <a href="https://www.facebook.com/TNLCommunityFund">Facebook</a> or <a href="https://twitter.com/TNLComFund">Twitter</a>.</p>
+        <p>If you keep encountering problems accessing our pages, please <a href="mailto:webmaster@tnlcommunityfund.org.uk">let us know</a>.</p>
+
+        <h2>Gwall</h2>
+        <p>Yn anffodus ni allwn ddangos y dudalen hon ar hyn o bryd. Ymweld â ni ar <a href="http://facebook.com/TNLCommunityFundwales">Facebook</a> neu <a href="http://twitter.com/CronGymYLG">Twitter</a>. Os byddwch yn profi anhawster o hyd wrth gyrchu ein tudalennau, <a href="mailto:webmaster@tnlcommunityfund.org.uk">rhowch wybod i ni</a>.</p>
+    </article>
+</main>
+
+</body>
+</html>

--- a/public/html/error.html
+++ b/public/html/error.html
@@ -12,8 +12,12 @@
         body {
             font-family: 'caecilia-sans-text', 'Trebuchet MS', sans-serif;
         }
+        h1, h2 {
+            font-family: caecilia;
+            margin: 0;
+        }
         main {
-            margin: 5em auto;
+            margin: 4em auto;
             max-width: 750px;
             display: block;
         }
@@ -22,20 +26,25 @@
             border-top: 4px solid #e5007d;
             padding: 20px;
         }
-        h1 {
-            margin-top: 0;
-            margin-bottom: 1em;
-            font-size: 24px;
-        }
         h2 {
             font-size: 20px;
         }
         p {
-            margin: 2em auto;
+            margin: 0 0 2em 0;
+            line-height: 1.5;
         }
         img {
-            margin: 2em 0;
+            margin: 1em 0;
             display: block;
+        }
+        a {
+            color: #0075b0;
+        }
+
+        hr {
+            border: 0;
+            border-top: 1px solid rgba(202, 202, 202, 0.5);
+            margin: 3em 0;
         }
     </style>
 </head>
@@ -43,23 +52,26 @@
 
 <main>
 
-    <img src="../images/site-logo-bilingual.svg" alt="The National Lottery Community Fund logo" width="200" />
+    <h1><img src="../images/site-logo-bilingual.svg" alt="The National Lottery Community Fund / Cronfa Gymunedol y Loteri Genedlaethol" width="200" /></h1>
 
     <article>
-        <h1>The National Lottery Community Fund</h1>
         <h2>Sorry, our website isn't working right now</h2>
         <p>But we're aware of the problem - and are working to fix it as soon as possible.</p>
 
-        <p><strong>If you keep having issues visiting our website</strong></p>
-        <p>Call us on <a href="tel:03454102030">0345 4 10 20 30</a> or email <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. You can also visit our <a href="https://www.facebook.com/TNLCommunityFund">Facebook</a> or <a href="https://twitter.com/TNLComFund">Twitter</a> pages.</p>
+        <p>
+            <strong>If you keep having issues visiting our website</strong><br />
+            Call us on <a href="tel:03454102030">0345 4 10 20 30</a> or email <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. You can also visit our <a href="https://www.facebook.com/TNLCommunityFund">Facebook</a> or <a href="https://twitter.com/TNLComFund">Twitter</a> pages.
+        </p>
 
+        <hr />
 
-        <h1>Cronfa Gymunedol y Loteri Genedlaethol</h1>
         <h2>Mae’n ddrwg gennym, nid yw ein gwefan yn gweithio ar hyn o bryd</h2>
         <p>Ond rydym yn ymwybodol o’r broblem – ac yn gweithio i’w drwsio mor fuan â phosibl.</p>
 
-        <p><strong>Os ydych yn parhau i gael problemau wrth ymweld â’n gwefan</strong></p>
-        <p>Ffoniwch ni ar <a href="tel:03454102030">0345 4 10 20 30</a> neu e-bostio <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. Gallwch hefyd ymweld â’n tudalennau <a href="http://facebook.com/TNLCommunityFundwales">Facebook</a> neu <a href="http://twitter.com/CronGymYLG">Twitter</a>.
+        <p>
+            <strong>Os ydych yn parhau i gael problemau wrth ymweld â’n gwefan</strong><br />
+            Ffoniwch ni ar <a href="tel:03454102030">0345 4 10 20 30</a> neu e-bostio <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. Gallwch hefyd ymweld â’n tudalennau <a href="http://facebook.com/TNLCommunityFundwales">Facebook</a> neu <a href="http://twitter.com/CronGymYLG">Twitter</a>.
+        </p>
 
     </article>
 </main>

--- a/public/html/error.html
+++ b/public/html/error.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Error | The National Lottery Community Fund</title>
+    <title>Error / Gwall | The National Lottery Community Fund</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">
@@ -13,8 +13,8 @@
             font-family: 'caecilia-sans-text', 'Trebuchet MS', sans-serif;
         }
         main {
-            margin: 6em auto;
-            max-width: 700px;
+            margin: 5em auto;
+            max-width: 750px;
             display: block;
         }
         article {
@@ -24,6 +24,11 @@
         }
         h1 {
             margin-top: 0;
+            margin-bottom: 1em;
+            font-size: 24px;
+        }
+        h2 {
+            font-size: 20px;
         }
         p {
             margin: 2em auto;
@@ -38,17 +43,24 @@
 
 <main>
 
-    <img src="../images/site-logo-bilingual.svg" alt="The National Lottery Community Fund logo" width="250" />
+    <img src="../images/site-logo-bilingual.svg" alt="The National Lottery Community Fund logo" width="200" />
 
     <article>
         <h1>The National Lottery Community Fund</h1>
-        <h2>Error</h2>
+        <h2>Sorry, our website isn't working right now</h2>
+        <p>But we're aware of the problem - and are working to fix it as soon as possible.</p>
 
-        <p>We're sorry, we are unable to show you this page at the moment. You can visit us on <a href="https://www.facebook.com/TNLCommunityFund">Facebook</a> or <a href="https://twitter.com/TNLComFund">Twitter</a>.</p>
-        <p>If you keep encountering problems accessing our pages, please <a href="mailto:webmaster@tnlcommunityfund.org.uk">let us know</a>.</p>
+        <p><strong>If you keep having issues visiting our website</strong></p>
+        <p>Call us on <a href="tel:03454102030">0345 4 10 20 30</a> or email <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. You can also visit our <a href="https://www.facebook.com/TNLCommunityFund">Facebook</a> or <a href="https://twitter.com/TNLComFund">Twitter</a> pages.</p>
 
-        <h2>Gwall</h2>
-        <p>Yn anffodus ni allwn ddangos y dudalen hon ar hyn o bryd. Ymweld â ni ar <a href="http://facebook.com/TNLCommunityFundwales">Facebook</a> neu <a href="http://twitter.com/CronGymYLG">Twitter</a>. Os byddwch yn profi anhawster o hyd wrth gyrchu ein tudalennau, <a href="mailto:webmaster@tnlcommunityfund.org.uk">rhowch wybod i ni</a>.</p>
+
+        <h1>Cronfa Gymunedol y Loteri Genedlaethol</h1>
+        <h2>Mae’n ddrwg gennym, nid yw ein gwefan yn gweithio ar hyn o bryd</h2>
+        <p>Ond rydym yn ymwybodol o’r broblem – ac yn gweithio i’w drwsio mor fuan â phosibl.</p>
+
+        <p><strong>Os ydych yn parhau i gael problemau wrth ymweld â’n gwefan</strong></p>
+        <p>Ffoniwch ni ar <a href="tel:03454102030">0345 4 10 20 30</a> neu e-bostio <a href="mailto:general.enquiries@tnlcommunityfund.org.uk">general.enquiries@tnlcommunityfund.org.uk</a>. Gallwch hefyd ymweld â’n tudalennau <a href="http://facebook.com/TNLCommunityFundwales">Facebook</a> neu <a href="http://twitter.com/CronGymYLG">Twitter</a>.
+
     </article>
 </main>
 

--- a/public/html/error.html
+++ b/public/html/error.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>#CelebrateNationalLottery25</title>
+    <title>Error | The National Lottery Community Fund</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">


### PR DESCRIPTION
Adds this page as a static file:

![image](https://user-images.githubusercontent.com/394376/71990279-02317680-322b-11ea-8c17-4981b36abb88.png)

This can be served out of S3 when we configure Cloudfront rules like so:

![image](https://user-images.githubusercontent.com/394376/71990372-25f4bc80-322b-11ea-8d82-bb370db44a9b.png)

We could probably test/simulate this by cheekily adding some routes by live-editing the TEST instance and adding something like this to a controller:

```
router.get('/error/:code', (req, res, next) => {
  return res.status(req.params.code).json({
      status: 'error',
      errorCode: req.params.code
  });
});
```
Then we could mock (say) 503 responses on TEST and confirm this page appears. Unless you have a better idea for triggering a real 5xx error...