### PR TITLE
Add Array.includes polyfill use core-js 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2306,13 +2306,15 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
           "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "node-notifier": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-6.0.0.tgz",
           "integrity": "sha512-SVfQ/wMw+DesunOm5cKqr6yDcvUTDl/yc97ybGHMrteNEY6oekXpNpS3lZwgLlwz0FLgHoiW28ZpmBHUDg37cw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "growly": "^1.3.0",
             "is-wsl": "^2.1.1",
@@ -2325,7 +2327,8 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "supports-color": {
           "version": "7.1.0",
@@ -4610,6 +4613,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -6334,9 +6343,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "babel-jest": "25.3.0",
     "babel-loader": "8.0.6",
     "concurrently": "5.1.0",
+    "core-js": "3.6.5",
     "cross-env": "7.0.2",
     "css-loader": "3.5.2",
     "cssnano": "4.1.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,9 @@ module.exports = {
     entry: {
         head: './assets/js/head.js',
         app: [
-            'core-js/modules/es6.promise',
-            'core-js/modules/es6.array.iterator',
+            'core-js/features/promise',
+            'core-js/features/array/includes',
+            'core-js/features/array/iterator',
             './assets/js/main.js',
         ],
     },


### PR DESCRIPTION
Seeing some warnings about `Array.includes` which is unsupported by older versions of Internet Explorer. Likely due to this upgrade https://github.com/kazupon/vue-i18n/compare/v8.16.0...v8.17.0#diff-1fdf421c05c1140f6d71444ea2b27638R465 (good spot @mattandrews).

Including a polyfill and upgrading `core-js` to the latest / an explicit version at the same time to make sure we are using the latest polyfills. 