### PR TITLE
Add an error message for budgets with £0 items

### DIFF
--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -441,7 +441,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                     {
                         type: 'number.min',
                         message: localise({
-                            en: 'Items must cost £1 or more',
+                            en: 'Amount must be £1 or more',
                             cy: `Rhaid i'r eitemau gostio £1 neu fwy`
                         })
                     },

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -439,6 +439,13 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                         })
                     },
                     {
+                        type: 'number.min',
+                        message: localise({
+                            en: 'Items must cost £1 or more',
+                            cy: `Rhaid i'r eitemau gostio £1 neu fwy`
+                        })
+                    },
+                    {
                         type: 'array.min',
                         message: localise({
                             en: 'Enter at least one item',


### PR DESCRIPTION
We only showed a generic error here so this adds a more useful one if someone deliberately enters a £0 item. 

I guess we could just allow these through but it seems a bit redundant to me.