### PR TITLE
Begin removing National Lottery Awards for All references from simple form

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1201,7 +1201,7 @@ awardsForAll:
           - type: action
             title: Gallu ymgeisio
           - type: step
-            title: Cais ar-lein Arian i Bawb
+            title: Cais ar-lein
             description: >
               Dywedwch wrthym am eich syniad i helpu pobl wella eu bywydau a’u cymunedau.
               Bydd gennych hyd at dair mis i orffen eich ffurflen gais ar-lein.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -888,10 +888,6 @@ applyNext:
     delete: Dileu
     createdAt: Wedi’i greu ar %s am %s
     expiresAt: Mae gennych nes <strong>%s</strong> i gwblhau eich cais
-  startApplication:
-    title: Dechrau cais am Arian i Bawb y Loteri Genedlaethol
-    intro: Ffordd sydyn a syml i gael grantiau Loteri Genedlaethol bychan rhwng £300 a £10,000
-    callToAction: Dechrau cais newydd
   dashboard:
     title: Eich ceisiadau
     introduction: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -821,10 +821,6 @@ applyNext:
     delete: Delete
     createdAt: Created %s at %s
     expiresAt: You have until <strong>%s</strong> to complete your application
-  startApplication:
-    title: Start an application for National Lottery Awards for All
-    intro: A quick and simple way to get small National Lottery grants of between £300 and £10,000
-    callToAction: Start a new application
   dashboard:
     title: Your applications
     introduction: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -866,7 +866,7 @@ applyNext:
     actions:
       simple:
         title: "Funding under £10,000: Start an application"
-        description: National Lottery Awards for All—a quick way to apply for smaller amounts of funding between £300 and £10,000.
+        description: A quick way to apply for smaller amounts of funding between £300 and £10,000.
         link:
           url: /apply/awards-for-all/start
           label: Start a new application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1120,7 +1120,7 @@ awardsForAll:
           - type: action
             title: Able to apply
           - type: step
-            title: Awards for all online application
+            title: Online application
             description: >
               Tell us about your idea to help people improve their lives and communities.
               You’ll have up to three months to finish your online application form.

--- a/controllers/apply/awards-for-all/form.js
+++ b/controllers/apply/awards-for-all/form.js
@@ -1359,8 +1359,8 @@ module.exports = function({
 
     const form = {
         title: localise({
-            en: 'National Lottery Awards for All',
-            cy: 'Arian i Bawb y Loteri Genedlaethol'
+            en: 'Funding under £10,000',
+            cy: 'Ariannu o dan £10,000'
         }),
         startLabel: localise({
             en: 'Start your application',

--- a/controllers/apply/awards-for-all/views/startpage.njk
+++ b/controllers/apply/awards-for-all/views/startpage.njk
@@ -11,12 +11,11 @@
         {% call contentBox(skipProse = true) %}
             {{ formHeader(
                 backUrl = sectionUrl if user else localify('/funding/under10k'),
-                title = formTitle,
-                prefix = globalCopy.brand.title
+                title = copy.title,
+                prefix = formTitle
             )}}
 
             <div class="s-prose">
-                <h2>{{ copy.beforeYouStart.title }}</h2>
                 {{ copy.beforeYouStart.body | safe }}
 
                 <h2>{{ copy.whatInformation.title }}</h2>

--- a/views/components/action-card/examples.njk
+++ b/views/components/action-card/examples.njk
@@ -4,7 +4,7 @@
 {% call sgExample('Defaults') %}
     {{ actionCard({
         title: 'Funding under £10,000: Start an application',
-        description: "National Lottery Awards for All—A quick way to apply for smaller amounts of funding between £300 and £10,000.",
+        description: "A quick way to apply for smaller amounts of funding between £300 and £10,000.",
         link: { url: '#', label: 'Button label' }
     }) }}
 {% endcall %}
@@ -12,7 +12,7 @@
 {% call sgExample('Secondary style') %}
     {{ actionCard({
         title: 'Funding under £10,000: Start an application',
-        description: "National Lottery Awards for All—A quick way to apply for smaller amounts of funding between £300 and £10,000.",
+        description: "A quick way to apply for smaller amounts of funding between £300 and £10,000.",
         link: { url: '#', label: 'Button label' }
     }, isSecondary = true) }}
 {% endcall %}


### PR DESCRIPTION
Begin removing National Lottery Awards for All references from simple form. Starting with the simplest swaps or removals. This is to support using the simple funding form for programmes other that Awards for All.