### PR TITLE
Remove need for injectCopy from updates router

### DIFF
--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -17,36 +17,32 @@ const heroSlug = 'pawzitive-letterbox-new';
 /**
  * News landing page handler
  */
-router.get(
-    '/',
-    injectCopy('news'),
-    injectHeroImage(heroSlug),
-    async (req, res, next) => {
-        try {
-            // We make two requests here to ensure we get a distinct amount
-            // of each content type (blogposts and people stories)
-            // otherwise there may be zero entries of one kind
-            // depending on frequency of posting of the other kind.
+router.get('/', injectHeroImage(heroSlug), async function (req, res, next) {
+    try {
+        // We make two requests here to ensure we get a distinct amount
+        // of each content type (blogposts and people stories)
+        // otherwise there may be zero entries of one kind
+        // depending on frequency of posting of the other kind.
 
-            const blogposts = await contentApi.getUpdates({
-                locale: req.i18n.getLocale(),
-                type: 'blog',
-            });
+        const blogposts = await contentApi.getUpdates({
+            locale: req.i18n.getLocale(),
+            type: 'blog',
+        });
 
-            const peopleStories = await contentApi.getUpdates({
-                locale: req.i18n.getLocale(),
-                type: 'people-stories',
-            });
+        const peopleStories = await contentApi.getUpdates({
+            locale: req.i18n.getLocale(),
+            type: 'people-stories',
+        });
 
-            res.render(path.resolve(__dirname, `./views/landing`), {
-                blogposts: blogposts.result,
-                peopleStories: peopleStories.result,
-            });
-        } catch (e) {
-            next(e);
-        }
+        res.render(path.resolve(__dirname, `./views/landing`), {
+            title: req.i18n.__('news.title'),
+            blogposts: blogposts.result,
+            peopleStories: peopleStories.result,
+        });
+    } catch (e) {
+        next(e);
     }
-);
+});
 
 function shouldRedirectLinkUrl(req, entry) {
     return (

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -19,20 +19,22 @@ const heroSlug = 'pawzitive-letterbox-new';
  */
 router.get('/', injectHeroImage(heroSlug), async function (req, res, next) {
     try {
-        // We make two requests here to ensure we get a distinct amount
-        // of each content type (blogposts and people stories)
-        // otherwise there may be zero entries of one kind
-        // depending on frequency of posting of the other kind.
-
-        const blogposts = await contentApi.getUpdates({
-            locale: req.i18n.getLocale(),
-            type: 'blog',
-        });
-
-        const peopleStories = await contentApi.getUpdates({
-            locale: req.i18n.getLocale(),
-            type: 'people-stories',
-        });
+        /**
+         * We make two requests here to ensure we get a distinct amount
+         * of each content type (blogposts and people stories)
+         * otherwise there may be zero entries of one kind
+         * depending on frequency of posting of the other kind.
+         */
+        const [blogposts, peopleStories] = await Promise.all([
+            await contentApi.getUpdates({
+                locale: req.i18n.getLocale(),
+                type: 'blog',
+            }),
+            await contentApi.getUpdates({
+                locale: req.i18n.getLocale(),
+                type: 'people-stories',
+            }),
+        ]);
 
         res.render(path.resolve(__dirname, `./views/landing`), {
             title: req.i18n.__('news.title'),

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -1,11 +1,8 @@
 {% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% from "components/blog/macro.njk" import blogTrail with context %}
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/hero.njk" import hero with context %}
-{% from "components/promo-card/macro.njk" import promoCard %}
-{% from "components/split-nav/macro.njk" import splitNav %}
 {% from "components/icons.njk" import iconFacebook, iconInstagram, iconTwitter %}
-{% from "components/blog/macro.njk" import blogTrail with context %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/updates/views/landing.njk
+++ b/controllers/updates/views/landing.njk
@@ -1,3 +1,4 @@
+{% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/hero.njk" import hero with context %}
@@ -6,33 +7,30 @@
 {% from "components/icons.njk" import iconFacebook, iconInstagram, iconTwitter %}
 {% from "components/blog/macro.njk" import blogTrail with context %}
 
-
-{% extends "layouts/main.njk" %}
-
 {% block content %}
     <main role="main" id="content">
         {{ hero(title, pageHero.image) }}
 
         <div class="nudge-up">
             {% call contentBox() %}
-                <p>{{ copy.introductions.newsLanding }}</p>
+                <p>{{ __('news.introductions.newsLanding') }}</p>
             {% endcall %}
 
             {# Social links #}
             <section class="u-inner-wide-only u-margin-bottom-l">
                 <div class="o-button-group-flex">
                     <a class="btn btn--small btn--outline"
-                        href="{{ globalCopy.brand.instagram }}">
+                        href="{{ __('global.brand.instagram') }}">
                         <span class="btn__icon">{{ iconInstagram() }}</span>
                         {{ __('global.misc.followUsOn') }} {{ __('global.misc.instagram') }}
                     </a>
                     <a class="btn btn--small btn--outline"
-                        href="{{ globalCopy.brand.facebook }}">
+                        href="{{ __('global.brand.facebook') }}">
                         <span class="btn__icon">{{ iconFacebook() }}</span>
                         {{ __('global.misc.followUsOn') }} {{ __('global.misc.facebook') }}
                     </a>
                     <a class="btn btn--small btn--outline"
-                        href="https://www.twitter.com/{{ globalCopy.brand.twitter }}" >
+                        href="https://www.twitter.com/{{ __('global.brand.twitter') }}" >
                         <span class="btn__icon">{{ iconTwitter() }}</span>
                         {{ __('global.misc.followUsOn') }} {{ __('global.misc.twitter') }}
                     </a>
@@ -42,7 +40,7 @@
             {# Blog posts #}
             <section class="related-content u-inner u-margin-bottom">
                 <header class="related-content__header">
-                    <h2 class="t--underline">{{ copy.types.blog.plural }}</h2>
+                    <h2 class="t--underline">{{ __('news.types.blog.plural') }}</h2>
                 </header>
                 <div class="related-content__content">
                     <ul class="flex-grid flex-grid--3up">
@@ -55,7 +53,7 @@
                 </div>
                 <div class="related-content__footer">
                     <a class="related-content__more" href="{{ localify('/news/blog') }}">
-                        {{ copy.blogpost.viewAllBlogPosts }} &rarr;
+                        {{ __('news.blogpost.viewAllBlogPosts') }} &rarr;
                     </a>
                 </div>
             </section>
@@ -64,7 +62,7 @@
             {% if peopleStories.length > 0 %}
                 <section class="related-content u-inner u-margin-bottom">
                     <header class="related-content__header">
-                        <h2 class="t--underline">{{ copy.types['people-stories'].plural }}</h2>
+                        <h2 class="t--underline">{{ __('news.types.people-stories.plural') }}</h2>
                     </header>
                     <div class="related-content__content">
                         <ul class="flex-grid flex-grid--3up">
@@ -77,7 +75,7 @@
                     </div>
                     <div class="related-content__footer">
                         <a class="related-content__more" href="{{ localify('/news/people-stories') }}">
-                            {{ copy['people-stories'].viewAllPeopleStories }} &rarr;
+                            {{ __('news.people-stories.viewAllPeopleStories') }} &rarr;
                         </a>
                     </div>
                 </section>
@@ -85,11 +83,11 @@
 
             {# Press releases #}
             {% call contentBox() %}
-                <h2>{{ copy.types['press-releases'].plural }}</h2>
-                <p>{{ copy.introductions.pressReleases }}</p>
+                <h2>{{ __('news.types.press-releases.plural') }}</h2>
+                <p>{{ __('news.introductions.pressReleases') }}</p>
                 <p>
                     <a href="{{ localify('/news/press-releases') }}" class="btn btn--medium">
-                        {{ copy.pressRelease.viewLatestPressReleases }}
+                        {{ __('news.pressRelease.viewLatestPressReleases') }}
                     </a>
                 </p>
             {% endcall %}

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -1,9 +1,7 @@
 {% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-{% from "components/article-teaser/macro.njk" import articleTeaser %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
-{% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/blog/macro.njk" import blogTrail with context %}
 
 {% set copy = __('news') %}

--- a/controllers/updates/views/listing/blog.njk
+++ b/controllers/updates/views/listing/blog.njk
@@ -1,3 +1,4 @@
+{% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/article-teaser/macro.njk" import articleTeaser %}
 {% from "components/hero.njk" import hero with context %}
@@ -5,7 +6,7 @@
 {% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/blog/macro.njk" import blogTrail with context %}
 
-{% extends "layouts/main.njk" %}
+{% set copy = __('news') %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -1,12 +1,12 @@
+{% extends "layouts/main.njk" %}
 {% from "components/article-teaser/macro.njk" import articleTeaser %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/split-nav/macro.njk" import splitNav %}
 {% from "components/hero.njk" import hero with context %}
-
 {% from "../view-helpers.njk" import entryRegions with context %}
 
-{% extends "layouts/main.njk" %}
+{% set copy = __('news') %}
 
 {% block content %}
     <main role="main" id="content">
@@ -14,7 +14,7 @@
 
         <section class="content-box u-inner-wide-only nudge-up">
             {{ breadcrumbTrail(breadcrumbs) }}
-        
+
             <div class="content-sidebar">
                 <div class="content-sidebar__primary">
                     {% if entries.length > 0 %}
@@ -64,7 +64,7 @@
                             {{ copy.pressRelease.noResultsFor }} "{{ entriesMeta.activeRegion.title }}",
                             <a href="{{ currentPath }}">{{ copy.pressRelease.viewAllPressReleases }}</a>
                         </p>
-                    {% endif %}        
+                    {% endif %}
                 </div>
 
                 <div class="content-sidebar__secondary">

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -8,6 +8,7 @@
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
 
+{% set copy = __('news') %}
 {% set bodyClass = 'has-static-header' %}
 
 {% macro articleMeta(entry) %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -1,14 +1,14 @@
+{% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/document-list/macro.njk" import documentList %}
 {% from "components/flexible-content/macro.njk" import flexibleContent %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
-
 {% from "../view-helpers.njk" import entryRegions with context %}
 
+{% set copy = __('news') %}
 {% set bodyClass = 'has-static-header' %}
-{% extends "layouts/main.njk" %}
 
 {% macro entryMeta(entry) %}
     <dl class="o-definition-list o-definition-list--compact">


### PR DESCRIPTION
As with other routers we've been moving away from using `injectCopy` in favour of using i18n directly. This removes `injectCopy` from the updates router and uses it as an excuse to tidy up the router code a bit.