### PR TITLE
Update .compare() validation to compare normalised values

### DIFF
--- a/controllers/apply/lib/joi-extensions/compare-object.js
+++ b/controllers/apply/lib/joi-extensions/compare-object.js
@@ -3,6 +3,18 @@ const isEqual = require('lodash/isEqual');
 const isObject = require('lodash/isObject');
 const sortBy = require('lodash/sortBy');
 
+/**
+ * Convert object values to an array of normalised strings
+ * Assumes a constraint that object only contains strings.
+ */
+function normaliseValues(sourceObject) {
+    return sortBy(
+        Object.values(sourceObject).map(function (value) {
+            return value.toString().toLowerCase().trim();
+        })
+    );
+}
+
 module.exports = function (joi) {
     return {
         base: joi.object(),
@@ -22,34 +34,20 @@ module.exports = function (joi) {
                         options
                     );
 
-                    /**
-                     * Convert object values to an array of normalised strings
-                     * Assumes a constraint that object only contains strings.
-                     * @param value
-                     * @returns {string}
-                     */
-                    function normalise(value) {
-                        return value.toString().toLowerCase().trim();
-                    }
-
-                    if (isObject(value) && isObject(referenceValue)) {
-                        if (
-                            isEqual(
-                                sortBy(Object.values(value).map(normalise)),
-                                sortBy(
-                                    Object.values(referenceValue).map(normalise)
-                                )
-                            ) === true
-                        ) {
-                            return this.createError(
-                                'object.isEqual',
-                                { v: value },
-                                state,
-                                options
-                            );
-                        } else {
-                            return value;
-                        }
+                    if (
+                        isObject(value) &&
+                        isObject(referenceValue) &&
+                        isEqual(
+                            normaliseValues(value),
+                            normaliseValues(referenceValue)
+                        ) === true
+                    ) {
+                        return this.createError(
+                            'object.isEqual',
+                            { v: value },
+                            state,
+                            options
+                        );
                     } else {
                         return value;
                     }

--- a/controllers/apply/lib/joi-extensions/compare-object.js
+++ b/controllers/apply/lib/joi-extensions/compare-object.js
@@ -1,12 +1,14 @@
 'use strict';
 const isEqual = require('lodash/isEqual');
+const isObject = require('lodash/isObject');
+const sortBy = require('lodash/sortBy');
 
 module.exports = function (joi) {
     return {
         base: joi.object(),
         name: 'object',
         language: {
-            isEqual: 'Objects must not match',
+            isEqual: 'Object values must not match',
         },
         rules: [
             {
@@ -15,18 +17,39 @@ module.exports = function (joi) {
                     ref: joi.func().ref(),
                 },
                 validate(params, value, state, options) {
-                    const refVal = params.ref(
+                    const referenceValue = params.ref(
                         state.reference || state.parent,
                         options
                     );
 
-                    if (isEqual(refVal, value) === true) {
-                        return this.createError(
-                            'object.isEqual',
-                            { v: value },
-                            state,
-                            options
-                        );
+                    /**
+                     * Convert object values to an array of normalised strings
+                     * Assumes a constraint that object only contains strings.
+                     * @param value
+                     * @returns {string}
+                     */
+                    function normalise(value) {
+                        return value.toString().toLowerCase().trim();
+                    }
+
+                    if (isObject(value) && isObject(referenceValue)) {
+                        if (
+                            isEqual(
+                                sortBy(Object.values(value).map(normalise)),
+                                sortBy(
+                                    Object.values(referenceValue).map(normalise)
+                                )
+                            ) === true
+                        ) {
+                            return this.createError(
+                                'object.isEqual',
+                                { v: value },
+                                state,
+                                options
+                            );
+                        } else {
+                            return value;
+                        }
                     } else {
                         return value;
                     }

--- a/controllers/apply/lib/joi-extensions/compare-object.test.js
+++ b/controllers/apply/lib/joi-extensions/compare-object.test.js
@@ -3,28 +3,45 @@
 const baseJoi = require('@hapi/joi');
 const Joi = baseJoi.extend(require('./compare-object'));
 
-test('compare equality of two objects by reference', () => {
-    const fieldSchema = Joi.object({
-        a: Joi.string().required(),
-        b: Joi.string().required(),
-    }).required();
+const objectSchema = Joi.object({
+    a: Joi.string().required(),
+    b: Joi.string().required(),
+}).required();
 
-    const schema = Joi.object({
-        exampleA: fieldSchema.compare(Joi.ref('exampleB')),
-        exampleB: fieldSchema.compare(Joi.ref('exampleA')),
-    });
+const schema = Joi.object({
+    exampleA: objectSchema.compare(Joi.ref('exampleB')),
+    exampleB: objectSchema.compare(Joi.ref('exampleA')),
+});
 
+test('compare equality of values in two objects', () => {
+    expect(
+        schema.validate({
+            exampleA: { a: 'these', b: 'match' },
+            exampleB: { a: 'these', b: 'match' },
+        }).error.message
+    ).toContain('Object values must not match');
+
+    expect(
+        schema.validate({
+            exampleA: { a: ' cAsE ', b: ' INSensiTive' },
+            exampleB: { a: ' caSE   ', b: ' inSeNsiTIVE' },
+        }).error.message
+    ).toContain('Object values must not match');
+});
+
+test('pass-through when reference is not present', function () {
+    expect(
+        schema.validate({
+            exampleA: { a: 'example', b: 'value' },
+        }).error.message
+    ).toContain(`"exampleB" is required`);
+});
+
+test('valid when values do not match', function () {
     expect(
         schema.validate({
             exampleA: { a: 'different', b: 'values' },
             exampleB: { a: 'not', b: 'the same' },
         }).error
     ).toBe(null);
-
-    expect(
-        schema.validate({
-            exampleA: { a: 'these', b: 'match' },
-            exampleB: { a: 'these', b: 'match' },
-        }).error.message
-    ).toContain('Objects must not match');
 });

--- a/controllers/apply/lib/joi-extensions/uk-address.js
+++ b/controllers/apply/lib/joi-extensions/uk-address.js
@@ -4,11 +4,11 @@ module.exports = function ukAddress(joi) {
     return {
         name: 'ukAddress',
         base: joi.object({
-            line1: joi.string().max(255).required(),
-            line2: joi.string().allow('').max(255).optional(),
-            townCity: joi.string().max(40).required(),
-            county: joi.string().allow('').max(80).optional(),
-            postcode: joi.string().postcode().required(),
+            line1: joi.string().trim().max(255).required(),
+            line2: joi.string().trim().allow('').max(255).optional(),
+            townCity: joi.string().trim().max(40).required(),
+            county: joi.string().trim().allow('').max(80).optional(),
+            postcode: joi.string().trim().postcode().required(),
         }),
     };
 };


### PR DESCRIPTION
Spotted our `.compare()` validation is a little lax. Previous behaviour was to do a shallow equality check on the objects. This is fine if the object has exactly the same values e.g.

```js
isEqual({ a: 'one', b: 'two' }, { a: 'one', b: 'two' }) // true
```

But fails for cases where the keys contained extra spaces or a mix of cases:

```js
isEqual({ a: ' oNe ', b: 'twO' }, { a: 'one', b: 'two' }) // false
```

Updating this check to compare the list of normalised values instead. The trade-off here is that assumes all object keys can be stringified. For our use case this is a reasonable trade-off as we only use this check for comparing nested text fields like addresses and names.