### PR TITLE
Remove enableExpiration flag

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -29,9 +29,6 @@
     "enableSeeders": false,
     "enableSessionExpiryWarning": true
   },
-  "awardsForAll": {
-    "enableExpiration": true
-  },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]
   },


### PR DESCRIPTION
Build on https://github.com/biglotteryfund/blf-alpha/pull/2917 and removes another unneeded feature flag.

The `enableExpiration` flag was originally introduced to allow the release of expiry behaviour to begin with, this is now used for all pending applications so we can safely remove the conditional code.