### PR TITLE
Remove transformOrgHasDifferentTradingName

### DIFF
--- a/controllers/apply/under10k/transforms.js
+++ b/controllers/apply/under10k/transforms.js
@@ -25,23 +25,9 @@ function transformProjectDateRange(applicationData) {
     return applicationData;
 }
 
-function transformOrgHasDifferentTradingName(applicationData) {
-    if (
-        get('organisationTradingName')(applicationData) &&
-        !get('organisationHasDifferentTradingName')(applicationData)
-    ) {
-        logger.info('Transforming organisationHasDifferentTradingName');
-        applicationData.organisationHasDifferentTradingName = 'yes';
-    }
-    return applicationData;
-}
-
 function transform(applicationData) {
     // Add any default transforms here
-    const transformsToRun = [
-        transformOrgHasDifferentTradingName,
-        transformProjectDateRange,
-    ];
+    const transformsToRun = [transformProjectDateRange];
 
     if (transformsToRun.length === 0) {
         return applicationData;
@@ -57,5 +43,4 @@ module.exports = {
     transform,
     // Export for tests
     transformProjectDateRange,
-    transformOrgHasDifferentTradingName,
 };

--- a/controllers/apply/under10k/transforms.test.js
+++ b/controllers/apply/under10k/transforms.test.js
@@ -2,10 +2,7 @@
 'use strict';
 
 const { mockResponse } = require('./mocks');
-const {
-    transformProjectDateRange,
-    transformOrgHasDifferentTradingName,
-} = require('./transforms');
+const { transformProjectDateRange } = require('./transforms');
 
 test('should transform project date range', function () {
     const startDate = { day: 27, month: 3, year: 2020 };
@@ -28,29 +25,4 @@ test('should transform project date range', function () {
     expect(result.projectStartDate).toEqual(startDate);
     expect(result.projectEndDate).toEqual(endDate);
     expect(result).not.toHaveProperty('projectDateRange');
-});
-
-test('should transform OrganisationHasDifferentTradingName', function () {
-    const original = mockResponse({
-        organisationTradingName: 'Some Trading Name',
-        organisationHasDifferentTradingName: null,
-    });
-
-    expect(original).toHaveProperty('organisationTradingName');
-
-    const result = transformOrgHasDifferentTradingName(original);
-
-    expect(result.organisationHasDifferentTradingName).toEqual('yes');
-
-    const unchanged = mockResponse({
-        organisationLegalName: 'My Legal Name',
-        organisationTradingName: null,
-        organisationHasDifferentTradingName: null,
-    });
-
-    const unmodifiedResult = transformOrgHasDifferentTradingName(unchanged);
-
-    expect(unmodifiedResult.organisationHasDifferentTradingName).not.toEqual(
-        'yes'
-    );
 });


### PR DESCRIPTION
It has been three months since we launched this change so this should no longer be needed. Metrics show this was last called on 15/04/2020. We can probably leave this a couple of days to confirm, but should be fairly safe to go.