### PR TITLE
Add new Insights route for Covid-19 insights via CMS

### DIFF
--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -11,6 +11,7 @@ const {
     setCommonLocals,
 } = require('../../common/inject-content');
 const { buildArchiveUrl, localify } = require('../../common/urls');
+const { basicContent } = require('../common');
 
 const router = express.Router();
 
@@ -76,6 +77,13 @@ router.get('/documents/:slug?', async function (req, res, next) {
         }
     }
 });
+
+router.use(
+    '/covid-19-resources/:slug/:child_slug?',
+    basicContent({
+        cmsPage: true,
+    })
+);
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {


### PR DESCRIPTION
This is a simple change but pairs with https://github.com/biglotteryfund/craft-dev/pull/255 to allow us to render CMS pages as regular flexible content (next).