### PR TITLE
Fix a bunch of syntax errors

### DIFF
--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -102,7 +102,9 @@ async function sendExpiryEmails(req, emailQueue) {
                     return getAppData('projectCountry');
                 } else if (formId === 'standard-enquiry') {
                     const countries = getAppData('projectCountries');
-                    return countries.length === 1 ? countries[0] : 'Multiple';
+                    return countries && countries.length === 1
+                        ? countries[0]
+                        : 'Multiple';
                 }
             }
 
@@ -110,7 +112,8 @@ async function sendExpiryEmails(req, emailQueue) {
                 if (formId === 'awards-for-all') {
                     return getAppData('projectCountry') === 'wales';
                 } else if (formId === 'standard-enquiry') {
-                    return getAppData('projectCountries').includes('wales');
+                    const countries = getAppData('projectCountries');
+                    return countries && countries.includes('wales');
                 }
             }
 
@@ -166,7 +169,7 @@ async function sendExpiryEmails(req, emailQueue) {
                         './emails/expiry-email.njk'
                     ),
                     templateData: {
-                        isBilingual: isBilingual(),
+                        isBilingual: isBilingual,
                         projectName: getAppData('projectName'),
                         countryPhoneNumber: getPhoneFor(projectCountry),
                         countryEmail: getEmailFor(projectCountry),
@@ -287,6 +290,7 @@ router.post('/', async (req, res) => {
 
         res.json(response);
     } catch (error) {
+        console.log(error);
         res.status(400).json({
             err: error.message
         });

--- a/controllers/apply/expiry.js
+++ b/controllers/apply/expiry.js
@@ -290,7 +290,6 @@ router.post('/', async (req, res) => {
 
         res.json(response);
     } catch (error) {
-        console.log(error);
         res.status(400).json({
             err: error.message
         });


### PR DESCRIPTION
Application expiries were breaking since our last deploy as the code (which I foolishly copy/pasted from the PR and didn't test on real data) assumed that `projectCountries` would always be defined/an array. Also caught a dodgy variable/function confusion after said copy/paste. Always practice safe code, kids.