### PR TITLE
Add shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,19 @@ env:
 
 dist: bionic
 
-addons:
-  chrome: stable
-
 # Defaults
 language: node_js
 
-before_install:
-  # Required for Cypress on xenial
-  # Subset of https://docs.cypress.io/guides/guides/continuous-integration.html#Docker
-  - sudo apt-get install -y libgconf-2-4
+addons:
+  apt:
+    packages:
+      # Required for Cypress on Ubuntu 16+
+      # See https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
+      - libgconf-2-4
+      # Used for checking deploy scripts
+      - shellcheck
+  # Used to run Cypress using headless chrome rather than default Electron
+  chrome: stable
 
 # Cache locations
 cache:
@@ -27,7 +30,8 @@ cache:
     - ~/.cache # Cypress installed into ~/.cache/Cypress
 
 script:
-#  - npm audit --production
+  - shellcheck deploy/*.sh
+  - npm audit --production
   - npm run lint
   - npm run test-unit
   - npm run build-production

--- a/deploy/store_deploy_info.sh
+++ b/deploy/store_deploy_info.sh
@@ -2,7 +2,7 @@
 set -ev
 
 destdir=$TRAVIS_BUILD_DIR/config/deploy.json
-touch $destdir
+touch "$destdir"
 if [ -f "$destdir" ]
 then
     echo "{ \"buildNumber\": \"$TRAVIS_BUILD_NUMBER\", \"deployId\": \"DEPLOY_ID\", \"commitId\": \"$TRAVIS_COMMIT\" }" > "$destdir"

--- a/deploy/userdata.sh
+++ b/deploy/userdata.sh
@@ -11,7 +11,7 @@
 apt-get update
 apt-get install ruby -y
 apt-get install wget -y
-cd /home/ubuntu
+cd /home/ubuntu || exit
 wget https://aws-codedeploy-eu-west-2.s3.amazonaws.com/latest/install
 chmod +x ./install
 ./install auto


### PR DESCRIPTION
Adds `shellcheck` to deploy scripts and fixes a couple of warnings flagged by the new check

Picks up where we left off in https://github.com/biglotteryfund/blf-alpha/pull/2825 (which was merged but reverted as it was doing too much at once).

