### PR TITLE
Add edit mode links

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1290,6 +1290,7 @@ applyNext:
   statusComplete: Cyflawn
   change: Newid
   continue: Parhau
+  backToSummary: Yn ôl i’r cynodeb
   saving: Yn arbed
   progressSaved: Cynnydd wedi’i arbed
   edit: Golygu

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1575,7 +1575,7 @@ applyNext:
   statusComplete: Complete
   change: Change
   continue: Continue
-  backToSummary: Back to Summary
+  backToSummary: Back to summary
   saving: Saving
   progressSaved: Progress saved
   edit: Edit

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1575,6 +1575,7 @@ applyNext:
   statusComplete: Complete
   change: Change
   continue: Continue
+  backToSummary: Back to Summary
   saving: Saving
   progressSaved: Progress saved
   edit: Edit

--- a/controllers/apply/form-router/steps.js
+++ b/controllers/apply/form-router/steps.js
@@ -70,11 +70,7 @@ module.exports = function(formId, formBuilder) {
          * redirect to the first step in the section.
          */
         if (!stepNumber) {
-            return res.redirect(
-                `${res.locals.formBaseUrl}/${section.slug}/1${
-                    isEditing ? '?edit' : ''
-                }`
-            );
+            return res.redirect(`${res.locals.formBaseUrl}/${section.slug}/1`);
         }
 
         const stepIndex = parseInt(stepNumber, 10) - 1;

--- a/controllers/apply/form-router/steps.js
+++ b/controllers/apply/form-router/steps.js
@@ -207,7 +207,7 @@ module.exports = function(formId, formBuilder) {
                 copy: res.locals.copy
             });
 
