### PR TITLE
Fixup url in legacy content logger

### DIFF
--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -37,7 +37,7 @@ function basicContent() {
         function logLegacyContentType(type) {
             logger.info(`Legacy content type: ${type}`, {
                 service: 'common-views',
-                url: req.url,
+                url: req.originalUrl,
             });
         }
 


### PR DESCRIPTION
Noticed the url we pass to the legacy content logger was always returning `/` meaning these logs don't help us work out which pages are using each template type. We want `req.originalUrl` instead.