### PR TITLE
Migrate forms to latest version of joi

### DIFF
--- a/controllers/apply/lib/field-types/address.js
+++ b/controllers/apply/lib/field-types/address.js
@@ -1,6 +1,6 @@
 'use strict';
 const compact = require('lodash/compact');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/address.test.js
+++ b/controllers/apply/lib/field-types/address.test.js
@@ -30,6 +30,7 @@ test('address field', function () {
         postcode: 'B15 1TR',
     });
 
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe(
         '1234 example street,\nEdgbaston,\nBirmingham,\nWest Midlands,\nB15 1TR'
     );

--- a/controllers/apply/lib/field-types/checkbox.js
+++ b/controllers/apply/lib/field-types/checkbox.js
@@ -29,7 +29,7 @@ class CheckboxField extends Field {
     defaultSchema() {
         const options = this.options || [];
         const baseSchema = Joi.array()
-            .items(Joi.string().valid(options.map((option) => option.value)))
+            .items(Joi.string().valid(...options.map((option) => option.value)))
             .single();
 
         if (this.isRequired) {

--- a/controllers/apply/lib/field-types/checkbox.js
+++ b/controllers/apply/lib/field-types/checkbox.js
@@ -1,7 +1,7 @@
 'use strict';
 const castArray = require('lodash/castArray');
 const uniq = require('lodash/uniq');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/checkbox.test.js
+++ b/controllers/apply/lib/field-types/checkbox.test.js
@@ -20,7 +20,7 @@ test('valid field', function () {
 
     field.withValue(['option-1', 'option-2']);
     expect(field.displayValue).toBe('Option 1,\nOption 2');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue(['bad-option']);
     expect(field.validate().error.message).toEqual(
@@ -41,7 +41,7 @@ test('optional field', function () {
         ],
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });
 
 test('must provide options', function () {

--- a/controllers/apply/lib/field-types/currency.js
+++ b/controllers/apply/lib/field-types/currency.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/currency.test.js
+++ b/controllers/apply/lib/field-types/currency.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
 
     field.withValue('120,000');
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toBe(120000);
     expect(field.displayValue).toBe('£120,000');
 });
@@ -28,5 +28,5 @@ test('optional field', function () {
         isRequired: false,
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/date.js
+++ b/controllers/apply/lib/field-types/date.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 const fromDateParts = require('../from-date-parts');
 
 const Field = require('./field');

--- a/controllers/apply/lib/field-types/date.test.js
+++ b/controllers/apply/lib/field-types/date.test.js
@@ -17,7 +17,7 @@ test('DateField', function () {
     const badInput = { day: 82, month: 3, year: 2100 };
 
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('1 March, 2100');
 
     field.withValue(badInput);

--- a/controllers/apply/lib/field-types/email.js
+++ b/controllers/apply/lib/field-types/email.js
@@ -1,6 +1,6 @@
 'use strict';
 const { oneLine } = require('common-tags');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/email.test.js
+++ b/controllers/apply/lib/field-types/email.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
     const badInput = 'not.a.real-email@bad';
 
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe(goodInput);
 
     field.withValue(badInput);
@@ -30,5 +30,5 @@ test('optional field', function () {
         name: 'example',
         isRequired: false,
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/field.js
+++ b/controllers/apply/lib/field-types/field.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 const isFunction = require('lodash/isFunction');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 class Field {
     constructor(props) {

--- a/controllers/apply/lib/field-types/field.test.js
+++ b/controllers/apply/lib/field-types/field.test.js
@@ -28,7 +28,7 @@ test('field base type', function () {
 
     field.withValue('something');
     expect(field.displayValue).toBe('something');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });
 
 test('required properties', function () {
@@ -73,7 +73,7 @@ test('optional default field', function () {
     });
 
     expect(optionalField.isRequired).toBeFalsy();
-    expect(optionalField.validate().error).toBeNull();
+    expect(optionalField.validate().error).toBeUndefined();
 });
 
 test('with errors', function () {
@@ -108,7 +108,7 @@ test('override schema', function () {
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM=');
     expect(field.displayValue).toBe('VE9PTUFOWVNFQ1JFVFM=');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM');
     expect(field.validate().error.message).toContain(
@@ -132,7 +132,7 @@ test('extend schema with a function', function () {
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM=');
     expect(field.displayValue).toBe('VE9PTUFOWVNFQ1JFVFM=');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM');
     expect(field.validate().error.message).toContain(

--- a/controllers/apply/lib/field-types/field.test.js
+++ b/controllers/apply/lib/field-types/field.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 'use strict';
 const Field = require('./field');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 test('field base type', function () {
     const field = new Field({

--- a/controllers/apply/lib/field-types/file.js
+++ b/controllers/apply/lib/field-types/file.js
@@ -4,7 +4,7 @@ const mime = require('mime-types');
 const fileSize = require('filesize');
 
 const Field = require('./field');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 class FileField extends Field {
     constructor(props) {

--- a/controllers/apply/lib/field-types/file.js
+++ b/controllers/apply/lib/field-types/file.js
@@ -36,7 +36,9 @@ class FileField extends Field {
         this.schema = Joi.object({
             filename: Joi.string().required(),
             size: Joi.number().max(maxFileSize.value).required(),
-            type: Joi.string().valid(supportedMimeTypes).required(),
+            type: Joi.string()
+                .valid(...supportedMimeTypes)
+                .required(),
         }).required();
 
         const typeList = supportedFileTypes

--- a/controllers/apply/lib/field-types/file.test.js
+++ b/controllers/apply/lib/field-types/file.test.js
@@ -18,7 +18,7 @@ test('FileField', function () {
         size: 13264,
         type: 'application/pdf',
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('example.pdf (PDF, 13 KB)');
 
     field.withValue({

--- a/controllers/apply/lib/field-types/name.js
+++ b/controllers/apply/lib/field-types/name.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/name.test.js
+++ b/controllers/apply/lib/field-types/name.test.js
@@ -18,5 +18,6 @@ test('NameField', function () {
     );
 
     field.withValue({ firstName: 'Björk', lastName: 'Guðmundsdóttir' });
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('Björk Guðmundsdóttir');
 });

--- a/controllers/apply/lib/field-types/phone.js
+++ b/controllers/apply/lib/field-types/phone.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/phone.test.js
+++ b/controllers/apply/lib/field-types/phone.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
     const badValue = '0345 444';
 
     field.withValue(goodValue);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toBe('028 9568 0143');
 
     field.withValue(badValue);
@@ -31,8 +31,8 @@ test('optional field', function () {
         isRequired: false,
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/radio.js
+++ b/controllers/apply/lib/field-types/radio.js
@@ -31,7 +31,7 @@ class RadioField extends Field {
     defaultSchema() {
         const options = this.options || [];
         const baseSchema = Joi.string().valid(
-            options.map((option) => option.value)
+            ...options.map((option) => option.value)
         );
 
         return this.isRequired ? baseSchema.required() : baseSchema.optional();

--- a/controllers/apply/lib/field-types/radio.js
+++ b/controllers/apply/lib/field-types/radio.js
@@ -2,7 +2,7 @@
 const find = require('lodash/fp/find');
 const uniq = require('lodash/uniq');
 const castArray = require('lodash/castArray');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/radio.test.js
+++ b/controllers/apply/lib/field-types/radio.test.js
@@ -19,7 +19,7 @@ test('valid field', function () {
 
     field.withValue('option-1');
     expect(field.displayValue).toBe('Option 1');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('bad-option');
     expect(field.validate().error.message).toEqual(

--- a/controllers/apply/lib/field-types/select.js
+++ b/controllers/apply/lib/field-types/select.js
@@ -43,7 +43,7 @@ class SelectField extends Field {
 
     defaultSchema() {
         const baseSchema = Joi.string().valid(
-            this.normalisedOptions.map((option) => option.value)
+            ...this.normalisedOptions.map((option) => option.value)
         );
 
         if (this.isRequired) {

--- a/controllers/apply/lib/field-types/select.js
+++ b/controllers/apply/lib/field-types/select.js
@@ -1,6 +1,6 @@
 'use strict';
 const uniq = require('lodash/uniq');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/select.test.js
+++ b/controllers/apply/lib/field-types/select.test.js
@@ -20,7 +20,7 @@ test('select field', function () {
 
     field.withValue('option-2');
     expect(field.displayValue).toBe('Option 2');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('bad-option');
     expect(field.validate().error.message).toEqual(

--- a/controllers/apply/lib/field-types/textarea.js
+++ b/controllers/apply/lib/field-types/textarea.js
@@ -1,7 +1,7 @@
 'use strict';
 const has = require('lodash/has');
 const countWords = require('../count-words');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -26,7 +26,7 @@ test('TextareaField', function () {
     expect(field.displayValue).toEqual(
         `${goodValue}\n\n${minWords + 1}/${maxWords} words`
     );
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue(faker.lorem.words(minWords - 1));
     expect(field.validate().error.message).toEqual(
@@ -48,7 +48,7 @@ test('TextareaField', function () {
         messages: [{ type: 'base', message: 'Enter a value' }],
     });
 
-    expect(optionalField.validate().error).toBeNull();
+    expect(optionalField.validate().error).toBeUndefined();
 });
 
 test('required properties', function () {

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -35,7 +35,7 @@ test('TextareaField', function () {
 
     field.withValue(faker.lorem.words(maxWords + 1));
     expect(field.validate().error.message).toEqual(
-        expect.stringContaining(`must have less than ${maxWords} words`)
+        expect.stringContaining(`must have no more than ${maxWords} words`)
     );
 
     const optionalField = new TextareaField({

--- a/controllers/apply/lib/form-model.js
+++ b/controllers/apply/lib/form-model.js
@@ -136,7 +136,8 @@ class FormModel {
          */
         const formIsEmpty = isEmpty(this.validation.value);
         this.progress = {
-            isComplete: formIsEmpty === false && this.validation.error === null,
+            isComplete:
+                formIsEmpty === false && this.validation.error === undefined,
             isPristine: formIsEmpty === true,
             sectionsComplete: this.sections.filter(
                 (section) => section.progress.status === 'complete'
@@ -212,7 +213,7 @@ class FormModel {
         return {
             value: value,
             error: error,
-            isValid: error === null && messages.length === 0,
+            isValid: error === undefined && messages.length === 0,
             messages: messages,
             featuredMessages: this._getFeaturedMessages(messages),
         };

--- a/controllers/apply/lib/form-model.js
+++ b/controllers/apply/lib/form-model.js
@@ -9,7 +9,7 @@ const isEmpty = require('lodash/isEmpty');
 const pick = require('lodash/pick');
 const reduce = require('lodash/reduce');
 
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joiNext');
 
 const { formatterFor } = require('./formatters');
 const normaliseErrors = require('./normalise-errors');

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -153,7 +153,9 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
              */
             schema: Joi.array()
                 .items(
-                    Joi.string().valid(options().map((option) => option.value))
+                    Joi.string().valid(
+                        ...options().map((option) => option.value)
+                    )
                 )
                 .single()
                 .required(),
@@ -187,13 +189,13 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
 
         function schema() {
             const isEnglandSelected = Joi.array().items(
-                Joi.string().only('england').required(),
+                Joi.string().valid('england').required(),
                 Joi.any()
             );
 
             const validAllEngland = Joi.array()
                 .items(
-                    Joi.string().only('all-england').required(),
+                    Joi.string().valid('all-england').required(),
                     Joi.any().strip()
                 )
                 .single()
@@ -201,7 +203,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
 
             const validRegionOptions = Joi.array()
                 .items(
-                    Joi.string().valid(options.map((option) => option.value))
+                    Joi.string().valid(...options.map((option) => option.value))
                 )
                 .single()
                 .required();
@@ -285,7 +287,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                 then: Joi.any().strip(),
                 otherwise: Joi.string()
                     .valid(
-                        flatMap(optgroups(), (group) => group.options).map(
+                        ...flatMap(optgroups(), (group) => group.options).map(
                             (option) => option.value
                         )
                     )
@@ -829,7 +831,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             schema: Joi.when('organisationType', {
                 is: 'statutory-body',
                 then: Joi.string()
-                    .valid(options.map((option) => option.value))
+                    .valid(...options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             }),
@@ -897,10 +899,10 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             options: options,
             schema: Joi.when('projectCountries', {
                 is: Joi.array()
-                    .items(Joi.string().only('wales').required(), Joi.any())
+                    .items(Joi.string().valid('wales').required(), Joi.any())
                     .required(),
                 then: Joi.string()
-                    .valid(options.map((option) => option.value))
+                    .valid(...options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             }),

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -6,7 +6,7 @@ const orderBy = require('lodash/orderBy');
 const { oneLine } = require('common-tags');
 const config = require('config');
 
-const Joi = require('../lib/joi-extensions');
+const Joi = require('../lib/joi-extensions-next');
 
 const {
     Field,

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -17,7 +17,7 @@ test('empty form', () => {
 test('valid form', () => {
     const data = mockResponse();
     const result = formBuilder({ data }).validation;
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 
     expect(result.value).toMatchSnapshot({
         yourIdeaProject: expect.any(String),
@@ -76,7 +76,7 @@ test('organisation sub-type required for statutory-body', function () {
         organisationSubType: 'fire-service',
     });
     const result = formBuilder({ data: validData }).validation;
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 });
 
 test('language preference required in wales', function () {
@@ -97,7 +97,7 @@ test('language preference required in wales', function () {
         }),
     });
 
-    expect(formValid.validation.error).toBeNull();
+    expect(formValid.validation.error).toBeUndefined();
 
     const formStrip = formBuilder({
         data: mockResponse({
@@ -121,7 +121,7 @@ test.each([
 
     const expected = omit(data, fieldName);
     const result = form.validate(expected);
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 });
 
 describe('new location questions', function () {

--- a/controllers/apply/under10k/__snapshots__/form.test.js.snap
+++ b/controllers/apply/under10k/__snapshots__/form.test.js.snap
@@ -22,13 +22,13 @@ Array [
   "organisationType: Select a type of organisation",
   "accountingYearDate: Enter a day and month",
   "totalIncomeYear: Enter a total income for the year (eg. a whole number with no commas or decimal points)",
-  "mainContactName: Enter first and last name",
   "mainContactDateOfBirth: Enter a date of birth",
   "mainContactAddress: Enter a full UK address",
   "mainContactAddressHistory: Enter a full UK address",
   "mainContactPhone: Enter a UK telephone number",
   "seniorContactRole: Choose a role",
   "seniorContactName: Enter first and last name",
+  "mainContactName: Enter first and last name",
   "seniorContactDateOfBirth: Enter a date of birth",
   "seniorContactAddress: Enter a full UK address",
   "seniorContactAddressHistory: Enter a full UK address",
@@ -116,15 +116,13 @@ Array [
   "yourIdeaCommunity: Answer must be no more than 200 words",
   "projectBudget: Costs you would like us to fund must be less than £10,000",
   "projectTotalCosts: Total cost must be the same as or higher than the amount you’re asking us to fund",
-  "mainContactName: Main contact name must be different from the senior contact's name",
   "mainContactDateOfBirth: Must be at least 16 years old",
   "mainContactAddress: Main contact address must be different from the senior contact's address",
   "mainContactAddressHistory: Enter a full UK address",
   "mainContactPhone: Enter a real UK telephone number",
-  "seniorContactRole: Senior contact role is not valid",
-  "seniorContactName: Senior contact name must be different from the main contact's name",
+  "seniorContactRole: Choose a role",
+  "mainContactName: Main contact name must be different from the senior contact's name",
   "seniorContactDateOfBirth: Must be at least 18 years old",
-  "seniorContactAddress: Senior contact address must be different from the main contact's address",
   "seniorContactAddressHistory: Enter a full UK address",
   "mainContactEmail: Main contact email address must be different from the senior contact's email address",
   "seniorContactPhone: Enter a real UK telephone number",
@@ -133,9 +131,8 @@ Array [
 
 exports[`invalid form 2`] = `
 Array [
-  "Main contact name must be different from the senior contact's name",
   "Enter a real UK telephone number",
-  "Senior contact role is not valid",
+  "Main contact name must be different from the senior contact's name",
   "Main contact email address must be different from the senior contact's email address",
 ]
 `;

--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -57,7 +57,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
     function multiChoice(options) {
         return Joi.array()
-            .items(Joi.string().valid(options.map((option) => option.value)))
+            .items(Joi.string().valid(...options.map((option) => option.value)))
             .single();
     }
 
@@ -66,7 +66,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             is: 'yes',
             then: Joi.when(Joi.ref('beneficiariesGroups'), {
                 is: Joi.array()
-                    .items(Joi.string().only(match).required(), Joi.any())
+                    .items(Joi.string().valid(match).required(), Joi.any())
                     .required(),
                 then: schema,
                 otherwise: Joi.any().strip(),
@@ -77,7 +77,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
     function stripIfExcludedOrgType(schema) {
         return Joi.when(Joi.ref('organisationType'), {
-            is: Joi.exist().valid(CONTACT_EXCLUDED_TYPES),
+            is: Joi.exist().valid(...CONTACT_EXCLUDED_TYPES),
             then: Joi.any().strip(),
             otherwise: schema,
         });
@@ -90,7 +90,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
             schema: stripIfExcludedOrgType(
                 Joi.object({
                     currentAddressMeetsMinimum: Joi.string()
-                        .valid(['yes', 'no'])
+                        .valid('yes', 'no')
                         .required(),
                     previousAddress: Joi.when(
                         Joi.ref('currentAddressMeetsMinimum'),
@@ -430,7 +430,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 },
             ],
             isRequired: true,
-            schema: Joi.string().valid(['yes', 'no']).required(),
+            schema: Joi.string().valid('yes', 'no').required(),
             messages: [
                 {
                     type: 'base',
@@ -1003,7 +1003,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 return Joi.when('projectCountry', {
                     is: 'wales',
                     then: Joi.string()
-                        .valid(this.options.map((option) => option.value))
+                        .valid(...this.options.map((option) => option.value))
                         .max(FREE_TEXT_MAXLENGTH.large)
                         .required(),
                     otherwise: Joi.any().strip(),
@@ -1061,7 +1061,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 return Joi.when('projectCountry', {
                     is: 'northern-ireland',
                     then: Joi.string()
-                        .valid(this.options.map((option) => option.value))
+                        .valid(...this.options.map((option) => option.value))
                         .required(),
                     otherwise: Joi.any().strip(),
                 });

--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -1465,18 +1465,6 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 en: 'This person has to live in the UK.',
                 cy: 'Rhaid i’r person hwn fyw ym Mhrydain',
             }),
-            schema(originalSchema) {
-                return originalSchema.compare(Joi.ref('mainContactName'));
-            },
-            messages: [
-                {
-                    type: 'object.isEqual',
-                    message: localise({
-                        en: `Senior contact name must be different from the main contact's name`,
-                        cy: `Rhaid i enw’r uwch gyswllt fod yn wahanol i enw’r prif gyswllt`,
-                    }),
-                },
-            ],
         }),
         seniorContactDateOfBirth: dateOfBirthField(
             'seniorContactDateOfBirth',
@@ -1493,20 +1481,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 en: `We need their home address to help confirm who they are. And we do check their address. So make sure you've entered it right. If you don't, it could delay your application.`,
                 cy: `Byddwn angen eu cyfeiriad cartref i helpu cadarnhau pwy ydynt. Ac rydym yn gwirio eu cyfeiriad. Felly sicrhewch eich bod wedi’i deipio’n gywir. Os nad ydych, gall oedi eich cais.`,
             }),
-            schema: stripIfExcludedOrgType(
-                Joi.ukAddress()
-                    .required()
-                    .compare(Joi.ref('mainContactAddress'))
-            ),
-            messages: [
-                {
-                    type: 'object.isEqual',
-                    message: localise({
-                        en: `Senior contact address must be different from the main contact's address`,
-                        cy: `Rhaid i gyfeiriad e-bost yr uwch gyswllt fod yn wahanol i gyfeiriad e-bost y prif gyswllt.`,
-                    }),
-                },
-            ],
+            schema: stripIfExcludedOrgType(Joi.ukAddress().required()),
         }),
         seniorContactAddressHistory: addressHistoryField({
             name: 'seniorContactAddressHistory',

--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -4,7 +4,7 @@ const get = require('lodash/fp/get');
 const moment = require('moment');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../lib/joi-extensions');
+const Joi = require('../lib/joi-extensions-next');
 
 const Field = require('../lib/field-types/field');
 const EmailField = require('../lib/field-types/email');

--- a/controllers/apply/under10k/fields/bank-account-name.js
+++ b/controllers/apply/under10k/fields/bank-account-name.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/bank-account-number.js
+++ b/controllers/apply/under10k/fields/bank-account-number.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/bank-sort-code.js
+++ b/controllers/apply/under10k/fields/bank-sort-code.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/building-society-number.js
+++ b/controllers/apply/under10k/fields/building-society-number.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/charity-number.js
+++ b/controllers/apply/under10k/fields/charity-number.js
@@ -23,10 +23,10 @@ module.exports = function (locale, data) {
         .max(FREE_TEXT_MAXLENGTH.large);
 
     const schema = Joi.when(Joi.ref('organisationType'), {
-        is: Joi.exist().valid(CHARITY_NUMBER_TYPES.required),
+        is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.required),
         then: baseSchema.required(),
     }).when(Joi.ref('organisationType'), {
-        is: Joi.exist().valid(CHARITY_NUMBER_TYPES.optional),
+        is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.optional),
         then: baseSchema.optional().allow('', null),
         otherwise: Joi.any().strip(),
     });

--- a/controllers/apply/under10k/fields/charity-number.js
+++ b/controllers/apply/under10k/fields/charity-number.js
@@ -18,7 +18,7 @@ module.exports = function (locale, data) {
     const excludeRegex = /^[^Oo]+$/;
 
     const baseSchema = Joi.string()
-        .regex(excludeRegex)
+        .pattern(excludeRegex)
         .min(4)
         .max(FREE_TEXT_MAXLENGTH.large);
 
@@ -52,12 +52,10 @@ module.exports = function (locale, data) {
                 }),
             },
             {
-                type: 'string.regex.base',
+                type: 'string.pattern.base',
                 message: localise({
-                    en:
-                        'Enter a real charity registration number. And don’t use any spaces. Scottish charity registration numbers must also use the number ‘0’ in ‘SC0’ instead of the letter ‘O’.',
-                    cy:
-                        'Rhowch rif cofrestru elusen go iawn. A pheidiwch â defnyddio unrhyw fylchau. Rhaid i rifau cofrestru elusennau Albanaidd ddefnyddio’r rhif ‘0’ yn ‘SC0’ yn hytrach na’r llythyren ‘O’',
+                    en: `Enter a real charity registration number. And don’t use any spaces. Scottish charity registration numbers must also use the number ‘0’ in ‘SC0’ instead of the letter ‘O’.`,
+                    cy: `Rhowch rif cofrestru elusen go iawn. A pheidiwch â defnyddio unrhyw fylchau. Rhaid i rifau cofrestru elusennau Albanaidd ddefnyddio’r rhif ‘0’ yn ‘SC0’ yn hytrach na’r llythyren ‘O’`,
                 }),
             },
             {

--- a/controllers/apply/under10k/fields/charity-number.js
+++ b/controllers/apply/under10k/fields/charity-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { CHARITY_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale, data) {
     /**

--- a/controllers/apply/under10k/fields/company-number.js
+++ b/controllers/apply/under10k/fields/company-number.js
@@ -9,7 +9,7 @@ module.exports = function (locale) {
 
     function stripUnlessOrgTypes(types, schema) {
         return Joi.when(Joi.ref('organisationType'), {
-            is: Joi.exist().valid(types),
+            is: Joi.exist().valid(...types),
             then: schema,
             otherwise: Joi.any().strip(),
         });

--- a/controllers/apply/under10k/fields/company-number.js
+++ b/controllers/apply/under10k/fields/company-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { COMPANY_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale) {
     const localise = get(locale);

--- a/controllers/apply/under10k/fields/contact-language-preference.js
+++ b/controllers/apply/under10k/fields/contact-language-preference.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale, props) {
     const localise = get(locale);

--- a/controllers/apply/under10k/fields/contact-language-preference.js
+++ b/controllers/apply/under10k/fields/contact-language-preference.js
@@ -32,7 +32,7 @@ module.exports = function (locale, props) {
             return Joi.when('projectCountry', {
                 is: 'wales',
                 then: Joi.string()
-                    .valid(this.options.map((option) => option.value))
+                    .valid(...this.options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             });

--- a/controllers/apply/under10k/fields/education-number.js
+++ b/controllers/apply/under10k/fields/education-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { EDUCATION_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale) {
     const localise = get(locale);

--- a/controllers/apply/under10k/fields/education-number.js
+++ b/controllers/apply/under10k/fields/education-number.js
@@ -9,7 +9,7 @@ module.exports = function (locale) {
 
     function stripUnlessOrgTypes(types, schema) {
         return Joi.when(Joi.ref('organisationType'), {
-            is: Joi.exist().valid(types),
+            is: Joi.exist().valid(...types),
             then: schema,
             otherwise: Joi.any().strip(),
         });

--- a/controllers/apply/under10k/fields/organisation-start-date.js
+++ b/controllers/apply/under10k/fields/organisation-start-date.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const moment = require('moment');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale) {
     const localise = get(locale);

--- a/controllers/apply/under10k/fields/organisation-type.js
+++ b/controllers/apply/under10k/fields/organisation-type.js
@@ -127,7 +127,7 @@ module.exports = function (locale) {
         options: options,
         isRequired: true,
         schema: Joi.string()
-            .valid(options.map((option) => option.value))
+            .valid(...options.map((option) => option.value))
             .required(),
         messages: [
             {

--- a/controllers/apply/under10k/fields/organisation-type.js
+++ b/controllers/apply/under10k/fields/organisation-type.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { ORGANISATION_TYPES } = require('../constants');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/project-end-date.js
+++ b/controllers/apply/under10k/fields/project-end-date.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const DateField = require('../../lib/field-types/date');
 
 const { MAX_PROJECT_DURATION } = require('../constants');

--- a/controllers/apply/under10k/fields/project-postcode.js
+++ b/controllers/apply/under10k/fields/project-postcode.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/project-start-date.js
+++ b/controllers/apply/under10k/fields/project-start-date.js
@@ -3,7 +3,7 @@ const get = require('lodash/fp/get');
 const moment = require('moment');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const DateField = require('../../lib/field-types/date');
 
 const getLeadTimeWeeks = require('../lib/lead-time');

--- a/controllers/apply/under10k/fields/project-total-costs.js
+++ b/controllers/apply/under10k/fields/project-total-costs.js
@@ -5,7 +5,7 @@ const sumBy = require('lodash/sumBy');
 
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 
 module.exports = function (locale, data) {
     const localise = get(locale);

--- a/controllers/apply/under10k/fields/senior-contact-role.js
+++ b/controllers/apply/under10k/fields/senior-contact-role.js
@@ -147,7 +147,7 @@ module.exports = function (locale, data) {
                 return Joi.string().required();
             } else {
                 return Joi.string()
-                    .valid(this.options.map((option) => option.value))
+                    .valid(...this.options.map((option) => option.value))
                     .required();
             }
         },

--- a/controllers/apply/under10k/fields/senior-contact-role.js
+++ b/controllers/apply/under10k/fields/senior-contact-role.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { ORGANISATION_TYPES, STATUTORY_BODY_TYPES } = require('../constants');
 const rolesFor = require('../lib/roles');
 

--- a/controllers/apply/under10k/fields/total-income-year.js
+++ b/controllers/apply/under10k/fields/total-income-year.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const isNewOrganisation = require('../lib/new-organisation');
 
 module.exports = function (locale, data = {}) {

--- a/controllers/apply/under10k/form.test.js
+++ b/controllers/apply/under10k/form.test.js
@@ -141,7 +141,7 @@ test('valid form for england', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for scotland', () => {
@@ -151,7 +151,7 @@ test('valid form for scotland', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for wales', () => {
@@ -165,7 +165,7 @@ test('valid form for wales', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Test for existence of country specific fields
     expect(form.getCurrentFields().map((field) => field.name)).toEqual(
@@ -186,7 +186,7 @@ test('valid form for northern-ireland', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Test for existence of country specific fields
     expect(form.getCurrentFields().map((field) => field.name)).toEqual(
@@ -212,7 +212,7 @@ test('valid form for unregistered-vco', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for unincorporated-registered-charity', function () {
@@ -224,7 +224,7 @@ test('valid form for unincorporated-registered-charity', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 
@@ -251,7 +251,7 @@ test('valid form for charitable-incorporated-organisation', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 
@@ -289,8 +289,8 @@ test('valid form for not-for-profit-company', function () {
         }),
     });
 
-    expect(form.validation.error).toBeNull();
-    expect(formWithCharityNumber.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
+    expect(formWithCharityNumber.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual([
         'companyNumber',
@@ -322,7 +322,7 @@ test('valid form for community-interest-company', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['companyNumber']);
 
@@ -351,7 +351,7 @@ test('valid form for school', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationType: 'school',
@@ -380,7 +380,7 @@ test('valid form for college-or-university', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationType: 'college-or-university',
@@ -412,7 +412,7 @@ test('valid form for statutory-body', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for faith-group', function () {
@@ -423,7 +423,7 @@ test('valid form for faith-group', function () {
         }),
     });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const formWithCharityNumber = formBuilder({
         data: mockResponse({
@@ -433,7 +433,7 @@ test('valid form for faith-group', function () {
         }),
     });
 
-    expect(formWithCharityNumber.validation.error).toBeNull();
+    expect(formWithCharityNumber.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 });
@@ -478,7 +478,7 @@ test('valid form for different trading names', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationLegalName: 'Balloon Rides For Sad Polar Bears',
@@ -505,7 +505,7 @@ test('maintain backwards compatibility for date schema', function () {
         }),
     });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Maintain backwards compatibility with salesforce schema
     const salesforceResult = form.forSalesforce();
@@ -562,7 +562,7 @@ test('start date must be at least 18 weeks away in England', function () {
         }),
     });
 
-    expect(validForm.validation.error).toBeNull();
+    expect(validForm.validation.error).toBeUndefined();
 });
 
 test('start date must be at least 12 weeks away in all other countries', function () {
@@ -614,7 +614,7 @@ test('start date must be at least 12 weeks away in all other countries', functio
             }),
         });
 
-        expect(validForm.validation.error).toBeNull();
+        expect(validForm.validation.error).toBeUndefined();
     });
 });
 
@@ -678,7 +678,7 @@ test('allow only "other" option for beneficiary groups', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('finance details required if organisation is over 15 months old', function () {
@@ -692,7 +692,7 @@ test('finance details required if organisation is over 15 months old', function 
     });
 
     const validForm = formBuilder({ data: validData });
-    expect(validForm.validation.error).toBeNull();
+    expect(validForm.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationStartDate: {

--- a/docs/__tests__/schema.test.js
+++ b/docs/__tests__/schema.test.js
@@ -10,7 +10,7 @@ function validateSchemaDocumentation(formBuilder, schemaDocPath) {
     const docContents = fs.readFileSync(schemaDocPath, 'utf8');
 
     describe(`${form.title} schema documentation`, function () {
-        test.each(Object.keys(form.schema.describe().children))(
+        test.each(Object.keys(form.schema.describe().keys))(
             '%s has documentation entry',
             (fieldName) => {
                 const fieldNameRegexp = new RegExp(`### ${fieldName}`);


### PR DESCRIPTION
Still branched off https://github.com/biglotteryfund/blf-alpha/pull/3222 but this is a clean version of https://github.com/biglotteryfund/blf-alpha/pull/3223 now that some earlier clean up has been merged. Also changed approach and avoided deleting the old joi version and extensions for now to leave a cleaner diff (we can come back later and do this).

Notably this refactoring https://github.com/biglotteryfund/blf-alpha/pull/3224 resolved the unexpected error with accounting year date and total income year, likely down to us switching to a more idiomatic way of validating these fields rather than relying on mutation.

Main user-facing trade-off is still that references in extensions can only go one way in the latest
version. This was true previously for regular references but now applied to extensions too. Means that validation rules for same name and address now need to be one-way so only associating the error with the second contact.