### PR TITLE
Add flex sidebar to child pages

### DIFF
--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -87,6 +87,10 @@
         max-width: $constrained;
         margin-bottom: $spacingUnit;
 
+        &.content-sidebar__primary--unconstrained {
+            max-width: 100%;
+        }
+
         @include mq('medium-major') {
             max-width: 100%;
             flex: 1 1 0%;

--- a/controllers/common/views/flexible-content-page.njk
+++ b/controllers/common/views/flexible-content-page.njk
@@ -18,7 +18,8 @@
                 {{ flexibleContent(
                     content.flexibleContent,
                     children = content.children,
-                    breadcrumbs = breadcrumbTrail(breadcrumbs)
+                    breadcrumbs = breadcrumbTrail(breadcrumbs),
+                    sidebar = sidebarContent
                 ) }}
             {% endif %}
         {% endblock %}

--- a/controllers/insights/views/covid-sidebar.njk
+++ b/controllers/insights/views/covid-sidebar.njk
@@ -1,0 +1,25 @@
+{% from "components/blog/macro.njk" import blogTrail with context %}
+
+<div class="u-tone-background-tint u-padded u-margin-bottom">
+    <h4>Latest blogposts</h4>
+    <ul>
+        {% for entry in blogposts | take(3) %}
+            <div class="o-media u-margin-bottom-s">
+                {% if entry.thumbnail.square %}
+                    <img src="{{ entry.thumbnail.square }}"
+                         alt="{{ entry.title }}"
+                         class="o-media__figure"
+                         width="60"/>
+                {% endif %}
+                <div class="o-media__body">
+                    <p class="u-margin-bottom-s">
+                        <a href="{{ entry.linkUrl }}">
+                            <strong>{{ entry.title }}</strong>
+                        </a>
+                    </p>
+                    <p class="u-text-small">{{ formatDate(entry.postDate.date) }}</p>
+                </div>
+            </div>
+        {% endfor %}
+    </ul>
+</div>

--- a/views/components/child-pages/macro.njk
+++ b/views/components/child-pages/macro.njk
@@ -1,7 +1,10 @@
 {% from "components/miniature-hero/macro.njk" import miniatureHero %}
 
-{% macro grid(children) %}
-    <section class="u-inner">
+{% macro grid(children, sidebar = null) %}
+    <section class="u-inner{% if sidebar %} content-sidebar{% endif %}">
+        {% if sidebar %}
+            <div class="content-sidebar__primary content-sidebar__primary--unconstrained">
+        {% endif %}
         <ul class="flex-grid">
             {% for page in children %}
                 <li class="flex-grid__item">
@@ -13,10 +16,22 @@
                 </li>
             {% endfor %}
         </ul>
+
+        {% if sidebar %}
+            </div>
+            <div class="content-sidebar__secondary">
+                {{ sidebar | safe }}
+            </div>
+        {% endif %}
     </section>
 {% endmacro %}
 
-{% macro list(children) %}
+{% macro list(children, sidebar = null) %}
+    {% if sidebar %}
+        <div class="content-sidebar">
+            <div class="content-sidebar__primary">
+    {% endif %}
+
     <ul class="section-links">
         {% for page in children %}
             <li class="section-links__item">
@@ -26,13 +41,21 @@
             </li>
         {% endfor %}
     </ul>
+
+    {% if sidebar %}
+            </div>
+            <div class="content-sidebar__secondary">
+                {{ sidebar | safe }}
+            </div>
+        </div>
+    {% endif %}
 {% endmacro %}
 
-{% macro childPages(children, mode) %}
+{% macro childPages(children, mode, sidebar = null) %}
     {% if (mode === 'grid') %}
-        {{ grid(children) }}
+        {{ grid(children, sidebar) }}
     {% else %}
-        {{ list(children) }}
+        {{ list(children, sidebar) }}
     {% endif %}
 {% endmacro %}
 

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -7,7 +7,7 @@
 
 {% set flexAnchor = 'item' %}
 
-{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null) %}
+{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null, sidebar = null) %}
     {% if flexibleContent.length > 0 %}
         {% set mediaAsideCycler = cycler(true, false) %}
 
@@ -20,7 +20,7 @@
                     <section class="content-box u-inner-wide-only" id="{{ flexAnchor + '-' + loop.index }}">
                 {% endif %}
 
-                {{ childPages(children, part.displayMode) }}
+                {{ childPages(children, part.displayMode, sidebar) }}
 
                 {% if useContentBox %}
                     </section>


### PR DESCRIPTION
This enables child page grids/lists to show a sidebar of arbitrary HTML content, defined in the controller. 

![image](https://user-images.githubusercontent.com/394376/80611017-f8c65700-8a31-11ea-93bd-158b88dece58.png)

At the moment the intention is for this sidebar to show alongside a grid of child pages, so that's where we render it, but it also works for text lists:

![image](https://user-images.githubusercontent.com/394376/80611094-13003500-8a32-11ea-92e4-4388c56d7497.png)

I couldn't think of a more CMS-y way of achieving this ("sidebar" block in FC?) but given this is hardcoded to a specific page I think we're okay for now.

In future it's probable that this will need some filtering, eg. only showing specifically-tagged blogposts etc, but for now Engagement are happy with it just showing all of them.