### PR TITLE
Remove redundant localify call

### DIFF
--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -119,9 +119,7 @@ router.get(
                             breadcrumbs: res.locals.breadcrumbs.concat(
                                 {
                                     label: typeCopy.plural,
-                                    url: res.locals.localify(
-                                        `${req.baseUrl}/press-releases`
-                                    )
+                                    url: `${req.baseUrl}/press-releases`
                                 },
                                 { label: entry.title }
                             )
@@ -189,7 +187,7 @@ router.get(
 
                 const crumbs = res.locals.breadcrumbs.concat({
                     label: typeCopy.plural,
-                    url: res.locals.localify(`${req.baseUrl}/${updateType}`)
+                    url: `${req.baseUrl}/${updateType}`
                 });
 
                 const crumbName = getCrumbName(response.meta);


### PR DESCRIPTION
Spotted whilst updating https://github.com/biglotteryfund/blf-alpha/pull/2905

Calling this method from locals like this is not something we do anywhere else in the codebase and as it happens is redundant as req.baseUrl already includes the current locale.