### PR TITLE
Don't put relatedContent flexible content in a box

### DIFF
--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -27,7 +27,7 @@
                 {% endif %}
             {% elseif part.type === 'relatedContent' %}
                 <section class="u-inner">
-                    <h2 class="t--underline">{{ part.heading }}</h2>
+                    <h2 class="t--underline">{{ part.title }}</h2>
                     <ul class="flex-grid flex-grid--3up">
                         {% for article in part.content %}
                             <li class="flex-grid__item">

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -25,6 +25,25 @@
                 {% if useContentBox %}
                     </section>
                 {% endif %}
+            {% elseif part.type === 'relatedContent' %}
+                <section class="u-inner">
+                    <h2 class="t--underline">{{ part.heading }}</h2>
+                    <ul class="flex-grid flex-grid--3up">
+                        {% for article in part.content %}
+                            <li class="flex-grid__item">
+                                {{ promoCard({
+                                    "title": article.title,
+                                    "summary": article.summary,
+                                    "image": {
+                                        "url": article.trailImage,
+                                        "alt": article.title
+                                    },
+                                    "link": { "url": article.linkUrl }
+                                }) }}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
             {% else %}
                 <section class="content-box u-inner-wide-only" id="{{ flexAnchor + '-' + loop.index }}">
                     {% if (breadcrumbs and loop.first) %}
@@ -44,23 +63,6 @@
                         ) }}
                     {% elseif part.type === 'factRiver' %}
                         {{ factRiver(part.content) }}
-                    {% elseif part.type === 'relatedContent' %}
-                        <h2 class="t--underline">{{ part.heading }}</h2>
-                        <ul class="flex-grid flex-grid--3up">
-                            {% for article in part.content %}
-                                <li class="flex-grid__item">
-                                    {{ promoCard({
-                                        "title": article.title,
-                                        "summary": article.summary,
-                                        "image": {
-                                            "url": article.trailImage,
-                                            "alt": article.title
-                                        },
-                                        "link": { "url": article.linkUrl }
-                                    }) }}
-                                </li>
-                            {% endfor %}
-                        </ul>
                     {% elseif part.type === 'tableOfContents' and flexibleContent %}
                         <div class="s-prose u-constrained-content-wide">
                             {{ part.content | safe }}


### PR DESCRIPTION
Re-jigs the logic for flexible content to be able to render the related project separately.

![image](https://user-images.githubusercontent.com/123386/78573252-6e1e7d80-7820-11ea-85c3-fef5d1facdc7.png)

Also fixes a related issue with duplicate titles:

![image](https://user-images.githubusercontent.com/123386/78573331-85f60180-7820-11ea-87c5-8ab0b7a1b3b1.png)
