### PR TITLE
Correct fallback date format for .calendar

### DIFF
--- a/common/locals.js
+++ b/common/locals.js
@@ -187,10 +187,15 @@ module.exports = function(req, res, next) {
      * @param dateString
      */
     res.locals.formatCalendarTime = function(dateString) {
-        return moment(dateString)
-            .tz('Europe/London')
-            .locale(locale)
-            .calendar();
+        return (
+            moment(dateString)
+                .tz('Europe/London')
+                // @TODO: Handle this consistently across date formatters
+                .locale(locale === 'en' ? 'en-gb' : 'cy')
+                .calendar(null, {
+                    sameElse: 'D MMMM, YYYY'
+                })
+        );
     };
 
     /**


### PR DESCRIPTION
.calendar() uses 'L' as the date format once the date is more than two weeks into the past/future. We were passing 'en' as the locale when we actually wanted `en-GB` as the former equals an American locale. Decided to also pass a custom date format for `sameElse` which determines the fallback format as it would be better if this was our common longer date format.

**Before**

![image](https://user-images.githubusercontent.com/123386/73193575-b172b680-4122-11ea-8bb3-eb2ba5e71c79.png)

**After**

![image](https://user-images.githubusercontent.com/123386/73193588-b6376a80-4122-11ea-937c-0470236e4d34.png)
