### PR TITLE
Fix duplicate emails

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -304,12 +304,35 @@ function getUserSession() {
     });
 }
 
+// Prevent clicks on submit buttons from taking effect if they occur within 1 second
+// of the previous click (eg. avoid double submits)
+// Original source: https://github.com/alphagov/govuk-frontend/commit/884e7dd73ad943d71fb701da15626e6a7ad0b933
+function preventDoubleSubmits() {
+    let debounceFormSubmitTimer = null;
+    const DEBOUNCE_TIMEOUT_IN_SECONDS = 3;
+    $('input[type="submit"][data-prevent-double-click="true"]').on(
+        'click',
+        function(event) {
+            // If the timer is still running then we want to prevent the click from submitting the form
+            if (debounceFormSubmitTimer) {
+                event.preventDefault();
+                return false;
+            }
+
+            debounceFormSubmitTimer = setTimeout(function() {
+                debounceFormSubmitTimer = null;
+            }, DEBOUNCE_TIMEOUT_IN_SECONDS * 1000);
+        }
+    );
+}
+
 function init() {
     handleConditionalRadios();
     handleExpandingDetails();
     warnOnUnsavedChanges();
     updateSecondaryNav();
     showLocalSaveWarning();
+    preventDoubleSubmits();
 
     // Hotjar tagging
     initHotjarTracking();

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -226,7 +226,7 @@
                     {% if csrfToken %}
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                     {% endif %}
-                    <input class="btn u-margin-bottom-s" type="submit" value="{{ copy.submit }}" />
+                    <input class="btn u-margin-bottom-s" type="submit" value="{{ copy.submit }}" data-prevent-double-click="true" />
                 </form>
             {% elseif not form.progress.isPristine %}
                 {{ submitActionsIncomplete() }}

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -41,9 +41,7 @@ async function handleSubmission(req, res, next) {
              * Allow updating if the password confirmation matches
              * and there is not an existing user with the requested email address
              */
-            const canUpdate =
-                passwordMatches === true &&
-                username !== get('username')(existingUser);
+            const canUpdate = passwordMatches === true && !existingUser;
 
             if (canUpdate) {
                 const userId = req.user.userData.id;

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -1,6 +1,5 @@
 'use strict';
 const path = require('path');
-const get = require('lodash/fp/get');
 const express = require('express');
 
 const { Users } = require('../../db/models');

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -44,7 +44,7 @@
                         }, errors = errors) }}
 
                         <div class="form-actions">
-                            <input type="submit" class="btn" value="{{ copy.actionLabel }}" />
+                            <input type="submit" class="btn" value="{{ copy.actionLabel }}" data-prevent-double-click="true" />
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
This does two things:

- Removes the bug where it's possible to change email address to a differently-cased version of an existing one (luckily the impact of this is low)

- Uses JavaScript to prevent multiple submit button clicks (taken from GDS source [here](https://design-system.service.gov.uk/components/button/#stop-users-from-accidentally-sending-information-more-than-once))

I checked and the issue of the user with `&amp;` in their email address is already fixed – they registered before we added [the fix here](https://github.com/biglotteryfund/blf-alpha/pull/2708) to convert it back into `&` again.

Once this is out I'll go through the list of duplicate users manually and fix up their accounts.