### PR TITLE
Consistent use of console logger during test runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start-test": "DB_CONNECTION_URI=sqlite://:memory PORT=8090 TEST_SERVER=true npm run start",
     "lint": "eslint . bin/* --ext .js,.vue && stylelint assets/sass",
     "format": "prettier --write '{*,**/*}.{js,vue,scss,md}'",
-    "test-unit": "jest --maxWorkers=4",
+    "test-unit": "IS_TEST_RUN=true jest --maxWorkers=4",
     "test": "npm run lint && npm run test-unit",
     "test-integration": "npm run start-test & wait-on http://localhost:8090 && npx cypress run --browser chrome",
     "clean": "del-cli $npm_package_config_dist_root/* ./config/assets.json",


### PR DESCRIPTION
Sometimes seeing local tests runs try and fail to log to cloudwatch.

After doing some digging this is because the node environment is set to `test` which also determines which config file to use. This means that cloudwatch logs are enabled as the app uses the same config as the test server.

The longer term fix for this would be to re-configure the staging site to used something other than test as the environment. Basically: https://glebbahmutov.com/blog/do-not-use-node-env-for-staging/

In the short term if rejigged the logger config to include a check for an explicit `IS_TEST_RUN` variable to make sure the console logger is always used in these cases.