### PR TITLE
Update Your Funding Proposal form to reflect that England will no longer be accepting proposals for non COVID-19 projects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1111,7 +1111,7 @@ yourFundingProposal:
       title: Before you start
       items:
         - Have a look at our website for <a href="/funding/over10k">information about funding over £10,000</a>
-        - If you'd rather chat to us on the phone about your idea—<a href="/contact">talk to us</a>
+        - If you have any questions—<a href="/contact">contact us</a>
         - If you <a href="/funding/under10k">need less than £10,000 you can apply straight away</a>
     whatInformation:
       title: What information will you need handy for this form?
@@ -1137,7 +1137,9 @@ yourFundingProposal:
             And any communication needs you have.
     ready:
       title: Ready to tell us your proposal?
-      intro: "Here's what happens next:"
+      intro: >
+        <p>You can tell us about it with our online form, or you can get in touch</p>
+        <p>Here's what happens next:</p>
       items:
         - We'll email you to let you know we got your proposal
         - Then we'll get in touch to talk about your proposal within 15 working days.

--- a/controllers/apply/standard-proposal/__snapshots__/confirmation.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/confirmation.test.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should return confirmation text for "england" 1`] = `
+<p>
+  We've emailed you a copy of what you wrote along
+with information about what happens next.
+Hold on to it in case you want to look at your answers again.
+It can be helpful to refer back to if we call.
+</p>
+<h2>
+  What happens next?
+</h2>
+<p>
+  Your proposal has been passed on to one of our funding officers.
+</p>
+<p>
+  At the moment we're now focusing on funding projects and organisations
+supporting communities through the COVID-19 pandemic, so they can start sooner.
+</p>
+<p>
+  We might get in touch to talk about your reserves and any other funding you might have.
+This is just so we can work out how best to support you financially.
+It would be great if you have these documents to hand, just in case we ask for them:
+</p>
+<ul>
+  <li>
+    your cashflow forecast for the next 12 months (or whatever you use to manage your budget)
+  </li>
+  <li>
+    your most recent annual accounts
+  </li>
+  <li>
+    your most recent bank statement.
+  </li>
+</ul>
+<p>
+  Once we’ve assessed your project we'll let you know
+if we're going to give you the funding.
+</p>
+<p>
+  Any questions in the meantime?
+  <a href="/contact">
+    Contact us
+  </a>
+</p>
+`;
+
+exports[`should return confirmation text for "northern-ireland" 1`] = `
+<p>
+  We've emailed you a copy of what you wrote along
+with information about what happens next.
+Hold on to it in case you want to look at your answers again.
+It can be helpful to refer back to if we call.
+</p>
+<h2>
+  What happens next?
+</h2>
+<p>
+  Your proposal has been passed on to one of our funding officers.
+</p>
+<p>
+  We’re now prioritising proposals for COVID-19 related projects,
+so they can start sooner. And it might take us longer to get
+back to you about proposals that aren’t COVID-19 related.
+</p>
+<p>
+  If it's something we can fund, you'll be asked if
+you want to make a full application.
+</p>
+<p>
+  Any questions in the meantime?
+  <a href="/contact">
+    Contact us
+  </a>
+</p>
+`;

--- a/controllers/apply/standard-proposal/confirmation.js
+++ b/controllers/apply/standard-proposal/confirmation.js
@@ -1,25 +1,54 @@
 'use strict';
+const getOr = require('lodash/fp/getOr');
+const { stripIndents } = require('common-tags');
 
-module.exports = function () {
+module.exports = function ({ data = {} }) {
+    const projectCountries = getOr([], 'projectCountries')(data);
+
+    function getNextSteps() {
+        if (projectCountries.includes('england')) {
+            return `<p>
+                At the moment we're now focusing on funding projects and organisations
+                supporting communities through the COVID-19 pandemic, so they can start sooner.
+            </p>
+            <p>
+                We might get in touch to talk about your reserves and any other funding you might have.
+                This is just so we can work out how best to support you financially.
+                It would be great if you have these documents to hand, just in case we ask for them:
+            </p>
+            <ul>
+                <li>your cashflow forecast for the next 12 months (or whatever you use to manage your budget)</li>
+                <li>your most recent annual accounts</li>
+                <li>your most recent bank statement.</li>
+            </ul>
+            <p>
+                Once we’ve assessed your project we'll let you know
+                if we're going to give you the funding. 
+            </p>`;
+        } else {
+            return `<p>
+                We’re now prioritising proposals for COVID-19 related projects,
+                so they can start sooner. And it might take us longer to get
+                back to you about proposals that aren’t COVID-19 related. 
+            </p>
+            <p>
+                If it's something we can fund, you'll be asked if
+                you want to make a full application.
+            </p>`;
+        }
+    }
+
     return {
         title: `Thanks for telling us your proposal`,
-        body: `<p>
+        body: stripIndents`<p>
             We've emailed you a copy of what you wrote along
             with information about what happens next.
             Hold on to it in case you want to look at your answers again.
             It can be helpful to refer back to if we call.
         </p>
         <h2>What happens next?</h2>
-        <p>
-            Your proposal has been passed on to one of our funding officers.
-            We’re now prioritising proposals for COVID-19 related projects,
-            so they can start sooner. And it might take us longer to get
-            back to you about proposals that aren’t COVID-19 related. 
-        </p>
-        <p>
-            If it's something we can fund, you'll be asked if
-            you want to make a full application.
-        </p>
+        <p>Your proposal has been passed on to one of our funding officers.</p>
+        ${getNextSteps()}
         <p>Any questions in the meantime? <a href="/contact">Contact us</a></p>`,
     };
 };

