### PR TITLE
Standard regions validation fix

### DIFF
--- a/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
@@ -4,6 +4,7 @@ exports[`empty form 1`] = `
 Array [
   "Enter a project name",
   "Select a country",
+  "Select one or more regions",
   "Tell us all of the locations that you'll be running your project in",
   "Enter a total cost for your project",
   "Tell us what you would like to do",

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -207,7 +207,10 @@ module.exports = function fieldsFor({ locale, data = {} }) {
 
             return Joi.when(Joi.ref('projectCountries'), {
                 is: isEnglandSelected,
-                then: [validAllEngland, validRegionOptions],
+                then: Joi.alternatives([
+                    validAllEngland,
+                    validRegionOptions,
+                ]).required(),
                 otherwise: Joi.any().strip(),
             });
         }

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -50,6 +50,17 @@ test('require region when england is selected', function () {
     );
 });
 
+test('strip region outside of england', function () {
+    const data = mockResponse({
+        projectCountries: ['northern-ireland'],
+        projectRegions: ['midlands', 'north-west'],
+    });
+
+    const form = formBuilder({ data });
+
+    expect(form.validation.value).not.toHaveProperty('projectRegions');
+});
+
 test('strip other region selections when all-england is selected', function () {
     const form = formBuilder({
         data: mockResponse({

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -42,12 +42,8 @@ test('invalid form', () => {
 });
 
 test('require region when england is selected', function () {
-    const form = formBuilder({
-        data: mockResponse({
-            projectCountries: ['england'],
-            projectRegions: null,
-        }),
-    });
+    const data = omit(mockResponse(), 'projectRegions');
+    const form = formBuilder({ data });
 
     expect(mapMessages(form.validation)).toEqual(
         expect.arrayContaining(['Select one or more regions'])

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1106,11 +1106,25 @@ it('should complete standard your funding proposal form', () => {
 
         submitStep();
 
-        mock.projectRegions.forEach(function (region) {
-            cy.findByLabelText(region).click();
-        });
+        /**
+         *
+         * Project regions step
+         */
+        if (mock.projectRegions) {
+            // Submit step w/no answers. Confirm error message
+            submitStep();
 
-        submitStep();
+            cy.findByTestId('form-errors').should(
+                'contain',
+                `Select one or more regions`
+            );
+
+            mock.projectRegions.forEach(function (region) {
+                cy.findByLabelText(region).click();
+            });
+
+            submitStep();
+        }
 
         cy.findByLabelText(
             'Where will most of your project take place?'


### PR DESCRIPTION
Spotted an issue with the validation rule for standard regions where it was possible to bypass the validation rules if you submitted an empty answer.

- We had a unit test for this but it was testing with `null` rather than true _absence_ of the field so was false positive. Updated this to completely omit the field
- Also added a missing test to validate that the region answers were stripped outside of England. This was working fine but need a test at our backs to help verify this fix
- Added an additional Cypress test to guard against this validation rule
