### PR TITLE
Merge deploy artefact scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,7 @@ before_deploy:
   - >
     if ! [ "$BEFORE_DEPLOY_RUN" ]; then
       export BEFORE_DEPLOY_RUN=1;
-      npm prune --production > /dev/null 2>&1;
-      sh deploy/store_deploy_info.sh;
-      zip -qr latest * -x .\* -x "README.md" -x assets/\*;
-      mkdir -p dpl_cd_upload
-      mv latest.zip dpl_cd_upload/build-$TRAVIS_BUILD_NUMBER.zip
+      ./deploy/travis-prepare-deploy.sh
     fi
 
 deploy:

--- a/deploy/store_deploy_info.sh
+++ b/deploy/store_deploy_info.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -ev
-
-destdir=$TRAVIS_BUILD_DIR/config/deploy.json
-touch "$destdir"
-if [ -f "$destdir" ]
-then
-    echo "{ \"buildNumber\": \"$TRAVIS_BUILD_NUMBER\", \"deployId\": \"DEPLOY_ID\", \"commitId\": \"$TRAVIS_COMMIT\" }" > "$destdir"
-fi

--- a/deploy/travis-prepare-deploy.sh
+++ b/deploy/travis-prepare-deploy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+#################################################
+# Prepare Deploy
+#################################################
+# This step creates a .zip file which is uploaded to S3
+# and used by CodeDeploy as its deploy artefact
+
+# Prune devDependencies from artefact
+npm prune --production > /dev/null 2>&1;
+
+# Store deploy metadata, later loaded via the app.
+# DEPLOY_ID is a placeholder which is replaced with the
+# CodeDeploy deployment ID as part of the bootstrap step.
+destdir=$TRAVIS_BUILD_DIR/config/deploy.json
+touch "$destdir"
+if [ -f "$destdir" ]
+then
+    echo "{ \"buildNumber\": \"$TRAVIS_BUILD_NUMBER\", \"deployId\": \"DEPLOY_ID\", \"commitId\": \"$TRAVIS_COMMIT\" }" > "$destdir"
+fi
+
+# Bundle deploy artefact, excluding any unneeded files
+zip -qr latest ./* -x .\* -x assets/\* -x cypress/\*;
+
+# Store artefact locally for later use in Travis deploy step
+mkdir -p dpl_cd_upload
+mv latest.zip dpl_cd_upload/build-"$TRAVIS_BUILD_NUMBER".zip


### PR DESCRIPTION
Steps for producing the deploy artefact were split across a script and inline in the travis.yml. This change merges this process into a single script, and adds explanatory comments.

(Extracted from https://github.com/biglotteryfund/blf-alpha/pull/2825)