### PR TITLE
Make start page back url contextual

### DIFF
--- a/controllers/apply/awards-for-all/views/startpage.njk
+++ b/controllers/apply/awards-for-all/views/startpage.njk
@@ -10,7 +10,7 @@
     <main role="main" id="content">
         {% call contentBox(skipProse = true) %}
             {{ formHeader(
-                backUrl = backUrl,
+                backUrl = sectionUrl if user else localify('/funding/under10k'),
                 title = formTitle,
                 prefix = globalCopy.brand.title
             )}}

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -79,7 +79,6 @@ function initFormRouter({
 
         if (startTemplate) {
             res.render(startTemplate, {
-                backUrl: res.locals.sectionUrl,
                 nextPageUrl: nextPageUrl
             });
         } else {

--- a/controllers/apply/standard-proposal/views/startpage.njk
+++ b/controllers/apply/standard-proposal/views/startpage.njk
@@ -10,7 +10,7 @@
     <main role="main" id="content">
         {% call contentBox(skipProse = true) %}
             {{ formHeader(
-                backUrl = backUrl,
+                backUrl = sectionUrl if user else localify('/funding/over10k'),
                 title = formTitle,
                 prefix = globalCopy.brand.title
             )}}


### PR DESCRIPTION
Noticed that the start page back url was set to `/apply`. This only makes sense if you are logged in. The start page is a public url, before auth, so this may not be true.

Updates the pages to link to an appropriate funding page if not logged in.