### PR TITLE
Fix welsh homepage

### DIFF
--- a/server.js
+++ b/server.js
@@ -242,11 +242,8 @@ forEach(sections, function (section, sectionId) {
     /**
      * Mount each section under both English and Welsh paths.
      */
-    app.use(
-        [section.path, makeWelsh(section.path)],
-        sectionLocals,
-        section.router
-    );
+    app.use(section.path, sectionLocals, section.router);
+    app.use(makeWelsh(section.path), sectionLocals, section.router);
 });
 
 /**


### PR DESCRIPTION
Mounting section routers using app.use array syntax caused the welsh homepage to stop rendering. Switching to two explicit mount points fixes this.