### PR TITLE
Fix preview URLs for new Craft version

### DIFF
--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -6,7 +6,7 @@ module.exports = function checkPreviewMode(queryParams) {
     }
 
     function isShareLink() {
-        return queryParams['x-craft-preview'] || queryParams['token'];
+        return queryParams['x-craft-preview'] && queryParams['token'];
     }
 
     return {

--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -2,11 +2,11 @@
 
 module.exports = function checkPreviewMode(queryParams) {
     function isLivePreview() {
-        return queryParams['x-craft-live-preview'] && queryParams['token'];
+        return queryParams['x-craft-live-preview'] || queryParams['token'];
     }
 
     function isShareLink() {
-        return queryParams['x-craft-preview'] && queryParams['token'];
+        return queryParams['x-craft-preview'] || queryParams['token'];
     }
 
     return {


### PR DESCRIPTION
Looks like some preview URLs Craft generates in the latest version don't include `?token` URL parameters, which means our `X-Frame-Options` doesn't get unset and the preview iframe fails. This change allows them through again.