### PR TITLE
Redirect broken link for under £10,000 managing your grant page

### DIFF
--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -6090,5 +6090,13 @@ Array [
     "from": "/welsh/funding/programmes/coastal-communities-fund-1",
     "to": "/welsh/funding/programmes/coastal-communities-fund",
   },
+  Object {
+    "from": "/funding/managing-your-grant/under10k",
+    "to": "/funding/managing-your-grant/under-10k",
+  },
+  Object {
+    "from": "/welsh/funding/managing-your-grant/under10k",
+    "to": "/welsh/funding/managing-your-grant/under-10k",
+  },
 ]
 `;

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -699,4 +699,8 @@ module.exports = createAliases([
         from: '/funding/programmes/coastal-communities-fund-1',
         to: '/funding/programmes/coastal-communities-fund',
     },
+    {
+        from: '/funding/managing-your-grant/under10k',
+        to: '/funding/managing-your-grant/under-10k',
+    },
 ]);


### PR DESCRIPTION
Spotted a few survey responses about this. Seems like there is a duff link for the under £10,000 managing grant section floating about. Page hasn't been updated recently, the hyphenated slug is the canonical version, probably a typo in some communications. 