### PR TITLE
Remove noindex from user routes

### DIFF
--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -13,10 +13,7 @@ const logger = require('../../common/logger');
 
 const router = express.Router();
 
-router.use(noStore, function(req, res, next) {
-    res.setHeader('X-Robots-Tag', 'noindex');
-    next();
-});
+router.use(noStore);
 
 /**
  * Staff auth


### PR DESCRIPTION
Noticed that useful pages like login, register, and forgotten password don't show up in search indexes. This is because we have `noindex` across all user routes. I had thought about removing it selectively on those three routes, but clocked that user auth would prevent any private routes from being indexed anyway so we are better off removing it.