### PR TITLE
Disable latest funding programmes

### DIFF
--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -13,20 +13,8 @@ const contentApi = require('../../common/content-api');
 const router = express.Router();
 
 router.get('/', injectHeroImage('funding-letterbox-new'), async (req, res) => {
-    /**
-     * Fetch latest funding programmes, but consider them optional,
-     * we can still render the page without them.
-     */
-    let latestProgrammes = [];
-    try {
-        latestProgrammes = await contentApi.getRecentFundingProgrammes(
-            req.i18n.getLocale()
-        );
-    } catch (error) {} // eslint-disable-line no-empty
-
     res.render(path.resolve(__dirname, './views/funding-landing'), {
         title: req.i18n.__('toplevel.funding.title'),
-        latestProgrammes: latestProgrammes,
     });
 });
 

--- a/controllers/funding/views/funding-landing.njk
+++ b/controllers/funding/views/funding-landing.njk
@@ -11,19 +11,6 @@
             <section class="content-box u-inner-wide-only">
                 {{ sectionLinks(__('toplevel.funding.sectionLinks')) }}
             </section>
-
-            {% if latestProgrammes.length > 0 %}
-                <section class="u-inner">
-                    <h2 class="t--underline">{{ __('toplevel.funding.latestTitle') }}</h2>
-                    <ul class="flex-grid flex-grid--3up">
-                        {% for programme in latestProgrammes %}
-                            <li class="flex-grid__item">
-                                {{ programmeCard(programme) }}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </section>
-            {% endif %}
         </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
Right now two of the three latest programmes are closed to applications until further notice. Because this list is dynamic it's very misleading. For now the simplest thing to do is to disable this list. If we reinstate this we should consider making this a featured/manual list, rather than based on published date.

![image](https://user-images.githubusercontent.com/123386/78685782-2532fb80-78ea-11ea-984b-57626be87292.png)

![image](https://user-images.githubusercontent.com/123386/78685801-2b28dc80-78ea-11ea-97d4-4d597315c1c7.png)
