### PR TITLE
Migrate content API to got

### DIFF
--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -9,10 +9,8 @@ const router = express.Router();
 router.get('/', injectCopy('toplevel.home'), async (req, res, next) => {
     try {
         const { featuredLinks, promotedUpdates } = await contentApi.getHomepage(
-            {
-                locale: req.i18n.getLocale(),
-                requestParams: req.query
-            }
+            req.i18n.getLocale(),
+            req.query
         );
 
         res.render(path.resolve(__dirname, './views/home'), {

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -3,7 +3,6 @@ const path = require('path');
 const express = require('express');
 const get = require('lodash/get');
 const isArray = require('lodash/isArray');
-const pick = require('lodash/pick');
 
 const { buildArchiveUrl, localify } = require('../../common/urls');
 const { injectCopy, injectHeroImage } = require('../../common/inject-content');
@@ -72,8 +71,7 @@ router.get(
                 type: 'press-releases',
                 date: req.params.date,
                 slug: req.params.slug,
-                query: pick(req.query, ['page', 'region', 'social']),
-                requestParams: req.query
+                searchParams: req.query
             });
 
             if (!response.result) {
@@ -153,15 +151,7 @@ router.get(
                 type: updateType,
                 date: req.params.date,
                 slug: req.params.slug,
-                query: pick(req.query, [
-                    'page',
-                    'tag',
-                    'author',
-                    'category',
-                    'region',
-                    'social'
-                ]),
-                requestParams: req.query
+                searchParams: req.query
             });
 
             if (!response.result) {

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1286,7 +1286,7 @@ it('should correctly email users with expiring applications', () => {
 
 it('should submit materials order', () => {
     cy.visit(
-        '/funding/funding-guidance/managing-your-funding/ordering-free-materials'
+        '/funding/managing-your-grant/promoting-your-project/order-free-materials'
     );
     cy.get('a[href="#monolingual"]').click();
 


### PR DESCRIPTION
Migrate content API to got. This is obviously fairly wide reaching so happy if we want to break this down into smaller PRs and do a content-type at a time or something.