### PR TITLE
Update .compare() validation to compare normalised values

### DIFF
--- a/controllers/apply/lib/joi-extensions/compare-object.js
+++ b/controllers/apply/lib/joi-extensions/compare-object.js
@@ -6,7 +6,7 @@ module.exports = function (joi) {
         base: joi.object(),
         name: 'object',
         language: {
-            isEqual: 'Objects must not match',
+            isEqual: 'Object values must not match',
         },
         rules: [
             {
@@ -15,12 +15,27 @@ module.exports = function (joi) {
                     ref: joi.func().ref(),
                 },
                 validate(params, value, state, options) {
-                    const refVal = params.ref(
+                    const referenceValue = params.ref(
                         state.reference || state.parent,
                         options
                     );
 
-                    if (isEqual(refVal, value) === true) {
+                    /**
+                     * Convert object values to an array of normalised strings
+                     * Assumes a constraint that object only contains strings.
+                     * @param value
+                     * @returns {string}
+                     */
+                    function normalise(value) {
+                        return value.toString().toLowerCase().trim();
+                    }
+
+                    if (
+                        isEqual(
+                            Object.values(value).map(normalise),
+                            Object.values(referenceValue).map(normalise)
+                        ) === true
+                    ) {
                         return this.createError(
                             'object.isEqual',
                             { v: value },

--- a/controllers/apply/lib/joi-extensions/compare-object.test.js
+++ b/controllers/apply/lib/joi-extensions/compare-object.test.js
@@ -26,5 +26,12 @@ test('compare equality of two objects by reference', () => {
             exampleA: { a: 'these', b: 'match' },
             exampleB: { a: 'these', b: 'match' },
         }).error.message
-    ).toContain('Objects must not match');
+    ).toContain('Object values must not match');
+
+    expect(
+        schema.validate({
+            exampleA: { a: ' cAsE ', b: ' INSensiTive' },
+            exampleB: { a: ' caSE   ', b: ' inSeNsiTIVE' },
+        }).error.message
+    ).toContain('Object values must not match');
 });

--- a/controllers/apply/lib/joi-extensions/full-name.js
+++ b/controllers/apply/lib/joi-extensions/full-name.js
@@ -4,8 +4,8 @@ module.exports = function fullName(joi) {
     return {
         name: 'fullName',
         base: joi.object({
-            firstName: joi.string().max(40).required(),
-            lastName: joi.string().max(80).required(),
+            firstName: joi.string().trim().max(40).required(),
+            lastName: joi.string().trim().max(80).required(),
         }),
     };
 };

--- a/controllers/apply/lib/joi-extensions/uk-address.js
+++ b/controllers/apply/lib/joi-extensions/uk-address.js
@@ -4,11 +4,11 @@ module.exports = function ukAddress(joi) {
     return {
         name: 'ukAddress',
         base: joi.object({
-            line1: joi.string().max(255).required(),
-            line2: joi.string().allow('').max(255).optional(),
-            townCity: joi.string().max(40).required(),
-            county: joi.string().allow('').max(80).optional(),
-            postcode: joi.string().postcode().required(),
+            line1: joi.string().trim().max(255).required(),
+            line2: joi.string().trim().allow('').max(255).optional(),
+            townCity: joi.string().trim().max(40).required(),
+            county: joi.string().trim().allow('').max(80).optional(),
+            postcode: joi.string().trim().postcode().required(),
         }),
     };
 };


### PR DESCRIPTION
Spotted our `.compare()` validation is a little lax. Previous behaviour was to do a shallow equality check on the objects. This is fine if the object has exactly the same values e.g.

```js
isEqual({ a: 'one', b: 'two' }, { a: 'one', b: 'two' }) // true
```

But fails for cases where the keys contained extra spaces or a mix of cases:

```js
isEqual({ a: ' oNe ', b: 'twO' }, { a: 'one', b: 'two' }) // false
```

Updating this check to compare the list of normalised values instead. The trade-off here is that assumes all object keys can be stringified. For our use case this is a reasonable trade-off as we only use this check for comparing nested text fields like addresses and names.