### PR TITLE
Skip straight to success screen if a duplicate application submission occurs

### DIFF
--- a/controllers/apply/form-router/submission.js
+++ b/controllers/apply/form-router/submission.js
@@ -50,7 +50,9 @@ module.exports = function(
             currentApplication.id
         );
         if (submittedApplicationExists) {
-            logger.info('Duplicate submission prevented');
+            logger.warn('Duplicate submission prevented', {
+                applicationId: currentApplication.id
+            });
             return renderConfirmation();
         }
 

--- a/controllers/apply/form-router/submission.js
+++ b/controllers/apply/form-router/submission.js
@@ -43,6 +43,17 @@ module.exports = function(
             return res.redirect(req.baseUrl);
         }
 
+        // Check whether this form has already been submitted
+        // (eg. accidental double click, reloading success screen etc)
+        // and show a success message without attempting to submit again
+        const submittedApplicationExists = await SubmittedApplication.findByPk(
+            currentApplication.id
+        );
+        if (submittedApplicationExists) {
+            logger.info('Duplicate submission prevented');
+            return renderConfirmation();
+        }
+
         function renderConfirmation() {
             unset(req.session, currentlyEditingSessionKey());
             req.session.save(function() {


### PR DESCRIPTION
Found this tricky to reproduce as reloading the success screen kicks you into the dashboard (as your currently-editing ID session key is deleted after submission), but it's possible that double clicks on submit might cause this, or weird network dropouts etc. Either way, this detects an existing submission and just renders the success screen instead of trying to re-insert it.