### PR TITLE
Fix contact email duplicate bug

### DIFF
--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -30,7 +30,6 @@ Array [
   "seniorContactDateOfBirth: Enter a date of birth",
   "seniorContactAddress: Enter a full UK address",
   "seniorContactAddressHistory: Enter a full UK address",
-  "seniorContactEmail: Enter an email address",
   "seniorContactPhone: Enter a UK telephone number",
   "bankAccountName: Enter the name of your organisation, as it appears on your bank statement",
   "bankSortCode: Enter a sort code",

--- a/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
+++ b/controllers/apply/awards-for-all/__snapshots__/form.test.js.snap
@@ -30,6 +30,8 @@ Array [
   "seniorContactDateOfBirth: Enter a date of birth",
   "seniorContactAddress: Enter a full UK address",
   "seniorContactAddressHistory: Enter a full UK address",
+  "seniorContactEmail: Enter an email address",
+  "mainContactEmail: Enter an email address",
   "seniorContactPhone: Enter a UK telephone number",
   "bankAccountName: Enter the name of your organisation, as it appears on your bank statement",
   "bankSortCode: Enter a sort code",

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1429,6 +1429,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: `Fe ddefnyddiwn hwn pryd bynnag y byddwn yn cysylltu ynglŷn â’r prosiect`
             }),
             schema: Joi.string()
+                .required()
                 .email()
                 .lowercase()
                 .invalid(Joi.ref('seniorContactEmail')),
@@ -1543,6 +1544,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 cy: `Byddwn yn defnyddio hwn pan fyddwn yn cysylltu ynglŷn â’r prosiect`
             }),
             schema: Joi.string()
+                .required()
                 .email()
                 .lowercase()
         }),

--- a/controllers/apply/awards-for-all/fields.js
+++ b/controllers/apply/awards-for-all/fields.js
@@ -1541,7 +1541,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             explanation: localise({
                 en: `We’ll use this whenever we get in touch about the project`,
                 cy: `Byddwn yn defnyddio hwn pan fyddwn yn cysylltu ynglŷn â’r prosiect`
-            })
+            }),
+            schema: Joi.string()
+                .email()
+                .lowercase()
         }),
         seniorContactPhone: new PhoneField({
             locale: locale,

--- a/controllers/apply/awards-for-all/form.test.js
+++ b/controllers/apply/awards-for-all/form.test.js
@@ -107,6 +107,38 @@ test('invalid form', () => {
     expect(featuredMessages).toMatchSnapshot();
 });
 
+test('contact email addresses must not match', function() {
+    const emails = {
+        lowercase: 'example@example.com',
+        uppercase: 'Example@example.com'
+    };
+    // Test each combination of cases to ensure the order of completion has no effect
+    const forms = [
+        formBuilder({
+            data: mockResponse({
+                mainContactEmail: emails.lowercase,
+                seniorContactEmail: emails.uppercase
+            })
+        }),
+        formBuilder({
+            data: mockResponse({
+                mainContactEmail: emails.uppercase,
+                seniorContactEmail: emails.lowercase
+            })
+        })
+    ];
+
+    forms.forEach(form => {
+        expect(mapMessages(form.validation)).toEqual(
+            expect.arrayContaining([
+                expect.stringContaining(
+                    'Main contact email address must be different'
+                )
+            ])
+        );
+    });
+});
+
 test('valid form for england', () => {
     const data = mockResponse({
         projectCountry: 'england',


### PR DESCRIPTION
Kind of a funny one, we thought we'd fixed it here: https://github.com/biglotteryfund/blf-alpha/pull/2738

Looking in the database after that change, the only time we encounter duplicate emails are where the **senior** contact uses non-lowercase text and the **main** contact is lowercase.

That's because the change above forces the main contact address to be transformed to lowercase – so if you filled out the form with `Example@foo.com` as Senior Contact, then entered `example@foo.com` as Main Contact, you wouldn't get an error, because Joi doesn't think they match – only the Main Contact gets lowercased.

If you did this the other way around, though (eg. entered `Example@foo.com` as Main Contact and `example@foo.com` as Senior), the Main Contact version gets converted to lowercase and it matches.

The test didn't help catch this because it only tests one of those two paths. This change forces the Senior Contact to lowercase too, and adds a test for the other condition. 