### PR TITLE
Move eligibility success title to model

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1047,7 +1047,6 @@ applyNext:
     conditionalNote: "<strong>Nodyn</strong>: gall y maes hwn fod yn ddewisol gan ddibynnu ar eich atebion eraill"
   eligibility:
     title: Gwiriad cymhwysedd
-    successfulTitle: Gwych! Rydych yn gymwys i ymgeisio am arian grant dan £10,000
     unsuccessfulTitle: Mae'n ddrwg gennym, nid ydych yn gymwys i ymgeisio ar hyn o bryd
     whatNow: Beth nesaf?
   feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -973,7 +973,6 @@ applyNext:
     conditionalNote: "<strong>Note</strong>: this field may be optional depending on your other answers"
   eligibility:
     title: Eligibility checker
-    successfulTitle: Great! You're eligible to apply for funding under £10,000
     unsuccessfulTitle: Sorry, you're not eligible to apply at this time
     whatNow: What now?
   feedback:

--- a/controllers/apply/form-router/views/eligibility.njk
+++ b/controllers/apply/form-router/views/eligibility.njk
@@ -9,7 +9,7 @@
         <div class="content-box u-inner-wide-only">
             {% if eligibilityStatus === 'eligible' %}
                 <div class="s-prose u-constrained-wide">
-                    <h1 class="t--underline">{{ __('applyNext.eligibility.successfulTitle', formTitle) }}</h1>
+                    <h1 class="t--underline">{{ eligibility.successTitle }}</h1>
                     {{ eligibility.successMessage | safe }}
                     <p class="form-actions">
                         <a class="btn" href="{{ formBaseUrl }}/new">{{ copy.common.startYourApplication }}</a>

--- a/controllers/apply/under10k/eligibility.js
+++ b/controllers/apply/under10k/eligibility.js
@@ -239,6 +239,10 @@ module.exports = function ({ locale }) {
             question4(),
             question5(),
         ],
+        successTitle: localise({
+            en: `Great! You're eligible to apply for funding under £10,000`,
+            cy: `Gwych! Rydych yn gymwys i ymgeisio am arian grant dan £10,000`,
+        }),
         successMessage: localise({
             en: `<p>
                 We're excited to hear more about your project and


### PR DESCRIPTION
Clean up work from https://github.com/biglotteryfund/blf-alpha/pull/3125

Move eligibility success title out of the locale file and into model, inline with the success message.