### PR TITLE
Cleanup seeders

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -24,8 +24,7 @@
   },
   "features": {
     "enableRelatedGrants": false,
-    "enableSalesforceConnector": true,
-    "enableSeeders": false
+    "enableSalesforceConnector": true
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]

--- a/config/development.json
+++ b/config/development.json
@@ -1,7 +1,6 @@
 {
   "logLevel": "debug",
   "features": {
-    "enableSeeders": true,
     "enableSalesforceConnector": false
   }
 }

--- a/controllers/apply/form-router/index.js
+++ b/controllers/apply/form-router/index.js
@@ -7,7 +7,6 @@ const get = require('lodash/get');
 const includes = require('lodash/includes');
 const pick = require('lodash/pick');
 const set = require('lodash/set');
-const features = require('config').get('features');
 const formidable = require('formidable');
 
 const {
@@ -18,6 +17,7 @@ const {
 const logger = require('../../../common/logger').child({ service: 'apply' });
 const { localify, isWelsh, removeWelsh } = require('../../../common/urls');
 const { noStore } = require('../../../common/cached');
+const { isDev } = require('../../../common/appData');
 const { requireActiveUserWithCallback } = require('../../../common/authed');
 
 const { getObject } = require('./lib/file-uploads');
@@ -87,7 +87,7 @@ function initFormRouter({
      * Application seed endpoint
      * Allows generation of seed applications in test environments
      */
-    if (features.enableSeeders) {
+    if (isDev) {
         router.post('/seed', async (req, res) => {
             const application = await PendingApplication.createNewApplication({
                 formId: formId,

--- a/controllers/tools/surveys.js
+++ b/controllers/tools/surveys.js
@@ -1,7 +1,6 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const faker = require('faker');
 const moment = require('moment');
 const concat = require('lodash/concat');
 const countBy = require('lodash/countBy');
@@ -12,9 +11,7 @@ const maxBy = require('lodash/maxBy');
 const minBy = require('lodash/minBy');
 const orderBy = require('lodash/orderBy');
 const partition = require('lodash/partition');
-const random = require('lodash/random');
 const times = require('lodash/times');
-const features = require('config').get('features');
 const { sanitise } = require('../../common/sanitise');
 const { parse } = require('json2csv');
 
@@ -154,36 +151,5 @@ router.get('/', async (req, res, next) => {
         }
     }
 });
-
-if (features.enableSeeders) {
-    router.get('/seed', async (_req, res, next) => {
-        function mockResponses(count) {
-            const promises = times(count, function() {
-                const choice = Math.random() > 0.05 ? 'yes' : 'no';
-                return SurveyAnswer.create({
-                    choice: choice,
-                    path: faker.random.arrayElement([
-                        '/',
-                        '/funding',
-                        '/about'
-                    ]),
-                    message: choice === 'no' ? faker.lorem.paragraphs(1) : null,
-                    createdAt: moment()
-                        .subtract(random(0, 90), 'days')
-                        .toISOString()
-                });
-            });
-
-            return Promise.all(promises);
-        }
-
-        try {
-            const results = await mockResponses(50);
-            res.send(`Seeded ${results.length} survey responses`);
-        } catch (error) {
-            next(error);
-        }
-    });
-}
 
 module.exports = router;

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -1,10 +1,10 @@
 'use strict';
 const express = require('express');
 const uuidv4 = require('uuid/v4');
-const features = require('config').get('features');
 const moment = require('moment-timezone');
 
 const { Users } = require('../../db/models');
+const { isDev } = require('../../common/appData');
 const { localify } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
 const { requireNotStaffAuth } = require('../../common/authed');
@@ -27,7 +27,7 @@ router.use('/staff', require('./staff'));
  * Seed users have isActive automatically set as true
  * to bypass activation flow in tests.
  */
-if (features.enableSeeders) {
+if (isDev) {
     router.post('/seed', (req, res) => {
         const username = `${uuidv4()}@example.com`;
         const password = uuidv4();

--- a/db/seeders/survey-responses.js
+++ b/db/seeders/survey-responses.js
@@ -6,14 +6,14 @@ const times = require('lodash/times');
 
 module.exports = {
     up: async function(queryInterface) {
-        const dateRange = times(30, function(i) {
+        const dateRange = times(90, function(i) {
             return moment()
                 .subtract(i, 'days')
                 .toDate();
         });
 
         const surveyResponses = dateRange.flatMap(function(date) {
-            return times(random(10, 25), function() {
+            return times(random(5, 15), function() {
                 const choice = Math.random() > 0.05 ? 'yes' : 'no';
                 return {
                     choice: choice,

--- a/db/seeders/survey-responses.js
+++ b/db/seeders/survey-responses.js
@@ -6,19 +6,28 @@ const times = require('lodash/times');
 
 module.exports = {
     up: async function(queryInterface) {
-        const surveyResponses = times(100, function() {
-            const choice = Math.random() > 0.05 ? 'yes' : 'no';
-            const createdAt = moment()
-                .subtract(random(0, 90), 'days')
+        const dateRange = times(30, function(i) {
+            return moment()
+                .subtract(i, 'days')
                 .toDate();
+        });
 
-            return {
-                choice: choice,
-                path: faker.random.arrayElement(['/', '/funding', '/about']),
-                message: choice === 'no' ? faker.lorem.paragraphs(1) : null,
-                createdAt: createdAt,
-                updatedAt: createdAt
-            };
+        const surveyResponses = dateRange.flatMap(function(date) {
+            const choice = Math.random() > 0.05 ? 'yes' : 'no';
+
+            return times(random(1, 20), function() {
+                return {
+                    choice: choice,
+                    path: faker.random.arrayElement([
+                        '/',
+                        '/funding',
+                        '/about'
+                    ]),
+                    message: choice === 'no' ? faker.lorem.paragraphs(1) : null,
+                    createdAt: date,
+                    updatedAt: date
+                };
+            });
         });
 
         return queryInterface.bulkInsert('survey', surveyResponses, {});

--- a/db/seeders/survey-responses.js
+++ b/db/seeders/survey-responses.js
@@ -13,9 +13,8 @@ module.exports = {
         });
 
         const surveyResponses = dateRange.flatMap(function(date) {
-            const choice = Math.random() > 0.05 ? 'yes' : 'no';
-
-            return times(random(1, 20), function() {
+            return times(random(10, 25), function() {
+                const choice = Math.random() > 0.05 ? 'yes' : 'no';
                 return {
                     choice: choice,
                     path: faker.random.arrayElement([

--- a/db/seeders/survey-responses.js
+++ b/db/seeders/survey-responses.js
@@ -1,0 +1,30 @@
+'use strict';
+const faker = require('faker');
+const moment = require('moment');
+const random = require('lodash/random');
+const times = require('lodash/times');
+
+module.exports = {
+    up: async function(queryInterface) {
+        const surveyResponses = times(100, function() {
+            const choice = Math.random() > 0.05 ? 'yes' : 'no';
+            const createdAt = moment()
+                .subtract(random(0, 90), 'days')
+                .toDate();
+
+            return {
+                choice: choice,
+                path: faker.random.arrayElement(['/', '/funding', '/about']),
+                message: choice === 'no' ? faker.lorem.paragraphs(1) : null,
+                createdAt: createdAt,
+                updatedAt: createdAt
+            };
+        });
+
+        return queryInterface.bulkInsert('survey', surveyResponses, {});
+    },
+
+    down: function(queryInterface) {
+        return queryInterface.bulkDelete('survey', null, {});
+    }
+};


### PR DESCRIPTION
- Migrates survey seeder to a sequelize seeder file
- Removes need for `enableSeeders` feature flag

The only `/seed` endpoints remaining are the ones that are called dynamically from Cypress tests.