### PR TITLE
Content cleanup continued

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -130,7 +130,9 @@ function _buildPagination(paginationMeta, currentQuery = {}) {
  ***********************************************/
 
 function getRoutes() {
-    return fetch('/v1/list-routes').then(mapAttrs);
+    return queryContentApi('v1/list-routes')
+        .json()
+        .then(mapAttrs);
 }
 
 function getAliasForLocale({ locale, urlPath }) {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -339,15 +339,17 @@ function getProjectStory({ locale, grantId, query = {}, requestParams = {} }) {
     }).then(getAttrs);
 }
 
-function getOurPeople({ locale, requestParams = {} }) {
-    return fetch(`/v1/${locale}/our-people`, {
-        qs: addPreviewParams(requestParams)
-    }).then(mapAttrs);
+function getOurPeople(locale, searchParams = {}) {
+    return queryContentApi(`v1/${locale}/our-people`, {
+        searchParams: addPreviewParams(searchParams)
+    })
+        .json()
+        .then(mapAttrs);
 }
 
-function getDataStats(locale, requestParams = {}) {
+function getDataStats(locale, searchParams = {}) {
     return queryContentApi(`v1/${locale}/data`, {
-        searchParams: addPreviewParams(requestParams)
+        searchParams: addPreviewParams(searchParams)
     })
         .json()
         .then(getAttrs);

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -356,11 +356,16 @@ function getDataStats(locale, searchParams = {}) {
 }
 
 function getMerchandise({ locale, showAll = false } = {}) {
-    let params = {};
+    let searchParams = {};
     if (showAll) {
-        params.all = 'true';
+        searchParams.all = 'true';
     }
-    return fetch(`/v1/${locale}/merchandise`, { qs: params }).then(mapAttrs);
+
+    return queryContentApi(`v1/${locale}/merchandise`, {
+        searchParams: searchParams
+    })
+        .json()
+        .then(mapAttrs);
 }
 
 module.exports = {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -343,10 +343,12 @@ function getOurPeople({ locale, requestParams = {} }) {
     }).then(mapAttrs);
 }
 
-function getDataStats({ locale, query = {}, requestParams = {} }) {
-    return fetch(`/v1/${locale}/data`, {
-        qs: addPreviewParams(requestParams, { ...query })
-    }).then(response => response.data.attributes);
+function getDataStats(locale, requestParams = {}) {
+    return queryContentApi(`v1/${locale}/data`, {
+        searchParams: addPreviewParams(requestParams)
+    })
+        .json()
+        .then(getAttrs);
 }
 
 function getMerchandise({ locale, showAll = false } = {}) {

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -13,13 +13,11 @@ router.get(
     injectHeroImage('fsn-new'),
     injectCopy('toplevel.data'),
     async (req, res, next) => {
-        const locale = req.i18n.getLocale();
-
         try {
-            const dataStats = await contentApi.getDataStats({
-                locale: locale,
-                requestParams: req.query
-            });
+            const dataStats = await contentApi.getDataStats(
+                req.i18n.getLocale(),
+                req.query
+            );
 
             res.locals.openGraph = get(dataStats, 'openGraph', false);
 

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -4,31 +4,25 @@ const express = require('express');
 const get = require('lodash/get');
 
 const contentApi = require('../../common/content-api');
-const { injectCopy, injectHeroImage } = require('../../common/inject-content');
+const { injectHeroImage } = require('../../common/inject-content');
 
 const router = express.Router();
 
-router.get(
-    '/',
-    injectHeroImage('fsn-new'),
-    injectCopy('toplevel.data'),
-    async (req, res, next) => {
-        try {
-            const dataStats = await contentApi.getDataStats(
-                req.i18n.getLocale(),
-                req.query
-            );
+router.get('/', injectHeroImage('fsn-new'), async function(req, res, next) {
+    try {
+        const dataStats = await contentApi.getDataStats(
+            req.i18n.getLocale(),
+            req.query
+        );
 
-            res.locals.openGraph = get(dataStats, 'openGraph', false);
-
-            res.render(path.resolve(__dirname, './views/data'), {
-                title: dataStats.title,
-                dataStats
-            });
-        } catch (error) {
-            next(error);
-        }
+        res.render(path.resolve(__dirname, './views/data'), {
+            title: dataStats.title,
+            openGraph: get(dataStats, 'openGraph', false),
+            dataStats: dataStats
+        });
+    } catch (error) {
+        next(error);
     }
-);
+});
 
 module.exports = router;

--- a/controllers/data/views/data.njk
+++ b/controllers/data/views/data.njk
@@ -1,7 +1,8 @@
+{% extends "layouts/main.njk" %}
 {% from "components/data.njk" import statsGrid %}
 {% from "components/hero.njk" import hero with context %}
 
-{% extends "layouts/main.njk" %}
+{% set copy = __('toplevel.data') %}
 
 {% macro mapPane(id, title, stats, isActive = false) %}
     <section id="region-{{ id }}" class="js-tab-pane tab__pane{% if isActive %} is-active{% endif %}">

--- a/controllers/our-people/index.js
+++ b/controllers/our-people/index.js
@@ -33,10 +33,10 @@ router.get('/', injectHeroImage('mental-health-foundation-new'), async function(
     next
 ) {
     try {
-        const people = await contentApi.getOurPeople({
-            locale: req.i18n.getLocale(),
-            requestParams: req.query
-        });
+        const people = await contentApi.getOurPeople(
+            req.i18n.getLocale(),
+            req.query
+        );
 
         res.render(path.resolve(__dirname, './views/our-people'), {
             ourPeopleLinks: mapLinks(people)
@@ -48,10 +48,10 @@ router.get('/', injectHeroImage('mental-health-foundation-new'), async function(
 
 router.get('/:slug', async function(req, res, next) {
     try {
-        const people = await contentApi.getOurPeople({
-            locale: req.i18n.getLocale(),
-            requestParams: req.query
-        });
+        const people = await contentApi.getOurPeople(
+            req.i18n.getLocale(),
+            req.query
+        );
 
         const entry = people.find(item => item.slug === req.params.slug);
 

--- a/controllers/our-people/views/our-people.njk
+++ b/controllers/our-people/views/our-people.njk
@@ -2,6 +2,8 @@
 {% from "components/hero.njk" import hero with context %}
 {% from "components/section-links/macro.njk" import sectionLinks %}
 
+{% set title = __('ourPeople.title') %}
+
 {% block content %}
     <main role="main">
         {{ hero(title, pageHero.image) }}
@@ -9,7 +11,7 @@
         <div class="nudge-up">
             <section class="content-box u-inner-wide-only">
                 <div class="s-prose">
-                    {{ copy.introduction | safe }}
+                    {{ __('ourPeople.introduction') | safe }}
                 </div>
                 {{ sectionLinks(ourPeopleLinks) }}
             </section>

--- a/controllers/our-people/views/profiles.njk
+++ b/controllers/our-people/views/profiles.njk
@@ -1,5 +1,4 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/document-list/macro.njk" import documentList %}
 {% from "components/hero.njk" import hero with context %}
 
@@ -9,8 +8,6 @@
 
         <div class="page-section u-inner-wide-only nudge-up">
             <div class="page-section__content">
-                {{ breadcrumbTrail(breadcrumbs) }}
-
                 {% for person in entry.people %}
                     <article id="profile-{{ person.name | slugify }}" class="content-box">
 


### PR DESCRIPTION
Continues `got` content API migration. This PR migrates any single-use content methods. In the process I'm also simplifying the respective routers to prefer using translations directly rather than via `injectCopy` (less indirection)