### PR TITLE
Migrate question fields to TextareaField

### DIFF
--- a/controllers/apply/awards-for-all/fields/your-idea-community.js
+++ b/controllers/apply/awards-for-all/fields/your-idea-community.js
@@ -1,6 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
-const Joi = require('../../lib/joi-extensions');
+
+const TextareaField = require('../../lib/field-types/textarea');
 
 module.exports = function(locale) {
     const localise = get(locale);
@@ -8,7 +9,8 @@ module.exports = function(locale) {
     const minWords = 50;
     const maxWords = 200;
 
-    return {
+    return new TextareaField({
+        locale: locale,
         name: 'yourIdeaCommunity',
         label: localise({
             en: `How does your project involve your community?`,
@@ -78,19 +80,8 @@ module.exports = function(locale) {
                 ond peidiwch â poeni os byddwch yn defnyddio llai.
             </strong></p>`
         }),
-        type: 'textarea',
-        settings: {
-            stackedSummary: true,
-            showWordCount: true,
-            minWords: minWords,
-            maxWords: maxWords
-        },
-        attributes: { rows: 15 },
-        isRequired: true,
-        schema: Joi.string()
-            .minWords(minWords)
-            .maxWords(maxWords)
-            .required(),
+        minWords: minWords,
+        maxWords: maxWords,
         messages: [
             {
                 type: 'base',
@@ -98,21 +89,7 @@ module.exports = function(locale) {
                     en: `Tell us how your project involves your community`,
                     cy: `Dywedwch wrthym sut mae eich prosiect yn cynnwys eich cymuned`
                 })
-            },
-            {
-                type: 'string.minWords',
-                message: localise({
-                    en: `Answer must be at least ${minWords} words`,
-                    cy: `Rhaid i’r ateb fod yn o leiaf ${minWords} gair`
-                })
-            },
-            {
-                type: 'string.maxWords',
-                message: localise({
-                    en: `Answer must be no more than ${maxWords} words`,
-                    cy: `Rhaid i’r ateb fod yn llai na ${maxWords} gair`
-                })
             }
         ]
-    };
+    });
 };

--- a/controllers/apply/awards-for-all/fields/your-idea-priorities.js
+++ b/controllers/apply/awards-for-all/fields/your-idea-priorities.js
@@ -1,6 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
-const Joi = require('../../lib/joi-extensions');
+
+const TextareaField = require('../../lib/field-types/textarea');
 
 module.exports = function(locale) {
     const localise = get(locale);
@@ -8,7 +9,8 @@ module.exports = function(locale) {
     const minWords = 50;
     const maxWords = 150;
 
-    return {
+    return new TextareaField({
+        locale: locale,
         name: 'yourIdeaPriorities',
         label: localise({
             en: `How does your project meet at least one of our funding priorities?`,
@@ -51,21 +53,9 @@ module.exports = function(locale) {
                 peidiwch â phoeni os byddwch yn defnyddio llai. 
             </strong></p>`
         }),
-        type: 'textarea',
-        settings: {
-            stackedSummary: true,
-            showWordCount: true,
-            minWords: minWords,
-            maxWords: maxWords
-        },
-        attributes: {
-            rows: 12
-        },
-        isRequired: true,
-        schema: Joi.string()
-            .minWords(minWords)
-            .maxWords(maxWords)
-            .required(),
+        minWords: minWords,
+        maxWords: maxWords,
+        attributes: { rows: 12 },
         messages: [
             {
                 type: 'base',
@@ -73,21 +63,7 @@ module.exports = function(locale) {
                     en: `Tell us how your project meets at least one of our funding priorities`,
                     cy: `Dywedwch wrthym sut mae eich prosiect yn cwrdd ag o leiaf un o’n blaenoriaethau ariannu`
                 })
-            },
-            {
-                type: 'string.minWords',
-                message: localise({
-                    en: `Answer must be at least ${minWords} words`,
-                    cy: `Rhaid i’r ateb fod yn o leiaf ${minWords} gair`
-                })
-            },
-            {
-                type: 'string.maxWords',
-                message: localise({
-                    en: `Answer must be no more than ${maxWords} words`,
-                    cy: `Rhaid i’r ateb fod yn llai na ${maxWords} gair`
-                })
             }
         ]
-    };
+    });
 };

--- a/controllers/apply/awards-for-all/fields/your-idea-project.js
+++ b/controllers/apply/awards-for-all/fields/your-idea-project.js
@@ -1,6 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
-const Joi = require('../../lib/joi-extensions');
+
+const TextareaField = require('../../lib/field-types/textarea');
 
 module.exports = function(locale) {
     const localise = get(locale);
@@ -8,7 +9,8 @@ module.exports = function(locale) {
     const minWords = 50;
     const maxWords = 300;
 
-    return {
+    return new TextareaField({
+        locale: locale,
         name: 'yourIdeaProject',
         label: localise({
             en: `What would you like to do?`,
@@ -57,18 +59,9 @@ module.exports = function(locale) {
             </strong></p>`
         }),
         type: 'textarea',
-        settings: {
-            stackedSummary: true,
-            showWordCount: true,
-            minWords: minWords,
-            maxWords: maxWords
-        },
+        minWords: minWords,
+        maxWords: maxWords,
         attributes: { rows: 20 },
-        isRequired: true,
-        schema: Joi.string()
-            .minWords(minWords)
-            .maxWords(maxWords)
-            .required(),
         messages: [
             {
                 type: 'base',
@@ -76,21 +69,7 @@ module.exports = function(locale) {
                     en: 'Tell us about your project',
                     cy: 'Dywedwch wrthym am eich prosiect'
                 })
-            },
-            {
-                type: 'string.minWords',
-                message: localise({
-                    en: `Answer must be at least ${minWords} words`,
-                    cy: `Rhaid i’r ateb fod yn o leiaf ${minWords} gair`
-                })
-            },
-            {
-                type: 'string.maxWords',
-                message: localise({
-                    en: `Answer must be no more than ${maxWords} words`,
-                    cy: `Rhaid i’r ateb fod yn llai na ${maxWords} gair`
-                })
             }
         ]
-    };
+    });
 };

--- a/controllers/apply/lib/field-types/textarea.js
+++ b/controllers/apply/lib/field-types/textarea.js
@@ -32,18 +32,8 @@ class TextareaField extends Field {
         this.schema = this.isRequired
             ? baseSchema.required()
             : baseSchema.allow('').optional();
-    }
 
-    getType() {
-        return 'textarea';
-    }
-
-    defaultAttributes() {
-        return { rows: 15 };
-    }
-
-    defaultMessages() {
-        return [
+        this.messages = [
             {
                 type: 'string.minWords',
                 message: this.localise({
@@ -58,7 +48,15 @@ class TextareaField extends Field {
                     cy: `Rhaid i’r ateb fod yn llai na ${this.maxWords} gair`
                 })
             }
-        ];
+        ].concat(props.messages || []);
+    }
+
+    getType() {
+        return 'textarea';
+    }
+
+    defaultAttributes() {
+        return { rows: 15 };
     }
 
     get displayValue() {

--- a/controllers/apply/lib/field-types/textarea.js
+++ b/controllers/apply/lib/field-types/textarea.js
@@ -62,8 +62,11 @@ class TextareaField extends Field {
     get displayValue() {
         if (this.value) {
             const val = this.value.toString();
-            const words = this.localise({ en: 'words', cy: 'gair' });
-            return `${val}\n\n(${countWords(val)} ${words})`;
+            const wordCountSummary = `${countWords(val)}/${
+                this.maxWords
+            } ${this.localise({ en: 'words', cy: 'gair' })}`;
+
+            return `${val}\n\n${wordCountSummary}`;
         } else {
             return '';
         }

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -24,7 +24,7 @@ test('TextareaField', function() {
 
     field.withValue(goodValue);
     expect(field.displayValue).toEqual(
-        `${goodValue}\n\n(${minWords + 1} words)`
+        `${goodValue}\n\n${minWords + 1}/${maxWords} words`
     );
     expect(field.validate().error).toBeNull();
 


### PR DESCRIPTION
- Migrate awards for all question fields to `TextareaField` in line with standard form
- Fix bug with default error messages
- Add max words to display value

<img width="960" alt="Screenshot 2020-02-11 at 10 27 53" src="https://user-images.githubusercontent.com/123386/74229375-25cc5e80-4cba-11ea-9830-b864837c41a9.png">
