### PR TITLE
Sleep for 3m 30s

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -12,7 +12,7 @@ apt-get install -y nginx-extras libnginx-mod-http-passenger
 # Install ClamAV
 apt-get install -y clamav clamav-daemon
 service clamav-freshclam restart
-sleep 3m
+sleep 210s
 service clamav-daemon start
 service clamav-daemon status
 


### PR DESCRIPTION
Increase clamav sleep. sleep doesn't seem to support a syntax of 3m30 so have used plain seconds.