### PR TITLE
Tidy up use of blog tags

### DIFF
--- a/assets/sass/components/_badges.scss
+++ b/assets/sass/components/_badges.scss
@@ -28,6 +28,21 @@
     }
 }
 
+.o-tag {
+    display: inline-block;
+    border: 1px solid get-color('brand', 'primary');
+    color: get-color('brand', 'primary');
+    display: inline-block;
+    padding: 2px 7px;
+    text-decoration: none;
+    font-size: 14px;
+    margin: 3px 3px 3px 0;
+    @include on-interact() {
+        border-color: darken(get-color('brand', 'primary'), 10%);
+        color: darken(get-color('brand', 'primary'), 10%);
+    }
+}
+
 /* =========================================================================
    Pills
    ========================================================================= */

--- a/assets/sass/components/_news.scss
+++ b/assets/sass/components/_news.scss
@@ -136,7 +136,7 @@
         flex-basis: 100%;
     }
 
-    .blogpost-attribution__tags {
+    .blogpost-attribution__extra {
         flex-basis: 100%;
     }
 
@@ -146,45 +146,8 @@
             order: 0;
             flex-basis: auto;
         }
-        .blogpost-attribution__tags {
+        .blogpost-attribution__extra {
             flex-basis: auto;
-        }
-    }
-}
-
-/* =========================================================================
-   Tag List
-   ========================================================================= */
-
-.tags-list {
-    $primaryColour: get-color('brand', 'primary');
-    $secondaryColour: get-color('text', 'note');
-    .tag {
-        display: inline-block;
-
-        a {
-            border: 1px solid $primaryColour;
-            color: $primaryColour;
-            display: inline-block;
-            padding: 2px 7px;
-            text-decoration: none;
-            font-size: 14px;
-            margin: 3px 3px 3px 0;
-            @include on-interact() {
-                border-color: darken($primaryColour, 10%);
-                color: darken($primaryColour, 10%);
-            }
-        }
-
-        &.tag--secondary {
-            a {
-                border-color: $secondaryColour;
-                color: $secondaryColour;
-                @include on-interact() {
-                    border-color: darken($secondaryColour, 10%);
-                    color: darken($secondaryColour, 10%);
-                }
-            }
         }
     }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -129,6 +129,7 @@ global:
     to: i
     on: ar
     of: o
+    in: yn
     phone: ffôn
     email: email
     printThisPage: Argraffu'r dudalen hon

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ global:
     to: to
     on: on
     of: of
+    in: in
     phone: phone
     email: email
     printThisPage: Print this page

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -157,7 +157,6 @@ router.get(
                 slug: req.params.slug,
                 query: pick(req.query, [
                     'page',
-                    'tag',
                     'author',
                     'category',
                     'region',
@@ -174,9 +173,6 @@ router.get(
                 const getCrumbName = entriesMeta => {
                     let title;
                     switch (entriesMeta.pageType) {
-                        case 'tag':
-                            title = `${copy.filters.tag}: ${entriesMeta.activeTag.title}`;
-                            break;
                         case 'category':
                             title = `${copy.filters.category}: ${entriesMeta.activeCategory.title}`;
                             break;

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -157,6 +157,7 @@ router.get(
                 slug: req.params.slug,
                 query: pick(req.query, [
                     'page',
+                    'tag',
                     'author',
                     'category',
                     'region',
@@ -173,6 +174,9 @@ router.get(
                 const getCrumbName = entriesMeta => {
                     let title;
                     switch (entriesMeta.pageType) {
+                        case 'tag':
+                            title = `${copy.filters.tag}: ${entriesMeta.activeTag.title}`;
+                            break;
                         case 'category':
                             title = `${copy.filters.category}: ${entriesMeta.activeCategory.title}`;
                             break;
@@ -206,28 +210,37 @@ router.get(
                 if (shouldRedirectLinkUrl(req, entry)) {
                     res.redirect(entry.linkUrl);
                 } else if (entry.content.length > 0) {
-                    res.locals.isBilingual =
-                        entry.availableLanguages.length === 2;
-                    res.locals.openGraph = get(entry, 'openGraph', false);
+                    const entryTags = get(entry, 'tags', []);
+                    const entryTagList = entryTags.map(function(tag) {
+                        return {
+                            label: tag.title.toLowerCase(),
+                            url: localify(req.i18n.getLocale())(
+                                `/news/${updateType}?tag=${tag.slug}`
+                            )
+                        };
+                    });
+
+                    const viewData = {
+                        updateType: updateType,
+                        title: entry.title,
+                        isBilingual: entry.availableLanguages.length === 2,
+                        description: entry.summary,
+                        openGraph: get(entry, 'openGraph', false),
+                        socialImage: get(entry, 'thumbnail.large', false),
+                        entry: entry,
+                        entryTagList: entryTagList,
+                        breadcrumbs: res.locals.breadcrumbs.concat(
+                            {
+                                label: typeCopy.singular,
+                                url: `${req.baseUrl}/${updateType}`
+                            },
+                            { label: entry.title }
+                        )
+                    };
 
                     return res.render(
                         path.resolve(__dirname, './views/post/blogpost'),
-                        {
-                            updateType: updateType,
-                            title: entry.title,
-                            description: entry.summary,
-                            socialImage: get(entry, 'thumbnail.large', false),
-                            entry: entry,
-                            breadcrumbs: res.locals.breadcrumbs.concat(
-                                {
-                                    label: typeCopy.singular,
-                                    url: res.locals.localify(
-                                        `${req.baseUrl}/${updateType}`
-                                    )
-                                },
-                                { label: entry.title }
-                            )
-                        }
+                        viewData
                     );
                 } else {
                     next();

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -36,9 +36,6 @@
                             {% endif %}
                         </div>
                     </aside>
-                {% elseif entriesMeta.pageType === 'tag' %}
-                    {% set activeTag = entriesMeta.activeTag %}
-                    <h1>{{ copy.filters.viewPostsTagged }} "{{ activeTag.title }}"</h1>
                 {% elseif entriesMeta.pageType === 'category' %}
                     {% set activeCategory = entriesMeta.activeCategory %}
                     <h1>{{ copy.filters.viewPostsIn }} {{ activeCategory.title }}</h1>

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -39,6 +39,9 @@
                 {% elseif entriesMeta.pageType === 'category' %}
                     {% set activeCategory = entriesMeta.activeCategory %}
                     <h1>{{ copy.filters.viewPostsIn }} {{ activeCategory.title }}</h1>
+                {% elseif entriesMeta.pageType === 'tag' %}
+                    {% set activeTag = entriesMeta.activeTag %}
+                    <h1>{{ copy.filters.viewPostsTagged }} "{{ activeTag.title }}"</h1>
                 {% else %}
                     <p>{{ copy.introductions[updateType] }}</p>
                 {% endif %}

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -3,6 +3,7 @@
 {% from "components/card/macro.njk" import card %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
+{% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
@@ -86,6 +87,13 @@
                     {{ articleMeta(entry) }}
                 </div>
             </div>
+
+            {% if entryTagList.length > 0 %}
+                {{ inlineLinks(
+                    prefix = __('global.misc.topics') | title,
+                    links = entryTagList
+                ) }}
+            {% endif %}
 
             <div class="o-button-group-flex u-gutter-half u-margin-top">
                 <a class="btn btn--small btn--outline"

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -10,48 +10,50 @@
 {% set bodyClass = 'has-static-header' %}
 
 {% macro articleMeta(entry) %}
-    {% set aboutTitle = copy.author.plural if entry.authors.length > 1  else copy.author.singular %}
-    {% call card(aboutTitle) %}
-        {% for author in entry.authors -%}
-            <aside class="o-media">
-                {% if author.photo %}
-                    <img src="{{ author.photo }}"
-                         alt="{{ author.title }}"
-                         class="o-media__figure"
-                         width="60"/>
-                {% endif %}
-                <div class="o-media__body">
-                    <p class="u-no-margin"><strong>{{ author.title }}</strong></p>
-                    {% if author.authorTitle %}
-                        <p>
-                            {{ author.authorTitle }}
-                            {% if author.shortBiography %}
-                                <br>
-                                {{ author.shortBiography}}
-                            {% endif %}
-                        </p>
-                    {% endif %}
-                </div>
-            </aside>
-            <p class="u-margin-top-s"><a href="{{ localify('/news/' + updateType + '?author=' + author.slug) }}">{{ copy.author.seeAllPosts }}</a></p>
-        {% endfor %}
-    {% endcall %}
-
     {% call card(copy.aboutThisContent[updateType]) %}
-        {% if entry.postDate %}
-            <p class="u-margin-bottom-s">
-                <strong>{{ copy.datePublished }}:</strong>
-                <time datetime="{{ entry.postDate.date }}">
-                    {{ formatDate(entry.postDate.date) }}
-                </time>
-            </p>
-        {% endif %}
+        <div class="s-prose">
+            {% if entry.postDate %}
+                <p>
+                    <strong>{{ copy.datePublished }}</strong>:<br/>
+                    <time datetime="{{ entry.postDate.date }}">
+                        {{ formatDate(entry.postDate.date) }}
+                    </time>
 
-        {% if entry.category %}
-            <p><a class="o-tag" href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
-                {{ entry.category.title }}
-            </a></p>
-        {% endif %}
+                    {% if entry.category %}
+                        {{ __('global.misc.in') }}
+                        <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
+                            {{ entry.category.title }}
+                        </a>
+                    {% endif %}
+                </p>
+            {% endif %}
+
+            <p><strong>
+                {{ copy.author.plural if entry.authors.length > 1  else copy.author.singular }}
+            </strong></p>
+
+            {% for author in entry.authors -%}
+                <div class="o-media u-margin-bottom-s">
+                    {% if author.photo %}
+                        <img src="{{ author.photo }}"
+                             alt="{{ author.title }}"
+                             class="o-media__figure"
+                             width="60"/>
+                    {% endif %}
+                    <div class="o-media__body">
+                        <p class="u-no-margin"><strong>{{ author.title }}</strong></p>
+                        {% if author.authorTitle %}
+                            <p>{{ author.authorTitle }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+                {% if author.shortBiography %}
+                    <p>{{ author.shortBiography}}</p>
+                {% endif %}
+
+                <p class="u-margin-top-s"><a href="{{ localify('/news/' + updateType + '?author=' + author.slug) }}">{{ copy.author.seeAllPosts }}</a></p>
+            {% endfor %}
+        </div>
     {% endcall %}
 {% endmacro %}
 

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -3,7 +3,6 @@
 {% from "components/card/macro.njk" import card %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
-{% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
@@ -11,7 +10,6 @@
 {% set bodyClass = 'has-static-header' %}
 
 {% macro articleMeta(entry) %}
-
     {% set aboutTitle = copy.author.plural if entry.authors.length > 1  else copy.author.singular %}
     {% call card(aboutTitle) %}
         {% for author in entry.authors -%}
@@ -49,25 +47,12 @@
             </p>
         {% endif %}
 
-        <ul class="tags-list">
-            {% if entry.category %}
-                <li class="tag">
-                    <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
-                        {{ entry.category.title }}
-                    </a>
-                </li>
-            {% endif %}
-            {% for tag in entry.tags %}
-                <li class="tag tag--secondary">
-                    <a href="{{ localify('/news/' + updateType + '?tag=' + tag.slug) }}">
-                        {{ tag.title }}
-                    </a>
-                </li>
-            {% endfor %}
-        </ul>
+        {% if entry.category %}
+            <p><a class="o-tag" href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
+                {{ entry.category.title }}
+            </a></p>
+        {% endif %}
     {% endcall %}
-
-
 {% endmacro %}
 
 {% block content %}
@@ -99,16 +84,6 @@
                     {{ articleMeta(entry) }}
                 </div>
             </div>
-
-            {% if entry.tags.length > 0 %}
-                <aside class="article__topics" role="aside">
-                    {% set links = [] %}
-                    {% for tag in entry.tags %}
-                        {% set links = (links.push({ "label": tag.title, "url": localify('/news/' + updateType + '?tag=' + tag.slug) }), links) %}
-                    {% endfor %}
-                    {{ inlineLinks(prefix = __('global.misc.topics') | title, links = links) }}
-                </aside>
-            {% endif %}
 
             <div class="o-button-group-flex u-gutter-half u-margin-top">
                 <a class="btn btn--small btn--outline"

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -66,7 +66,7 @@
             {{ breadcrumbTrail(breadcrumbs) }}
 
             <div class="content-sidebar">
-                <div class="content-sidebar__primary s-prose">
+                <div class="content-sidebar__primary">
 
                     {% if entry.thumbnail %}
                         <img src="{{ entry.thumbnail.medium }}"

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -2,7 +2,6 @@
 {% from "components/card/macro.njk" import card %}
 {% from "components/document-list/macro.njk" import documentList %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
-{% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 
@@ -31,7 +30,7 @@
 {% block content %}
     <main role="main">
         {{ pageTitle(title) }}
-    
+
         <section class="content-box u-inner-wide-only">
             {{ breadcrumbTrail(breadcrumbs) }}
 

--- a/controllers/updates/views/view-helpers.njk
+++ b/controllers/updates/views/view-helpers.njk
@@ -55,17 +55,14 @@
                 </div>
             {% endif %}
 
-            <div class="blogpost-attribution__tags">
-                <ul class="tags-list">
-                    {% if entry.category %}
-                        <li class="tag">
-                            <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
-                                {{ entry.category.title }}
-                            </a>
-                        </li>
-                    {% endif %}
-                </ul>
-            </div>
+            {% if entry.category %}
+                <div class="blogpost-attribution__extra">
+                    <a class="o-tag"
+                       href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
+                    {{ entry.category.title }}
+                    </a>
+                </div>
+            {% endif %}
         </div>
     {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Makes a change to blog posts to remove tags and, as a result, simplify the post metadata section.

Ran this by @LynseyJReynolds and aggree this makes sense as the practical use of this is a) low usage based on analytics and b) noisy. with many tags per post leading to a messy taxonomy.

We already have (more stable) categories for posts so having two taxonomies here doesn't make sense given our current use case.

Will give the appropriate people a heads up before this goes out and we might want to refine the meta section a bit, but hopefully the benefit of the before and after is clear.

**Before**

<img width="1045" alt="Screenshot 2020-01-31 at 16 17 23" src="https://user-images.githubusercontent.com/123386/73555397-7683c200-4445-11ea-8fd1-1b9e4cf72983.png">

**After**

<img width="1031" alt="Screenshot 2020-01-31 at 16 15 12" src="https://user-images.githubusercontent.com/123386/73555437-8b605580-4445-11ea-8449-efcda6d20e7f.png">
