### PR TITLE
Add automaticContentList Flexible Content component

### DIFF
--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -29,7 +29,7 @@
                             {% for entry in entries %}
                                 <li class="article-listing__item">
                                     {% set subtitle %}
-                                        <time class="article-teaser__pubdate" datetime="{{ props.postDate.date }}">
+                                        <time class="article-teaser__pubdate" datetime="{{ entry.postDate.date }}">
                                             {{ formatDate(entry.postDate.date) }}
                                         </time>
 

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -1,7 +1,10 @@
+{% from "components/article-teaser/macro.njk" import articleTeaser %}
+{% from "components/blog/macro.njk" import blogTrail with context %}
 {% from "components/callout/macro.njk" import callout %}
 {% from "components/child-pages/macro.njk" import childPages %}
 {% from "components/fact-river/macro.njk" import factRiver %}
 {% from "components/media-aside/macro.njk" import mediaAside %}
+{% from "components/programmes.njk" import programmeCard with context %}
 {% from "components/promo-card/macro.njk" import promoCard with context %}
 {% from "components/table-of-contents/macro.njk" import tableOfContents %}
 
@@ -42,6 +45,41 @@
                                 }) }}
                             </li>
                         {% endfor %}
+                    </ul>
+                </section>
+            {% elseif part.type === 'automaticContentList' %}
+                <section class="u-inner">
+                    {% if part.title %}
+                        <h2 class="t--underline">{{ part.title }}</h2>
+                    {% endif %}
+                    <ul class="flex-grid flex-grid--3up">
+                        {% if part.sectionType === 'blogposts' %}
+                            {% for entry in part.items %}
+                                <li class="flex-grid__item">
+                                    {{ blogTrail(
+                                        entry = entry,
+                                        updateType = 'blog'
+                                    ) }}
+                                </li>
+                            {% endfor %}
+                        {% elseif part.sectionType === 'pressReleases' %}
+                            {% for entry in part.items %}
+                                <li class="flex-grid__item">
+                                    {{ articleTeaser({
+                                        'title': entry.trailText or entry.title,
+                                        'subtitle': formatDate(entry.postDate.date),
+                                        'summary': entry.summary,
+                                        'linkUrl': entry.linkUrl
+                                    }) }}
+                                </li>
+                            {% endfor %}
+                        {% elseif part.sectionType === 'fundingProgrammes' %}
+                            {% for entry in part.items %}
+                                <li class="flex-grid__item">
+                                    {{ programmeCard(entry) }}
+                                </li>
+                            {% endfor %}
+                        {% endif %}
                     </ul>
                 </section>
             {% else %}

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -30,7 +30,9 @@
                 {% endif %}
             {% elseif part.type === 'relatedContent' %}
                 <section class="u-inner">
-                    <h2 class="t--underline">{{ part.title }}</h2>
+                    {% if part.title %}
+                        <h2 class="t--underline">{{ part.title }}</h2>
+                    {% endif %}
                     <ul class="flex-grid flex-grid--3up">
                         {% for article in part.content %}
                             <li class="flex-grid__item">

--- a/views/components/flexible-content/macro.njk
+++ b/views/components/flexible-content/macro.njk
@@ -3,10 +3,10 @@
 {% from "components/promo-card/macro.njk" import promoCard with context %}
 
 {% macro flexibleContentPart(part, cycler = null) %}
-    {% if part.title %}
-        <h2 class="t1">{{ part.title }}</h2>
-    {% endif %}
     {% if part.type === 'mediaAside' %}
+        {% if part.title %}
+            <h2 class="t--underline">{{ part.title }}</h2>
+        {% endif %}
         {{ mediaAside(
             quoteText = part.quoteText,
             link = { "label": part.linkText, "url": part.linkUrl },
@@ -14,7 +14,9 @@
             isReversed = cycler.next() if cycler else false
         ) }}
     {% elseif part.type === 'relatedContent' %}
-        <h2 class="t--underline">{{ part.heading }}</h2>
+        {% if part.title %}
+            <h2 class="t--underline">{{ part.title }}</h2>
+        {% endif %}
         <ul class="flex-grid flex-grid--3up">
             {% for article in part.content %}
                 <li class="flex-grid__item">
@@ -31,6 +33,9 @@
             {% endfor %}
         </ul>
     {% else %}
+        {% if part.title %}
+            <h2 class="t1">{{ part.title }}</h2>
+        {% endif %}
         <div class="s-prose u-constrained-content-wide">
             {% if part.type === 'contentArea' %}
                 {{ part.content | safe }}


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/265 and allows adding automatically-fetched content to pages:

![image](https://user-images.githubusercontent.com/394376/80819869-b76aae80-8bcd-11ea-8251-50eb322e7f5c.png)

Uses existing patterns/macros to display the three supported types of content (blogs, press releases and funding programmes). 

Also fixed a related bug on pages [like this](https://www.tnlcommunityfund.org.uk/about/the-national-lotterys-25th-birthday) which use the old FC macros and didn't have the title logic.
![image](https://user-images.githubusercontent.com/394376/80819912-cea99c00-8bcd-11ea-9062-7d06f5758163.png)
