### PR TITLE
Remove projectLocationDescription from featured errors

### DIFF
--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -213,9 +213,6 @@ module.exports = function({ locale = 'en', data = {} } = {}) {
             cy: 'Dechrau ar eich cynnig'
         }),
         allFields,
-        featuredErrorsAllowList: [
-            { fieldName: 'projectLocationDescription', includeBase: true }
-        ],
         summary: summary(),
         schemaVersion: 'v0.2',
         forSalesforce() {

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -123,16 +123,3 @@ test.each([
     const result = form.validate(expected);
     expect(result.error).toBeNull();
 });
-
-test('featured messages based on allow list', () => {
-    const form = formBuilder({
-        data: mockResponse({
-            projectLocationDescription: null
-        })
-    });
-
-    const messages = form.validation.featuredMessages.map(item => item.msg);
-    expect(messages).toEqual([
-        expect.stringContaining('Tell us all of the locations')
-    ]);
-});


### PR DESCRIPTION
We introduced this in https://github.com/biglotteryfund/blf-alpha/pull/2740 to account for us changing the location description field from optional to required. This error appears for all new pending applications as soon as you start the form which is heavy-handed. Enough time has passed since the original change that we can remove this from the feature list.