### PR TITLE
Replace arbitrary sleep with while check

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -9,10 +9,18 @@ sh -c 'echo deb https://oss-binaries.phusionpassenger.com/apt/passenger bionic m
 apt-get update
 apt-get install -y nginx-extras libnginx-mod-http-passenger
 
-# Install ClamAV
+# Install ClamAV and start fetching virus datbases
 apt-get install -y clamav clamav-daemon
 service clamav-freshclam restart
-sleep 210s
+
+# Wait for daily virus database to be ready
+while [ ! -f /var/lib/clamav/daily.cvd ]
+do
+    sleep 1
+done
+sleep 5
+
+# Start clamd
 service clamav-daemon start
 service clamav-daemon status
 


### PR DESCRIPTION
Test using a while check on the existence of the virus database before starting clamav-daemon