-            if (isEditing) {
+            if (isEditing && !isPaginationLinks()) {
                 return `${res.locals.formBaseUrl}/summary`;
             } else {
                 return req.body.previousBtn ? previousPage.url : nextPage.url;

--- a/controllers/apply/form-router/views/step.njk
+++ b/controllers/apply/form-router/views/step.njk
@@ -6,6 +6,7 @@
 {% from "./expiry-warnings.njk" import expiryPending, expiryLoggedOut with context %}
 
 {% macro saveButton() %}
+    {% set initialCta = __('applyNext.backToSummary') if isEditing else __('applyNext.continue') %}
     <button
         type="submit"
         class="btn btn--save js-save-btn"
@@ -16,7 +17,7 @@
             {{ iconTick() }}
         </span>
         <span class="btn--save__label js-save-btn-label">
-            {{ __('applyNext.continue') }}
+            {{ initialCta }}
         </span>
 
         <span class="btn__icon btn__icon-left btn--save__dots">

--- a/controllers/apply/form-router/views/step.njk
+++ b/controllers/apply/form-router/views/step.njk
@@ -6,7 +6,6 @@
 {% from "./expiry-warnings.njk" import expiryPending, expiryLoggedOut with context %}
 
 {% macro saveButton() %}
-    {% set initialCta = __('applyNext.backToSummary') if isEditing else __('applyNext.continue') %}
     <button
         type="submit"
         class="btn btn--save js-save-btn"
@@ -17,7 +16,7 @@
             {{ iconTick() }}
         </span>
         <span class="btn--save__label js-save-btn-label">
-            {{ initialCta }}
+            {{ __('applyNext.continue') }}
         </span>
 
         <span class="btn__icon btn__icon-left btn--save__dots">

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -114,17 +114,17 @@
     <section class="section-summary section-summary--{{ section.progress.status }}">
         <header class="section-progress-bar section-progress-bar--{{ section.progress.status }}">
             <h2 class="section-progress-bar__title">
-                <a href="{{ formBaseUrl }}/{{ section.slug }}?edit" class="u-link-unstyled">
+                <a href="{{ formBaseUrl }}/{{ section.slug }}" class="u-link-unstyled">
                     {{ secTitle }}
                 </a>
 
                 {% set editWord = copy.continue if section.progress.status === 'incomplete' else copy.edit %}
-                <a class="section-progress-bar__edit u-edit-link u-dont-print" href="{{ formBaseUrl }}/{{ section.slug }}?edit">
+                <a class="section-progress-bar__edit u-edit-link u-dont-print" href="{{ formBaseUrl }}/{{ section.slug }}">
                     {{ editWord }}<span class="u-visually-hidden"> "{{ secTitle }}" section</span>
                 </a>
             </h2>
 
-            <a class="section-progress-bar__marker u-link-unstyled" href="{{ formBaseUrl }}/{{ section.slug }}?edit">
+            <a class="section-progress-bar__marker u-link-unstyled" href="{{ formBaseUrl }}/{{ section.slug }}">
                 {% if section.progress.status === 'complete' %}
                     {{ iconTick() }}
                     {{ copy.statusComplete }}

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -188,7 +188,7 @@
 
             {{ formHeaderWithData(formTitle, form.summary.title) }}
 
-            <h1 class="t2 u-tone-brand-primary">{{ copy.summary.title }}</h1>
+            <h1 class="t2 u-tone-brand-primary" data-testid="summary-title">{{ copy.summary.title }}</h1>
 
             {{ summariseErrors() }}
 
@@ -210,7 +210,8 @@
                         class="btn-link u-text-small js-toggle-all-details js-only u-align-right"
                         aria-expanded="{% if expandSections %}true{% else %}false{% endif %}"
                         data-label-open="{{ copy.summary.collapseAll }}"
-                        data-label-closed="{{ copy.summary.expandAll }}">
+                        data-label-closed="{{ copy.summary.expandAll }}"
+                        data-testid="expand-all-sections">
                     </button>
                 </p>
             {% endif %}

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -94,7 +94,7 @@
                             </div>
                         </div>
                         <div class="step-summary__data__link">
-                            <a href="{{ formBaseUrl }}/{{ step.slug }}#form-field-{{ field.name }}" class="u-edit-link">
+                            <a href="{{ formBaseUrl }}/{{ step.slug }}?edit#form-field-{{ field.name }}" class="u-edit-link">
                                 {{ copy.change }} <span class="u-visually-hidden">{{ field.label | safe }}</span>
                             </a>
                         </div>
@@ -114,17 +114,17 @@
     <section class="section-summary section-summary--{{ section.progress.status }}">
         <header class="section-progress-bar section-progress-bar--{{ section.progress.status }}">
             <h2 class="section-progress-bar__title">
-                <a href="{{ formBaseUrl }}/{{ section.slug }}" class="u-link-unstyled">
+                <a href="{{ formBaseUrl }}/{{ section.slug }}?edit" class="u-link-unstyled">
                     {{ secTitle }}
                 </a>
 
                 {% set editWord = copy.continue if section.progress.status === 'incomplete' else copy.edit %}
-                <a class="section-progress-bar__edit u-edit-link u-dont-print" href="{{ formBaseUrl }}/{{ section.slug }}">
+                <a class="section-progress-bar__edit u-edit-link u-dont-print" href="{{ formBaseUrl }}/{{ section.slug }}?edit">
                     {{ editWord }}<span class="u-visually-hidden"> "{{ secTitle }}" section</span>
                 </a>
             </h2>
 
-            <a class="section-progress-bar__marker u-link-unstyled" href="{{ formBaseUrl }}/{{ section.slug }}">
+            <a class="section-progress-bar__marker u-link-unstyled" href="{{ formBaseUrl }}/{{ section.slug }}?edit">
                 {% if section.progress.status === 'complete' %}
                     {{ iconTick() }}
                     {{ copy.statusComplete }}

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -23,28 +23,6 @@ function checkRedirect({ from, to, isRelative = true, status = 301 }) {
     });
 }
 
