### PR TITLE
Strip tags on change a11y text

### DIFF
--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -95,7 +95,7 @@
                         </div>
                         <div class="step-summary__data__link">
                             <a href="{{ formBaseUrl }}/{{ step.slug }}?edit#form-field-{{ field.name }}" class="u-edit-link">
-                                {{ copy.change }} <span class="u-visually-hidden">{{ field.label | safe }}</span>
+                                {{ copy.change }} <span class="u-visually-hidden">{{ field.label | striptags }}</span>
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
Fixes this bug where we were outputting the raw HTML of the label for the visually hidden text alongside change links

<img width="973" alt="Screenshot 2020-02-11 at 16 12 45" src="https://user-images.githubusercontent.com/123386/74255569-f59cb400-4ce9-11ea-80d0-fce00e5c45a8.png">

Calls `| striptags` instead so we get a plain string version of the label.

![image](https://user-images.githubusercontent.com/123386/74255659-15cc7300-4cea-11ea-97a7-419163857de6.png)
