### PR TITLE
Warn about TODOs via eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,10 @@ module.exports = {
         'require-atomic-updates': 'off',
         'semi': ['error', 'always'],
         'strict': ['warn', 'safe'],
+        'no-warning-comments': [
+            'warn',
+            { location: 'anywhere', terms: ['todo'] },
+        ],
 
         // Plugins
         'no-only-tests/no-only-tests': 'error',


### PR DESCRIPTION
Noticed that eslint has a core rule about warning comments. Have configured this to look for TODOs in our app and log them as lint warnings.