### PR TITLE
Make sure checkPreviewMode returns booleans, not values

### DIFF
--- a/common/check-preview-mode.js
+++ b/common/check-preview-mode.js
@@ -1,12 +1,13 @@
 'use strict';
+const has = require('lodash/has');
 
 module.exports = function checkPreviewMode(queryParams) {
     function isLivePreview() {
-        return queryParams['x-craft-live-preview'];
+        return has(queryParams, 'x-craft-live-preview');
     }
 
     function isShareLink() {
-        return queryParams['x-craft-preview'] && queryParams['token'];
+        return has(queryParams, 'x-craft-preview') && has(queryParams, 'token');
     }
 
     return {

--- a/common/check-preview-mode.test.js
+++ b/common/check-preview-mode.test.js
@@ -11,22 +11,22 @@ test('checkPreviewMode', function () {
             'token': '456',
         })
     ).toStrictEqual({
-        isLivePreview: 'abc',
-        isPreview: 'abc',
-        isShareLink: '456',
+        isLivePreview: true,
+        isPreview: true,
+        isShareLink: true,
     });
 
     expect(checkPreviewMode({ 'x-craft-live-preview': 'abc' })).toStrictEqual({
-        isLivePreview: 'abc',
-        isPreview: 'abc',
-        isShareLink: undefined,
+        isLivePreview: true,
+        isPreview: true,
+        isShareLink: false,
     });
 
     expect(
         checkPreviewMode({ 'x-craft-preview': '123', 'token': '456' })
     ).toStrictEqual({
-        isLivePreview: undefined,
-        isPreview: '456',
-        isShareLink: '456',
+        isLivePreview: false,
+        isPreview: true,
+        isShareLink: true,
     });
 });


### PR DESCRIPTION
Thanks to the test @mo-durvesh added in https://github.com/biglotteryfund/blf-alpha/pull/3156 I spotted that the current behaviour of `checkPreviewMode` was returning the _values_ for the checks rather than a boolean. 

Technically this works because our code does truthy checks on these values but is unexpected behaviour. This PR fixes this and updates the tests.