### PR TITLE
Replace redirectForLocale with consistent localify use

### DIFF
--- a/common/authed.js
+++ b/common/authed.js
@@ -1,5 +1,5 @@
 'use strict';
-const { localify, redirectForLocale } = require('./urls');
+const { localify } = require('./urls');
 const logger = require('./logger').child({ service: 'auth' });
 
 function isStaff(user) {
@@ -13,12 +13,13 @@ function isActivated(user) {
 function redirectWithReturnUrl(req, res, urlPath) {
     req.session.redirectUrl = req.originalUrl;
     req.session.save(() => {
-        redirectForLocale(req, res, urlPath);
+        res.redirect(localify(req.i18n.getLocale())(urlPath));
     });
 }
 
 function redirectUrlWithFallback(req, res, urlPath) {
     let redirectUrl = localify(req.i18n.getLocale())(urlPath);
+
     if (req.query.redirectUrl) {
         redirectUrl = req.query.redirectUrl;
     } else if (req.body.redirectUrl) {
@@ -39,7 +40,7 @@ function redirectUrlWithFallback(req, res, urlPath) {
  */
 function requireNoAuth(req, res, next) {
     if (req.user) {
-        redirectForLocale(req, res, '/user');
+        res.redirect(localify(req.i18n.getLocale())('/user'));
     } else {
         next();
     }

--- a/common/urls.js
+++ b/common/urls.js
@@ -38,16 +38,16 @@ function localify(locale) {
     return function(urlPath) {
         if (isAbsoluteUrl(urlPath)) {
             return urlPath;
-        }
-        const urlIsWelsh = isWelsh(urlPath);
+        } else {
+            let newUrlPath = urlPath;
+            if (locale === 'cy' && !isWelsh(urlPath)) {
+                newUrlPath = makeWelsh(urlPath);
+            } else if (locale === 'en' && isWelsh(urlPath)) {
+                newUrlPath = urlPath.replace(WELSH_REGEX, '/');
+            }
 
-        let newUrlPath = urlPath;
-        if (locale === 'cy' && !urlIsWelsh) {
-            newUrlPath = makeWelsh(urlPath);
-        } else if (locale === 'en' && urlIsWelsh) {
-            newUrlPath = urlPath.replace(WELSH_REGEX, '/');
+            return stripTrailingSlashes(newUrlPath);
         }
-        return stripTrailingSlashes(newUrlPath);
     };
 }
 
@@ -148,11 +148,6 @@ function getCurrentUrl(req, requestedLocale) {
         : parsedPathname;
 }
 
-function redirectForLocale(req, res, urlPath) {
-    const url = localify(req.i18n.getLocale())(urlPath);
-    res.redirect(url);
-}
-
 /**
  *  We default to a 2017 crawl because it's the last date before we began
  *  redirecting pages to the archives, meaning we can no longer send old pages there.
@@ -171,7 +166,6 @@ module.exports = {
     localify,
     makeWelsh,
     pathCouldBeAlias,
-    redirectForLocale,
     removeWelsh,
     sanitiseUrlPath,
     stripTrailingSlashes,

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -5,7 +5,7 @@ const features = require('config').get('features');
 const moment = require('moment-timezone');
 
 const { Users } = require('../../db/models');
-const { localify, redirectForLocale } = require('../../common/urls');
+const { localify } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
 const { requireNotStaffAuth } = require('../../common/authed');
 const { injectCopy } = require('../../common/inject-content');
@@ -116,7 +116,7 @@ router.get('/logout', function(req, res) {
     res.locals.clearAuthCookie();
     logger.info('User logout', { service: 'user' });
     req.session.save(() => {
-        redirectForLocale(req, res, '/user/login?s=loggedOut');
+        res.redirect(localify(req.i18n.getLocale())('/user/login?s=loggedOut'));
     });
 });
 

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -6,7 +6,7 @@ const Sentry = require('@sentry/node');
 const { Users } = require('../../db/models');
 const { sanitise } = require('../../common/sanitise');
 const { sendHtmlEmail } = require('../../common/mail');
-const { redirectForLocale } = require('../../common/urls');
+const { localify } = require('../../common/urls');
 const { requireNoAuth } = require('../../common/authed');
 const { injectCopy } = require('../../common/inject-content');
 
@@ -136,7 +136,7 @@ router
                 renderResetFormExpired(req, res);
             }
         } else {
-            redirectForLocale(req, res, '/user/login');
+            res.redirect(localify(req.i18n.getLocale())('/user/login'));
         }
     })
     .post(async (req, res) => {
@@ -175,7 +175,11 @@ router
                         });
                         await sendPasswordResetNotification(req, username);
                         logger.info('Password change successful');
-                        redirectForLocale(req, res, '/user?s=passwordUpdated');
+                        res.redirect(
+                            localify(req.i18n.getLocale())(
+                                '/user?s=passwordUpdated'
+                            )
+                        );
                     } catch (error) {
                         logger.warn('Password change failed', error);
                         renderResetForm(req, res, validationResult.value, [
@@ -203,7 +207,7 @@ router
             res.locals.token = token;
 
             if (!token) {
-                redirectForLocale(req, res, '/user/login');
+                res.redirect(localify(req.i18n.getLocale())('/user/login'));
             } else {
                 // Is this user's token valid to modify this password?
                 let decodedData, user;
@@ -241,14 +245,16 @@ router
 
                             logger.info('Password reset email sent');
 
-                            return redirectForLocale(
-                                req,
-                                res,
-                                '/user/login?s=passwordUpdated'
+                            return res.redirect(
+                                localify(req.i18n.getLocale())(
+                                    '/user/login?s=passwordUpdated'
+                                )
                             );
                         } else {
                             logger.info('Password reset not valid for user');
-                            redirectForLocale(req, res, '/user/login');
+                            return res.redirect(
+                                localify(req.i18n.getLocale())('/user/login')
+                            );
                         }
                     } catch (error) {
                         logger.warn('Password reset failed', error);

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -4,7 +4,7 @@ const get = require('lodash/fp/get');
 const express = require('express');
 
 const { Users } = require('../../db/models');
-const { redirectForLocale } = require('../../common/urls');
+const { localify } = require('../../common/urls');
 const { csrfProtection } = require('../../common/cached');
 const { requireUserAuth } = require('../../common/authed');
 const { injectCopy } = require('../../common/inject-content');
@@ -54,7 +54,9 @@ async function handleSubmission(req, res, next) {
                 const updatedUser = await Users.findByPk(userId);
                 await sendActivationEmail(req, updatedUser);
                 logger.info('Update email change successful');
-                redirectForLocale(req, res, '/user?s=emailUpdated');
+                res.redirect(
+                    localify(req.i18n.getLocale())('/user?s=emailUpdated')
+                );
             } else {
                 logger.warn(`Invalid credentials when updating email address`);
 


### PR DESCRIPTION
Every time I came across the `redirectForLocale` method I had to double check the behaviour. Realised it's an alias for `localify`. Given we use `localify` in 99% of cases directly I've opted to remove `redirectForLocale` in favour of using `localify` directly.