### PR TITLE
Lock vue-i18n to 8.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22416,9 +22416,9 @@
       "dev": true
     },
     "vue-i18n": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.17.0.tgz",
-      "integrity": "sha512-A6FlYeZtB9YOLNv+XRcu9xdVXDbIx1j6IprJC7mZ7nubLvXprRjQizauH8UrgGZI0KddoLJpA0UG3Dk87TIcnQ==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-8.16.0.tgz",
+      "integrity": "sha512-cp9JOsx4ETzlCsnD22FE8ZhAmD8kcyNLRKV0DPsS7bBNTCdIlOKuyTGonWKYcGCUtNMtwemDWRBevRm8eevBVg==",
       "dev": true
     },
     "vue-jest": {

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "stylelint-config-recommended": "3.0.0",
     "stylelint-scss": "3.17.0",
     "vue": "2.6.11",
-    "vue-i18n": "8.17.0",
+    "vue-i18n": "8.16.0",
     "vue-jest": "3.0.5",
     "vue-loader": "15.9.1",
     "vue-template-compiler": "2.6.11",


### PR DESCRIPTION
Recent 8.17.* release caused a regression in IE 11. Locking to 8.16.0 to fix the regression.

Regression caused by library starting to use `Array.prototype.includes` and `String.prototype.endsWith`.  Added an includes polyfill in https://github.com/biglotteryfund/blf-alpha/pull/3192 but missed the endsWith change. As this is causing a degraded experience for people using IE 11 we are better of reverting this upgrade for now.