### PR TITLE
Add TOC titles

### DIFF
--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -3,7 +3,7 @@
 {% from "components/fact-river/macro.njk" import factRiver %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
 {% from "components/promo-card/macro.njk" import promoCard with context %}
-{% from "components/segment-links/macro.njk" import tableOfContentLinks %}
+{% from "components/table-of-contents/macro.njk" import tableOfContentLinks %}
 
 {% set flexAnchor = 'item' %}
 

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -3,7 +3,7 @@
 {% from "components/fact-river/macro.njk" import factRiver %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
 {% from "components/promo-card/macro.njk" import promoCard with context %}
-{% from "components/segment-links/macro.njk" import segmentLinks %}
+{% from "components/segment-links/macro.njk" import tableOfContentLinks %}
 
 {% set flexAnchor = 'item' %}
 
@@ -65,7 +65,7 @@
                         <div class="s-prose u-constrained-content-wide">
                             {{ part.content | safe }}
                         </div>
-                        {{ segmentLinks(flexibleContent, anchor = flexAnchor) }}
+                        {{ tableOfContentLinks(flexibleContent, anchor = flexAnchor) }}
                     {% else %}
                         <div class="s-prose u-constrained-content-wide">
                             {% if part.type === 'contentArea' %}

--- a/views/components/segment-links/macro.njk
+++ b/views/components/segment-links/macro.njk
@@ -12,20 +12,3 @@
         </div>
     {% endif %}
 {% endmacro %}
-
-
-{% macro tableOfContentLinks(flexibleContent, prefix = null, anchor = 'segment') %}
-    {% if flexibleContent.length > 1 %}
-        <div class="segment-links">
-            {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}</p>{% endif %}
-            <ul>
-                {% for block in flexibleContent %}
-                    {% set titleToUse = block.tocTitle or block.title %}
-                    {% if titleToUse %}
-                        <li><a href="#{{ anchor }}-{{ loop.index }}">{{ titleToUse }}</a></li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        </div>
-    {% endif %}
-{% endmacro %}

--- a/views/components/segment-links/macro.njk
+++ b/views/components/segment-links/macro.njk
@@ -12,3 +12,20 @@
         </div>
     {% endif %}
 {% endmacro %}
+
+
+{% macro tableOfContentLinks(flexibleContent, prefix = null, anchor = 'segment') %}
+    {% if flexibleContent.length > 1 %}
+        <div class="segment-links">
+            {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}</p>{% endif %}
+            <ul>
+                {% for block in flexibleContent %}
+                    {% set titleToUse = block.tocTitle or block.title %}
+                    {% if titleToUse %}
+                        <li><a href="#{{ anchor }}-{{ loop.index }}">{{ titleToUse }}</a></li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/views/components/table-of-contents/macro.njk
+++ b/views/components/table-of-contents/macro.njk
@@ -1,0 +1,15 @@
+{% macro tableOfContentLinks(flexibleContent, prefix = null, anchor = 'segment') %}
+    {% if flexibleContent.length > 1 %}
+        <div class="segment-links">
+            {% if prefix %}<p class="u-margin-bottom-s">{{ prefix }}</p>{% endif %}
+            <ul>
+                {% for block in flexibleContent %}
+                    {% set titleToUse = block.tocTitle or block.title %}
+                    {% if titleToUse %}
+                        <li><a href="#{{ anchor }}-{{ loop.index }}">{{ titleToUse }}</a></li>
+                    {% endif %}
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{% endmacro %}

--- a/views/filters.js
+++ b/views/filters.js
@@ -63,7 +63,7 @@ function numberWithCommas(str = '') {
 }
 
 function widont(str) {
-    return str.replace(/\s([^\s<]+)\s*$/, '&nbsp;$1');
+    return str ? str.replace(/\s([^\s<]+)\s*$/, '&nbsp;$1') : null;
 }
 
 function removeQueryParam(queryParams, param) {


### PR DESCRIPTION
Allows custom Table of Contents titles to be used instead of a Flexible Content's block `title` element, if provided. Means we can shorten lengthy lists like these:

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/394376/78271395-02789f80-7504-11ea-8b2a-34003652d9d2.png">

Pairs with [a CMS change which adds these fields](https://github.com/biglotteryfund/craft-dev/pull/241). Also fixes a previewing issue which would throw 500 errors when a string was `null`.