--- a/controllers/apply/standard-proposal/confirmation.test.js
+++ b/controllers/apply/standard-proposal/confirmation.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+'use strict';
+const confirmationBuilder = require('./confirmation');
+
+test.each(['england', 'northern-ireland'])(
+    'should return confirmation text for %p',
+    function (country) {
+        const result = confirmationBuilder({
+            locale: 'en',
+            data: { projectCountries: [country] },
+        });
+
+        expect(result.body).toMatchSnapshot();
+    }
+);

--- a/controllers/apply/standard-proposal/views/startpage.njk
+++ b/controllers/apply/standard-proposal/views/startpage.njk
@@ -1,7 +1,6 @@
 {% extends "layouts/main.njk" %}
 {% from "components/form-header/macro.njk" import formHeader with context %}
 {% from "components/content-box/macro.njk" import contentBox %}
-{% from "components/process-map/macro.njk" import processMap %}
 
 {% set copy = __('yourFundingProposal.startPage') %}
 {% block title %}{{ copy.title }} | {{ formTitle }} | {% endblock %}
@@ -45,7 +44,7 @@
                 </ul>
 
                 <h2>{{ copy.ready.title }}</h2>
-                <p>{{ copy.ready.intro }}</p>
+                {{ copy.ready.intro | safe }}
 
                 <ul>
                     {% for item in copy.ready.items %}
@@ -53,19 +52,6 @@
                     {% endfor %}
                 </ul>
             </div>
-
-            {% set processItems = [] %}
-            {% for item in copy.processMap.process %}
-                {% set processItems = (processItems.push({
-                    type: item.type,
-                    title: item.title,
-                    description: item.description,
-                    isCompleted: loop.index === 1,
-                    isCurrent: loop.index === 1
-                }), processItems) %}
-            {% endfor %}
-
-            {{ processMap(processItems, copy.processMap.indicatorLabel) }}
 
             <p class="form-actions u-margin-bottom-l">
                 <a href="{{ nextPageUrl }}" class="btn">{{ copy.startAction }}</a>

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1043,13 +1043,17 @@ it('should allow editing from the summary screen', () => {
     });
 });
 
-it('should complete standard your funding proposal form', () => {
-    const orgTradingName = sample([faker.company.companyName(), '']);
+function standardApplication({
+    projectCountries,
+    projectRegions = [],
+    projectLocation,
+    organisationAddress,
+}) {
     const mock = {
         projectName: faker.lorem.words(5),
-        projectCountries: ['England'],
-        projectRegions: ['North West', 'South West'],
-        projectLocation: 'Bournemouth',
+        projectCountries: projectCountries,
+        projectRegions: projectRegions,
+        projectLocation: projectLocation,
         projectLocationDescription: faker.lorem.words(5),
         projectCosts: random(10001, 5000000),
         projectDurationYears: sample(['3 years', '4 years', '5 years']),
@@ -1057,12 +1061,8 @@ it('should complete standard your funding proposal form', () => {
         yourIdeaCommunity: faker.lorem.words(random(50, 500)),
         yourIdeaActivities: faker.lorem.words(random(50, 350)),
         organisationName: faker.company.companyName(),
-        organisationTradingName: orgTradingName,
-        organisationAddress: {
-            streetAddress: `The Bar, 2 St James' Blvd`,
-            city: 'Newcastle',
-            postcode: 'NE4 7JH',
-        },
+        organisationTradingName: sample([faker.company.companyName(), '']),
+        organisationAddress: organisationAddress,
         organisationType: sample([
             'Unregistered voluntary or community organisation',
             'Not-for-profit company',
@@ -1110,7 +1110,7 @@ it('should complete standard your funding proposal form', () => {
          *
          * Project regions step
          */
-        if (mock.projectRegions) {
+        if (mock.projectRegions.length > 0) {
             // Submit step w/no answers. Confirm error message
             submitStep();
 
@@ -1209,6 +1209,32 @@ it('should complete standard your funding proposal form', () => {
         cy.findAllByText('Submit application').first().click();
 
         cy.get('h1').should('contain', 'Thanks for telling us your proposal');
+    });
+}
+
+it('should complete standard your funding proposal in england', () => {
+    standardApplication({
+        projectCountries: ['England'],
+        projectRegions: ['North West', 'South West'],
+        projectLocation: 'Bournemouth',
+        organisationAddress: {
+            streetAddress: `The Bar, 2 St James' Blvd`,
+            city: 'Newcastle',
+            postcode: 'NE4 7JH',
+        },
+    });
+});
+
+it('should complete standard your funding proposal in northern-ireland', () => {
+    standardApplication({
+        projectCountries: ['Northern Ireland'],
+        projectRegions: [],
+        projectLocation: 'Belfast',
+        organisationAddress: {
+            streetAddress: `1 Cromac Pl`,
+            city: 'Belfast',
+            postcode: 'BT7 2JD',
+        },
     });
 });
 


### PR DESCRIPTION
## Before you start page

![start-after](https://user-images.githubusercontent.com/123386/80479881-a3158000-8947-11ea-9ff8-8f13f039231c.png)

Main change here is to **remove the process map**. This is currently inaccurate and too variable so the best thing we can do for now is to remove it.

## Confirmation page

Currently we have the following for "What happens next" on the confirmation page:

<img width="916" alt="confirmation-other-countries" src="https://user-images.githubusercontent.com/123386/80480000-d2c48800-8947-11ea-9b43-24719a5b7ca2.png">

This text is inaccurate for England. We'll be keeping the existing text for all other countries but varying this if in England. New confirmation text is as follows:

<img width="939" alt="confirmation-england" src="https://user-images.githubusercontent.com/123386/80480146-0a333480-8948-11ea-9912-25ee5205ee12.png">

Added snapshot tests for the confirmation text, like we do for simple, now this is variable. Also updated our integration tests to submit a separate test proposal for both England and Northern Ireland.



