### PR TITLE
Correct logging for application expiry Lambda function

### DIFF
--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -201,14 +201,17 @@ async function deleteExpiredApplications(expiredApplications) {
 
             const dbStatus = await PendingApplication.deleteBatch(ids);
 
-            expiredApplications.forEach(application => {
+            const status = expiredApplications.map(application => {
                 logger.info(`Deleting expired application`, {
                     formId: application.formId,
                     applicationStatus: application.currentProgressState
                 });
+                return {
+                    applicationDeleted: true
+                };
             });
 
-            return dbStatus === expiredApplications.length;
+            return dbStatus === expiredApplications.length ? status : false;
         } else {
             logger.info(
                 `Simulated deleting ${expiredApplications.length} expired applications`


### PR DESCRIPTION
Noticed there was an issue with how we log expiries compared to expiry emails. Lambda function currently gets this output:

```
{
    "emailQueue": [],
    "expired": true
}

```
`expired` there should be an array for each expiry processed (like the `emailQueue` is) rather than a success/fail flag.

This change makes it match `emailQueue`, so the output will be:
```

{
  "emailQueue": [],
  "expired": [
    {
      "applicationDeleted": true
    },
    {
      "applicationDeleted": true
    }
  ]
}
```