### PR TITLE
Remove old references to trailImageNew, thumbnail, heroNew etc

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -302,7 +302,14 @@ function getListingPage({ locale, path, query = {}, requestParams = {} }) {
         })
     }).then(response => {
         const attributes = response.data.map(item => item.attributes);
-        return attributes.find(_ => _.linkUrl === stripTrailingSlashes(path));
+        // @TODO remove the check for attr.path, which will shortly be removed the CMS
+        return attributes.find(attr => {
+            if (get(attr, 'path')) {
+                return attr.path === sanitisedPath;
+            } else {
+                return attr.linkUrl === stripTrailingSlashes(path);
+            }
+        });
     });
 }
 

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -16,7 +16,7 @@ const logger = require('./logger');
 const getAttrs = response => get('data.attributes')(response);
 const mapAttrs = response => map('attributes')(response.data);
 
-const { sanitiseUrlPath } = require('./urls');
+const { sanitiseUrlPath, stripTrailingSlashes } = require('./urls');
 let { CONTENT_API_URL } = require('./secrets');
 
 function fetch(urlPath, options) {
@@ -162,12 +162,10 @@ function getHeroImage({ locale, slug }) {
     );
 }
 
-function getHomepage({ locale, query= {}, requestParams = {} }) {
+function getHomepage({ locale, query = {}, requestParams = {} }) {
     return fetch(`/v1/${locale}/homepage`, {
         qs: addPreviewParams(requestParams, { ...query })
-    }).then(
-        response => response.data.attributes
-    );
+    }).then(response => response.data.attributes);
 }
 
 /**
@@ -304,7 +302,7 @@ function getListingPage({ locale, path, query = {}, requestParams = {} }) {
         })
     }).then(response => {
         const attributes = response.data.map(item => item.attributes);
-        return attributes.find(_ => _.path === sanitisedPath);
+        return attributes.find(_ => _.linkUrl === stripTrailingSlashes(path));
     });
 }
 

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -10,9 +10,8 @@ const checkPreviewMode = require('./check-preview-mode');
  * Populate hero image (with social image URLs too)
  * */
 function setHeroLocals({ res, entry }) {
-    // @TODO: Rename this once API has been updated back to `hero`
-    const heroImage = get('heroNew.image')(entry);
-    const heroCredit = get('heroNew.credit')(entry);
+    const heroImage = get('hero.image')(entry);
+    const heroCredit = get('hero.credit')(entry);
 
     if (heroImage) {
         res.locals.pageHero = {

--- a/controllers/common/views/listing-page.njk
+++ b/controllers/common/views/listing-page.njk
@@ -38,7 +38,7 @@
                             {{ miniatureHero({
                                 "title": page.trailText | default(page.title, true),
                                 "linkUrl": page.linkUrl,
-                                "image": { "url": page.trailImage if page.trailImage else page.photo }
+                                "image": { "url": page.trailImage }
                             }, isLarge = true) }}
                         </li>
                     {% endfor %}

--- a/controllers/grants/views/grant-detail.njk
+++ b/controllers/grants/views/grant-detail.njk
@@ -142,9 +142,9 @@
                         "alt": mainProgramme.title
                     } %}
 
-                    {% if fundingProgramme and fundingProgramme.heroNew %}
+                    {% if fundingProgramme and fundingProgramme.hero %}
                         {% set image = {
-                            "url": fundingProgramme.heroNew.image.large,
+                            "url": fundingProgramme.hero.image.large,
                             "alt": mainProgramme.title
                         } %}
                     {% endif %}

--- a/controllers/insights/views/insights-detail.njk
+++ b/controllers/insights/views/insights-detail.njk
@@ -69,9 +69,9 @@
                                 <div class="card__body">
                                     {% for programme in entry.relatedFundingProgrammes %}
                                         <a href="{{ programme.linkUrl }}" class="related-programme">
-                                            {% if programme.thumbnail %}
+                                            {% if programme.trailImage %}
                                                 <span class="related-programme__media">
-                                                    <img src="{{ programme.thumbnail }}"
+                                                    <img src="{{ programme.trailImage }}"
                                                         alt="{{ programme.title }}" />
                                                 </span>
                                             {% endif %}

--- a/controllers/strategic-investments/views/strategic-investments.njk
+++ b/controllers/strategic-investments/views/strategic-investments.njk
@@ -14,7 +14,7 @@
                             "title": programme.title,
                             "trailText": programme.trailText,
                             "image": {
-                                "url": programme.trailImage if programme.trailImage else programme.thumbnail,
+                                "url": programme.trailImage,
                                 "alt": programme.title
                             },
                             "link": { "url": programme.linkUrl, "label": "Learn more" }

--- a/views/components/child-pages/macro.njk
+++ b/views/components/child-pages/macro.njk
@@ -8,7 +8,7 @@
                     {{ miniatureHero({
                         "title": page.trailText | default(page.title, true),
                         "linkUrl": page.linkUrl,
-                        "image": { "url": page.trailImage if page.trailImage else page.photo }
+                        "image": { "url": page.trailImage }
                     }, isLarge = true) }}
                 </li>
             {% endfor %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -42,7 +42,7 @@
         "title": programme.title,
         "trailText": description | safe,
         "image": {
-            "url": programme.trailImageNew if programme.trailImageNew else programme.trailImage,
+            "url": programme.trailImage,
             "alt": programme.hero.caption or programme.title
         },
         "link": {
@@ -57,8 +57,8 @@
         <div class="u-tone-background-tint u-padded u-margin-top-l">
             {% for programme in programmes %}
                 <div class="o-media u-margin-bottom">
-                    {% if programme.thumbnail or programme.thumbnailNew %}
-                        <img src="{{ programme.thumbnailNew if programme.thumbnailNew else programme.thumbnail }}"
+                    {% if programme.thumbnail %}
+                        <img src="{{ programme.thumbnail }}"
                              alt="{{ programme.title }}"
                              class="o-media__figure"
                              width="100" />


### PR DESCRIPTION
Updates references to `heroNew` to just use `hero`. Ditto for `trailImageNew` too. Removes some outdated references to `photo`, `path` and `thumbnail`, too.

Have tested this fairly extensively locally and I'm confident it doesn't break anything that I could spot. Coordinating deployment will be slightly fiddly but I'm happy to risk a few minutes of missing images / errors, if we can avoid having to deploy `/v2/` versions for half the API endpoints, or continuing to support both versions of the field names etc. Thoughts welcome on this, though!

Pairs with [the CMS change request here](https://github.com/biglotteryfund/craft-dev/pull/208).