### PR TITLE
Vary lead times based on country

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1782,7 +1782,8 @@ awardsForAll:
             description: >
               Tell us about your idea to help people improve their lives and communities.
               You’ll have up to three months to finish your online application form.
-              Once you send us your application, it’ll take around 18 weeks for us to assess it.
+              Once you send us your application, it’ll take around 12 weeks for us to assess it
+              (or 18 weeks for projects in England).
           - type: action
             title: Application assessed
           - type: step

--- a/controllers/apply/awards-for-all/__snapshots__/confirmation.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/confirmation.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`confirmation builder should return confirmation text based on country 1`] = `
+exports[`should return confirmation text based on country 1`] = `
 <p>
   Thank you for submitting your application to National Lottery Awards for All.
 </p>
@@ -40,7 +40,7 @@ exports[`confirmation builder should return confirmation text based on country 1
 </p>
 `;
 
-exports[`confirmation builder should return confirmation text based on country 2`] = `
+exports[`should return confirmation text based on country 2`] = `
 <p>
   Thank you for submitting your application to National Lottery Awards for All.
 </p>
@@ -51,7 +51,7 @@ exports[`confirmation builder should return confirmation text based on country 2
   We will now review your application and may contact you
     to find out more about your project. It will take around
   <strong>
-    18 weeks
+    12 weeks
   </strong>
   for us to make a decision and we will
     let you know whether you have been successful by email.

--- a/controllers/apply/awards-for-all/confirmation.js
+++ b/controllers/apply/awards-for-all/confirmation.js
@@ -1,8 +1,6 @@
 'use strict';
 const { get } = require('lodash/fp');
 
-const { MIN_START_DATE } = require('./constants');
-
 function getEmailFor(country) {
     const countryEmail = {
         'default': 'general.enquiries@tnlcommunityfund.org.uk',
@@ -35,7 +33,7 @@ module.exports = function({ locale, data = {} }) {
 <p>
     We will now review your application and may contact you
     to find out more about your project. It will take around
-    <strong>${localise(MIN_START_DATE.label)}</strong>
+    <strong>18 weeks</strong>
     for us to make a decision and we will
     let you know whether you have been successful by email.
 </p>
@@ -62,7 +60,7 @@ module.exports = function({ locale, data = {} }) {
 <p>
     Byddwn nawr yn adolygu eich cais ac efallai byddwn mewn cysylltiad i 
     ddarganfod mwy am eich prosiect. Bydd yn cymryd oddeutu
-    <strong>${localise(MIN_START_DATE.label)}</strong>
+    <strong>18 wythnos</strong>
     i ni wneud penderfyniad a byddwn yn gadael i chi wybod 
     p’un a ydych wedi bod yn llwyddiannus ai beidio drwy e-bost.
 </p>

--- a/controllers/apply/awards-for-all/confirmation.js
+++ b/controllers/apply/awards-for-all/confirmation.js
@@ -1,6 +1,8 @@
 'use strict';
 const { get } = require('lodash/fp');
 
+const getLeadTimeWeeks = require('./lib/lead-time');
+
 function getEmailFor(country) {
     const countryEmail = {
         'default': 'general.enquiries@tnlcommunityfund.org.uk',
@@ -33,7 +35,7 @@ module.exports = function({ locale, data = {} }) {
 <p>
     We will now review your application and may contact you
     to find out more about your project. It will take around
-    <strong>18 weeks</strong>
+    <strong>${getLeadTimeWeeks(country)} weeks</strong>
     for us to make a decision and we will
     let you know whether you have been successful by email.
 </p>
@@ -60,7 +62,7 @@ module.exports = function({ locale, data = {} }) {
 <p>
     Byddwn nawr yn adolygu eich cais ac efallai byddwn mewn cysylltiad i 
     ddarganfod mwy am eich prosiect. Bydd yn cymryd oddeutu
-    <strong>18 wythnos</strong>
+    <strong>${getLeadTimeWeeks(country)} wythnos</strong>
     i ni wneud penderfyniad a byddwn yn gadael i chi wybod 
     p’un a ydych wedi bod yn llwyddiannus ai beidio drwy e-bost.
 </p>

--- a/controllers/apply/awards-for-all/confirmation.test.js
+++ b/controllers/apply/awards-for-all/confirmation.test.js
@@ -1,22 +1,19 @@
 /* eslint-env jest */
-// @ts-nocheck
 'use strict';
 const confirmationBuilder = require('./confirmation');
 
-describe('confirmation builder', () => {
-    test('should return confirmation text based on country', () => {
-        const england = confirmationBuilder({
-            locale: 'en',
-            data: { projectCountry: 'england' }
-        });
-
-        expect(england.body).toMatchSnapshot();
-
-        const scotland = confirmationBuilder({
-            locale: 'en',
-            data: { projectCountry: 'scotland' }
-        });
-
-        expect(scotland.body).toMatchSnapshot();
+test('should return confirmation text based on country', () => {
+    const england = confirmationBuilder({
+        locale: 'en',
+        data: { projectCountry: 'england' }
     });
+
+    expect(england.body).toMatchSnapshot();
+
+    const scotland = confirmationBuilder({
+        locale: 'en',
+        data: { projectCountry: 'scotland' }
+    });
+
+    expect(scotland.body).toMatchSnapshot();
 });

--- a/controllers/apply/awards-for-all/constants.js
+++ b/controllers/apply/awards-for-all/constants.js
@@ -17,12 +17,6 @@ const ORG_MIN_AGE = {
     label: { en: '15 months', cy: '15 mis' }
 };
 
-const MIN_START_DATE = {
-    amount: 18,
-    unit: 'weeks',
-    label: { en: '18 weeks', cy: '18 wythnos' }
-};
-
 const SUGGESTED_PROJECT_DURATION = {
     en: '12 months',
     cy: '12 mis'
@@ -131,7 +125,6 @@ module.exports = {
     MIN_AGE_MAIN_CONTACT,
     MIN_AGE_SENIOR_CONTACT,
     MIN_BUDGET_TOTAL_GBP,
-    MIN_START_DATE,
     ORG_MIN_AGE,
     ORGANISATION_TYPES,
     STATUTORY_BODY_TYPES,

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -93,17 +93,16 @@ module.exports = function({ locale }) {
         if (config.get('awardsForAll.enableNewDateRange')) {
             return {
                 question: localise({
-                    en: oneLine`Does your project start at least 12 weeks from
-                      when you plan to submit your application? (If your project
-                      is in England, it needs to start after at least 18 weeks)`,
+                    en: oneLine`Do you want to start your project at least
+                        12 weeks after you plan to send us your application?
+                        (If your project is in England, it needs to start after at least 18 weeks)`,
                     cy: `@TODO i18n`
                 }),
                 explanation: localise({
-                    en: oneLine`We need 12 weeks to be able to assess your application
-                      and pay your grant, if you're successful.
-                      So projects need to start at least 12 weeks from the date
-                      you submit your application to us—unless your project's in England,
-                      where it needs to start after at least 18 weeks.`,
+                    en: oneLine`We need to know because we need to give ourselves
+                        at least 12 weeks to assess your application
+                        (or 18 weeks if your project is in England).
+                        And then make a decision on whether we'll fund your project or not.`,
                     cy: `@TODO i18n`
                 }),
                 yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
