### PR TITLE
Launch new standard location questions

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
     "expiryPeriod": [3, "months"]
   },
   "standardFundingProposal": {
-    "enableNewLocationQuestions": false,
+    "enableNewLocationQuestions": true,
     "allowedCountries": ["england", "northern-ireland"]
   },
   "session": {

--- a/config/development.json
+++ b/config/development.json
@@ -2,8 +2,5 @@
   "logLevel": "debug",
   "features": {
     "enableSalesforceConnector": false
-  },
-  "standardFundingProposal": {
-    "enableNewLocationQuestions": true
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -4,8 +4,5 @@
       "formUploadBucket": "tnlcf-uploads-test"
     }
   },
-  "hotjarId": "1036292",
-  "standardFundingProposal": {
-    "enableNewLocationQuestions": true
-  }
+  "hotjarId": "1036292"
 }

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -310,7 +310,7 @@ module.exports = function ({
         }),
         allFields,
         summary: summary(),
-        schemaVersion: flags.enableNewLocationQuestions ? 'v1.0-beta' : 'v0.2',
+        schemaVersion: flags.enableNewLocationQuestions ? 'v1.0' : 'v0.2',
         forSalesforce() {
             const enriched = clone(data);
             if (metadata && metadata.programme) {

--- a/docs/application-forms/standard-proposal/schema.md
+++ b/docs/application-forms/standard-proposal/schema.md
@@ -4,7 +4,7 @@ The following documents the data schema for the standard product funding proposa
 
 ## Changelog
 
-### v1.0-beta
+### v1.0
 
 -   Add new conditional `projectRegions` value for applications in england. Used to determine new queue mapping rules.
 


### PR DESCRIPTION
- Makes `enableNewLocationQuestions` default to `true`. We can come back and clean up the feature flag code afterwards
- Removes `-beta` suffix from the schema version