### PR TITLE
Fix the definition of a week

### DIFF
--- a/controllers/apply/awards-for-all/constants.js
+++ b/controllers/apply/awards-for-all/constants.js
@@ -102,7 +102,7 @@ const EXPIRY_EMAIL_REMINDERS = [
     {
         emailType: 'AFA_ONE_WEEK',
         sendBeforeExpiry: {
-            amount: 14,
+            amount: 7,
             unit: 'days'
         }
     },

--- a/controllers/apply/standard-proposal/constants.js
+++ b/controllers/apply/standard-proposal/constants.js
@@ -11,7 +11,7 @@ const EXPIRY_EMAIL_REMINDERS = [
     {
         emailType: 'STANDARD_ONE_WEEK',
         sendBeforeExpiry: {
-            amount: 14,
+            amount: 7,
             unit: 'days'
         }
     },


### PR DESCRIPTION
Got this email at the weekend and was a bit confused

<img width="464" alt="image" src="https://user-images.githubusercontent.com/394376/73648501-9ac5e580-4675-11ea-92f3-215a0728517e.png">

This fixes things so a week is 7 days, not 14.

I guess an alternative fix would be to change the email subject to read "You have two weeks..." which means all the ones scheduled to go out will have the correct text? Or otherwise we could move all the `STANDARD_ONE_WEEK` and `AFA_ONE_WEEK` emails back a week? Or just leave it and let it work itself out... thoughts welcome!