@@ -114,25 +113,27 @@ module.exports = function({ locale }) {
                 }),
                 ineligible: {
                     reason: localise({
-                        en: oneLine`This is because you told us that your project
-                        doesn't start at least 12 weeks from when you plan to
-                        submit your application (or after at least 18 weeks
-                        for a project in England).`,
+                        en: oneLine`This is because you want to start your
+                            project sooner than we can assess your application.`,
                         cy: `@TODO i18n`
                     }),
                     detail: localise({
                         en: `<p>
-                        We don't want communities to miss out on a
-                         great idea that will help them thrive.
-                    </p>
-                    <p>
-                        Have a think and see if it's possible to
-                        start your project at least 12 weeks from now 
-                        (or after at least 18 weeks for a project in England).
-                        We need this time to consider your application,
-                        carry out checks and, if successful, pay your grant.
-                        If it is possible, continue with your application.
-                    </p>`,
+                            <strong>Can you start your project a bit later than you planned?</strong></p>
+                            <p>
+                                We don't want communities to miss out on a great
+                                idea that will help them thrive.
+                            <p>
+                                Have a think and see if it's possible to start
+                                your project at least 12 weeks from now
+                                (or 18 weeks from now if your project is in England).
+                            </p>
+
+                            <p><strong>
+                                If you've now decided you can start your project
+                                a bit later than you planned
+                            </strong></p>
+                            <p>Continue your application.</p>`,
                         cy: `@TODO i18n`
                     })
                 }

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -119,21 +119,19 @@ module.exports = function({ locale }) {
                     }),
                     detail: localise({
                         en: `<p>
-                            <strong>Can you start your project a bit later than you planned?</strong></p>
-                            <p>
-                                We don't want communities to miss out on a great
-                                idea that will help them thrive.
-                            <p>
-                                Have a think and see if it's possible to start
-                                your project at least 12 weeks from now
-                                (or 18 weeks from now if your project is in England).
-                            </p>
+                            We don't want communities to miss out on a great
+                            idea that will help them thrive.
+                        <p>
+                            Have a think and see if it's possible to start
+                            your project at least 12 weeks from now
+                            (or 18 weeks from now if your project is in England).
+                        </p>
 
-                            <p><strong>
-                                If you've now decided you can start your project
-                                a bit later than you planned
-                            </strong></p>
-                            <p>Continue your application.</p>`,
+                        <p><strong>
+                            If you've now decided you can start your project
+                            a bit later than you planned
+                        </strong></p>
+                        <p>Continue your application.</p>`,
                         cy: `@TODO i18n`
                     })
                 }

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -95,15 +95,23 @@ module.exports = function({ locale }) {
                 question: localise({
                     en: oneLine`Do you want to start your project at least
                         12 weeks after you plan to send us your application?
-                        (If your project is in England, it needs to start after at least 18 weeks)`,
-                    cy: `@TODO i18n`
+                        (If your project is in England, it needs to start
+                        after at least 18 weeks)`,
+                    cy: oneLine`A ydych eisiau dechrau eich prosiect o leiaf 12
+                        wythnos ar ôl i chi gynllunio anfon eich cais?
+                        (Os yw eich prosiect yn Lloegr, mae angen iddo ddechrau
+                        ar ôl o leiaf 18 wythnos)`
                 }),
                 explanation: localise({
                     en: oneLine`We need to know because we need to give ourselves
                         at least 12 weeks to assess your application
                         (or 18 weeks if your project is in England).
                         And then make a decision on whether we'll fund your project or not.`,
-                    cy: `@TODO i18n`
+                    cy: oneLine`Rydym angen gwybod gan fod angen i ni roi o leiaf
+                        12 wythnos i’n hunain i asesu eich cais
+                        (neu 18 wythnos os yw eich prosiect yn Lloegr).
+                        Ac yna gwneud penderfyniad ar p’un ai byddwn yn
+                        ariannu eich prosiect neu beidio.`
                 }),
                 yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
                 noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
@@ -115,24 +123,39 @@ module.exports = function({ locale }) {
                     reason: localise({
                         en: oneLine`This is because you want to start your
                             project sooner than we can assess your application.`,
-                        cy: `@TODO i18n`
+                        cy: oneLine`Mae hyn oherwydd eich bod eisiau dechrau eich
+                            prosiect yn gynt nag y gallwn asesu eich cais.`
                     }),
                     detail: localise({
                         en: `<p>
                             We don't want communities to miss out on a great
                             idea that will help them thrive.
+                        </p>
                         <p>
                             Have a think and see if it's possible to start
                             your project at least 12 weeks from now
                             (or 18 weeks from now if your project is in England).
                         </p>
-
                         <p><strong>
                             If you've now decided you can start your project
                             a bit later than you planned
                         </strong></p>
                         <p>Continue your application.</p>`,
-                        cy: `@TODO i18n`
+
+                        cy: `<p>
+                            Nid ydym eisiau i gymunedau fethu allan ar syniad
+                            gwych fydd yn eu helpu i ffynnu.
+                        </p>
+                        <p>
+                            Meddyliwch a yw’n bosibl dechrau eich prosiect
+                            o leiaf 12 wythnos oddi wrth o nawr (neu 18 wythnos
+                            oddi wrth o nawr os yw eich prosiect yn Lloegr).
+                        </p>
+                        <p><strong>
+                            Os ydych nawr wedi penderfynu y gallwch ddechrau
+                            eich prosiect ychydig yn ddiweddarach nag y cynllunioch chi
+                        </strong></p>
+                        <p>Parhewch â’ch cais.</p>`
                     })
                 }
             };

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -16,102 +16,112 @@ module.exports = function({ locale }) {
     const maxProjectDurationLabel = localise(SUGGESTED_PROJECT_DURATION);
     const orgMinAgeLabel = localise(ORG_MIN_AGE.label);
 
-    const question1 = {
-        question: localise({
-            en: oneLine`Does your organisation have at least two unconnected people on the board or committee?`,
-            cy: oneLine`Oes gan eich sefydliad o leiaf dau berson heb gysylltiad i’w gilydd ar y bwrdd neu bwyllgor?`
-        }),
-        explanation: localise({
-            en: oneLine`By unconnected, we mean not a relation by blood, marriage,
+    function question1() {
+        return {
+            question: localise({
+                en: oneLine`Does your organisation have at least two unconnected people on the board or committee?`,
+                cy: oneLine`Oes gan eich sefydliad o leiaf dau berson heb gysylltiad i’w gilydd ar y bwrdd neu bwyllgor?`
+            }),
+            explanation: localise({
+                en: oneLine`By unconnected, we mean not a relation by blood, marriage,
                 in a long-term relationship or people living together at the same address.`,
-            cy: oneLine`Drwy gysylltiad i’w gilydd, rydym yn golygu ddim yn
+                cy: oneLine`Drwy gysylltiad i’w gilydd, rydym yn golygu ddim yn
                 berthynas drwy waed, mewn perthynas hir dymor neu bobl
                 sy’n byw â’u gilydd yn yr un cyfeiriad.`
-        }),
-        yesLabel: localise({ en: 'Yes', cy: 'Oes' }),
-        noLabel: localise({ en: 'No', cy: 'Nac oes' }),
-        errorMessage: localise({ en: 'Answer Yes or No', cy: 'Oes / Nac oes' }),
-        ineligible: {
-            reason: localise({
-                en: `This is because you told us that your organisation does not have at least two unconnected people on the board or committee`,
-                cy: `Mae hyn gan eich bod wedi dweud wrthym nad oes gan eich sefydliad o leiaf dau berson heb gysylltiad i’w gilydd ar y bwrdd neu bwyllgor`
             }),
-            detail: localise({
-                en: `<p>We want to fund great ideas that help communities to thrive, but we are also responsible for making sure our funding is in safe hands.</p>
+            yesLabel: localise({ en: 'Yes', cy: 'Oes' }),
+            noLabel: localise({ en: 'No', cy: 'Nac oes' }),
+            errorMessage: localise({
+                en: 'Answer Yes or No',
+                cy: 'Oes / Nac oes'
+            }),
+            ineligible: {
+                reason: localise({
+                    en: `This is because you told us that your organisation does not have at least two unconnected people on the board or committee`,
+                    cy: `Mae hyn gan eich bod wedi dweud wrthym nad oes gan eich sefydliad o leiaf dau berson heb gysylltiad i’w gilydd ar y bwrdd neu bwyllgor`
+                }),
+                detail: localise({
+                    en: `<p>We want to fund great ideas that help communities to thrive, but we are also responsible for making sure our funding is in safe hands.</p>
 
                 <p>Before applying, make sure there are two people on your organisation's board or committee who aren't married or in a long-term relationship with each other, living together at the same address, or related by blood.</p>`,
-                cy: `<p>Rydym eisiau ariannu syniadau gwych a fydd yn helpu cymunedau i ffynnu, ond rydym hefyd yn gyfrifol am sicrhau bod ein harian mewn dwylo diogel.</p>
+                    cy: `<p>Rydym eisiau ariannu syniadau gwych a fydd yn helpu cymunedau i ffynnu, ond rydym hefyd yn gyfrifol am sicrhau bod ein harian mewn dwylo diogel.</p>
                 
                 <p>Cyn ymgeisio, sicrhewch bod dau berson ar fwrdd neu bwyllgor eich sefydliad sydd ddim yn gysylltiedig drwy briodas, perthynas hir dymor â’u gilydd, yn byw yn yr un cyfeiriad nag yn perthyn drwy waed.</p>`
-            })
-        }
-    };
+                })
+            }
+        };
+    }
 
