### PR TITLE
Handle 404 errors correctly for Insights pages

### DIFF
--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -110,7 +110,6 @@ router.get('/:slug/:child_slug?', async function (req, res, next) {
             next();
         }
     } catch (error) {
-        console.log(error.response.statusCode);
         if (error.response.statusCode >= 500) {
             next(error);
         } else {

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -71,7 +71,11 @@ router.get(
                 pagination: research.pagination,
             });
         } catch (error) {
-            next(error);
+            if (error.statusCode >= 500) {
+                next(error);
+            } else {
+                next();
+            }
         }
     }
 );
@@ -106,7 +110,11 @@ router.get('/:slug/:child_slug?', async function (req, res, next) {
             next();
         }
     } catch (error) {
-        next(error);
+        if (error.statusCode >= 500) {
+            next(error);
+        } else {
+            next();
+        }
     }
 });
 

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -71,7 +71,7 @@ router.get(
                 pagination: research.pagination,
             });
         } catch (error) {
-            if (error.statusCode >= 500) {
+            if (error.response.statusCode >= 500) {
                 next(error);
             } else {
                 next();
@@ -110,7 +110,8 @@ router.get('/:slug/:child_slug?', async function (req, res, next) {
             next();
         }
     } catch (error) {
-        if (error.statusCode >= 500) {
+        console.log(error.response.statusCode);
+        if (error.response.statusCode >= 500) {
             next(error);
         } else {
             next();

--- a/controllers/programmes/index.js
+++ b/controllers/programmes/index.js
@@ -231,7 +231,7 @@ router.get('/:slug/:child_slug?', async (req, res, next) => {
             next();
         }
     } catch (error) {
-        if (error.statusCode >= 500) {
+        if (error.response.statusCode >= 500) {
             next(error);
         } else {
             next();

--- a/controllers/strategic-investments/index.js
+++ b/controllers/strategic-investments/index.js
@@ -30,7 +30,7 @@ router.get('/', injectListingContent, async function (req, res, next) {
             }),
         });
     } catch (error) {
-        if (error.statusCode >= 500) {
+        if (error.response.statusCode >= 500) {
             next(error);
         } else {
             next();
@@ -65,7 +65,7 @@ router.get('/:slug/:child_slug?', async function (req, res, next) {
             next();
         }
     } catch (error) {
-        if (error.statusCode >= 500) {
+        if (error.response.statusCode >= 500) {
             next(error);
         } else {
             next();

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -121,7 +121,7 @@ router.get(
                 }
             }
         } catch (error) {
-            if (error.statusCode >= 500) {
+            if (error.response.statusCode >= 500) {
                 next(error);
             } else {
                 next();
@@ -238,8 +238,12 @@ router.get(
                     next();
                 }
             }
-        } catch (e) {
-            next(e);
+        } catch (error) {
+            if (error.response.statusCode >= 500) {
+                next(error);
+            } else {
+                next();
+            }
         }
     }
 );


### PR DESCRIPTION
Seeing a bit of log noise over the weekend about dodgy Insights page URLs which return 500 errors. This uses the same approach as other controllers to return a 404 when the content is missing.