### PR TITLE
Remove minTimeAgo validation rule

### DIFF
--- a/controllers/apply/lib/joi-extensions/month-year.js
+++ b/controllers/apply/lib/joi-extensions/month-year.js
@@ -51,25 +51,6 @@ module.exports = function (joi) {
                     }
                 },
             },
-            {
-                name: 'minTimeAgo',
-                params: {
-                    amount: joi.number().required(),
-                    units: joi.string().required(),
-                },
-                /* eslint-disable-next-line no-unused-vars */
-                validate(params, value, state, options) {
-                    const minDate = moment().subtract(
-                        params.amount,
-                        params.units
-                    );
-                    const isBeforeMin = valueToDate(value).isSameOrBefore(
-                        minDate
-                    );
-                    value.isBeforeMin = isBeforeMin;
-                    return value;
-                },
-            },
         ],
     };
 };

--- a/controllers/apply/under10k/__snapshots__/form.test.js.snap
+++ b/controllers/apply/under10k/__snapshots__/form.test.js.snap
@@ -20,6 +20,8 @@ Array [
   "organisationStartDate: Enter a month and year",
   "organisationAddress: Enter a full UK address",
   "organisationType: Select a type of organisation",
+  "accountingYearDate: Enter a day and month",
+  "totalIncomeYear: Enter a total income for the year (eg. a whole number with no commas or decimal points)",
   "mainContactName: Enter first and last name",
   "mainContactDateOfBirth: Enter a date of birth",
   "mainContactAddress: Enter a full UK address",

--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -39,6 +39,7 @@ const fieldYourIdeaCommunity = require('./fields/your-idea-community');
 const fieldYourIdeaPriorities = require('./fields/your-idea-priorities');
 const fieldYourIdeaProject = require('./fields/your-idea-project');
 
+const isNewOrganisation = require('./lib/new-organisation');
 const {
     BENEFICIARY_GROUPS,
     CONTACT_EXCLUDED_TYPES,
@@ -1294,11 +1295,9 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             }),
             type: 'day-month',
             isRequired: true,
-            schema: Joi.when(Joi.ref('organisationStartDate.isBeforeMin'), {
-                is: true,
-                then: Joi.dayMonth().required(),
-                otherwise: Joi.any().strip(),
-            }),
+            schema: isNewOrganisation(get('organisationStartDate')(data))
+                ? Joi.any().strip()
+                : Joi.dayMonth().required(),
             messages: [
                 {
                     type: 'base',
@@ -1316,7 +1315,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 },
             ],
         },
-        totalIncomeYear: fieldTotalIncomeYear(locale),
+        totalIncomeYear: fieldTotalIncomeYear(locale, data),
         mainContactName: new NameField({
             locale: locale,
             name: 'mainContactName',

--- a/controllers/apply/under10k/fields/organisation-start-date.js
+++ b/controllers/apply/under10k/fields/organisation-start-date.js
@@ -4,8 +4,6 @@ const moment = require('moment');
 
 const Joi = require('../../lib/joi-extensions');
 
-const { ORG_MIN_AGE } = require('../constants');
-
 module.exports = function (locale) {
     const localise = get(locale);
 
@@ -25,10 +23,7 @@ module.exports = function (locale) {
                  <p><strong>Er enghraifft: 11 ${exampleYear}</strong></p>`,
         }),
         isRequired: true,
-        schema: Joi.monthYear()
-            .pastDate()
-            .minTimeAgo(ORG_MIN_AGE.amount, ORG_MIN_AGE.unit)
-            .required(),
+        schema: Joi.monthYear().pastDate().required(),
         messages: [
             {
                 type: 'base',

--- a/controllers/apply/under10k/fields/total-income-year.js
+++ b/controllers/apply/under10k/fields/total-income-year.js
@@ -3,8 +3,9 @@ const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
 const Joi = require('../../lib/joi-extensions');
+const isNewOrganisation = require('../lib/new-organisation');
 
-module.exports = function (locale) {
+module.exports = function (locale, data = {}) {
     const localise = get(locale);
 
     return {
@@ -19,11 +20,9 @@ module.exports = function (locale) {
         }),
         type: 'currency',
         isRequired: true,
-        schema: Joi.when(Joi.ref('organisationStartDate.isBeforeMin'), {
-            is: true,
-            then: Joi.friendlyNumber().integer().required(),
-            otherwise: Joi.any().strip(),
-        }),
+        schema: isNewOrganisation(get('organisationStartDate')(data))
+            ? Joi.any().strip()
+            : Joi.friendlyNumber().integer().required(),
         messages: [
             {
                 type: 'base',

--- a/controllers/apply/under10k/lib/new-organisation.js
+++ b/controllers/apply/under10k/lib/new-organisation.js
@@ -1,0 +1,16 @@
+'use strict';
+const toInteger = require('lodash/toInteger');
+const moment = require('moment');
+
+const { ORG_MIN_AGE } = require('../constants');
+
+module.exports = function isNewOrganisation(dayMonth = {}) {
+    const minDate = moment().subtract(ORG_MIN_AGE.amount, ORG_MIN_AGE.unit);
+    return minDate.isSameOrBefore(
+        moment({
+            year: toInteger(dayMonth.year),
+            month: toInteger(dayMonth.month) - 1,
+            day: 1,
+        })
+    );
+};

--- a/controllers/apply/under10k/lib/new-organisation.test.js
+++ b/controllers/apply/under10k/lib/new-organisation.test.js
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+'use strict';
+const isNewOrganisation = require('./new-organisation');
+
+test('check if this is a recent organisation based on start date', () => {
+    const now = new Date();
+    expect(
+        isNewOrganisation({
+            month: now.getMonth() + 1,
+            year: now.getFullYear(),
+        })
+    ).toBeTruthy();
+
+    expect(
+        isNewOrganisation({
+            month: now.getMonth() + 1,
+            year: now.getFullYear() - 2,
+        })
+    ).toBeFalsy();
+});


### PR DESCRIPTION
Re-do of https://github.com/biglotteryfund/blf-alpha/pull/3215 with _just_ the validation rule changes.

The `minTimeAgo` validation rule never actually _validated_ anything, but instead mutated data. We are better making this check a shared function instead.