-function startAwardsForAllApplication({ endOnSummaryScreen = false } = {}) {
-    // Dashboard
-    cy.findByText('Start a new application').click();
-
-    // Start page
-    cy.findByText('Start your application').click();
-
-    // Eligibility checker
-    times(5, function() {
-        cy.findByLabelText('Yes').click();
-        cy.findByText('Continue').click();
-    });
-    cy.findByText('Start your application').click();
-
-    if (!endOnSummaryScreen) {
-        // Leave summary page and go to first step
-        cy.findAllByText('Start your application')
-            .first()
-            .click();
-    }
-}
-
 it('should have expected cache headers', () => {
     cy.request('/').then(response => {
         expect(response.headers['cache-control']).to.eq(
@@ -559,6 +537,26 @@ it('should submit full awards for all application', () => {
         }
 
         cy.findByLabelText('Postcode').type(postcode);
+    }
+
+    function startApplication() {
+        // Dashboard
+        cy.findByText('Start a new application').click();
+
+        // Start page
+        cy.findByText('Start your application').click();
+
+        // Eligibility checker
+        times(5, function() {
+            cy.findByLabelText('Yes').click();
+            cy.findByText('Continue').click();
+        });
+        cy.findByText('Start your application').click();
+
+        // Summary page
+        cy.findAllByText('Start your application')
+            .first()
+            .click();
     }
 
     function stepProjectName(mock) {
@@ -1127,7 +1125,7 @@ it('should submit full awards for all application', () => {
         cy.visit('/apply/awards-for-all');
 
         acceptCookieConsent();
-        startAwardsForAllApplication();
+        startApplication();
 
         sectionYourProject(mock);
         sectionBeneficiaries(mock);
@@ -1145,12 +1143,7 @@ it('should submit full awards for all application', () => {
 
 it('should allow editing from the Summary screen', () => {
     cy.seedAndLogin().then(() => {
-        cy.visit('/apply/awards-for-all');
-
-        acceptCookieConsent();
-        startAwardsForAllApplication({
-            endOnSummaryScreen: true
-        });
+        cy.visit('/apply/awards-for-all/new');
 
         cy.findByTestId('expand-all-sections').click();
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -23,7 +23,7 @@ function checkRedirect({ from, to, isRelative = true, status = 301 }) {
     });
 }
 
-function startAwardsForAllApplication({ endOnSummaryScreen = false }) {
+function startAwardsForAllApplication({ endOnSummaryScreen = false } = {}) {
     // Dashboard
     cy.findByText('Start a new application').click();
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1155,7 +1155,7 @@ it('should allow editing from the Summary screen', () => {
             'My project'
         );
 
-        cy.findByText('Back to Summary').click();
+        cy.findByText('Continue').click();
 
         cy.findByTestId('summary-title').should('contain', 'Summary');
     });

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -561,8 +561,6 @@ it('should submit full awards for all application', () => {
         cy.findByLabelText('Postcode').type(postcode);
     }
 
-    startAwardsForAllApplication();
-
     function stepProjectName(mock) {
         cy.checkA11y();
 
@@ -1129,7 +1127,7 @@ it('should submit full awards for all application', () => {
         cy.visit('/apply/awards-for-all');
 
         acceptCookieConsent();
-        startApplication();
+        startAwardsForAllApplication();
 
         sectionYourProject(mock);
         sectionBeneficiaries(mock);

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -23,6 +23,28 @@ function checkRedirect({ from, to, isRelative = true, status = 301 }) {
     });
 }
 
+function startAwardsForAllApplication({ endOnSummaryScreen = false }) {
+    // Dashboard
+    cy.findByText('Start a new application').click();
+
+    // Start page
+    cy.findByText('Start your application').click();
+
+    // Eligibility checker
+    times(5, function() {
+        cy.findByLabelText('Yes').click();
+        cy.findByText('Continue').click();
+    });
+    cy.findByText('Start your application').click();
+
+    if (!endOnSummaryScreen) {
+        // Leave summary page and go to first step
+        cy.findAllByText('Start your application')
+            .first()
+            .click();
+    }
+}
+
 it('should have expected cache headers', () => {
     cy.request('/').then(response => {
         expect(response.headers['cache-control']).to.eq(
@@ -539,25 +561,7 @@ it('should submit full awards for all application', () => {
         cy.findByLabelText('Postcode').type(postcode);
     }
 
-    function startApplication() {
-        // Dashboard
-        cy.findByText('Start a new application').click();
-
-        // Start page
-        cy.findByText('Start your application').click();
-
-        // Eligibility checker
-        times(5, function() {
-            cy.findByLabelText('Yes').click();
-            cy.findByText('Continue').click();
-        });
-        cy.findByText('Start your application').click();
-
-        // Summary page
-        cy.findAllByText('Start your application')
-            .first()
-            .click();
-    }
+    startAwardsForAllApplication();
 
     function stepProjectName(mock) {
         cy.checkA11y();
@@ -1138,6 +1142,31 @@ it('should submit full awards for all application', () => {
         sectionTermsAndConditions(mock);
 
         submitApplication();
+    });
+});
+
+it('should allow editing from the Summary screen', () => {
+    cy.seedAndLogin().then(() => {
+        cy.visit('/apply/awards-for-all');
+
+        acceptCookieConsent();
+        startAwardsForAllApplication({
+            endOnSummaryScreen: true
+        });
+
+        cy.findByTestId('expand-all-sections').click();
+
+        cy.findAllByText('Change')
+            .first()
+            .click();
+
+        cy.findByLabelText('What is the name of your project?').type(
+            'My project'
+        );
+
+        cy.findByText('Back to Summary').click();
+
+        cy.findByTestId('summary-title').should('contain', 'Summary');
     });
 });
 


### PR DESCRIPTION
This adds support for `?edit` in step URLs, which changes the button wording to "Back to Summary", and means that after submission (validation errors or not), you'll end up back on the Summary screen.