### PR TITLE
att.path check removed and confirmed this is no longer used.

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -383,11 +383,7 @@ function getListingPage({ locale, path, query = {}, requestParams = {} }) {
             const attributes = response.data.map((item) => item.attributes);
             // @TODO remove the check for attr.path, which will shortly be removed the CMS
             return attributes.find((attr) => {
-                if (get(attr, 'path')) {
-                    return attr.path === sanitisedPath;
-                } else {
                     return attr.linkUrl === stripTrailingSlashes(path);
-                }
             });
         });
 }


### PR DESCRIPTION
Removed the check for att.path and tested the cms pages (e.g. funding, big lunch, about) pages. All are still functional and so can confirm it is no longer needed.