### PR TITLE
Update applications dashboard to show all feedback

### DIFF
--- a/controllers/tools/applications.js
+++ b/controllers/tools/applications.js
@@ -172,6 +172,23 @@ function getProjectCountry(applicationId, applicationData) {
     }
 }
 
+function getFeedbackForForm(applicationId) {
+    const descriptions =
+        {
+            'awards-for-all': [
+                'National Lottery Awards for All',
+                'Apply for funding under £10,000',
+            ],
+            'standard-enquiry': ['Your funding proposal'],
+        }[applicationId] || [];
+
+    if (descriptions && descriptions.length > 0) {
+        return Feedback.findAllForDescription(descriptions);
+    } else {
+        return Promise.resolve(null);
+    }
+}
+
 router.get('/', function (req, res) {
     res.redirect('/tools');
 });
@@ -223,12 +240,7 @@ router.get('/:applicationId', async (req, res, next) => {
         const applicationTitle = getApplicationTitle(req.params.applicationId);
         const dataStudioUrl = getDataStudioUrlForForm(req.params.applicationId);
 
-        const feedbackDescription = getApplicationTitle(
-            req.params.applicationId
-        );
-        const feedback = feedbackDescription
-            ? await Feedback.findAllForDescription(feedbackDescription)
-            : null;
+        const feedback = await getFeedbackForForm(req.params.applicationId);
 
         const appTypes = [
             {

--- a/controllers/tools/feedback.js
+++ b/controllers/tools/feedback.js
@@ -21,9 +21,9 @@ async function render(req, res) {
 }
 
 async function renderDownload(req, res, next) {
-    const feedback = await Feedback.findAllForDescription(
-        sanitise(req.query.download)
-    );
+    const feedback = await Feedback.findAllForDescription([
+        sanitise(req.query.download),
+    ]);
 
     if (feedback.length > 0) {
         const preparedResults = feedback.map((item) => {

--- a/db/models/feedback.js
+++ b/db/models/feedback.js
@@ -47,11 +47,11 @@ class Feedback extends Model {
         }).then(groupBy((result) => result.description.toLowerCase()));
     }
 
-    static findAllForDescription(description) {
+    static findAllForDescription(descriptions = []) {
         return this.findAll({
             where: {
                 description: {
-                    [Op.eq]: description,
+                    [Op.in]: descriptions,
                 },
             },
             order: [


### PR DESCRIPTION
Currently the awards for all dashboard stops showing feedback after 3rd April. With the form title change we now need to account for feedback having either the old or new form title. Updates `findAllForDescription` to accept an array of descriptions to filter by.

(Note: all feedback shows on the feedback dashboard so we are collecting responses, they are just not showing on the previous dashboard)

