### PR TITLE
Launch awards for all start page

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -27,8 +27,7 @@
     "enableRelatedGrants": false,
     "enableSalesforceConnector": true,
     "enableSeeders": false,
-    "enableSessionExpiryWarning": true,
-    "enableStartPageBeforeLogin": false
+    "enableSessionExpiryWarning": true
   },
   "awardsForAll": {
     "enableExpiration": true,

--- a/config/development.json
+++ b/config/development.json
@@ -2,8 +2,7 @@
   "logLevel": "debug",
   "features": {
     "enableSeeders": true,
-    "enableSalesforceConnector": false,
-    "enableStartPageBeforeLogin": true
+    "enableSalesforceConnector": false
   },
   "awardsForAll": {
     "enableNewDateRange": true

--- a/config/test.json
+++ b/config/test.json
@@ -5,8 +5,7 @@
     }
   },
   "features": {
-    "enableHotjar": true,
-    "enableStartPageBeforeLogin": true
+    "enableHotjar": true
   },
   "awardsForAll": {
     "enableNewDateRange": true

--- a/controllers/apply/awards-for-all/index.js
+++ b/controllers/apply/awards-for-all/index.js
@@ -1,8 +1,6 @@
 'use strict';
 const path = require('path');
 
-const { isNotProduction } = require('../../../common/appData');
-
 const { initFormRouter } = require('../form-router');
 
 const formBuilder = require('./form');
@@ -11,17 +9,11 @@ const confirmationBuilder = require('./confirmation');
 const { EXPIRY_EMAIL_REMINDERS } = require('./constants');
 const { transform } = require('./transforms');
 
-function getStartTemplate() {
-    return isNotProduction
-        ? path.resolve(__dirname, './views/startpage.njk')
-        : null;
-}
-
 module.exports = initFormRouter({
     formId: 'awards-for-all',
     eligibilityBuilder: eligibilityBuilder,
     formBuilder: formBuilder,
-    startTemplate: getStartTemplate(),
+    startTemplate: path.resolve(__dirname, './views/startpage.njk'),
     confirmationBuilder: confirmationBuilder,
     transformFunction: transform,
     expiryEmailPeriods: EXPIRY_EMAIL_REMINDERS

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -69,10 +69,7 @@ function initFormRouter({
      */
     router.use(noStore, redirectWelsh, setCommonLocals);
 
-    /**
-     * Route: Start page
-     */
-    function renderStartPage(req, res) {
+    router.get('/start', function(req, res) {
         const nextPageUrl = eligibilityBuilder
             ? `${req.baseUrl}/eligibility/1`
             : `${req.baseUrl}/new`;
@@ -84,11 +81,7 @@ function initFormRouter({
         } else {
             res.redirect(nextPageUrl);
         }
-    }
-
-    if (features.enableStartPageBeforeLogin) {
-        router.get('/start', renderStartPage);
-    }
+    });
 
     /**
      * Application seed endpoint
@@ -213,10 +206,6 @@ function initFormRouter({
             '/eligibility',
             require('./eligibility')(eligibilityBuilder, formId)
         );
-    }
-
-    if (features.enableStartPageBeforeLogin === false) {
-        router.get('/start', renderStartPage);
     }
 
     function redirectCurrentlyEditing(req, res, applicationId) {


### PR DESCRIPTION
For when https://github.com/biglotteryfund/blf-alpha/pull/2881 is merged and we're happy to launch this page.

Launch awards for all start page and remove enableStartPageBeforeLogin flag. This makes start pages before log in the consistent behaviour