### PR TITLE
Blog improvements

### DIFF
--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -49,12 +49,6 @@
             </p>
         {% endif %}
 
-        {% if entry.thumbnail %}
-            <img src="{{ entry.thumbnail.small }}"
-                 alt="{{ entry.title }}"
-                 class="u-margin-bottom" />
-        {% endif %}
-
         <ul class="tags-list">
             {% if entry.category %}
                 <li class="tag">
@@ -85,6 +79,13 @@
 
             <div class="content-sidebar">
                 <div class="content-sidebar__primary s-prose">
+
+                    {% if entry.thumbnail %}
+                        <img src="{{ entry.thumbnail.medium }}"
+                             alt="{{ entry.title }}"
+                             class="u-margin-bottom" />
+                    {% endif %}
+
                     {% if entry.body %}
                         <div class="s-prose">
                             {{ entry.body | safe }}

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -1,16 +1,14 @@
+{% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-{% from "components/card/macro.njk" import card %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
 {% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
-{% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/split-nav/macro.njk" import splitNav %}
 
 {% set bodyClass = 'has-static-header' %}
-{% extends "layouts/main.njk" %}
 
 {% macro articleMeta(entry) %}
 

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -64,13 +64,6 @@
                             </a>
                         </li>
                     {% endif %}
-                    {% for tag in entry.tags %}
-                        <li class="tag tag--secondary">
-                            <a href="{{ localify('/news/' + updateType + '?tag=' + tag.slug) }}">
-                                {{ tag.title }}
-                            </a>
-                        </li>
-                    {% endfor %}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Makes two, hopefully uncontroversial, changes to blog and news pages.

## 1. Removes tags from trail cards

These are…overwhelming…and are not well used enough to demand as much space as they take IMO. Suggesting removing these from listings, but keeping them on the post pages.

**Before**

<img width="1035" alt="Screenshot 2020-01-30 at 10 19 03" src="https://user-images.githubusercontent.com/123386/73440995-35f34e00-434a-11ea-9ddb-b1f3c35bada8.png">

**After**

<img width="1029" alt="Screenshot 2020-01-30 at 10 19 13" src="https://user-images.githubusercontent.com/123386/73441010-3986d500-434a-11ea-8dd5-d0193a37c522.png">

## 2. Move entry lead image to top of post rather than in sidebar

Can't quite remember the original intent here but they way these images are being used in practice means that they look incongruous when placed in the sidebar. We have a large version of them available so we should show them inline in the post body. Fixes #1941

**Before**

<img width="1077" alt="Screenshot 2020-01-30 at 10 18 51" src="https://user-images.githubusercontent.com/123386/73441199-82d72480-434a-11ea-9c3f-ecc9e055a1c6.png">

**After**

<img width="1056" alt="Screenshot 2020-01-30 at 10 18 43" src="https://user-images.githubusercontent.com/123386/73441216-89fe3280-434a-11ea-8f67-2b86a6ac5d7a.png">
