### PR TITLE
Remove enableSessionExpiryWarning flag

### DIFF
--- a/assets/js/common/forms.js
+++ b/assets/js/common/forms.js
@@ -11,7 +11,6 @@ const expiryCheckIntervalSeconds = 30;
 // Note: if changing this, the accompanying copy will need to change too
 const warningShownSecondsRemaining = 10 * 60;
 
-const showWarnings = window.AppConfig.apply.enableSessionExpiryWarning;
 let hasShownWarning = false;
 
 function handleBeforeUnload(e) {
@@ -254,17 +253,13 @@ function handleSessionExpiration() {
             tagHotjarRecording(['App: User session expired']);
             // Prevent the page abandonment warning from showing
             removeBeforeUnload();
-            if (showWarnings) {
-                modal.triggerModal('apply-expiry-expired');
-            }
+            modal.triggerModal('apply-expiry-expired');
         } else if (expiryTimeRemaining <= warningShownSecondsRemaining) {
             // The user has a few minutes remaining before logout
             if (!hasShownWarning) {
                 trackEvent('Session', 'Warning', 'Timeout almost reached');
                 tagHotjarRecording(['App: User shown session expiry warning']);
-                if (showWarnings) {
-                    modal.triggerModal('apply-expiry-pending');
-                }
+                modal.triggerModal('apply-expiry-pending');
                 hasShownWarning = true;
             }
         }

--- a/config/default.json
+++ b/config/default.json
@@ -26,8 +26,7 @@
     "enableHotjar": false,
     "enableRelatedGrants": false,
     "enableSalesforceConnector": true,
-    "enableSeeders": false,
-    "enableSessionExpiryWarning": true
+    "enableSeeders": false
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]

--- a/views/includes/metaHead.njk
+++ b/views/includes/metaHead.njk
@@ -9,9 +9,6 @@
         locale: '{{ locale }}',
         localePrefix: '{{ localePrefix }}',
         sessionExpirySeconds: {{ appData.config.get('session.expiryInSeconds') }},
-        apply: {
-            enableSessionExpiryWarning: {{ appData.config.get('features.enableSessionExpiryWarning') }}
-        },
         authCookieName: '{{ appData.config.get('session.cookieLogin') }}'
     };
 


### PR DESCRIPTION
`enableSessionExpiryWarning` is always true and is now standard behaviour so we can safely remove this flag