### PR TITLE
Live preview check fix

### DIFF
--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -6,11 +6,13 @@ module.exports = function checkPreviewMode(queryParams) {
             return queryParams['x-craft-live-preview'] && queryParams['token'];
         else
             return queryParams['x-craft-live-preview'] !== null ? queryParams['x-craft-live-preview'] : queryParams['token'];
-
     }
 
     function isShareLink() {
-        return queryParams['x-craft-preview'] || queryParams['token'];
+        if (queryParams['x-craft-live-preview'] !== null && queryParams['token'] !== null)
+            return queryParams['x-craft-live-preview'] && queryParams['token'];
+        else
+            return queryParams['x-craft-live-preview'] !== null ? queryParams['x-craft-live-preview'] : queryParams['token'];
     }
 
     return {

--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -2,17 +2,11 @@
 
 module.exports = function checkPreviewMode(queryParams) {
     function isLivePreview() {
-        if (queryParams['x-craft-live-preview'] !== null && queryParams['token'] !== null)
-            return queryParams['x-craft-live-preview'] && queryParams['token'];
-        else
-            return queryParams['x-craft-live-preview'] !== null ? queryParams['x-craft-live-preview'] : queryParams['token'];
+        return queryParams['x-craft-live-preview'];
     }
 
     function isShareLink() {
-        if (queryParams['x-craft-live-preview'] !== null && queryParams['token'] !== null)
-            return queryParams['x-craft-live-preview'] && queryParams['token'];
-        else
-            return queryParams['x-craft-live-preview'] !== null ? queryParams['x-craft-live-preview'] : queryParams['token'];
+        return queryParams['x-craft-preview'] && queryParams['token'];
     }
 
     return {

--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -2,7 +2,11 @@
 
 module.exports = function checkPreviewMode(queryParams) {
     function isLivePreview() {
-        return queryParams['x-craft-live-preview'] || queryParams['token'];
+        if (queryParams['x-craft-live-preview'] !== null && queryParams['token'] !== null)
+            return queryParams['x-craft-live-preview'] && queryParams['token'];
+        else
+            return queryParams['x-craft-live-preview'] !== null ? queryParams['x-craft-live-preview'] : queryParams['token'];
+
     }
 
     function isShareLink() {

--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -2,11 +2,11 @@
 
 module.exports = function checkPreviewMode(queryParams) {
     function isLivePreview() {
-        return queryParams['x-craft-live-preview'] && queryParams['token'];
+        return queryParams['x-craft-live-preview'] || queryParams['token'];
     }
 
     function isShareLink() {
-        return queryParams['x-craft-preview'] && queryParams['token'];
+        return queryParams['x-craft-preview'] || queryParams['token'];
     }
 
     return {

--- a/common/check-preview-mode.test.js
+++ b/common/check-preview-mode.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+'use strict';
+
+const preview = require('./check-preview-mode');
+
+
+test('preview', function () {
+    expect(preview({'x-craft-live-preview' : 'abc', 'x-craft-preview': '123', 'token': '456'})).toStrictEqual({isLivePreview: "abc", isPreview: "abc", isShareLink: "456"});
+    expect(preview({'x-craft-live-preview' : 'abc'})).toStrictEqual({isLivePreview: "abc", isPreview: "abc", isShareLink: undefined});
+    expect(preview({'x-craft-preview': '123', 'token': '456'})).toStrictEqual({isLivePreview: undefined, isPreview: "456", isShareLink: "456"});
+});


### PR DESCRIPTION
Updated the check for if it is a live preview, it will only require the x-craft-live-preview or the token rather than both. Also implemented the same for the share link.