### PR TITLE
minimist audit fix and set audit-level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ cache:
 
 script:
   - shellcheck deploy/*.sh
-  - npm audit --production || true
+  - npm audit --production --audit-level=moderate
   - npm run lint
   - npm run test-unit
   - npm run build-production

--- a/package-lock.json
+++ b/package-lock.json
@@ -9062,6 +9062,12 @@
             "ci-info": "^1.5.0"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "url": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
@@ -20972,9 +20978,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "3.0.2",


### PR DESCRIPTION
We have a security advisory for `minimist` (https://www.npmjs.com/advisories/1179) which is depended on by many of our node_modules. 

This is a low severity advisory and has a couple of modules that are still pending a fix. Attempting to balance running npm audit in report only mode (i.e. don't fail the build) which we do now vs. blocking too aggressively. 

This PR tests setting `--audit-level=moderate` to only fail the build if there is a moderate level advisory or above in our production dependencies.

We can confirm this works if the build passes but we see three low level security advisories in the build output.