### PR TITLE
Update awards for all expiry email

### DIFF
--- a/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
+++ b/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
@@ -4,18 +4,18 @@ exports[`expiry email for awards for all 1`] = `
 " Hello,
 
  Your National Lottery Awards for All application isn’t finished yet
-We noticed you started applying for Example project name, but haven’t finished your application. 
+We noticed you started applying for Example project name, but haven’t finished yet. 
 
  You have until 1 June, 2050 12:00 to finish your application 
-If you don’t complete it before that time, we’ll delete it–so that we can keep your data safe. 
+If you don’t complete it before that time, we’ll delete it, so we can keep your data safe. 
 
- How to finish your application Log in to your account
-[https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer the rest of the
-questions. 
+ How to finish your application
+Log in to your account [https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer
+the rest of the questions. 
 
  If you don’t want more reminders from us
-You can tell us to stop sending you these reminder emails
-[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN]. 
+You can tell us to stop sending you these reminder emails.
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN] 
 
  If you have any questions at all
 You can call 0345 4 10 20 30. Or email general.enquiries@tnlcommunityfund.org.uk. We’ll be happy to help you. 
@@ -55,18 +55,18 @@ Neges ddwyieithog – y Gymraeg i’w weld isod.
 Hello,
 
  Your National Lottery Awards for All application isn’t finished yet
-We noticed you started applying for Example project name, but haven’t finished your application. 
+We noticed you started applying for Example project name, but haven’t finished yet. 
 
  You have until 1 June, 2050 12:00 to finish your application 
-If you don’t complete it before that time, we’ll delete it–so that we can keep your data safe. 
+If you don’t complete it before that time, we’ll delete it, so we can keep your data safe. 
 
- How to finish your application Log in to your account
-[https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer the rest of the
-questions. 
+ How to finish your application
+Log in to your account [https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer
+the rest of the questions. 
 
  If you don’t want more reminders from us
-You can tell us to stop sending you these reminder emails
-[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN]. 
+You can tell us to stop sending you these reminder emails.
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN] 
 
  If you have any questions at all
 You can call 0300 123 0735. Or email wales@tnlcommunityfund.org.uk. We’ll be happy to help you. 
@@ -77,13 +77,13 @@ The National Lottery Awards for All Team
 
 ----------------------------------------------------------------------------------------------------------------------------------
 
-Hello,
+Helo,
 
  Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi ei orffen eto
 Fe sylweddolom eich bod wedi dechrau ymgeisio am Example project name, ond heb orffen eich cais. 
 
  Mae gennych tan 1 Mehefin, 2050 12:00 i orffen eich cais 
-Os nad ydych yn cwblhau eich cais cyn hynny, byddwn yn ei ddileu—felly gallwn gadw eich data yn ddiogel. 
+Os nad ydych yn ei gwblhau yn yr amser yna, byddwn yn ei ddileu, er mwyn i ni gadw eich data’n ddiogel. 
 
  Sut i orffen eich cais Mewngofnodi i’ch cyfrif
 [https://www.tnlcommunityfund.org.uk/welsh//apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]ac ateb gweddill y

--- a/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
+++ b/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
@@ -3,24 +3,24 @@
 exports[`expiry email for awards for all 1`] = `
 " Hello,
 
- Your National Lottery Awards for All application isn’t finished yet.
-We noticed you started applying for Example project name. But you haven’t finished your application. 
+ Your National Lottery Awards for All application isn’t finished yet
+We noticed you started applying for Example project name, but haven’t finished your application. 
 
- You have until 1 June, 2050 12:00 to finish your application.
-If you don’t complete your application before that time, we’ll delete it - so that we can keep your data safe. 
+ You have until 1 June, 2050 12:00 to finish your application 
+If you don’t complete it before that time, we’ll delete it–so that we can keep your data safe. 
 
