### PR TITLE
Add redirect for old coastal communities fund URL

### DIFF
--- a/controllers/__snapshots__/aliases.test.js.snap
+++ b/controllers/__snapshots__/aliases.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`aliases should export mappedAliases 1`] = `
+exports[`should export mappedAliases 1`] = `
 Array [
   Object {
     "from": "/home/funding",
@@ -6081,6 +6081,14 @@ Array [
   Object {
     "from": "/welsh/news/press-releases/2019-07-18/100-million-national-lottery-climate-action-fund-launched-for-communities-across-the-uk",
     "to": "/welsh/news/press-releases/2019-07-18/100million-national-lottery-climate-action-fund-launched-for-communities-across-the-uk",
+  },
+  Object {
+    "from": "/funding/programmes/coastal-communities-fund-1",
+    "to": "/funding/programmes/coastal-communities-fund",
+  },
+  Object {
+    "from": "/welsh/funding/programmes/coastal-communities-fund-1",
+    "to": "/welsh/funding/programmes/coastal-communities-fund",
   },
 ]
 `;

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -683,5 +683,9 @@ module.exports = createAliases([
     {
         from: `/news/press-releases/2019-07-18/100-million-national-lottery-climate-action-fund-launched-for-communities-across-the-uk`,
         to: `/news/press-releases/2019-07-18/100million-national-lottery-climate-action-fund-launched-for-communities-across-the-uk`
+    },
+    {
+        from: '/funding/programmes/coastal-communities-fund-1',
+        to: '/funding/programmes/coastal-communities-fund'
     }
 ]);

--- a/controllers/aliases.js
+++ b/controllers/aliases.js
@@ -4,6 +4,13 @@ const flatten = require('lodash/flatten');
 const uniqBy = require('lodash/fp/uniqBy');
 const { makeWelsh } = require('../common/urls');
 
+/**
+ * The previous biglotteryfund.org.uk website duplicated content
+ * under country specific paths. For any urls that existed on
+ * the old website that we want to redirect we need to make sure
+ * we handle each variant. This method allows us to mark an alias
+ * as needing these extra redirects.
+ */
 function withRegionPrefixes(alias) {
     const prefixes = [
         '',
@@ -18,6 +25,10 @@ function withRegionPrefixes(alias) {
     });
 }
 
+/**
+ * Create full list of aliases
+ * Takes list of urls and duplicates them with a corresponding /welsh redirect
+ */
 function createAliases(aliases) {
     return flatMap(uniqBy(alias => alias.from)(flatten(aliases)), alias => {
         return [

--- a/controllers/aliases.test.js
+++ b/controllers/aliases.test.js
@@ -2,8 +2,12 @@
 'use strict';
 const aliases = require('./aliases');
 
-describe('aliases', () => {
-    it('should export mappedAliases', () => {
-        expect(aliases).toMatchSnapshot();
-    });
+/**
+ * The list of redirects is largely static but includes
+ * some dynamic generation of welsh language and multi-region
+ * versions of each URL. A snapshot test is a quick way of us
+ * confirming that each alias has the expected variants.
+ */
+test('should export mappedAliases', () => {
+    expect(aliases).toMatchSnapshot();
 });


### PR DESCRIPTION
The page was mistakenly published at `/funding/programmes/coastal-communities-fund-1`. We've corrected this to be `/funding/programmes/coastal-communities-fund` canonically but need a redirect to catch any people coming to the previous URL.

Also used this as an excuse to add some explanatory comments to the aliases code.