### PR TITLE
Fixup spacing on covid-19 banner

### DIFF
--- a/assets/sass/components/_messages.scss
+++ b/assets/sass/components/_messages.scss
@@ -126,10 +126,6 @@
     color: white;
     background-color: get-color('brand', 'primary');
 
-    &.announcement-banner--major {
-        margin-bottom: 5px;
-    }
-
     a {
         color: white;
         font-weight: font-weight('body', 'bold');
@@ -142,4 +138,12 @@
     @media print {
         display: none;
     }
+}
+
+.announcement-banner.announcement-banner--major {
+    font-size: 16px;
+}
+
+.has-static-header .announcement-banner--major {
+    margin-bottom: 15px;
 }


### PR DESCRIPTION
Uses `.has-static-header` class to adjust the spacing.

![image](https://user-images.githubusercontent.com/123386/77531377-b8037d00-6e8a-11ea-9f7e-df8dd50b9971.png)

![image](https://user-images.githubusercontent.com/123386/77531396-bf2a8b00-6e8a-11ea-8f36-3f677e7e94ab.png)
