### PR TITLE
Add last updated support to flexible content

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -158,6 +158,7 @@ global:
     day: Diwrnod
     month: Mis
     year: Blwyddyn
+    lastUpdated: Wedi’i ddiweddaru diwethaf
   programmes:
     programmeLabels:
       area: Ardal

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ global:
     day: Day
     month: Month
     year: Year
+    lastUpdated: Last updated
   programmes:
     programmeLabels:
       area: Area

--- a/controllers/common/views/flexible-content-page.njk
+++ b/controllers/common/views/flexible-content-page.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/main.njk" %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
-{% from "components/flexible-content-next/macro.njk" import flexibleContent %}
+{% from "components/flexible-content-next/macro.njk" import flexibleContent with context %}
 
 {% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
 

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -63,10 +63,18 @@
                         ) }}
                     {% elseif part.type === 'factRiver' %}
                         {{ factRiver(part.content) }}
-                    {% elseif part.type === 'tableOfContents' and flexibleContent %}
+                    {% elseif part.type === 'tableOfContents' %}
                         <div class="s-prose u-constrained-content-wide">
                             {{ part.content | safe }}
                         </div>
+
+                        {% if part.lastUpdated %}
+                            <div class="message message--minor">
+                                <strong>{{ __('global.misc.lastUpdated') }}</strong>:
+                                {{ formatDate(part.lastUpdated.date, "dddd D MMMM, YYYY") }}
+                            </div>
+                        {% endif %}
+
                         {{ tableOfContents(flexibleContent, anchor = flexAnchor) }}
                     {% else %}
                         <div class="s-prose u-constrained-content-wide">


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/262

Adds support for a last updated message to flexible content pages.  Main motivation is the new insights pages https://www.tnlcommunityfund.org.uk/insights/covid-19-resources/responding-to-covid-19/covid-19-the-immediate-issues which have manual last updated dates which is error prone and already incorrect on those pages.

Opted to just show the day for now, not sure we need to show exact times.

![image](https://user-images.githubusercontent.com/123386/80086290-644f8680-8551-11ea-829a-b21d1d74f892.png)

Required a little bit of reworking of the flexible content macro so that we pass the full entry in rather than just the flexible content part. Gives us access to the last updated date.
