### PR TITLE
Add guard when no base error message is provided

### DIFF
--- a/controllers/apply/lib/field-types/checkbox.test.js
+++ b/controllers/apply/lib/field-types/checkbox.test.js
@@ -11,7 +11,8 @@ test('valid field', function() {
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' },
             { label: 'Option 3', value: 'option-3' }
-        ]
+        ],
+        messages: [{ type: 'base', message: 'Select an option' }]
     });
 
     expect(field.type).toBe('checkbox');
@@ -48,7 +49,8 @@ test('must provide options', function() {
         new CheckboxField({
             locale: 'en',
             name: 'example',
-            label: 'Example field'
+            label: 'Example field',
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Must provide options');
 });
@@ -63,7 +65,8 @@ test('options must contain unique values', function() {
                 { label: 'Option 1', value: 'duplicate-value' },
                 { label: 'Option 2', value: 'duplicate-value' },
                 { label: 'Option 3', value: 'option-3' }
-            ]
+            ],
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Options must contain unique values');
 });

--- a/controllers/apply/lib/field-types/currency.test.js
+++ b/controllers/apply/lib/field-types/currency.test.js
@@ -6,7 +6,8 @@ test('valid field', function() {
     const field = new CurrencyField({
         locale: 'en',
         name: 'example',
-        label: 'Currency field'
+        label: 'Currency field',
+        messages: [{ type: 'base', message: 'Enter an amount' }]
     });
 
     expect(field.type).toBe('currency');

--- a/controllers/apply/lib/field-types/date.test.js
+++ b/controllers/apply/lib/field-types/date.test.js
@@ -6,7 +6,8 @@ test('DateField', function() {
     const field = new DateField({
         locale: 'en',
         name: 'example',
-        label: 'Date field'
+        label: 'Date field',
+        messages: [{ type: 'base', message: 'Enter a date' }]
     });
 
     expect(field.type).toBe('date');

--- a/controllers/apply/lib/field-types/field.js
+++ b/controllers/apply/lib/field-types/field.js
@@ -48,6 +48,15 @@ class Field {
         // @TODO Should this merge based on key rather than a plain concat?
         this.messages = this.defaultMessages().concat(props.messages || []);
 
+        if (
+            this.isRequired &&
+            this.messages.some(message => message.type === 'base') === false
+        ) {
+            throw new Error(
+                'Required fields must provide a base error message'
+            );
+        }
+
         this.warnings = props.warnings || [];
 
         this.value = undefined;

--- a/controllers/apply/lib/field-types/field.test.js
+++ b/controllers/apply/lib/field-types/field.test.js
@@ -7,11 +7,12 @@ test('field base type', function() {
     const field = new Field({
         locale: 'en',
         name: 'example',
-        label: 'Text field'
+        label: 'Example field',
+        messages: [{ type: 'base', message: 'Enter a value' }]
     });
 
     expect(field.locale).toBe('en');
-    expect(field.label).toEqual('Text field');
+    expect(field.label).toEqual('Example field');
     expect(field.defaultLabel()).toBeNull(); // For sub-classes
 
     expect(field.name).toBe('example');
@@ -33,23 +34,34 @@ test('field base type', function() {
 test('required properties', function() {
     expect(() => {
         new Field({
-            label: 'Example field'
+            label: 'Example field',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         });
     }).toThrowError('Must provide name');
 
     expect(() => {
         new Field({
             name: 'example',
-            label: 'Example field'
+            label: 'Example field',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         });
     }).toThrowError('Must provide locale');
 
     expect(() => {
         new Field({
             locale: 'en',
-            name: 'example'
+            name: 'example',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         });
     }).toThrowError('Must provide label');
+
+    expect(() => {
+        new Field({
+            locale: 'en',
+            name: 'example',
+            label: 'Example field'
+        });
+    }).toThrowError('Required fields must provide a base error message');
 });
 
 test('optional default field', function() {
@@ -68,7 +80,8 @@ test('with errors', function() {
     const field = new Field({
         locale: 'en',
         name: 'example',
-        label: 'Text field'
+        label: 'Text field',
+        messages: [{ type: 'base', message: 'Enter a value' }]
     });
 
     const mockErrors = [
@@ -89,7 +102,8 @@ test('override schema', function() {
         type: 'base64',
         schema: Joi.string()
             .base64()
-            .required()
+            .required(),
+        messages: [{ type: 'base', message: 'Enter a value' }]
     });
 
     expect(field.type).toBe('base64');
@@ -109,7 +123,8 @@ test('localise helper', function() {
         new Field({
             locale: 'en',
             name: 'example',
-            label: 'Text field'
+            label: 'Text field',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         }).localise({ en: 'english', cy: 'welsh' })
     ).toEqual('english');
 
@@ -117,7 +132,8 @@ test('localise helper', function() {
         new Field({
             locale: 'cy',
             name: 'example',
-            label: 'Text field'
+            label: 'Text field',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         }).localise({ en: 'english', cy: 'welsh' })
     ).toEqual('welsh');
 });

--- a/controllers/apply/lib/field-types/file.test.js
+++ b/controllers/apply/lib/field-types/file.test.js
@@ -6,7 +6,8 @@ test('FileField', function() {
     const field = new FileField({
         locale: 'en',
         name: 'example',
-        label: 'File field'
+        label: 'File field',
+        messages: [{ type: 'base', message: 'Please provide a file' }]
     });
 
     expect(field.type).toBe('file');

--- a/controllers/apply/lib/field-types/radio.test.js
+++ b/controllers/apply/lib/field-types/radio.test.js
@@ -10,7 +10,8 @@ test('valid field', function() {
         options: [
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' }
-        ]
+        ],
+        messages: [{ type: 'base', message: 'Select an option' }]
     });
 
     expect(field.type).toBe('radio');
@@ -31,7 +32,8 @@ test('required properties', function() {
         new RadioField({
             locale: 'en',
             name: 'example',
-            label: 'Example field'
+            label: 'Example field',
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Must provide options');
 
@@ -44,7 +46,8 @@ test('required properties', function() {
                 { label: 'Option 1', value: 'duplicate-value' },
                 { label: 'Option 2', value: 'duplicate-value' },
                 { label: 'Option 3', value: 'option-3' }
-            ]
+            ],
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Options must contain unique values');
 });

--- a/controllers/apply/lib/field-types/select.test.js
+++ b/controllers/apply/lib/field-types/select.test.js
@@ -11,7 +11,8 @@ test('select field', function() {
             { label: 'Option 1', value: 'option-1' },
             { label: 'Option 2', value: 'option-2' },
             { label: 'Option 3', value: 'option-3' }
-        ]
+        ],
+        messages: [{ type: 'base', message: 'Select an option' }]
     });
 
     expect(field.type).toBe('select');
@@ -42,7 +43,8 @@ test('select field supports optgroups', function() {
                 label: 'Group 2',
                 options: [{ label: 'Option 2', value: 'option-2' }]
             }
-        ]
+        ],
+        messages: [{ type: 'base', message: 'Select an option' }]
     });
 
     expect(field.normalisedOptions).toEqual([
@@ -61,7 +63,8 @@ test('required properties', function() {
                 { label: 'Option 1', value: 'duplicate-value' },
                 { label: 'Option 2', value: 'duplicate-value' },
                 { label: 'Option 3', value: 'option-3' }
-            ]
+            ],
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Options must contain unique values');
 
@@ -80,7 +83,8 @@ test('required properties', function() {
                     label: 'Group 2',
                     options: [{ label: 'Option 2', value: 'duplicate-value' }]
                 }
-            ]
+            ],
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Options must contain unique values');
 
@@ -94,7 +98,8 @@ test('required properties', function() {
                     label: 'Group 1',
                     options: [{ label: 'Option 1', value: 'duplicate-value' }]
                 }
-            ]
+            ],
+            messages: [{ type: 'base', message: 'Select an option' }]
         });
     }).toThrowError('Must provide default option when using optgroups');
 });

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -13,7 +13,8 @@ test('TextareaField', function() {
         name: 'example',
         label: 'Textarea field',
         minWords: minWords,
-        maxWords: maxWords
+        maxWords: maxWords,
+        messages: [{ type: 'base', message: 'Enter a value' }]
     });
 
     expect(field.type).toBe('textarea');
@@ -43,7 +44,8 @@ test('TextareaField', function() {
         isRequired: false,
         label: 'Radio field',
         minWords: minWords,
-        maxWords: maxWords
+        maxWords: maxWords,
+        messages: [{ type: 'base', message: 'Enter a value' }]
     });
 
     expect(optionalField.validate().error).toBeNull();
@@ -54,7 +56,8 @@ test('required properties', function() {
         new TextareaField({
             locale: 'en',
             name: 'example',
-            label: 'Example field'
+            label: 'Example field',
+            messages: [{ type: 'base', message: 'Enter a value' }]
         });
     }).toThrowError('Must provide minWords and maxWords');
 });


### PR DESCRIPTION
Pulled out the error catching code from https://github.com/biglotteryfund/blf-alpha/pull/2854

Requires all required field types to provide a `base` error message.