### PR TITLE
Remove description from programme cards

### DIFF
--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -7,7 +7,7 @@
             <dt>{{ labels.area }}</dt>
             <dd>{{ programme.area.label }}</dd>
         {% endif %}
-        
+
         {% if programme.organisationType %}
             <dt>{{ labels.organisationTypes }}</dt>
             <dd>{{ programme.organisationType }}</dd>
@@ -35,7 +35,6 @@
 
 {% macro programmeCard(programme) %}
     {% set description %}
-        {{ programme.description | safe }}
         {{ programmeStats(programme) }}
     {% endset %}
     {{ promoCard({


### PR DESCRIPTION
There is currently a large amount of announcement text on most programme detail pages. Best choice for now is to remove the description from cards (we can look at shortening this / another approach later on).

**Before**
![image](https://user-images.githubusercontent.com/123386/78572087-eab05c80-781e-11ea-8ea2-b1b452d7bd03.png)

**After**

![image](https://user-images.githubusercontent.com/123386/78572166-0451a400-781f-11ea-888b-2d707f70e4aa.png)

