### PR TITLE
Add log out link to user dashboard

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -722,6 +722,8 @@ user:
       href: /welsh/user/update-email
     - label: Gweld eich ceisiadau ariannu
       href: /welsh/apply/under-10k
+    - label: Allgofnodi
+      href: /welsh/user/logout
   login:
     title: Mewngofnodi
     introduction: >

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,8 @@ user:
       href: /user/update-email
     - label: View your funding applications
       href: /apply/under-10k
+    - label: Log out
+      href: /user/logout
   login:
     title: Log in
     introduction: >


### PR DESCRIPTION
Occasionally getting reports of users missing the log out link in the header (either due to not seeing it, or potentially it not switching from the default state). A bit belt and braces but adding a log out link to the account screen.

<img width="486" alt="Screenshot 2020-04-08 at 10 44 22" src="https://user-images.githubusercontent.com/123386/78770566-a5a73a00-7986-11ea-840f-9a72d1b929e9.png">
