### PR TITLE
Add margin to buttons in s-prose

### DIFF
--- a/assets/sass/scopes/_prose.scss
+++ b/assets/sass/scopes/_prose.scss
@@ -79,6 +79,10 @@
         }
     }
 
+    .btn {
+        margin-bottom: .5em;
+    }
+
     table {
         $table-spacing: 4px;
 


### PR DESCRIPTION
Tiny change to stop this happening for buttons inside content areas on small screens:

<img width="334" alt="Screenshot 2020-02-28 at 14 30 01" src="https://user-images.githubusercontent.com/123386/75557156-6e647580-5a37-11ea-968f-4174e46034a6.png">

Now looks like this:

<img width="342" alt="Screenshot 2020-02-28 at 14 33 46" src="https://user-images.githubusercontent.com/123386/75557150-6c9ab200-5a37-11ea-96fa-5faa54754ba3.png">
