### PR TITLE
Remove remaining request uses in content-api

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -11,7 +11,6 @@ const sortBy = require('lodash/fp/sortBy');
 const uniqBy = require('lodash/uniqBy');
 
 const got = require('got');
-const request = require('request-promise-native');
 const querystring = require('querystring');
 
 const logger = require('./logger');
@@ -32,21 +31,6 @@ const queryContentApi = got.extend({
         ],
     },
 });
-
-function fetch(urlPath, options) {
-    logger.debug(
-        `Fetching ${CONTENT_API_URL}${urlPath}${
-            options && options.qs ? '?' + querystring.stringify(options.qs) : ''
-        }`
-    );
-
-    const defaults = {
-        url: `${CONTENT_API_URL}${urlPath}`,
-        json: true,
-    };
-    const params = Object.assign({}, defaults, options);
-    return request(params);
-}
 
 /**
  * Adds the preview parameters to the request
@@ -262,13 +246,13 @@ function getResearch({
     type = null,
 }) {
     if (slug) {
-        return queryContentApi(`/v1/${locale}/research/${slug}`, {
+        return queryContentApi(`v1/${locale}/research/${slug}`, {
             searchParams: withPreviewParams(requestParams, { ...query }),
         })
             .json()
             .then(getAttrs);
     } else {
-        let path = `/v1/${locale}/research`;
+        let path = `v1/${locale}/research`;
         if (type) {
             path += `/${type}`;
         }
@@ -344,7 +328,7 @@ function getPublications({
 
 function getPublicationTags({ locale, programme }) {
     return queryContentApi(
-        `/v1/${locale}/funding/publications/${programme}/tags`
+        `v1/${locale}/funding/publications/${programme}/tags`
     )
         .json()
         .then(function (response) {
@@ -388,7 +372,7 @@ function getStrategicProgrammes({
 
 function getListingPage({ locale, path, query = {}, requestParams = {} }) {
     const sanitisedPath = sanitiseUrlPath(path);
-    return queryContentApi(`/v1/${locale}/listing`, {
+    return queryContentApi(`v1/${locale}/listing`, {
         searchParams: withPreviewParams(requestParams, {
             ...query,
             ...{ path: sanitisedPath },
@@ -421,9 +405,11 @@ function getFlexibleContent({ locale, path, query = {}, requestParams = {} }) {
 }
 
 function getProjectStory({ locale, grantId, query = {}, requestParams = {} }) {
-    return fetch(`/v1/${locale}/project-stories/${grantId}`, {
-        qs: withPreviewParams(requestParams, { ...query }),
-    }).then(getAttrs);
+    return queryContentApi(`v1/${locale}/project-stories/${grantId}`, {
+        searchParams: withPreviewParams(requestParams, { ...query }),
+    })
+        .json()
+        .then(getAttrs);
 }
 
 function getOurPeople(locale, searchParams = {}) {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -388,22 +388,24 @@ function getStrategicProgrammes({
 
 function getListingPage({ locale, path, query = {}, requestParams = {} }) {
     const sanitisedPath = sanitiseUrlPath(path);
-    return fetch(`/v1/${locale}/listing`, {
-        qs: withPreviewParams(requestParams, {
+    return queryContentApi(`/v1/${locale}/listing`, {
+        searchParams: withPreviewParams(requestParams, {
             ...query,
             ...{ path: sanitisedPath },
         }),
-    }).then((response) => {
-        const attributes = response.data.map((item) => item.attributes);
-        // @TODO remove the check for attr.path, which will shortly be removed the CMS
-        return attributes.find((attr) => {
-            if (get(attr, 'path')) {
-                return attr.path === sanitisedPath;
-            } else {
-                return attr.linkUrl === stripTrailingSlashes(path);
-            }
+    })
+        .json()
+        .then((response) => {
+            const attributes = response.data.map((item) => item.attributes);
+            // @TODO remove the check for attr.path, which will shortly be removed the CMS
+            return attributes.find((attr) => {
+                if (get(attr, 'path')) {
+                    return attr.path === sanitisedPath;
+                } else {
+                    return attr.linkUrl === stripTrailingSlashes(path);
+                }
+            });
         });
-    });
 }
 
 function getFlexibleContent({ locale, path, query = {}, requestParams = {} }) {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -262,23 +262,30 @@ function getResearch({
     type = null,
 }) {
     if (slug) {
-        return fetch(`/v1/${locale}/research/${slug}`, {
-            qs: withPreviewParams(requestParams, { ...query }),
-        }).then(getAttrs);
+        return queryContentApi(`/v1/${locale}/research/${slug}`, {
+            searchParams: withPreviewParams(requestParams, { ...query }),
+        })
+            .json()
+            .then(getAttrs);
     } else {
         let path = `/v1/${locale}/research`;
         if (type) {
             path += `/${type}`;
         }
-        return fetch(path, {
-            qs: withPreviewParams(requestParams, { ...query }),
-        }).then((response) => {
-            return {
-                meta: response.meta,
-                result: mapAttrs(response),
-                pagination: _buildPagination(response.meta.pagination, query),
-            };
-        });
+        return queryContentApi(path, {
+            searchParams: withPreviewParams(requestParams, { ...query }),
+        })
+            .json()
+            .then((response) => {
+                return {
+                    meta: response.meta,
+                    result: mapAttrs(response),
+                    pagination: _buildPagination(
+                        response.meta.pagination,
+                        query
+                    ),
+                };
+            });
     }
 }
 

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -162,9 +162,9 @@ function getAlias(urlPath) {
 }
 
 function getHeroImage({ locale, slug }) {
-    return fetch(`/v1/${locale}/hero-image/${slug}`).then(
-        (response) => response.data.attributes
-    );
+    return queryContentApi(`v1/${locale}/hero-image/${slug}`)
+        .json()
+        .then(getAttrs);
 }
 
 function getHomepage(locale, searchParams = {}) {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -402,12 +402,14 @@ function getListingPage({ locale, path, query = {}, requestParams = {} }) {
 
 function getFlexibleContent({ locale, path, query = {}, requestParams = {} }) {
     const sanitisedPath = sanitiseUrlPath(path);
-    return fetch(`/v1/${locale}/flexible-content`, {
-        qs: withPreviewParams(requestParams, {
+    return queryContentApi(`v1/${locale}/flexible-content`, {
+        searchParams: withPreviewParams(requestParams, {
             ...query,
             ...{ path: sanitisedPath },
         }),
-    }).then((response) => response.data.attributes);
+    })
+        .json()
+        .then(getAttrs);
 }
 
 function getProjectStory({ locale, grantId, query = {}, requestParams = {} }) {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -137,30 +137,26 @@ function getRoutes() {
     return queryContentApi('v1/list-routes').json().then(mapAttrs);
 }
 
-function getAliasForLocale({ locale, urlPath }) {
-    return fetch(`/v1/${locale}/aliases`)
+function getAliasForLocale(locale, urlPath) {
+    return queryContentApi(`v1/${locale}/aliases`)
+        .json()
         .then(mapAttrs)
         .then((matches) => {
-            const findAlias = find(
-                (alias) => alias.from.toLowerCase() === urlPath.toLowerCase()
-            );
-            return findAlias(matches);
+            return find(function (alias) {
+                return alias.from.toLowerCase() === urlPath.toLowerCase();
+            })(matches);
         });
 }
 
 function getAlias(urlPath) {
     const getOrHomepage = getOr('/', 'to');
-    return getAliasForLocale({
-        locale: 'en',
-        urlPath: urlPath,
-    }).then((enMatch) => {
+    return getAliasForLocale('en', urlPath).then((enMatch) => {
         if (enMatch) {
             return getOrHomepage(enMatch);
         } else {
-            return getAliasForLocale({
-                locale: 'cy',
-                urlPath: urlPath,
-            }).then((cyMatch) => (cyMatch ? getOrHomepage(cyMatch) : null));
+            return getAliasForLocale('cy', urlPath).then((cyMatch) =>
+                cyMatch ? getOrHomepage(cyMatch) : null
+            );
         }
     });
 }

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -194,27 +194,34 @@ function getUpdates({
     requestParams = {},
 }) {
     if (slug) {
-        return fetch(`/v1/${locale}/updates/${type}/${date}/${slug}`, {
-            qs: withPreviewParams(requestParams, { ...query }),
-        }).then((response) => {
-            return {
-                meta: response.meta,
-                result: response.data.attributes,
-            };
-        });
+        return queryContentApi(`v1/${locale}/updates/${type}/${date}/${slug}`, {
+            searchParams: withPreviewParams(requestParams, { ...query }),
+        })
+            .json()
+            .then((response) => {
+                return {
+                    meta: response.meta,
+                    result: response.data.attributes,
+                };
+            });
     } else {
-        return fetch(`/v1/${locale}/updates/${type || ''}`, {
-            qs: withPreviewParams(requestParams, {
+        return queryContentApi(`/v1/${locale}/updates/${type || ''}`, {
+            searchParams: withPreviewParams(requestParams, {
                 ...query,
                 ...{ 'page-limit': 10 },
             }),
-        }).then((response) => {
-            return {
-                meta: response.meta,
-                result: mapAttrs(response),
-                pagination: _buildPagination(response.meta.pagination, query),
-            };
-        });
+        })
+            .json()
+            .then((response) => {
+                return {
+                    meta: response.meta,
+                    result: mapAttrs(response),
+                    pagination: _buildPagination(
+                        response.meta.pagination,
+                        query
+                    ),
+                };
+            });
     }
 }
 

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -310,33 +310,44 @@ function getPublications({
 
     const baseUrl = `/v1/${locale}/funding/publications/${programme}`;
     if (slug) {
-        return fetch(`${baseUrl}/${slug}`, {
-            qs: withPreviewParams(requestParams, { ...apiRequestParams }),
-        }).then((response) => {
-            return {
-                meta: response.meta,
-                entry: getAttrs(response),
-            };
-        });
+        return queryContentApi(`${baseUrl}/${slug}`, {
+            searchParams: withPreviewParams(requestParams, {
+                ...apiRequestParams,
+            }),
+        })
+            .json()
+            .then((response) => {
+                return {
+                    meta: response.meta,
+                    entry: getAttrs(response),
+                };
+            });
     } else {
-        return fetch(baseUrl, {
-            qs: withPreviewParams(requestParams, { ...apiRequestParams }),
-        }).then((response) => {
-            return {
-                meta: response.meta,
-                result: mapAttrs(response),
-                pagination: _buildPagination(
-                    response.meta.pagination,
-                    apiRequestParams
-                ),
-            };
-        });
+        return queryContentApi(baseUrl, {
+            searchParams: withPreviewParams(requestParams, {
+                ...apiRequestParams,
+            }),
+        })
+            .json()
+            .then((response) => {
+                return {
+                    meta: response.meta,
+                    result: mapAttrs(response),
+                    pagination: _buildPagination(
+                        response.meta.pagination,
+                        apiRequestParams
+                    ),
+                };
+            });
     }
 }
 
 function getPublicationTags({ locale, programme }) {
-    return fetch(`/v1/${locale}/funding/publications/${programme}/tags`).then(
-        (response) => {
+    return queryContentApi(
+        `/v1/${locale}/funding/publications/${programme}/tags`
+    )
+        .json()
+        .then(function (response) {
             const attrs = mapAttrs(response);
             // Strip entries to just their tags
             const allTags = flatten(attrs.map((_) => _.tags));
@@ -348,8 +359,7 @@ function getPublicationTags({ locale, programme }) {
                 return tag;
             });
             return sortBy('count')(tags).reverse();
-        }
-    );
+        });
 }
 
 function getStrategicProgrammes({


### PR DESCRIPTION
Now uses `got` via `queryContentApi` across the board.