-    const question2 = {
-        question: localise({
-            en: `Are you applying for an amount between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} that you’ll spend in around ${maxProjectDurationLabel}?`,
-            cy: `A ydych yn ymgeisio am swm rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} byddwch yn ei wario o fewn oddeutu ${maxProjectDurationLabel}?`
-        }),
-        explanation: localise({
-            en: `We know it's not always possible to complete a project in ${maxProjectDurationLabel} for lots of reasons. So we can consider projects which are slightly longer than this. We will also consider applications for one-off events such as a festival, gala day or conference.`,
-            cy: `Rydym yn gwybod nad yw bob tro’n bosib i gwblhau prosiect o fewn ${maxProjectDurationLabel} am nifer o resymau. Felly mi allwn ystyried prosiectau sydd ychydig yn hirach na hyn. Byddwn hefyd yn ystyried ceisiadau am ddigwyddiadau a fydd yn digwydd unwaith yn unig, megis gwyliau, diwrnod gala neu gynhadledd.`
-        }),
-        yesLabel: localise({ en: 'Yes', cy: 'Ydw' }),
-        noLabel: localise({ en: 'No', cy: 'Nac ydw' }),
-        errorMessage: localise({ en: 'Answer Yes or No', cy: 'Ydw / Nac ydw' }),
-        ineligible: {
-            reason: localise({
-                en: `This is because you can only apply for funding between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} for a project that will be finished in about ${maxProjectDurationLabel} through National Lottery Awards for All, and it sounds like you need a different amount of funding from us.`,
-                cy: `Y rheswm dros hyn yw gallwch dim ond ymgeisio am arian rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} am brosiect a fydd wedi gorffen o fewn oddeutu ${maxProjectDurationLabel} drwy ein rhaglen Arian i Bawb y Loteri Genedlaethol, ac mae’n swnio fel eich bod angen math gwahanol o grant gennym.`
+    function question2() {
+        return {
+            question: localise({
+                en: `Are you applying for an amount between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} that you’ll spend in around ${maxProjectDurationLabel}?`,
+                cy: `A ydych yn ymgeisio am swm rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} byddwch yn ei wario o fewn oddeutu ${maxProjectDurationLabel}?`
             }),
-            detail: localise({
-                en: `<p>This isn't the end. Here are a couple of ideas about what you can do:</p>
+            explanation: localise({
+                en: `We know it's not always possible to complete a project in ${maxProjectDurationLabel} for lots of reasons. So we can consider projects which are slightly longer than this. We will also consider applications for one-off events such as a festival, gala day or conference.`,
+                cy: `Rydym yn gwybod nad yw bob tro’n bosib i gwblhau prosiect o fewn ${maxProjectDurationLabel} am nifer o resymau. Felly mi allwn ystyried prosiectau sydd ychydig yn hirach na hyn. Byddwn hefyd yn ystyried ceisiadau am ddigwyddiadau a fydd yn digwydd unwaith yn unig, megis gwyliau, diwrnod gala neu gynhadledd.`
+            }),
+            yesLabel: localise({ en: 'Yes', cy: 'Ydw' }),
+            noLabel: localise({ en: 'No', cy: 'Nac ydw' }),
+            errorMessage: localise({
+                en: 'Answer Yes or No',
+                cy: 'Ydw / Nac ydw'
+            }),
+            ineligible: {
+                reason: localise({
+                    en: `This is because you can only apply for funding between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} for a project that will be finished in about ${maxProjectDurationLabel} through National Lottery Awards for All, and it sounds like you need a different amount of funding from us.`,
+                    cy: `Y rheswm dros hyn yw gallwch dim ond ymgeisio am arian rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} am brosiect a fydd wedi gorffen o fewn oddeutu ${maxProjectDurationLabel} drwy ein rhaglen Arian i Bawb y Loteri Genedlaethol, ac mae’n swnio fel eich bod angen math gwahanol o grant gennym.`
+                }),
+                detail: localise({
+                    en: `<p>This isn't the end. Here are a couple of ideas about what you can do:</p>
                 <ul>
                     <li>Consider asking us to fund part of your project through National Lottery Awards for All, and find out if there are other sources of funding that can cover the rest of your project</li>
                     <li><a href="/funding/over10k">Look at our other funding programmes</a> to see if they cover the amount of funding you want to apply for and the length of time you want to run your project for, and consider applying to us for a grant worth over £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}.</li>
                 </ul>`,
-                cy: `<p>Nid dyma diwedd y daith. Dyma rhai syniadau am yr hyn gallwch ei wneud:</p>
+                    cy: `<p>Nid dyma diwedd y daith. Dyma rhai syniadau am yr hyn gallwch ei wneud:</p>
                 <ul>
                     <li>Ystyried gofyn i ni ariannu rhan o’ch prosiect drwy Arian i Bawb y Loteri Genedlaethol, a darganfod os oes ffynonellau eraill o arian gall ariannu gweddill eich prosiect</li>
                     <li><a href="/welsh/funding/over10k">Edrych ar ein rhaglenni ariannu eraill</a> i weld os ydynt yn talu’r swm o arian rydych eisiau ymgeisio amdano a hyd yr amser rydych eisiau rhedeg eich prosiect, ac ystyriwch ymgeisio inni am grant sydd werth mwy na £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}.</li>
                 </ul>`
-            })
-        }
-    };
+                })
+            }
+        };
+    }
 
-    let question3;
-    if (config.get('awardsForAll.enableNewDateRange')) {
-        question3 = {
-            question: localise({
-                en: oneLine`Does your project start at least 12 weeks from
+    function question3() {
+        if (config.get('awardsForAll.enableNewDateRange')) {
+            return {
+                question: localise({
+                    en: oneLine`Does your project start at least 12 weeks from
                       when you plan to submit your application? (If your project
                       is in England, it needs to start after at least 18 weeks)`,
-                cy: `@TODO i18n`
-            }),
-            explanation: localise({
-                en: oneLine`We need 12 weeks to be able to assess your application
+                    cy: `@TODO i18n`
+                }),
+                explanation: localise({
+                    en: oneLine`We need 12 weeks to be able to assess your application
                       and pay your grant, if you're successful.
                       So projects need to start at least 12 weeks from the date
                       you submit your application to us—unless your project's in England,
                       where it needs to start after at least 18 weeks.`,
-                cy: `@TODO i18n`
-            }),
-            yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
-            noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
-            errorMessage: localise({
-                en: 'Answer Yes or No',
-                cy: 'Ydi / Nac ydi'
-            }),
-            ineligible: {
-                reason: localise({
-                    en: oneLine`This is because you told us that your project
+                    cy: `@TODO i18n`
+                }),
+                yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
+                noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
+                errorMessage: localise({
+                    en: 'Answer Yes or No',
+                    cy: 'Ydi / Nac ydi'
+                }),
+                ineligible: {
+                    reason: localise({
+                        en: oneLine`This is because you told us that your project
                         doesn't start at least 12 weeks from when you plan to
                         submit your application (or after at least 18 weeks
                         for a project in England).`,
-                    cy: `@TODO i18n`
-                }),
-                detail: localise({
-                    en: `<p>
+                        cy: `@TODO i18n`
+                    }),
+                    detail: localise({
+                        en: `<p>
                         We don't want communities to miss out on a
                          great idea that will help them thrive.
                     </p>
@@ -123,97 +133,114 @@ module.exports = function({ locale }) {
                         carry out checks and, if successful, pay your grant.
                         If it is possible, continue with your application.
                     </p>`,
-                    cy: `@TODO i18n`
-                })
-            }
-        };
-    } else {
-        question3 = {
+                        cy: `@TODO i18n`
+                    })
+                }
+            };
+        } else {
+            return {
+                question: localise({
+                    en: `Does your project start at least 18 weeks from when you plan to submit your application?`,
+                    cy: `A yw eich prosiect yn dechrau o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais?`
+                }),
+                explanation: localise({
+                    en: `We need 18 weeks to be able to assess your application and pay your grant, if you're successful. So projects need to start at least 18 weeks from the date you submit your application to us.`,
+                    cy: `Rydym angen 18 wythnos i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf 18 wythnos o’r dyddiad rydych yn anfon eich cais.`
+                }),
+                yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
+                noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
+                errorMessage: localise({
+                    en: 'Answer Yes or No',
+                    cy: 'Ydi / Nac ydi'
+                }),
+                ineligible: {
+                    reason: localise({
+                        en: `This is because you told us that your project doesn't start at least 18 weeks from when you plan to submit your application.`,
+                        cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais.`
+                    }),
+                    detail: localise({
+                        en: `<p>We don't want communities to miss out on a great idea that will help them thrive.</p>
+                         <p>Have a think and see if it's possible to start your project at least 18 weeks from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
+                        cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn eu helpu i ffynnu.</p>
+                         <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf 18 wythnos o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
+                    })
+                }
+            };
+        }
+    }
+
+    function question4() {
+        return {
             question: localise({
-                en: `Does your project start at least 18 weeks from when you plan to submit your application?`,
-                cy: `A yw eich prosiect yn dechrau o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais?`
+                en: `Do you have a UK bank account or building society account? It needs to be in the legal name of your organisation, with at least two unrelated people who are able to manage the account.`,
+                cy: `Oes gennych gyfrif banc neu gymdeithas adeiladu Prydeinig? Mae angen iddo fod yn enw cyfreithiol eich sefydliad, gydag o leiaf dau berson sydd ddim yn perthyn i reoli’r cyfrif.`
             }),
             explanation: localise({
-                en: `We need 18 weeks to be able to assess your application and pay your grant, if you're successful. So projects need to start at least 18 weeks from the date you submit your application to us.`,
-                cy: `Rydym angen 18 wythnos i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf 18 wythnos o’r dyddiad rydych yn anfon eich cais.`
+                en: `This should be the legal name of your organisation as it appears on your bank statement, not the name of your bank. This will usually be the same as your organisation's name on your governing document.`,
+                cy: `Dylai hwn fod yr enw cyfreithiol i’ch sefydliad fel mae’n ymddangos ar eich cyfriflen banc, nid enw eich banc. Bydd hwn fel arfer yr un peth ag enw eich sefydliad ar eich dogfen lywodraethol.`
             }),
-            yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
-            noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
+            yesLabel: localise({ en: 'Yes', cy: 'Oes' }),
+            noLabel: localise({ en: 'No', cy: 'Nac oes' }),
             errorMessage: localise({
                 en: 'Answer Yes or No',
-                cy: 'Ydi / Nac ydi'
+                cy: 'Oes / Nac oes'
             }),
             ineligible: {
                 reason: localise({
-                    en: `This is because you told us that your project doesn't start at least 18 weeks from when you plan to submit your application.`,
-                    cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais.`
+                    en: `This is because you told us that your organisation doesn't have a UK bank account in the legal name of your organisation.`,
+                    cy: `Mae hyn oherwydd eich bod wedi dweud nad oes gan eich sefydliad gyfrif banc Prydeinig yn enw cyfreithiol eich sefydliad.`
                 }),
                 detail: localise({
-                    en: `<p>We don't want communities to miss out on a great idea that will help them thrive.</p>
-                         <p>Have a think and see if it's possible to start your project at least 18 weeks from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
-                    cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn eu helpu i ffynnu.</p>
-                         <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf 18 wythnos o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
+                    en: `<p>We don't want communities to miss out on a great idea that will help them to thrive.</p>
+                <p>So you might want to double check whether you have a UK bank account in the legal name of your organisation. Or you might want to open an account like that before you apply.</p>`,
+                    cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn helpu eu cymuned i ffynnu.</p>
+                <p>Felly efallai bod werth ail wirio a oes gennych chi gyfrif banc Prydeinig yn enw cyfreithiol eich sefydliad. Neu efallai y hoffech agor cyfrif cyn ichi ymgeisio.</p>`
                 })
             }
         };
     }
 
-    const question4 = {
-        question: localise({
-            en: `Do you have a UK bank account or building society account? It needs to be in the legal name of your organisation, with at least two unrelated people who are able to manage the account.`,
-            cy: `Oes gennych gyfrif banc neu gymdeithas adeiladu Prydeinig? Mae angen iddo fod yn enw cyfreithiol eich sefydliad, gydag o leiaf dau berson sydd ddim yn perthyn i reoli’r cyfrif.`
-        }),
-        explanation: localise({
-            en: `This should be the legal name of your organisation as it appears on your bank statement, not the name of your bank. This will usually be the same as your organisation's name on your governing document.`,
-            cy: `Dylai hwn fod yr enw cyfreithiol i’ch sefydliad fel mae’n ymddangos ar eich cyfriflen banc, nid enw eich banc. Bydd hwn fel arfer yr un peth ag enw eich sefydliad ar eich dogfen lywodraethol.`
-        }),
-        yesLabel: localise({ en: 'Yes', cy: 'Oes' }),
-        noLabel: localise({ en: 'No', cy: 'Nac oes' }),
-        errorMessage: localise({ en: 'Answer Yes or No', cy: 'Oes / Nac oes' }),
-        ineligible: {
-            reason: localise({
-                en: `This is because you told us that your organisation doesn't have a UK bank account in the legal name of your organisation.`,
-                cy: `Mae hyn oherwydd eich bod wedi dweud nad oes gan eich sefydliad gyfrif banc Prydeinig yn enw cyfreithiol eich sefydliad.`
-            }),
-            detail: localise({
-                en: `<p>We don't want communities to miss out on a great idea that will help them to thrive.</p>
-                <p>So you might want to double check whether you have a UK bank account in the legal name of your organisation. Or you might want to open an account like that before you apply.</p>`,
-                cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn helpu eu cymuned i ffynnu.</p>
-                <p>Felly efallai bod werth ail wirio a oes gennych chi gyfrif banc Prydeinig yn enw cyfreithiol eich sefydliad. Neu efallai y hoffech agor cyfrif cyn ichi ymgeisio.</p>`
-            })
-        }
-    };
-
-    const question5 = {
-        question: localise({
-            en: oneLine`Do you produce annual accounts (or did you set up your organisation
+    function question5() {
+        return {
+            question: localise({
+                en: oneLine`Do you produce annual accounts (or did you set up your organisation
                 less than ${orgMinAgeLabel} ago and haven't produced annual accounts yet)?`,
-            cy: oneLine`A ydych yn cynhyrchu cyfrifon blynyddol (neu a yw eich sefydliad
+                cy: oneLine`A ydych yn cynhyrchu cyfrifon blynyddol (neu a yw eich sefydliad
                 yn iau na ${orgMinAgeLabel} oed a heb gynhyrchu cyfrifon blynyddol eto)?`
-        }),
-        explanation: localise({
-            en: `By annual accounts, we mean a summary of your financial activity. If you are a small organisation, this may be produced by your board and doesn't have to be done by an accountant.`,
-            cy: `Drwy gyfrifon blynyddol, rydym yn golygu crynodeb o’ch gweithgaredd ariannol. Os ydych yn sefydliad bach, gall hwn gael ei gynhyrchu gan eich bwrdd a nid oes rhaid iddo gael ei wneud gan gyfrifydd.`
-        }),
-        yesLabel: localise({ en: 'Yes', cy: 'Ydw' }),
-        noLabel: localise({ en: 'No', cy: 'Nac ydw' }),
-        errorMessage: localise({ en: 'Answer Yes or No', cy: 'Ydw / Nac ydw' }),
-        ineligible: {
-            reason: localise({
-                en: `This is because you told us that your organisation was set up more than ${orgMinAgeLabel} ago and hasn't produced annual accounts yet.`,
-                cy: `Mae hyn oherwydd eich bod wedi dweud wrthym bod eich sefydliad wedi ei sefydlu mwy na ${orgMinAgeLabel} yn ôl, a heb gynhyrchu cyfrifon blynyddol eto.`
             }),
-            detail: localise({
-                en: `<p>This isn't the end. Before applying, make sure your organisation has produced annual accounts.</p>
+            explanation: localise({
+                en: `By annual accounts, we mean a summary of your financial activity. If you are a small organisation, this may be produced by your board and doesn't have to be done by an accountant.`,
+                cy: `Drwy gyfrifon blynyddol, rydym yn golygu crynodeb o’ch gweithgaredd ariannol. Os ydych yn sefydliad bach, gall hwn gael ei gynhyrchu gan eich bwrdd a nid oes rhaid iddo gael ei wneud gan gyfrifydd.`
+            }),
+            yesLabel: localise({ en: 'Yes', cy: 'Ydw' }),
+            noLabel: localise({ en: 'No', cy: 'Nac ydw' }),
+            errorMessage: localise({
+                en: 'Answer Yes or No',
+                cy: 'Ydw / Nac ydw'
+            }),
+            ineligible: {
+                reason: localise({
+                    en: `This is because you told us that your organisation was set up more than ${orgMinAgeLabel} ago and hasn't produced annual accounts yet.`,
+                    cy: `Mae hyn oherwydd eich bod wedi dweud wrthym bod eich sefydliad wedi ei sefydlu mwy na ${orgMinAgeLabel} yn ôl, a heb gynhyrchu cyfrifon blynyddol eto.`
+                }),
+                detail: localise({
+                    en: `<p>This isn't the end. Before applying, make sure your organisation has produced annual accounts.</p>
                 <p>By 'annual accounts' we mean a summary of your financial activity. If you're a small organisation, this can be produced by your board or committee, and doesn't have to be done by an accountant.</p>`,
-                cy: `<p>Nid dyma ddiwedd y daith. Cyn ymgeisio, sicrhewch bod eich sefydliad wedi cynhyrchu cyfrifon blynyddol.</p>
+                    cy: `<p>Nid dyma ddiwedd y daith. Cyn ymgeisio, sicrhewch bod eich sefydliad wedi cynhyrchu cyfrifon blynyddol.</p>
                 <p>Drwy ‘gyfrifon  blynyddol’, rydym yn golygu crynodeb o’ch gweithgaredd ariannol. Os ydych yn sefydliad bach, gall hwn gael ei gynhyrchu gan eich bwrdd neu bwyllgor, ac nid oes rhaid iddo gael ei wneud gan gyfrifydd.</p>`
-            })
-        }
-    };
+                })
+            }
+        };
+    }
 
     return {
-        questions: [question1, question2, question3, question4, question5],
+        questions: [
+            question1(),
+            question2(),
+            question3(),
+            question4(),
+            question5()
+        ],
         successMessage: localise({
             en: `<p>
                 We're excited to hear more about your project and

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
@@ -78,31 +79,84 @@ module.exports = function({ locale }) {
         }
     };
 
-    const question3 = {
-        question: localise({
-            en: `Does your project start at least 18 weeks from when you plan to submit your application?`,
-            cy: `A yw eich prosiect yn dechrau o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais?`
-        }),
-        explanation: localise({
-            en: `We need 18 weeks to be able to assess your application and pay your grant, if you're successful. So projects need to start at least 18 weeks from the date you submit your application to us.`,
-            cy: `Rydym angen 18 wythnos i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf 18 wythnos o’r dyddiad rydych yn anfon eich cais.`
-        }),
-        yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
-        noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
-        errorMessage: localise({ en: 'Answer Yes or No', cy: 'Ydi / Nac ydi' }),
-        ineligible: {
-            reason: localise({
-                en: `This is because you told us that your project doesn't start at least 18 weeks from when you plan to submit your application.`,
-                cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais.`
+    let question3;
+    if (config.get('awardsForAll.enableNewDateRange')) {
+        question3 = {
+            question: localise({
+                en: oneLine`Does your project start at least 12 weeks from
+                      when you plan to submit your application? (If your project
+                      is in England, it needs to start after at least 18 weeks)`,
+                cy: `@TODO i18n`
             }),
-            detail: localise({
-                en: `<p>We don't want communities to miss out on a great idea that will help them thrive.</p>
-                <p>Have a think and see if it's possible to start your project at least 18 weeks from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
-                cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn eu helpu i ffynnu.</p>
-                <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf 18 wythnos o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
-            })
-        }
-    };
+            explanation: localise({
+                en: oneLine`We need 12 weeks to be able to assess your application
+                      and pay your grant, if you're successful.
+                      So projects need to start at least 12 weeks from the date
+                      you submit your application to us—unless your project's in England,
+                      where it needs to start after at least 18 weeks.`,
+                cy: `@TODO i18n`
+            }),
+            yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
+            noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
+            errorMessage: localise({
+                en: 'Answer Yes or No',
+                cy: 'Ydi / Nac ydi'
+            }),
+            ineligible: {
+                reason: localise({
+                    en: oneLine`This is because you told us that your project
+                        doesn't start at least 12 weeks from when you plan to
+                        submit your application (or after at least 18 weeks
+                        for a project in England).`,
+                    cy: `@TODO i18n`
+                }),
+                detail: localise({
+                    en: `<p>
+                        We don't want communities to miss out on a
+                         great idea that will help them thrive.
+                    </p>
+                    <p>
+                        Have a think and see if it's possible to
+                        start your project at least 12 weeks from now 
+                        (or after at least 18 weeks for a project in England).
+                        We need this time to consider your application,
+                        carry out checks and, if successful, pay your grant.
+                        If it is possible, continue with your application.
+                    </p>`,
+                    cy: `@TODO i18n`
+                })
+            }
+        };
+    } else {
+        question3 = {
+            question: localise({
+                en: `Does your project start at least 18 weeks from when you plan to submit your application?`,
+                cy: `A yw eich prosiect yn dechrau o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais?`
+            }),
+            explanation: localise({
+                en: `We need 18 weeks to be able to assess your application and pay your grant, if you're successful. So projects need to start at least 18 weeks from the date you submit your application to us.`,
+                cy: `Rydym angen 18 wythnos i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf 18 wythnos o’r dyddiad rydych yn anfon eich cais.`
+            }),
+            yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
+            noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
+            errorMessage: localise({
+                en: 'Answer Yes or No',
+                cy: 'Ydi / Nac ydi'
+            }),
+            ineligible: {
+                reason: localise({
+                    en: `This is because you told us that your project doesn't start at least 18 weeks from when you plan to submit your application.`,
+                    cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais.`
+                }),
+                detail: localise({
+                    en: `<p>We don't want communities to miss out on a great idea that will help them thrive.</p>
+                         <p>Have a think and see if it's possible to start your project at least 18 weeks from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
+                    cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn eu helpu i ffynnu.</p>
+                         <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf 18 wythnos o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
+                })
+            }
+        };
+    }
 
     const question4 = {
         question: localise({

--- a/controllers/apply/awards-for-all/eligibility.js
+++ b/controllers/apply/awards-for-all/eligibility.js
@@ -4,7 +4,6 @@ const { oneLine } = require('common-tags');
 
 const {
     MIN_BUDGET_TOTAL_GBP,
-    MIN_START_DATE,
     MAX_BUDGET_TOTAL_GBP,
     SUGGESTED_PROJECT_DURATION,
     ORG_MIN_AGE
@@ -13,7 +12,6 @@ const {
 module.exports = function({ locale }) {
     const localise = get(locale);
 
-    const minStartDateLabel = localise(MIN_START_DATE.label);
     const maxProjectDurationLabel = localise(SUGGESTED_PROJECT_DURATION);
     const orgMinAgeLabel = localise(ORG_MIN_AGE.label);
 
@@ -82,26 +80,26 @@ module.exports = function({ locale }) {
 
     const question3 = {
         question: localise({
-            en: `Does your project start at least ${minStartDateLabel} from when you plan to submit your application?`,
-            cy: `A yw eich prosiect yn dechrau o leiaf ${minStartDateLabel} o bryd rydych yn bwriadu anfon eich cais?`
+            en: `Does your project start at least 18 weeks from when you plan to submit your application?`,
+            cy: `A yw eich prosiect yn dechrau o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais?`
         }),
         explanation: localise({
-            en: `We need ${minStartDateLabel} to be able to assess your application and pay your grant, if you're successful. So projects need to start at least ${minStartDateLabel} from the date you submit your application to us.`,
-            cy: `Rydym angen ${minStartDateLabel} i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf ${minStartDateLabel} o’r dyddiad rydych yn anfon eich cais.`
+            en: `We need 18 weeks to be able to assess your application and pay your grant, if you're successful. So projects need to start at least 18 weeks from the date you submit your application to us.`,
+            cy: `Rydym angen 18 wythnos i allu asesu eich cais a thalu eich grant, os ydych yn llwyddiannus. Felly mae angen i brosiectau ddechrau o leiaf 18 wythnos o’r dyddiad rydych yn anfon eich cais.`
         }),
         yesLabel: localise({ en: 'Yes', cy: 'Ydi' }),
         noLabel: localise({ en: 'No', cy: 'Nac ydi' }),
         errorMessage: localise({ en: 'Answer Yes or No', cy: 'Ydi / Nac ydi' }),
         ineligible: {
             reason: localise({
-                en: `This is because you told us that your project doesn't start at least ${minStartDateLabel} from when you plan to submit your application.`,
-                cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf ${minStartDateLabel} o bryd rydych yn bwriadu anfon eich cais.`
+                en: `This is because you told us that your project doesn't start at least 18 weeks from when you plan to submit your application.`,
+                cy: `Mae hyn oherwydd eich bod wedi dweud wrthym nad yw eich prosiect yn dechrau tan o leiaf 18 wythnos o bryd rydych yn bwriadu anfon eich cais.`
             }),
             detail: localise({
                 en: `<p>We don't want communities to miss out on a great idea that will help them thrive.</p>
-                <p>Have a think and see if it's possible to start your project at least ${minStartDateLabel} from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
+                <p>Have a think and see if it's possible to start your project at least 18 weeks from now. We need this time to consider your application, carry out checks and, if successful, pay your grant. If it is possible, continue with your application.</p>`,
                 cy: `<p>Nid ydym eisiau i gymunedau fethu allan ar syniad gwych a fydd yn eu helpu i ffynnu.</p>
-                <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf ${minStartDateLabel} o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
+                <p>Meddyliwch os yw’n bosib dechrau eich prosiect o leiaf 18 wythnos o rŵan. Rydym angen yr amser hyn i ystyried eich cais, cynnal gwiriadau ac os y byddwch yn llwyddiannus, talu eich grant.</p>`
             })
         }
     };

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1839,7 +1839,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
     };
 
     if (flags.enableNewDateRange) {
-        allFields.projectStartDate = fieldProjectStartDate(locale);
+        allFields.projectStartDate = fieldProjectStartDate(locale, data);
         allFields.projectEndDate = fieldProjectEndDate(locale);
     } else {
         allFields.projectDateRange = fieldProjectDateRange(locale);

--- a/controllers/apply/awards-for-all/fields/project-date-range.js
+++ b/controllers/apply/awards-for-all/fields/project-date-range.js
@@ -5,7 +5,6 @@ const { oneLine } = require('common-tags');
 
 const {
     MAX_PROJECT_DURATION,
-    MIN_START_DATE,
     SUGGESTED_PROJECT_DURATION
 } = require('../constants');
 const Joi = require('../../lib/joi-extensions');
@@ -13,7 +12,7 @@ const Joi = require('../../lib/joi-extensions');
 module.exports = function(locale) {
     const localise = get(locale);
 
-    const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
+    const minDate = moment().add(18, 'weeks');
 
     function formatAfterDate(format = 'D MMMM YYYY') {
         return minDate

--- a/controllers/apply/awards-for-all/fields/project-start-date.js
+++ b/controllers/apply/awards-for-all/fields/project-start-date.js
@@ -6,12 +6,16 @@ const { oneLine } = require('common-tags');
 const Joi = require('../../lib/joi-extensions');
 const DateField = require('../../lib/field-types/date');
 
-const { MIN_START_DATE } = require('../constants');
+function minDateFor(projectCountry) {
+    const startDateOffsetWeeks = projectCountry === 'england' ? 18 : 12;
+    return moment().add(startDateOffsetWeeks, 'weeks');
+}
 
-module.exports = function(locale) {
+module.exports = function(locale, data = {}) {
     const localise = get(locale);
 
-    const minDate = moment().add(MIN_START_DATE.amount, MIN_START_DATE.unit);
+    const projectCountry = get('projectCountry')(data);
+    const minDate = minDateFor(projectCountry);
 
     const minDateExample = minDate
         .clone()

--- a/controllers/apply/awards-for-all/fields/project-start-date.js
+++ b/controllers/apply/awards-for-all/fields/project-start-date.js
@@ -6,16 +6,13 @@ const { oneLine } = require('common-tags');
 const Joi = require('../../lib/joi-extensions');
 const DateField = require('../../lib/field-types/date');
 
-function minDateFor(projectCountry) {
-    const startDateOffsetWeeks = projectCountry === 'england' ? 18 : 12;
-    return moment().add(startDateOffsetWeeks, 'weeks');
-}
+const getLeadTimeWeeks = require('../lib/lead-time');
 
 module.exports = function(locale, data = {}) {
     const localise = get(locale);
 
     const projectCountry = get('projectCountry')(data);
-    const minDate = minDateFor(projectCountry);
+    const minDate = moment().add(getLeadTimeWeeks(projectCountry), 'weeks');
 
     const minDateExample = minDate
         .clone()

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -127,7 +127,9 @@ module.exports = function({
 
     function stepProjectLength() {
         const stepFields = flags.enableNewDateRange
-            ? [fields.projectStartDate, fields.projectEndDate]
+            ? has('projectCountry')(data)
+                ? [fields.projectStartDate, fields.projectEndDate]
+                : []
             : [fields.projectDateRange];
 
         return new Step({

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -73,20 +73,6 @@ module.exports = function({
         });
     }
 
-    function stepProjectLength() {
-        const stepFields = flags.enableNewDateRange
-            ? [fields.projectStartDate, fields.projectEndDate]
-            : [fields.projectDateRange];
-
-        return new Step({
-            title: localise({
-                en: 'Project length',
-                cy: 'Hyd y prosiect'
-            }),
-            fieldsets: [{ fields: stepFields }]
-        });
-    }
-
     function stepProjectCountry() {
         return new Step({
             title: localise({
@@ -136,6 +122,20 @@ module.exports = function({
                     }
                 }
             ]
+        });
+    }
+
+    function stepProjectLength() {
+        const stepFields = flags.enableNewDateRange
+            ? [fields.projectStartDate, fields.projectEndDate]
+            : [fields.projectDateRange];
+
+        return new Step({
+            title: localise({
+                en: 'Project length',
+                cy: 'Hyd y prosiect'
+            }),
+            fieldsets: [{ fields: stepFields }]
         });
     }
 
@@ -1150,14 +1150,23 @@ module.exports = function({
                     Dyma’r adran bwysicaf pan fydd yn dod i wneud penderfyniad p’un 
                     a ydych wedi bod yn llwyddiannus ai beidio.`
             }),
-            steps: [
-                stepProjectName(),
-                stepProjectLength(),
-                stepProjectCountry(),
-                stepProjectLocation(),
-                stepYourIdea(),
-                stepProjectCosts()
-            ]
+            steps: flags.enableNewDateRange
+                ? [
+                      stepProjectName(),
+                      stepProjectCountry(),
+                      stepProjectLocation(),
+                      stepProjectLength(),
+                      stepYourIdea(),
+                      stepProjectCosts()
+                  ]
+                : [
+                      stepProjectName(),
+                      stepProjectLength(),
+                      stepProjectCountry(),
+                      stepProjectLocation(),
+                      stepYourIdea(),
+                      stepProjectCosts()
+                  ]
         };
     }
 

--- a/controllers/apply/awards-for-all/lib/lead-time.js
+++ b/controllers/apply/awards-for-all/lib/lead-time.js
@@ -1,0 +1,17 @@
+'use strict';
+const config = require('config');
+
+module.exports = function getLeadTimeWeeks(
+    country,
+    enableVariableLeadTime = config.get('awardsForAll.enableNewDateRange')
+) {
+    if (enableVariableLeadTime) {
+        if (country === 'england') {
+            return 18;
+        } else {
+            return 12;
+        }
+    } else {
+        return 18;
+    }
+};

--- a/controllers/apply/awards-for-all/lib/lead-time.test.js
+++ b/controllers/apply/awards-for-all/lib/lead-time.test.js
@@ -1,0 +1,18 @@
+/* eslint-env jest */
+'use strict';
+const getLeadTimeWeeks = require('./lead-time');
+
+test('lead time conditional on country', () => {
+    expect(getLeadTimeWeeks('england', true)).toBe(18);
+    ['scotland', 'northern-ireland', 'wales'].forEach(function(country) {
+        expect(getLeadTimeWeeks(country, true)).toBe(12);
+    });
+});
+
+test('lead time 18 weeks when variable lead times disabled', function() {
+    ['england', 'scotland', 'northern-ireland', 'wales', null].forEach(function(
+        country
+    ) {
+        expect(getLeadTimeWeeks(country, false)).toBe(18);
+    });
+});

--- a/controllers/apply/contacts-next/constants.js
+++ b/controllers/apply/contacts-next/constants.js
@@ -17,12 +17,6 @@ const ORG_MIN_AGE = {
     label: { en: '15 months', cy: '15 mis' }
 };
 
-const MIN_START_DATE = {
-    amount: 18,
-    unit: 'weeks',
-    label: { en: '18 weeks', cy: '18 wythnos' }
-};
-
 const SUGGESTED_PROJECT_DURATION = {
     en: '12 months',
     cy: '12 mis'
@@ -144,7 +138,6 @@ module.exports = {
     MIN_AGE_MAIN_CONTACT,
     MIN_AGE_SENIOR_CONTACT,
     MIN_BUDGET_TOTAL_GBP,
-    MIN_START_DATE,
     ORG_MIN_AGE,
     ORGANISATION_TYPES,
     STATUTORY_BODY_TYPES,

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -569,30 +569,6 @@ it('should submit full awards for all application', () => {
         submitStep();
     }
 
-    function stepProjectDates(mock) {
-        cy.checkA11y();
-
-        function fillDateParts(momentInstance) {
-            cy.findByLabelText('Day').type(momentInstance.date());
-            cy.findByLabelText('Month').type(momentInstance.month() + 1);
-            cy.findByLabelText('Year').type(momentInstance.year());
-        }
-
-        cy.findByText('When would you like to start your project?')
-            .parent()
-            .within(() => {
-                fillDateParts(mock.projectDateRange.startDate);
-            });
-
-        cy.findByText('When would you like to finish your project?')
-            .parent()
-            .within(() => {
-                fillDateParts(mock.projectDateRange.endDate);
-            });
-
-        submitStep();
-    }
-
     function stepProjectCountry(mock) {
         cy.findByLabelText(mock.country).click();
         submitStep();
@@ -641,6 +617,30 @@ it('should submit full awards for all application', () => {
         cy.findByLabelText('What is the postcode', { exact: false }).type(
             location.postcode
         );
+
+        submitStep();
+    }
+
+    function stepProjectDates(mock) {
+        cy.checkA11y();
+
+        function fillDateParts(momentInstance) {
+            cy.findByLabelText('Day').type(momentInstance.date());
+            cy.findByLabelText('Month').type(momentInstance.month() + 1);
+            cy.findByLabelText('Year').type(momentInstance.year());
+        }
+
+        cy.findByText('When would you like to start your project?')
+            .parent()
+            .within(() => {
+                fillDateParts(mock.projectDateRange.startDate);
+            });
+
+        cy.findByText('When would you like to finish your project?')
+            .parent()
+            .within(() => {
+                fillDateParts(mock.projectDateRange.endDate);
+            });
 
         submitStep();
     }
@@ -695,9 +695,9 @@ it('should submit full awards for all application', () => {
 
     function sectionYourProject(mock) {
         stepProjectName(mock);
-        stepProjectDates(mock);
         stepProjectCountry(mock);
         stepProjectLocation(mock);
+        stepProjectDates(mock);
         stepYourIdea(mock);
         stepProjectCosts(mock);
     }


### PR DESCRIPTION
Starts the work to vary lead times based on country. To keep the implementation simpler, I've put this behind the `enableProjectDate` flag.

I've also inlined the `MIN_START_DATE` for now as we'll be rewriting the eligibility criteria and help text so want to simplify ahead of that before reintroducing a new abstraction for the variable start date once I know what the text looks like.