### PR TITLE
Remove injectCopy from user routes

### DIFF
--- a/controllers/user/activate.js
+++ b/controllers/user/activate.js
@@ -8,7 +8,6 @@ const {
     requireUnactivatedUser,
     isActivated,
 } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
 const logger = require('../../common/logger').child({ service: 'user' });
 
 const { verifyTokenActivate } = require('./lib/jwt');
@@ -18,12 +17,13 @@ const router = express.Router();
 
 function renderTemplate(req, res) {
     const template = path.resolve(__dirname, './views/activate');
-    res.render(template);
+    res.render(template, {
+        title: req.i18n.__('user.activate.title'),
+    });
 }
 
 router
     .route('/')
-    .all(injectCopy('user.activate'))
     .get(async function (req, res) {
         // Prevent activated users from persisting on this page
         if (req.user && isActivated(req.user)) {

--- a/controllers/user/dashboard.js
+++ b/controllers/user/dashboard.js
@@ -3,22 +3,16 @@ const path = require('path');
 const express = require('express');
 
 const { requireUserAuth, requireActiveUser } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
 
 const router = express.Router();
 
-router.get(
-    '/',
-    requireUserAuth,
-    requireActiveUser,
-    injectCopy('user.dashboard'),
-    (req, res) => {
-        res.render(path.resolve(__dirname, './views/dashboard'), {
-            alertMessage: req.query.s
-                ? req.i18n.__(`user.common.alertMessages.${req.query.s}`)
-                : null,
-        });
-    }
-);
+router.get('/', requireUserAuth, requireActiveUser, function (req, res) {
+    res.render(path.resolve(__dirname, './views/dashboard'), {
+        title: req.i18n.__('user.dashboard.title'),
+        alertMessage: req.query.s
+            ? req.i18n.__(`user.common.alertMessages.${req.query.s}`)
+            : null,
+    });
+});
 
 module.exports = router;

--- a/controllers/user/index.js
+++ b/controllers/user/index.js
@@ -8,7 +8,6 @@ const { isDev } = require('../../common/appData');
 const { localify } = require('../../common/urls');
 const { noStore } = require('../../common/cached');
 const { requireNotStaffAuth } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
 const logger = require('../../common/logger');
 
 const router = express.Router();
@@ -74,7 +73,7 @@ router.get('/session', function (req, res) {
  * Public user routes
  * Disallow staff from this point on
  */
-router.use(requireNotStaffAuth, injectCopy('apply'), function (req, res, next) {
+router.use(requireNotStaffAuth, function (req, res, next) {
     res.locals.bodyClass = 'has-static-header'; // No hero images on user pages
     res.locals.sectionTitle = req.i18n.__('user.common.yourAccount');
     res.locals.sectionUrl = req.baseUrl;

--- a/controllers/user/login.js
+++ b/controllers/user/login.js
@@ -3,26 +3,22 @@ const path = require('path');
 const express = require('express');
 const passport = require('passport');
 
-const logger = require('../../common/logger').child({
-    service: 'user',
-});
-
 const {
     rateLimiterConfigs,
     RateLimiter,
 } = require('../../common/rate-limiter');
-
-const { injectCopy } = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback,
 } = require('../../common/authed');
 const { csrfProtection } = require('../../common/cached');
+const logger = require('../../common/logger').child({ service: 'user' });
 
 const router = express.Router();
 
 function renderForm(req, res, formValues = null, errors = []) {
     res.render(path.resolve(__dirname, './views/login'), {
+        title: req.i18n.__('user.login.title'),
         csrfToken: req.csrfToken(),
         formValues: formValues,
         errors: errors,
@@ -30,17 +26,15 @@ function renderForm(req, res, formValues = null, errors = []) {
 }
 
 function renderRateLimitError(req, res, minutesLeft) {
-    const copy = req.i18n.__('user.rateLimited');
     res.status(429).render(path.resolve(__dirname, './views/rate-limited'), {
-        copy: copy,
-        title: copy.title,
+        title: req.i18n.__('user.rateLimited.title'),
         minutesLeft: minutesLeft,
     });
 }
 
 router
     .route('/')
-    .all(csrfProtection, requireNoAuth, injectCopy('user.login'))
+    .all(csrfProtection, requireNoAuth)
     .get(function (req, res) {
         if (req.query.s) {
             res.locals.alertMessage = req.i18n.__(
@@ -104,7 +98,7 @@ router
                         await LoginRateLimiter.consumeRateLimit();
                         return renderForm(req, res, req.body, [
                             {
-                                msg: res.locals.copy.credentialError,
+                                msg: req.i18n.__('user.login.credentialError'),
                             },
                         ]);
                     } catch (rateLimitRejection) {

--- a/controllers/user/password.js
+++ b/controllers/user/password.js
@@ -8,8 +8,7 @@ const { sanitise } = require('../../common/sanitise');
 const { sendHtmlEmail } = require('../../common/mail');
 const { localify } = require('../../common/urls');
 const { requireNoAuth } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
-
+const validateSchema = require('../../common/validate-schema');
 const logger = require('../../common/logger').child({
     service: 'user',
 });
@@ -17,7 +16,6 @@ const logger = require('../../common/logger').child({
 const { verifyTokenPasswordReset } = require('./lib/jwt');
 const { processResetRequest } = require('./lib/password-reset');
 const schemas = require('./lib/account-schemas');
-const validateSchema = require('../../common/validate-schema');
 
 const router = express.Router();
 
@@ -44,6 +42,7 @@ function sendPasswordResetNotification(req, email) {
 
 function renderForgotForm(req, res, data = null, errors = []) {
     res.render(path.resolve(__dirname, './views/forgotten-password'), {
+        title: req.i18n.__('user.forgottenPassword.title'),
         formValues: data,
         errors: errors,
     });
@@ -51,13 +50,16 @@ function renderForgotForm(req, res, data = null, errors = []) {
 
 function renderResetForm(req, res, data = null, errors = []) {
     res.render(path.resolve(__dirname, './views/reset-password'), {
+        title: req.i18n.__('user.resetPassword.title'),
         formValues: data,
         errors: errors,
     });
 }
 
 function renderResetFormExpired(req, res) {
-    res.render(path.resolve(__dirname, './views/reset-password-expired'));
+    res.render(path.resolve(__dirname, './views/reset-password-expired'), {
+        title: req.i18n.__('user.resetPassword.title'),
+    });
 }
 
 /**
@@ -65,7 +67,7 @@ function renderResetFormExpired(req, res) {
  */
 router
     .route('/forgot')
-    .all(requireNoAuth, injectCopy('user.forgottenPassword'))
+    .all(requireNoAuth)
     .get(renderForgotForm)
     .post(async function (req, res) {
         const validationResult = validateSchema(
@@ -113,8 +115,7 @@ router
  */
 router
     .route('/reset')
-    .all(injectCopy('user.resetPassword'))
-    .get(async (req, res) => {
+    .get(async function (req, res) {
         function token() {
             return req.query.token ? req.query.token : res.locals.token;
         }

--- a/controllers/user/register.js
+++ b/controllers/user/register.js
@@ -9,7 +9,6 @@ const { localify } = require('../../common/urls');
 const { sanitise } = require('../../common/sanitise');
 const logger = require('../../common/logger').child({ service: 'user' });
 const { csrfProtection } = require('../../common/cached');
-const { injectCopy } = require('../../common/inject-content');
 const {
     requireNoAuth,
     redirectUrlWithFallback,
@@ -40,6 +39,7 @@ function logIn(req, res, next) {
 
 function renderForm(req, res, data = null, errors = []) {
     res.render(path.resolve(__dirname, './views/register'), {
+        title: req.i18n.__('user.register.title'),
         csrfToken: req.csrfToken(),
         formValues: data,
         errors: errors,
@@ -48,7 +48,7 @@ function renderForm(req, res, data = null, errors = []) {
 
 router
     .route('/')
-    .all(requireNoAuth, csrfProtection, injectCopy('user.register'))
+    .all(requireNoAuth, csrfProtection)
     .get(renderForm)
     .post(async function handleRegister(req, res, next) {
         const validationResult = validateSchema(
@@ -64,7 +64,7 @@ router
         const fallbackErrors = [
             {
                 msg: req.i18n.__(
-                    res.locals.copy.genericError,
+                    'user.register.genericError',
                     localify(req.i18n.getLocale())('/user/password/forgot')
                 ),
             },

--- a/controllers/user/update-email.js
+++ b/controllers/user/update-email.js
@@ -2,22 +2,22 @@
 const path = require('path');
 const express = require('express');
 
-const { Users } = require('../../db/models');
 const { localify } = require('../../common/urls');
 const { csrfProtection } = require('../../common/cached');
 const { requireUserAuth } = require('../../common/authed');
-const { injectCopy } = require('../../common/inject-content');
-
 const logger = require('../../common/logger').child({ service: 'user' });
+const validateSchema = require('../../common/validate-schema');
+
+const { Users } = require('../../db/models');
 
 const { emailOnly } = require('./lib/account-schemas');
-const validateSchema = require('../../common/validate-schema');
 const sendActivationEmail = require('./lib/activation-email');
 
 const router = express.Router();
 
 function render(req, res, data = null, errors = []) {
     res.render(path.resolve(__dirname, './views/update-email'), {
+        title: req.i18n.__('user.updateEmail.title'),
         csrfToken: req.csrfToken(),
         formValues: data,
         errors: errors,
@@ -62,7 +62,7 @@ async function handleSubmission(req, res, next) {
                  * exists with the requested email address
                  */
                 render(req, res, validationResult.value, [
-                    { msg: res.locals.copy.genericError },
+                    { msg: req.i18n.__('user.updateEmail.genericError') },
                 ]);
             }
         } catch (error) {
@@ -75,7 +75,7 @@ async function handleSubmission(req, res, next) {
 
 router
     .route('/')
-    .all(requireUserAuth, csrfProtection, injectCopy('user.updateEmail'))
+    .all(requireUserAuth, csrfProtection)
     .get(render)
     .post(handleSubmission);
 

--- a/controllers/user/views/activate.njk
+++ b/controllers/user/views/activate.njk
@@ -1,5 +1,6 @@
 {% extends "layouts/main.njk" %}
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
+{% set copy = __('user.activate') %}
 
 {% macro resendButton() %}
     <form action="" method="POST">

--- a/controllers/user/views/dashboard.njk
+++ b/controllers/user/views/dashboard.njk
@@ -17,7 +17,7 @@
             {% endif %}
 
             <div class="u-margin-bottom">
-                {{ sectionLinks(copy.sectionLinks) }}
+                {{ sectionLinks(__('user.dashboard.sectionLinks')) }}
             </div>
         </div>
     </main>

--- a/controllers/user/views/forgotten-password.njk
+++ b/controllers/user/views/forgotten-password.njk
@@ -2,6 +2,7 @@
 {% from "components/back-link/macro.njk" import backLink with context %}
 {% from "components/form-fields/macros.njk" import formErrors, formField with context %}
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
+{% set copy = __('user.forgottenPassword') %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -1,5 +1,6 @@
 {% extends "layouts/main.njk" %}
 {% from "components/form-fields/macros.njk" import formErrors, formField with context %}
+{% set copy = __('user.login') %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/user/views/rate-limited.njk
+++ b/controllers/user/views/rate-limited.njk
@@ -1,6 +1,7 @@
 {% extends "layouts/main.njk" %}
 {% from "components/back-link/macro.njk" import backLink with context %}
 {% from "components/content-box/macro.njk" import contentBox %}
+{% set copy = __('user.rateLimited') %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -1,5 +1,6 @@
 {% extends "layouts/main.njk" %}
 {% from "components/form-fields/macros.njk" import formErrors, formField with context %}
+{% set copy = __('user.register') %}
 
 {% block content %}
     <main role="main" id="content">

--- a/controllers/user/views/reset-password-expired.njk
+++ b/controllers/user/views/reset-password-expired.njk
@@ -2,8 +2,6 @@
 {% from "components/back-link/macro.njk" import backLink with context %}
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
 
-{% set title = 'Reset password' %}
-
 {% block content %}
     <main role="main" id="content">
         <div class="content-box u-inner-wide-only">
@@ -17,7 +15,7 @@
             <h1 class="t--underline">{{ title }}</h1>
 
             <div class="message" role="alert">
-                {{ copy.errorExpired | safe }}
+                {{ __('user.resetPassword.errorExpired') | safe }}
             </div>
         </div>
     </main>

--- a/controllers/user/views/reset-password.njk
+++ b/controllers/user/views/reset-password.njk
@@ -15,7 +15,7 @@
             <h1 class="t--underline">{{ title }}</h1>
 
             <div class="s-prose u-constrained-wide">
-                {{ copy.introduction | safe }}
+                {{ __('user.resetPassword.introduction') | safe }}
             </div>
 
             {% if alertMessage %}

--- a/controllers/user/views/update-email.njk
+++ b/controllers/user/views/update-email.njk
@@ -10,7 +10,7 @@
             <h1 class="t--underline">{{ title }}</h1>
 
             <div class="s-prose u-constrained-wide">
-                {{ copy.introduction | safe }}
+                {{ __('user.updateEmail.introduction') | safe }}
             </div>
 
             {% if alertMessage %}
@@ -42,7 +42,7 @@
                 }, errors = errors) }}
 
                 <div class="form-actions">
-                    <input type="submit" class="btn" value="{{ copy.title }}" />
+                    <input type="submit" class="btn" value="{{ title }}" />
                 </div>
             </form>
         </div>


### PR DESCRIPTION
Removes injectCopy from user routes in favour of using translation methods directly.

Like with previous removals this reduces the overhead of working out what "copy" refers to in this context. Particularly notable here as there were nested injectCopy calls so copy could either be the top-level user locale or a more specific one (always seemed to be overridden but still possible.)