### PR TITLE
Manually download initial clamav database

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -11,8 +11,13 @@ apt-get install -y nginx-extras libnginx-mod-http-passenger
 
 # Install ClamAV
 apt-get install -y clamav clamav-daemon
-service clamav-freshclam restart
-sleep 210s
+
+# Initial update of antivirus databases
+# We do this so that we can start clamav-daemon without an arbitrary `sleep`
+wget -O /var/lib/clamav/main.cvd https://database.clamav.net/main.cvd && \
+wget -O /var/lib/clamav/daily.cvd https://database.clamav.net/daily.cvd && \
+wget -O /var/lib/clamav/bytecode.cvd https://database.clamav.net/bytecode.cvd
+
 service clamav-daemon start
 service clamav-daemon status
 


### PR DESCRIPTION
After reviewing a few more clamav install scripts, notably Dockerfiles, noticed that a common approach was to manually download the three database files upfront before starting freshclam in the background. Tested these steps on a plain Ubuntu VM successfully so worth giving this a go.