### PR TITLE
Launch new lead times, set enableNewDateRange to true

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -31,7 +31,7 @@
   },
   "awardsForAll": {
     "enableExpiration": true,
-    "enableNewDateRange": false
+    "enableNewDateRange": true
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]

--- a/config/development.json
+++ b/config/development.json
@@ -3,8 +3,5 @@
   "features": {
     "enableSeeders": true,
     "enableSalesforceConnector": false
-  },
-  "awardsForAll": {
-    "enableNewDateRange": true
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -6,8 +6,5 @@
   },
   "features": {
     "enableHotjar": true
-  },
-  "awardsForAll": {
-    "enableNewDateRange": true
   }
 }


### PR DESCRIPTION
For when we are ready to launch the new lead times and new date range fields. Plenty to clean up after this but we can come back to that in a future PR.