### PR TITLE
Remove leading slash from content API call

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -174,7 +174,7 @@ function getUpdates({
                 };
             });
     } else {
-        return queryContentApi(`/v1/${locale}/updates/${type || ''}`, {
+        return queryContentApi(`v1/${locale}/updates/${type || ''}`, {
             searchParams: withPreviewParams(requestParams, {
                 ...query,
                 ...{ 'page-limit': 10 },
@@ -292,7 +292,7 @@ function getPublications({
         ...filteredRequestParams,
     };
 
-    const baseUrl = `/v1/${locale}/funding/publications/${programme}`;
+    const baseUrl = `v1/${locale}/funding/publications/${programme}`;
     if (slug) {
         return queryContentApi(`${baseUrl}/${slug}`, {
             searchParams: withPreviewParams(requestParams, {

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -277,28 +277,23 @@ function getPublications({
     locale,
     programme,
     slug = null,
-    requestParams = {},
+    searchParams = {},
 }) {
-    const filteredRequestParams = pick(requestParams, [
-        'page',
-        'tag',
-        'q',
-        'sort',
-    ]);
-
-    const apiRequestParams = {
+    const customSearchParams = {
         // Override default page-limit
         ...{ 'page-limit': 10 },
-        ...filteredRequestParams,
+        ...pick(searchParams, ['page', 'tag', 'q', 'sort']),
     };
 
-    const baseUrl = `v1/${locale}/funding/publications/${programme}`;
+    const combinedSearchParams = withPreviewParams(searchParams, {
+        ...customSearchParams,
+    });
+
     if (slug) {
-        return queryContentApi(`${baseUrl}/${slug}`, {
-            searchParams: withPreviewParams(requestParams, {
-                ...apiRequestParams,
-            }),
-        })
+        return queryContentApi(
+            `v1/${locale}/funding/publications/${programme}/${slug}`,
+            { searchParams: combinedSearchParams }
+        )
             .json()
             .then((response) => {
                 return {
@@ -307,11 +302,10 @@ function getPublications({
                 };
             });
     } else {
-        return queryContentApi(baseUrl, {
-            searchParams: withPreviewParams(requestParams, {
-                ...apiRequestParams,
-            }),
-        })
+        return queryContentApi(
+            `v1/${locale}/funding/publications/${programme}`,
+            { searchParams: combinedSearchParams }
+        )
             .json()
             .then((response) => {
                 return {
@@ -319,7 +313,7 @@ function getPublications({
                     result: mapAttrs(response),
                     pagination: _buildPagination(
                         response.meta.pagination,
-                        apiRequestParams
+                        customSearchParams
                     ),
                 };
             });

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -54,7 +54,7 @@ router.get(
                 contentApi.getPublications({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
-                    requestParams: req.query,
+                    searchParams: req.query,
                 }),
             ]);
 
@@ -88,7 +88,7 @@ router.get(
                 locale: req.i18n.getLocale(),
                 programme: req.params.programme,
                 slug: req.params.slug,
-                requestParams: req.query,
+                searchParams: req.query,
             });
             setCommonLocals(req, res, publication.entry);
             res.locals.breadcrumbs = res.locals.breadcrumbs.concat(


### PR DESCRIPTION
Fixes requests to /api//v1/en/updates/people-stories?page-limit=10 with a double // after /api. The request works but is noisy so fixing that.