### PR TITLE
Breadcrumb tweak

### DIFF
--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -83,7 +83,6 @@ function renderPressDetail(req, res, entry) {
                 label: req.i18n.__('news.types.press-releases.plural'),
                 url: `${req.baseUrl}/press-releases`,
             },
-            { label: entry.title },
         ]),
     });
 }
@@ -194,15 +193,10 @@ function renderUpdatesDetail(req, res, entry) {
         socialImage: get(entry, 'thumbnail.large', false),
         entry: entry,
         entryTagList: entryTagList,
-        breadcrumbs: res.locals.breadcrumbs.concat(
-            {
-                label: req.i18n.__(
-                    `news.types.${req.params.updateType}.singular`
-                ),
-                url: `${req.baseUrl}/${req.params.updateType}`,
-            },
-            { label: entry.title }
-        ),
+        breadcrumbs: res.locals.breadcrumbs.concat({
+            label: req.i18n.__(`news.types.${req.params.updateType}.singular`),
+            url: `${req.baseUrl}/${req.params.updateType}`,
+        }),
     });
 }
 

--- a/views/components/breadcrumb-trail/macro.njk
+++ b/views/components/breadcrumb-trail/macro.njk
@@ -4,11 +4,10 @@
             {%- if isFlush %} breadcrumb-trail--flush{% endif -%}
             {%- if isTinted %} breadcrumb-trail--tinted{% endif -%}">
             {% for crumb in trail %}
-                {% set isLinked = crumb.url and not loop.last %}
                 <li class="breadcrumb-trail__item">
-                    {%- if isLinked -%}<a class="breadcrumb-trail__link" href="{{ crumb.url }}">{%- endif -%}
+                    {%- if crumb.url -%}<a class="breadcrumb-trail__link" href="{{ crumb.url }}">{%- endif -%}
                     {{ crumb.label }}
-                    {%- if isLinked -%}</a>{%- endif -%}
+                    {%- if crumb.url -%}</a>{%- endif -%}
                 </li>
             {% endfor %}
         </ol>


### PR DESCRIPTION
Because news titles are often much longer than typical page titles, including the title in the breadcrumb can create a lot of visual noise. Removing it in these cases.

**Before**
<img width="351" alt="Screenshot 2020-04-09 at 12 17 26" src="https://user-images.githubusercontent.com/123386/78890109-ee312700-7a5c-11ea-99fc-535aebef195e.png">

**After**
<img width="348" alt="Screenshot 2020-04-09 at 12 19 34" src="https://user-images.githubusercontent.com/123386/78890100-ec676380-7a5c-11ea-8f53-6b716af4d1cd.png">