### PR TITLE
Add a new class for user icons

### DIFF
--- a/assets/sass/components/_global-header.scss
+++ b/assets/sass/components/_global-header.scss
@@ -319,6 +319,7 @@ $breakpointLarge: 840px;
 
         .global-header__account-link {
             position: relative;
+            .icon--user,
             .icon--login,
             .icon--logout {
                 position: absolute;

--- a/assets/sass/components/_icons.scss
+++ b/assets/sass/components/_icons.scss
@@ -69,6 +69,7 @@ $spinnerColour: get-color('brand', 'primary');
     fill: darken(get-color('border', 'base'), 30%);
 }
 
+.icon--user,
 .icon--login,
 .icon--logout {
     $iconWidth: 20px;


### PR DESCRIPTION
Spotted this got a bit broken, probably from renaming/duplicating a user icon which added a class (`.icon--user`) without any styles.

Here's a before/after:

![fixed](https://user-images.githubusercontent.com/394376/80980220-4838c880-8e20-11ea-8465-46387e8e23e9.gif)
