### PR TITLE
Add support for Fact River component via CMS API

### DIFF
--- a/views/components/fact-river/macro.njk
+++ b/views/components/fact-river/macro.njk
@@ -1,0 +1,17 @@
+{% macro factRiver(facts, useLocalImages = false) %}
+    <ul class="fact-river">
+        {% for fact in facts %}
+            <li class="fact-river__item">
+                <div class="fact-item{% if (loop.index % 2 === 0) %} fact-item--reversed{% endif %}">
+                    {% if fact.image %}
+                        {% set imgSource = "/assets/images/illustrations/" + fact.image if useLocalImages else fact.image  %}
+                        <div class="fact-item__image">
+                            <img src="{{ imgSource }}" alt="">
+                        </div>
+                    {% endif %}
+                    <div class="fact-item__text">{{ fact.text | safe }}</div>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+{% endmacro %}

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -1,5 +1,6 @@
 {% from "components/callout/macro.njk" import callout %}
 {% from "components/child-pages/macro.njk" import childPages %}
+{% from "components/fact-river/macro.njk" import factRiver %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
 {% from "components/related-content/macro.njk" import relatedContent %}
 {% from "components/segment-links/macro.njk" import segmentLinks %}
@@ -41,6 +42,8 @@
                             image = { "url": part.photo, "caption": part.photoCaption },
                             isReversed = mediaAsideCycler.next() if mediaAsideCycler else false
                         ) }}
+                    {% elseif part.type === 'factRiver' %}
+                        {{ factRiver(part.content) }}
                     {% elseif part.type === 'relatedContent' %}
                         {{ relatedContent(
                             articles = part.content,

--- a/views/static-pages/region.njk
+++ b/views/static-pages/region.njk
@@ -1,24 +1,9 @@
 {% from "components/hero.njk" import hero with context %}
 {% from "components/content-tabs/macro.njk" import contentTabs %}
+{% from "components/fact-river/macro.njk" import factRiver %}
 
 {% extends "layouts/main.njk" %}
 
-{% macro factRiver(facts) %}
-    <ul class="fact-river">
-        {% for fact in facts %}
-            <li class="fact-river__item">
-                <div class="fact-item{% if (loop.index % 2 === 0) %} fact-item--reversed{% endif %}">
-                    {% if fact.image %}
-                        <div class="fact-item__image">
-                            <img src="{{ "/assets/images/illustrations/" + fact.image }} " alt="">
-                        </div>
-                    {% endif %}
-                    <div class="fact-item__text">{{ fact.text | safe }}</div>
-                </div>
-            </li>
-        {% endfor %}
-    </ul>
-{% endmacro %}
 
 {% block content %}
     {% set availableFundingContent %}
@@ -61,7 +46,7 @@
             {% if (copy.sections.fundingInRegion.groups.length > 1) %}
                 <h2 class="t2 t--underline">{{ group.description }}</h2>
             {% endif %}
-            {{ factRiver(group.facts) }}
+            {{ factRiver(group.facts, useLocalImages = true) }}
         {% endfor %}
     {% endset %}
 


### PR DESCRIPTION
Add support for "Fact Rivers" via flexible content:

![image](https://user-images.githubusercontent.com/394376/73932922-399b4d80-48d3-11ea-9155-589e5b497625.png)

![image](https://user-images.githubusercontent.com/394376/73932934-48820000-48d3-11ea-94b1-3f8618684923.png)

Pairs with https://github.com/biglotteryfund/craft-dev/pull/205