### PR TITLE
Allow Insight pages to have children

### DIFF
--- a/controllers/insights/views/insights-detail.njk
+++ b/controllers/insights/views/insights-detail.njk
@@ -11,7 +11,7 @@
 
 {% block content %}
     <main role="main">
-            {% if pageHero %}
+        {% if pageHero %}
             {{ hero(title, pageHero.image) }}
         {% endif %}
 


### PR DESCRIPTION
Makes it possible for Insight pages to have children, eg:

`/insights/youth-serious-violence/knife-crime-report`:

![image](https://user-images.githubusercontent.com/394376/73742400-40e02100-4744-11ea-829f-fcfbe9e77bb5.png)

Pairs with https://github.com/biglotteryfund/craft-dev/pull/203 and this is happening as we're seeing some of these pages extend a bit more than we'd like.