### PR TITLE
Remove array.includes polyfill

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,6 @@ module.exports = {
         head: './assets/js/head.js',
         app: [
             'core-js/features/promise',
-            'core-js/features/array/includes',
             'core-js/features/array/iterator',
             './assets/js/main.js',
         ],


### PR DESCRIPTION
Rolled back vue-i18n to fix root cause rather than symptom in https://github.com/biglotteryfund/blf-alpha/pull/3193. To avoid any future confusion removing this unneeded polyfill.