### PR TITLE
Clean up and document homepage router

### DIFF
--- a/assets/sass/utilities/_utilities-display.scss
+++ b/assets/sass/utilities/_utilities-display.scss
@@ -117,26 +117,8 @@
    Visibility
    ========================================================================= */
 
-@include mq('large', 'max') {
-    .u-wide-only {
-        display: none !important;
-    }
-}
-
-@include mq('large') {
-    .u-not-wide {
-        display: none !important;
-    }
-}
-
 @include mq('medium', 'max') {
     .u-desktop-only {
-        display: none !important;
-    }
-}
-
-@include mq('medium') {
-    .u-mobile-only {
         display: none !important;
     }
 }
@@ -147,10 +129,6 @@
 
 .u-visually-hidden {
     @include visually-hidden();
-}
-
-.u-invisible {
-    visibility: hidden;
 }
 
 // hide JS things for users without JS

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -63,14 +63,14 @@ function fetchAllLocales(toUrlPathFn, options = {}) {
  * Adds the preview parameters to the request
  * (if accessed via the preview domain)
  */
-function addPreviewParams(requestParams = {}, params = {}) {
-    const globalParams = pick(requestParams, [
+function withPreviewParams(rawSearchParams = {}, extraSearchParams = {}) {
+    const globalParams = pick(rawSearchParams, [
         'social',
         'x-craft-live-preview',
         'x-craft-preview',
         'token'
     ]);
-    return Object.assign({}, globalParams, params);
+    return Object.assign({}, globalParams, extraSearchParams);
 }
 
 /**
@@ -169,10 +169,12 @@ function getHeroImage({ locale, slug }) {
     );
 }
 
-function getHomepage({ locale, query = {}, requestParams = {} }) {
-    return fetch(`/v1/${locale}/homepage`, {
-        qs: addPreviewParams(requestParams, { ...query })
-    }).then(response => response.data.attributes);
+function getHomepage(locale, searchParams = {}) {
+    return queryContentApi(`v1/${locale}/homepage`, {
+        searchParams: withPreviewParams(searchParams)
+    })
+        .json()
+        .then(getAttrs);
 }
 
 /**
@@ -195,7 +197,7 @@ function getUpdates({
 }) {
     if (slug) {
         return fetch(`/v1/${locale}/updates/${type}/${date}/${slug}`, {
-            qs: addPreviewParams(requestParams, { ...query })
+            qs: withPreviewParams(requestParams, { ...query })
         }).then(response => {
             return {
                 meta: response.meta,
@@ -204,7 +206,7 @@ function getUpdates({
         });
     } else {
         return fetch(`/v1/${locale}/updates/${type || ''}`, {
-            qs: addPreviewParams(requestParams, {
+            qs: withPreviewParams(requestParams, {
                 ...query,
                 ...{ 'page-limit': 10 }
             })
@@ -251,7 +253,7 @@ function getRecentFundingProgrammes(locale) {
 
 function getFundingProgramme({ locale, slug, query = {}, requestParams = {} }) {
     return fetch(`/v2/${locale}/funding-programmes/${slug}`, {
-        qs: addPreviewParams(requestParams, { ...query })
+        qs: withPreviewParams(requestParams, { ...query })
     }).then(response => get('data.attributes')(response));
 }
 
@@ -264,7 +266,7 @@ function getResearch({
 }) {
     if (slug) {
         return fetch(`/v1/${locale}/research/${slug}`, {
-            qs: addPreviewParams(requestParams, { ...query })
+            qs: withPreviewParams(requestParams, { ...query })
         }).then(getAttrs);
     } else {
         let path = `/v1/${locale}/research`;
@@ -272,7 +274,7 @@ function getResearch({
             path += `/${type}`;
         }
         return fetch(path, {
-            qs: addPreviewParams(requestParams, { ...query })
+            qs: withPreviewParams(requestParams, { ...query })
         }).then(response => {
             return {
                 meta: response.meta,
@@ -291,7 +293,7 @@ function getStrategicProgrammes({
 }) {
     if (slug) {
         return fetch(`/v1/${locale}/strategic-programmes/${slug}`, {
-            qs: addPreviewParams(requestParams, { ...query })
+            qs: withPreviewParams(requestParams, { ...query })
         }).then(response => get('data.attributes')(response));
     } else {
         return fetchAllLocales(
@@ -306,7 +308,7 @@ function getStrategicProgrammes({
 function getListingPage({ locale, path, query = {}, requestParams = {} }) {
     const sanitisedPath = sanitiseUrlPath(path);
     return fetch(`/v1/${locale}/listing`, {
-        qs: addPreviewParams(requestParams, {
+        qs: withPreviewParams(requestParams, {
             ...query,
             ...{ path: sanitisedPath }
         })
@@ -326,7 +328,7 @@ function getListingPage({ locale, path, query = {}, requestParams = {} }) {
 function getFlexibleContent({ locale, path, query = {}, requestParams = {} }) {
     const sanitisedPath = sanitiseUrlPath(path);
     return fetch(`/v1/${locale}/flexible-content`, {
-        qs: addPreviewParams(requestParams, {
+        qs: withPreviewParams(requestParams, {
             ...query,
             ...{ path: sanitisedPath }
         })
@@ -335,13 +337,13 @@ function getFlexibleContent({ locale, path, query = {}, requestParams = {} }) {
 
 function getProjectStory({ locale, grantId, query = {}, requestParams = {} }) {
     return fetch(`/v1/${locale}/project-stories/${grantId}`, {
-        qs: addPreviewParams(requestParams, { ...query })
+        qs: withPreviewParams(requestParams, { ...query })
     }).then(getAttrs);
 }
 
 function getOurPeople(locale, searchParams = {}) {
     return queryContentApi(`v1/${locale}/our-people`, {
-        searchParams: addPreviewParams(searchParams)
+        searchParams: withPreviewParams(searchParams)
     })
         .json()
         .then(mapAttrs);
@@ -349,7 +351,7 @@ function getOurPeople(locale, searchParams = {}) {
 
 function getDataStats(locale, searchParams = {}) {
     return queryContentApi(`v1/${locale}/data`, {
-        searchParams: addPreviewParams(searchParams)
+        searchParams: withPreviewParams(searchParams)
     })
         .json()
         .then(getAttrs);

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -182,18 +182,11 @@ global:
 toplevel:
   home:
     title: Hafan
-    intro: >
-      Diolch i chwaraewyr y <a href="%s">Loteri Genedlaethol</a> yn codi arian ar gyfer achosion da,
-      rydym yn dosbarthu mwy na <a href="%s">£500 miliwn</a> i gymunedau ar draws y Deyrnas Unedig bob blwyddy
-    introNew:
+    intro:
       title: Rydym yn cefnogi pobl a chymunedau i ffynnu
       description: <p>Diolch i chwaraewyr y <a href="%s">Loteri Genedlaethol</a> sy’n codi arian ar gyfer achosion da, rydym yn dosbarthu mwy na <a href="%s">£500 miliwn</a> i gymunedau ledled y Deyrnas Unedig bob blwyddyn</p>
-    under10k:
-      short: Ymgeisio am grant o dan £10,000
-      long: Cael gwybod sut i ymgeisio am grant o dan £10,000
-    over10k:
-      short: Ymgeisio am grant dros £10,000
-      long: Cael gwybod sut i ymgeisio am grant dros £10,000
+    under10k: Ymgeisio am grant o dan £10,000
+    over10k: Ymgeisio am grant dros £10,000
   wales:
     title: Cymru
     introduction: Cronfa Gymunedol y Loteri Genedlaethol yw ariannwr cymunedol mwyaf y Deyrnas Unedig.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,20 +184,13 @@ global:
 toplevel:
   home:
     title: Home
-    intro: >
-      Thanks to <a href="%s">National Lottery</a> players raising funding for good causes,
-        we give out more than <a href="%s">£500 million</a> to communities across the UK each year
-    introNew:
+    intro:
       title: When people are in the lead, communities thrive
       description: >
         The National Lottery Community Fund distributes <a href="%s">over £600m</a> a year to communities across the UK,
         raised by players of <a href="%s">The National Lottery</a>
-    under10k:
-      short: Apply for funding under £10,000
-      long: Learn how to apply for funding under £10,000
-    over10k:
-      short: Apply for funding over £10,000
-      long: Learn how to apply for funding over £10,000
+    under10k: Apply for funding under £10,000
+    over10k: Apply for funding over £10,000
   funding:
     title: Funding
     latestProgrammes: Latest Programmes

--- a/controllers/home/README.md
+++ b/controllers/home/README.md
@@ -1,0 +1,3 @@
+# Homepage router
+
+This router handles the homepage. This is a hybrid page, the main hero and social content are static within the app but the navigation panels and latest news are fetched from the CMS.

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -1,23 +1,21 @@
 'use strict';
 const path = require('path');
 const express = require('express');
+
 const contentApi = require('../../common/content-api');
-const { injectCopy } = require('../../common/inject-content');
 
 const router = express.Router();
 
-router.get('/', injectCopy('toplevel.home'), async (req, res, next) => {
+router.get('/', async function(req, res, next) {
     try {
-        const { featuredLinks, promotedUpdates } = await contentApi.getHomepage(
-            {
-                locale: req.i18n.getLocale(),
-                requestParams: req.query
-            }
-        );
+        const entry = await contentApi.getHomepage({
+            locale: req.i18n.getLocale(),
+            requestParams: req.query
+        });
 
         res.render(path.resolve(__dirname, './views/home'), {
-            featuredLinks,
-            promotedUpdates,
+            featuredLinks: entry.featuredLinks,
+            promotedUpdates: entry.promotedUpdates,
             heroImage: {
                 small: '/assets/images/home/superhero-small-v2.jpg',
                 medium: '/assets/images/home/superhero-medium-v2.jpg',

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -8,10 +8,10 @@ const router = express.Router();
 
 router.get('/', async function(req, res, next) {
     try {
-        const entry = await contentApi.getHomepage({
-            locale: req.i18n.getLocale(),
-            requestParams: req.query
-        });
+        const entry = await contentApi.getHomepage(
+            req.i18n.getLocale(),
+            req.query
+        );
 
         res.render(path.resolve(__dirname, './views/home'), {
             featuredLinks: entry.featuredLinks,

--- a/controllers/home/views/home.njk
+++ b/controllers/home/views/home.njk
@@ -3,6 +3,9 @@
 {% from "components/miniature-hero/macro.njk" import miniatureHero %}
 {% from "components/social-bar/macro.njk" import socialBar with context %}
 
+{% set copy = __('toplevel.home') %}
+{% set title = copy.title %}
+
 {% block content %}
     <main role="main">
         {# Hero introduction #}
@@ -22,23 +25,21 @@
             </figure>
             <div class="super-hero__content">
                 <div class="super-hero__header" id="content">
-                    <h1 class="super-hero__title">{{ copy.introNew.title | widont | safe }}</h1>
+                    <h1 class="super-hero__title">{{ copy.intro.title | widont | safe }}</h1>
                     <div class="super-hero__intro">
-                        {{ __(copy.introNew.description, localify('/data'), 'https://www.national-lottery.co.uk/') | safe }}
+                        {{ __(copy.intro.description, localify('/data'), 'https://www.national-lottery.co.uk/') | safe }}
                     </div>
 
                     <div class="o-button-group">
                         <a class="btn btn--medium btn--reversed"
                             href="{{ localify('/funding/under10k') }}"
                             id="qa-button-under10k">
-                            <span class="u-wide-only">{{ copy.under10k.long }}</span>
-                            <span class="u-not-wide">{{ copy.under10k.short }}</span>
+                            {{ copy.under10k }}
                         </a>
                         <a class="btn btn--medium btn--reversed"
                             href="{{ localify('/funding/over10k') }}"
                             id="qa-button-over10k">
-                            <span class="u-wide-only">{{ copy.over10k.long }}</span>
-                            <span class="u-not-wide">{{ copy.over10k.short }}</span>
+                            {{ copy.over10k }}
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
- Adds README.md
- Replaces injectCopy with direct i18n use
- Removes old translation copy
- Standardise button copy across breakpoints
- Update getHomepage to use got

Only visual change is to go from this:

![image](https://user-images.githubusercontent.com/123386/76340656-d8acce00-62f3-11ea-9c9f-33bf950a45ee.png)

To this:

![image](https://user-images.githubusercontent.com/123386/76340672-e1050900-62f3-11ea-91cc-c7ee387e6404.png)

Motivated by us switching to this wording on the funding landing page too:

![image](https://user-images.githubusercontent.com/123386/76340694-ecf0cb00-62f3-11ea-9247-27e8af2b0bfe.png)

Has the benefit of a) using consistent wording across breakpoints and b) allows us to remove a bunch of now unused display helpers.


