### PR TITLE
Add homepage welsh language regression test

### DIFF
--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -15,8 +15,25 @@ function acceptCookieConsent() {
 
 it('should test common interactions', () => {
     cy.visit('/');
-
     cy.checkA11y();
+
+    // Switch to welsh language version of homepage
+    cy.get('.qa-lang-switcher').click();
+
+    // Check welsh language text
+    // When people are in the lead, communities thrive
+    cy.findByText('Rydym yn cefnogi pobl a chymunedau i ffynnu').should(
+        'be.visible'
+    );
+
+    // Switch back to English
+    cy.get('.qa-lang-switcher').click();
+
+    // Check welsh language text
+    // When people are in the lead, communities thrive
+    cy.findByText('When people are in the lead, communities thrive').should(
+        'be.visible'
+    );
 
     cy.viewport(375, 667);
 


### PR DESCRIPTION
Follow on from https://github.com/biglotteryfund/blf-alpha/pull/3202

Add a smoke test for the welsh language version of the homepage to avoid regressions.