- To finish your application
-Log in to your account [https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer
-the rest of the questions. 
+ How to finish your application Log in to your account
+[https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer the rest of the
+questions. 
 
  If you don’t want more reminders from us
-You can tell us to stop sending emails [https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN] that remind
-you about your application. 
+You can tell us to stop sending you these reminder emails
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN]. 
 
  If you have any questions at all
 You can call 0345 4 10 20 30. Or email general.enquiries@tnlcommunityfund.org.uk. We’ll be happy to help you. 
 
-Best wishes,
+ Best wishes,
 The National Lottery Awards for All Team"
 `;
 

--- a/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
+++ b/controllers/apply/expiries/__snapshots__/send-expiry-email.test.js.snap
@@ -47,3 +47,104 @@ You can call 0345 4 10 20 30. Or email general.enquiries@tnlcommunityfund.org.uk
 Best wishes,
 The National Lottery Community Fund"
 `;
+
+exports[`welsh expiry email for awards for all 1`] = `
+" Bilingual message – please scroll down for Welsh.
+Neges ddwyieithog – y Gymraeg i’w weld isod. 
+
+Hello,
+
+ Your National Lottery Awards for All application isn’t finished yet
+We noticed you started applying for Example project name, but haven’t finished your application. 
+
+ You have until 1 June, 2050 12:00 to finish your application 
+If you don’t complete it before that time, we’ll delete it–so that we can keep your data safe. 
+
+ How to finish your application Log in to your account
+[https://www.tnlcommunityfund.org.uk/apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]and answer the rest of the
+questions. 
+
+ If you don’t want more reminders from us
+You can tell us to stop sending you these reminder emails
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN]. 
+
+ If you have any questions at all
+You can call 0300 123 0735. Or email wales@tnlcommunityfund.org.uk. We’ll be happy to help you. 
+
+ Best wishes,
+The National Lottery Awards for All Team 
+
+
+----------------------------------------------------------------------------------------------------------------------------------
+
+Hello,
+
+ Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi ei orffen eto
+Fe sylweddolom eich bod wedi dechrau ymgeisio am Example project name, ond heb orffen eich cais. 
+
+ Mae gennych tan 1 Mehefin, 2050 12:00 i orffen eich cais 
+Os nad ydych yn cwblhau eich cais cyn hynny, byddwn yn ei ddileu—felly gallwn gadw eich data yn ddiogel. 
+
+ Sut i orffen eich cais Mewngofnodi i’ch cyfrif
+[https://www.tnlcommunityfund.org.uk/welsh//apply/awards-for-all/edit/MOCK_APPLICATION_ID?s=expiryEmail]ac ateb gweddill y
+cwestiynau. 
+
+ Os nad ydych eisiau rhagor o nodiadau atgoffa gennym
+Gallwch ddweud wrthym i stopio anfon yr e-byst atgoffa hyn atoch
+[https://www.tnlcommunityfund.org.uk/welsh/apply/emails/unsubscribe?token=MOCK_TOKEN]. 
+
+ Os oes gennych unrhyw gwestiynau
+Gallwch ffonio 0300 123 0735. Neu e-bostio wales@tnlcommunityfund.org.uk. Byddwn yn hapus i’ch helpu. 
+
+ Cofion gorau,
+Tîm Arian i Bawb y Loteri Genedlaethol"
+`;
+
+exports[`welsh expiry email for standard funding proposal 1`] = `
+" Bilingual message – please scroll down for Welsh.
+Neges ddwyieithog – y Gymraeg i’w weld isod. 
+
+Hello,
+
+ Your funding proposal isn’t finished yet
+We noticed you started telling us about Example project name. But you haven’t finished yet. 
+
+ You have until 1 June, 2050 12:00 to finish your funding proposal. 
+If you don’t complete it before that time, we’ll delete it - so that we can keep your data safe. 
+
+ How to finish your funding proposal
+Log in to your account [https://www.tnlcommunityfund.org.uk/apply/your-funding-proposal/edit/MOCK_APPLICATION_ID?s=expiryEmail]and
+answer the rest of the questions. 
+
+ If you don’t want more reminders from us
+You can tell us to stop sending you these reminder emails.
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN] 
+
+ If you have any questions at all
+You can call 0300 123 0735. Or email wales@tnlcommunityfund.org.uk. We’ll be happy to help you. 
+
+Best wishes,
+The National Lottery Community Fund 
+
+Hello,
+
+ Nid yw eich cynnig ariannu wedi gorffen eto
+Fe sylweddolom eich bod wedi dechrau dweud wrthym am Example project name. Ond nid ydych wedi gorffen eto. 
+
+ Mae gennych tan 1 June, 2050 12:00 i orffen eich cynnig ariannu. 
+Os nad ydych yn ei gwblhau yn yr amser yna, byddwn yn ei ddileu - er mwyn i ni allu cadw eich data yn ddiogel. 
+
+ Sut i orffen eich cynnig ariannu
+Mewngofnodwch i’ch cyfrif [https://www.tnlcommunityfund.org.uk/apply/your-funding-proposal/edit/MOCK_APPLICATION_ID?s=expiryEmail]
+ac ateb gweddill y cwestiynau. 
+
+ Os nad ydych eisiau mwy o nodiadau atgoffa gennym
+Gallwch ddweud wrthym i stopio anfon yr e-byst atgoffa hyn
+[https://www.tnlcommunityfund.org.uk/apply/emails/unsubscribe?token=MOCK_TOKEN] 
+
+ Os oes gennych unrhyw gwestiynau
+Gallwch ffonio 0300 123 0735. Neu e-bostio wales@tnlcommunityfund.org.uk. Byddwn yn hapus i’ch helpu. 
+
+Cofion gorau,
+Cronfa Gymunedol y Loteri Genedlaethol"
+`;

--- a/controllers/apply/expiries/send-expiry-email.test.js
+++ b/controllers/apply/expiries/send-expiry-email.test.js
@@ -5,11 +5,11 @@ const moment = require('moment');
 
 const sendExpiryEmail = require('./send-expiry-email');
 
-test('expiry email for awards for all', async function() {
-    const mockTransport = nodemailer.createTransport({
-        jsonTransport: true
-    });
+const mockTransport = nodemailer.createTransport({
+    jsonTransport: true
+});
 
+test('expiry email for awards for all', async function() {
     const info = await sendExpiryEmail(
         {
             emailType: 'AFA_ONE_MONTH',
@@ -34,11 +34,32 @@ test('expiry email for awards for all', async function() {
     expect(infoMessage.text).toMatchSnapshot();
 });
 
-test('expiry email for standard funding proposal', async function() {
-    const mockTransport = nodemailer.createTransport({
-        jsonTransport: true
-    });
+test('welsh expiry email for awards for all', async function() {
+    const info = await sendExpiryEmail(
+        {
+            emailType: 'AFA_ONE_MONTH',
+            unsubscribeToken: 'MOCK_TOKEN',
+            formId: 'awards-for-all',
+            applicationId: 'MOCK_APPLICATION_ID',
+            applicationData: {
+                projectCountry: 'wales',
+                projectName: 'Example project name'
+            },
+            expiresAt: moment('2050-06-01 12:00').toISOString(),
+            sendTo: 'example@example.com'
+        },
+        mockTransport
+    );
 
+    const infoMessage = JSON.parse(info.message);
+
+    expect(infoMessage.subject).toBe(
+        'You have one month to finish your application / Mae gennych fis i orffen eich cais'
+    );
+    expect(infoMessage.text).toMatchSnapshot();
+});
+
+test('expiry email for standard funding proposal', async function() {
     const info = await sendExpiryEmail(
         {
             emailType: 'STANDARD_ONE_MONTH',
@@ -46,7 +67,7 @@ test('expiry email for standard funding proposal', async function() {
             formId: 'standard-enquiry',
             applicationId: 'MOCK_APPLICATION_ID',
             applicationData: {
-                projectCountry: 'england',
+                projectCountries: ['england'],
                 projectName: 'Example project name'
             },
             expiresAt: moment('2050-06-01 12:00').toISOString(),
@@ -59,6 +80,31 @@ test('expiry email for standard funding proposal', async function() {
 
     expect(infoMessage.subject).toBe(
         'You have one month to finish your funding proposal'
+    );
+    expect(infoMessage.text).toMatchSnapshot();
+});
+
+test('welsh expiry email for standard funding proposal', async function() {
+    const info = await sendExpiryEmail(
+        {
+            emailType: 'STANDARD_ONE_MONTH',
+            unsubscribeToken: 'MOCK_TOKEN',
+            formId: 'standard-enquiry',
+            applicationId: 'MOCK_APPLICATION_ID',
+            applicationData: {
+                projectCountries: ['wales'],
+                projectName: 'Example project name'
+            },
+            expiresAt: moment('2050-06-01 12:00').toISOString(),
+            sendTo: 'example@example.com'
+        },
+        mockTransport
+    );
+
+    const infoMessage = JSON.parse(info.message);
+
+    expect(infoMessage.subject).toBe(
+        'You have one month to finish your funding proposal / Mae gennych fis ar ôl i orffen eich cynnig'
     );
     expect(infoMessage.text).toMatchSnapshot();
 });

--- a/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
+++ b/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
@@ -11,7 +11,7 @@
     <p>
         <strong>Your National Lottery Awards for All application isn’t finished yet</strong><br/>
         We noticed you started applying{% if projectName %} for {{ projectName | safe }}{% endif %},
-        but haven’t finished your application.
+        but haven’t finished yet.
     </p>
     <p>
         <strong>
@@ -19,18 +19,18 @@
             to finish your application
         </strong><br/>
         If you don’t complete it before that time,
-        we’ll delete it–so that we can keep your data safe.
+        we’ll delete it, so we can keep your data safe.
     </p>
     <p>
-        <strong>How to finish your application</strong>
+        <strong>How to finish your application</strong><br/>
         <a href="{{ editLink.en }}">Log in to your account</a>
         and answer the rest of the questions.
     </p>
     <p>
         <strong>If you don’t want more reminders from us</strong><br/>
         You can <a href="{{ unsubscribeLink.en }}">
-            tell us to stop sending you these reminder emails
-        </a>.
+            tell us to stop sending you these reminder emails.
+        </a>
     </p>
     <p>
         <strong>If you have any questions at all</strong><br/>
@@ -44,7 +44,7 @@
     {% if isBilingual %}
         <hr />
 
-        <p>Hello,</p>
+        <p>Helo,</p>
         <p>
             <strong>Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi ei orffen eto</strong><br/>
             Fe sylweddolom eich bod wedi dechrau ymgeisio{% if projectName %} am {{ projectName | safe }}{% endif %},
@@ -55,8 +55,8 @@
                 Mae gennych tan {{ expiryDate.cy }}
                 i orffen eich cais
             </strong><br/>
-            Os nad ydych yn cwblhau eich cais cyn hynny,
-            byddwn yn ei ddileu—felly gallwn gadw eich data yn ddiogel.
+            Os nad ydych yn ei gwblhau yn yr amser yna,
+            byddwn yn ei ddileu, er mwyn i ni gadw eich data’n ddiogel.
         </p>
         <p>
             <strong>Sut i orffen eich cais</strong>
@@ -65,18 +65,18 @@
         </p>
         <p>
             <strong>Os nad ydych eisiau rhagor o nodiadau atgoffa gennym</strong><br/>
-            <a href="{{ unsubscribeLink.cy }}">
-                Gallwch ddweud wrthym i stopio anfon yr e-byst atgoffa hyn atoch
+            Gallwch ddweud wrthym i <a href="{{ unsubscribeLink.cy }}">
+                stopio anfon yr e-byst atgoffa hyn atoch
             </a>.
         </p>
         <p>
             <strong>Os oes gennych unrhyw gwestiynau</strong><br/>
-            Gallwch ffonio {{ countryPhoneNumber }}. Neu e-bostio {{ countryEmail }}. Byddwn yn hapus i’ch helpu.
+            Gallwch ffonio {{ countryPhoneNumber }}. Neu e-bostio {{ countryEmail }}.
+            Byddwn yn hapus i’ch helpu.
         </p>
         <p>
             <strong>Cofion gorau,<br/>
             Tîm Arian i Bawb y Loteri Genedlaethol</strong>
         </p>
     {% endif %}
-
 {% endblock %}

--- a/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
+++ b/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
@@ -1,45 +1,45 @@
 {% extends "../../../../views/layouts/emails.njk" %}
 
 {% block content %}
-
     {% if isBilingual %}
-        <p>
-            <strong>
-                Bilingual message – please scroll down for Welsh.<br />
-                Neges ddwyieithog – y Gymraeg i’w weld isod.
-            </strong>
-        </p>
+        <p><strong>
+            Bilingual message – please scroll down for Welsh.<br />
+            Neges ddwyieithog – y Gymraeg i’w weld isod.
+        </strong></p>
     {% endif %}
-
     <p>Hello,</p>
-
     <p>
-        <strong>Your National Lottery Awards for All application isn’t finished yet.</strong><br/>
-        We noticed you started applying{% if projectName %} for {{ projectName | safe }}{% endif %}. But you haven’t finished your application.
+        <strong>Your National Lottery Awards for All application isn’t finished yet</strong><br/>
+        We noticed you started applying{% if projectName %} for {{ projectName | safe }}{% endif %},
+        but haven’t finished your application.
     </p>
-
     <p>
-        <strong>You have until {{ expiryDate.en }} to finish your application.</strong><br/>
-        If you don’t complete your application before that time, we’ll delete it - so that we can keep your data safe.
+        <strong>
+            You have until {{ expiryDate.en }}
+            to finish your application
+        </strong><br/>
+        If you don’t complete it before that time,
+        we’ll delete it–so that we can keep your data safe.
     </p>
-
     <p>
-        <strong>To finish your application</strong><br/>
+        <strong>How to finish your application</strong>
         <a href="{{ editLink.en }}">Log in to your account</a>
         and answer the rest of the questions.
     </p>
-
     <p>
         <strong>If you don’t want more reminders from us</strong><br/>
-        You can <a href="{{ unsubscribeLink.en }}">tell us to stop sending emails</a> that remind you about your application.
+        You can <a href="{{ unsubscribeLink.en }}">
+            tell us to stop sending you these reminder emails
+        </a>.
     </p>
-
     <p>
         <strong>If you have any questions at all</strong><br/>
         You can call {{ countryPhoneNumber }}. Or email {{ countryEmail }}. We’ll be happy to help you.
     </p>
-
-    <p><strong>Best wishes,<br/>  The National Lottery Awards for All Team</strong></p>
+    <p>
+        <strong>Best wishes,<br/>
+        The National Lottery Awards for All Team</strong>
+    </p>
 
     {% if isBilingual %}
         <hr />

--- a/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
+++ b/controllers/apply/expiries/views/awards-for-all-expiry-email.njk
@@ -44,34 +44,39 @@
     {% if isBilingual %}
         <hr />
 
-        <p>Helo,</p>
-
+        <p>Hello,</p>
         <p>
-            <strong>Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi’i gwblhau eto.</strong><br/>
-            Fe sylweddolom eich bod wedi dechrau ymgeisio{% if projectName %} am {{ projectName | safe }}{% endif %}. Ond nid ydych wedi cwblhau eich cais.
+            <strong>Nid yw eich cais Arian i Bawb y Loteri Genedlaethol wedi ei orffen eto</strong><br/>
+            Fe sylweddolom eich bod wedi dechrau ymgeisio{% if projectName %} am {{ projectName | safe }}{% endif %},
+            ond heb orffen eich cais.
         </p>
-
         <p>
-            <strong>Mae gennych tan {{ expiryDate.cy }} i orffen eich cais.</strong><br />
-            Os nad ydych yn cwblhau eich cais cyn hynny, byddwn yn ei ddileu – felly gallwn gadw eich data yn ddiogel.
+            <strong>
+                Mae gennych tan {{ expiryDate.cy }}
+                i orffen eich cais
+            </strong><br/>
+            Os nad ydych yn cwblhau eich cais cyn hynny,
+            byddwn yn ei ddileu—felly gallwn gadw eich data yn ddiogel.
         </p>
-
         <p>
-            <strong>I orffen eich cais</strong><br />
-            <a href="{{ editLink.cy }}">Mewngofnodwch i'ch cyfrif ac ateb gweddill y cwestiynau</a>.
+            <strong>Sut i orffen eich cais</strong>
+            <a href="{{ editLink.cy }}">Mewngofnodi i’ch cyfrif</a>
+            ac ateb gweddill y cwestiynau.
         </p>
-
         <p>
-            <strong>Os nad ydych eisiau mwy o nodiadau atgoffa gennym</strong><br />
-            <a href="{{ unsubscribeLink.cy }}">Gallwch ddweud wrthym i stopio anfon e-byst  sy’n eich atgoffa am eich cais</a>.
+            <strong>Os nad ydych eisiau rhagor o nodiadau atgoffa gennym</strong><br/>
+            <a href="{{ unsubscribeLink.cy }}">
+                Gallwch ddweud wrthym i stopio anfon yr e-byst atgoffa hyn atoch
+            </a>.
         </p>
-
         <p>
-            <strong>Os oes gennych unrhyw gwestiynau</strong><br />
-            Gallwch ffonio {{ countryPhoneNumber }}. Neu e-bostiwch cymru@cronfagymunedolylg.org.uk. Byddwn yn hapus i’ch helpu.
+            <strong>Os oes gennych unrhyw gwestiynau</strong><br/>
+            Gallwch ffonio {{ countryPhoneNumber }}. Neu e-bostio {{ countryEmail }}. Byddwn yn hapus i’ch helpu.
         </p>
-
-        <p><strong>Cofion,<br /> Tîm Arian i Bawb y Loteri Genedlaethol</strong></p>
+        <p>
+            <strong>Cofion gorau,<br/>
+            Tîm Arian i Bawb y Loteri Genedlaethol</strong>
+        </p>
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Revises the copy to avoid saying 'application' over and over again and to simplify some of the language used.

Have sent the latest copy for translation