### PR TITLE
Under £10,000 copy tweaks

### DIFF
--- a/common/locals.js
+++ b/common/locals.js
@@ -65,6 +65,7 @@ module.exports = function (req, res, next) {
      * Default to true, allow overriding on specific pages
      */
     res.locals.showCOVID19AnnouncementBanner = true;
+    res.locals.enableNewCOVID19Flow = config.get('fundingUnder10k.enableNewCOVID19Flow');
 
     /**
      * Global copy

--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,6 @@
     "enableSalesforceConnector": false
   },
   "fundingUnder10k": {
-    "enableNewCOVID19Flow": true
+    "enableNewCOVID19Flow": false
   }
 }

--- a/config/development.json
+++ b/config/development.json
@@ -4,6 +4,6 @@
     "enableSalesforceConnector": false
   },
   "fundingUnder10k": {
-    "enableNewCOVID19Flow": false
+    "enableNewCOVID19Flow": true
   }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1107,6 +1107,34 @@ awardsForAll:
       title: Barod i ymgeisio?
       processMap:
         indicatorLabel: Rydych yma
+        processNew:
+          - type: step
+            title: Gwirio os gallwch ymgeisio
+            description: >
+              Cyn i chi dreulio amser yn llenwi ffurflen gais,
+              byddwn yn gofyn rhai cwestiynau i sicrhau y gallwch
+              ymgeisio yn gyntaf (gan ddefnyddio ein ‘gwiriad cymhwysedd’).
+              Os na allwch ymgeisio, byddwn yn rhoi gwybod pam i chi.
+              Dylai’r adborth hwn helpu os byddwch eisiau ymgeisio eto yn y dyfodol.
+          - type: action
+            title: Gallu ymgeisio
+          - type: step
+            title: Llenwi cais ar-lein
+            description: >
+              Dywedwch wrthym am eich syniad i helpu pobl wella eu bywydau a’u cymunedau.
+              Bydd gennych hyd at dair mis i orffen eich ffurflen gais ar-lein.
+              Ar ôl i chi anfon eich ffurflen gais atom, byddwn yn ei hasesu.
+              @TODO: i18n
+          - type: action
+            title: Cais wedi’i asesu
+          - type: step
+            title: Byddwn yn penderfynu i ariannu eich prosiect neu beidio
+            description: >
+              Efallai byddwn yn cysylltu â chi i siarad a gofyn cwestiynau am eich cais.
+              Yna, byddwn yn gwneud penderfyniad terfynol p’un a byddwn yn ariannu eich prosiect neu ddim.
+              Os byddwch yn llwyddiannus, gallwch
+              <a href="/welsh/funding/managing-your-grant/promoting-your-project">hyrwyddo eich prosiect</a>
+              a dechrau <a href="/welsh/funding/managing-your-grant/under10k">rheoli eich grant</a>.
         process:
           - type: step
             title: Gwirio os gallwch ymgeisio

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1103,6 +1103,37 @@ awardsForAll:
       title: Ready to apply?
       processMap:
         indicatorLabel: You are here
+        processNew:
+          - type: step
+            title: Check you can apply
+            description: >
+              Before you spend time filling out an application form,
+              we’ll ask a few questions to make sure you can apply first
+              (using our ‘eligibility checker’).
+              If you can’t apply, we’ll let you know why.
+              This feedback should help, if you want to try again in future.
+          - type: action
+            title: Able to apply
+          - type: step
+            title: Fill out an online application
+            description: >
+              Tell us about your idea to help people improve their lives and communities.
+              You’ll have up to three months to finish your online application form.
+              Once you send us your application form,  we’ll assess it.
+              Given the emergency, we're now prioritising decisions for COVID-19
+              related projects, so they can start sooner. In England, we’re focusing
+              our funding on projects supporting communities through the COVID-19 pandemic.
+              So we ask organisations in England who aren’t looking for COVID-19
+              related funding to not submit applications at this time.
+          - type: action
+            title: Application assessed
+          - type: step
+            title: We’ll decide to fund your project or not
+            description: >
+              We might get in touch to talk to you, and ask questions about your application.
+              Then we’ll make a final decision to fund your project or not. If successful, you can
+              <a href="/funding/managing-your-grant/promoting-your-project">promote your project</a>
+              and start <a href="/funding/managing-your-grant/under10k">managing your grant</a>.
         process:
           - type: step
             title: Check you can apply

--- a/controllers/apply/under10k/__snapshots__/confirmation.test.js.snap
+++ b/controllers/apply/under10k/__snapshots__/confirmation.test.js.snap
@@ -14,10 +14,10 @@ we'll start assessing it as soon as we can
 </h2>
 <p>
   We’ll look at your idea and do some checks.
-We’re now prioritising decisions for COVID-19 related
-projects, so they can start sooner. And it might take us
-up to six months
-to assess applications that aren’t about COVID-19.
+Given the emergency and huge demand for funding,
+we’re now focusing on funding projects and organisations
+helping communities through the COVID-19 pandemic,
+so they can start as soon as possible
 </p>
 <h2>
   While we’re assessing your application – we might get in touch
@@ -80,8 +80,7 @@ we'll start assessing it as soon as we can
 <p>
   We’ll look at your idea and do some checks.
 We’re now prioritising decisions for COVID-19 related
-projects, so they can start sooner. And it might take us
-longer
+projects, so they can start sooner. And it might take us longer
 to assess applications that aren’t about COVID-19.
 </p>
 <h2>

--- a/controllers/apply/under10k/confirmation.js
+++ b/controllers/apply/under10k/confirmation.js
@@ -1,8 +1,10 @@
 'use strict';
+const config = require('config');
 const get = require('lodash/fp/get');
 const { stripIndents } = require('common-tags');
 
 const { getContactFullName } = require('./lib/contacts');
+const enableNewCOVID19Flow = config.get('fundingUnder10k.enableNewCOVID19Flow');
 
 function getEmailFor(country) {
     const countryEmail = {
@@ -42,6 +44,35 @@ module.exports = function ({ locale, data = {} }) {
     );
 
     function enConfirmationBody() {
+        function leadTimeText() {
+            if (enableNewCOVID19Flow) {
+                if (country === 'england') {
+                    return `<p>
+                        We’ll look at your idea and do some checks.
+                        Given the emergency and huge demand for funding,
+                        we’re now focusing on funding projects and organisations
+                        helping communities through the COVID-19 pandemic,
+                        so they can start as soon as possible
+                    </p>`;
+                } else {
+                    return `<p>
+                        We’ll look at your idea and do some checks.
+                        We’re now prioritising decisions for COVID-19 related
+                        projects, so they can start sooner. And it might take us longer
+                        to assess applications that aren’t about COVID-19.
+                    </p>`;
+                }
+            } else {
+                return `<p>
+                    We’ll look at your idea and do some checks.
+                    We’re now prioritising decisions for COVID-19 related
+                    projects, so they can start sooner. And it might take us
+                    ${country === 'england' ? 'up to six months' : 'longer'}
+                    to assess applications that aren’t about COVID-19.
+                </p>`;
+            }
+        }
+
         return stripIndents`
             <h2>We’ve just sent an email to your main and senior contact</h2>
             <p>
@@ -52,13 +83,7 @@ module.exports = function ({ locale, data = {} }) {
                 Now we’ve got your application – 
                 we'll start assessing it as soon as we can
             </h2>
-            <p>
-                We’ll look at your idea and do some checks.
-                We’re now prioritising decisions for COVID-19 related
-                projects, so they can start sooner. And it might take us
-                ${country === 'england' ? 'up to six months' : 'longer'}
-                to assess applications that aren’t about COVID-19.
-            </p>
+            ${leadTimeText()}
             <h2>While we’re assessing your application – we might get in touch</h2>
             <p>
                 We don’t always do this. It’s only if we need a bit more information.
@@ -90,18 +115,33 @@ module.exports = function ({ locale, data = {} }) {
     }
 
     function cyConfirmationBody() {
+        function leadTimeText() {
+            if (enableNewCOVID19Flow) {
+                if (country === 'england') {
+                    return `@TODO: i18n`;
+                } else {
+                    return `<p>Byddwn yn edrych ar eich syniad ac yn gwneud rhai gwiriadau. 
+                    Rydym nawr yn blaenoriaethu penderfyniadau ar gyfer prosiectau 
+                    cysylltiedig â COVID-19, fel y gallant gychwyn yn gynt. Ac fe allai gymryd 
+                    mwy o amser i ni asesu ceisiadau nad ydyn nhw'n ymwneud â COVID-19.</p>`;
+                }
+            } else {
+                return `<p>Byddwn yn edrych ar eich syniad ac yn gwneud rhai gwiriadau. 
+                Rydym nawr yn blaenoriaethu penderfyniadau ar gyfer prosiectau 
+                cysylltiedig â COVID-19, fel y gallant gychwyn yn gynt. Ac fe allai gymryd 
+                ${country === 'england' ? 'hyd at chwe mis' : 'mwy o amser'}
+                i ni asesu ceisiadau nad ydyn nhw'n ymwneud â COVID-19.</p>`;
+            }
+        }
+
         return stripIndents`
             <h2>Rydym newydd anfon e-bost i’ch prif ac uwch gyswllt </h2>
             <p>Dim ond e-bost cadarnhad yw hwn, gyda chrynodeb o’ch atebion 
             (rhag ofn eich bod eisiau edrych yn ôl arnyn nhw ar unrhyw bwynt).</p>
 
             <h2>Nawr bod gennym eich cais, byddwn yn dechrau ei asesu cyn gynted ag y gallwn</h2>
-            <p>Byddwn yn edrych ar eich syniad ac yn gwneud rhai gwiriadau. 
-            Rydym nawr yn blaenoriaethu penderfyniadau ar gyfer prosiectau 
-            cysylltiedig â COVID-19, fel y gallant gychwyn yn gynt. Ac fe allai gymryd  ${
-                country === 'england' ? 'hyd at chwe mis' : 'mwy o amser'
-            } i ni asesu ceisiadau nad ydyn nhw'n ymwneud â COVID-19.</p>
-            
+            ${leadTimeText()}
+        
             <h2>Tra rydym yn asesu eich cais – efallai byddwn mewn cysylltiad</h2>
             <p>Nid ydym yn gwneud hyn o hyd. Dim ond os ydym angen ychydig mwy o
              wybodaeth. Felly peidiwch â phoeni os nad ydych yn clywed gennym.</p>

--- a/controllers/apply/under10k/constants.js
+++ b/controllers/apply/under10k/constants.js
@@ -17,11 +17,6 @@ const ORG_MIN_AGE = {
     label: { en: '15 months', cy: '15 mis' },
 };
 
-const SUGGESTED_PROJECT_DURATION = {
-    en: '12 months',
-    cy: '12 mis',
-};
-
 const ORGANISATION_TYPES = {
     UNREGISTERED_VCO: 'unregistered-vco',
     UNINCORPORATED_REGISTERED_CHARITY: 'unincorporated-registered-charity',
@@ -114,7 +109,6 @@ module.exports = {
     COMPANY_NUMBER_TYPES,
     CONTACT_EXCLUDED_TYPES,
     MAX_BUDGET_TOTAL_GBP,
-    SUGGESTED_PROJECT_DURATION,
     MIN_AGE_MAIN_CONTACT,
     MIN_AGE_SENIOR_CONTACT,
     MIN_BUDGET_TOTAL_GBP,

--- a/controllers/apply/under10k/eligibility.js
+++ b/controllers/apply/under10k/eligibility.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
@@ -8,6 +9,8 @@ const {
     SUGGESTED_PROJECT_DURATION,
     ORG_MIN_AGE,
 } = require('./constants');
+
+const enableNewCOVID19Flow = config.get('fundingUnder10k.enableNewCOVID19Flow');
 
 module.exports = function ({ locale }) {
     const localise = get(locale);
@@ -52,15 +55,38 @@ module.exports = function ({ locale }) {
     }
 
     function question2() {
+        const question = enableNewCOVID19Flow
+            ? localise({
+                  en: oneLine`Are you applying for an amount between
+                    £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and
+                    £${MAX_BUDGET_TOTAL_GBP.toLocaleString()}
+                    that you’ll spend in around in around 12 months?
+                    (or in 6 months for projects in England)`,
+                  cy: `@TODO: i18n`,
+              })
+            : localise({
+                  en: `Are you applying for an amount between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} that you’ll spend in around ${maxProjectDurationLabel}?`,
+                  cy: `A ydych yn ymgeisio am swm rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} byddwch yn ei wario o fewn oddeutu ${maxProjectDurationLabel}?`,
+              });
+
+        const explanation = enableNewCOVID19Flow
+            ? localise({
+                  en: oneLine`We know it's not always possible to complete a
+                      project in 12 months for lots of reasons. So we can
+                      consider projects which are slightly longer than this.
+                      But groups in England need to spend the funding in 6 months.
+                      We will also consider applications for one-off events
+                      such as a festival, gala day or conference`,
+                  cy: `@TODO: i18n`,
+              })
+            : localise({
+                  en: `We know it's not always possible to complete a project in ${maxProjectDurationLabel} for lots of reasons. So we can consider projects which are slightly longer than this. We will also consider applications for one-off events such as a festival, gala day or conference.`,
+                  cy: `Rydym yn gwybod nad yw bob tro’n bosib i gwblhau prosiect o fewn ${maxProjectDurationLabel} am nifer o resymau. Felly mi allwn ystyried prosiectau sydd ychydig yn hirach na hyn. Byddwn hefyd yn ystyried ceisiadau am ddigwyddiadau a fydd yn digwydd unwaith yn unig, megis gwyliau, diwrnod gala neu gynhadledd.`,
+              });
+
         return {
-            question: localise({
-                en: `Are you applying for an amount between £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} and £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} that you’ll spend in around ${maxProjectDurationLabel}?`,
-                cy: `A ydych yn ymgeisio am swm rhwng £${MIN_BUDGET_TOTAL_GBP.toLocaleString()} a £${MAX_BUDGET_TOTAL_GBP.toLocaleString()} byddwch yn ei wario o fewn oddeutu ${maxProjectDurationLabel}?`,
-            }),
-            explanation: localise({
-                en: `We know it's not always possible to complete a project in ${maxProjectDurationLabel} for lots of reasons. So we can consider projects which are slightly longer than this. We will also consider applications for one-off events such as a festival, gala day or conference.`,
-                cy: `Rydym yn gwybod nad yw bob tro’n bosib i gwblhau prosiect o fewn ${maxProjectDurationLabel} am nifer o resymau. Felly mi allwn ystyried prosiectau sydd ychydig yn hirach na hyn. Byddwn hefyd yn ystyried ceisiadau am ddigwyddiadau a fydd yn digwydd unwaith yn unig, megis gwyliau, diwrnod gala neu gynhadledd.`,
-            }),
+            question: question,
+            explanation: explanation,
             yesLabel: localise({ en: 'Yes', cy: 'Ydw' }),
             noLabel: localise({ en: 'No', cy: 'Nac ydw' }),
             errorMessage: localise({

--- a/controllers/apply/under10k/eligibility.js
+++ b/controllers/apply/under10k/eligibility.js
@@ -6,7 +6,6 @@ const { oneLine } = require('common-tags');
 const {
     MIN_BUDGET_TOTAL_GBP,
     MAX_BUDGET_TOTAL_GBP,
-    SUGGESTED_PROJECT_DURATION,
     ORG_MIN_AGE,
 } = require('./constants');
 
@@ -15,7 +14,11 @@ const enableNewCOVID19Flow = config.get('fundingUnder10k.enableNewCOVID19Flow');
 module.exports = function ({ locale }) {
     const localise = get(locale);
 
-    const maxProjectDurationLabel = localise(SUGGESTED_PROJECT_DURATION);
+    const maxProjectDurationLabel = localise({
+        en: '12 months',
+        cy: '12 mis',
+    });
+
     const orgMinAgeLabel = localise(ORG_MIN_AGE.label);
 
     function question1() {

--- a/controllers/apply/under10k/views/startpage.njk
+++ b/controllers/apply/under10k/views/startpage.njk
@@ -24,8 +24,14 @@
                 <h2>{{ copy.readyToApply.title }}</h2>
             </div>
 
+            {% if enableNewCOVID19Flow %}
+                {% set processItemsSource = copy.readyToApply.processMap.processNew %}
+            {% else %}
+                {% set processItemsSource = copy.readyToApply.processMap.process %}
+            {% endif %}
+
             {% set processItems = [] %}
-            {% for item in copy.readyToApply.processMap.process %}
+            {% for item in processItemsSource %}
                 {% set processItems = (processItems.push({
                     type: item.type,
                     title: item.title,
@@ -34,7 +40,6 @@
                     isCurrent: loop.index === 1
                 }), processItems) %}
             {% endfor %}
-
             {{ processMap(processItems, copy.readyToApply.processMap.indicatorLabel) }}
 
             <p class="form-actions u-margin-bottom-l">


### PR DESCRIPTION
All behind the `enableNewCOVID19Flow` flag so there's a little bit of duplication to enable that. Paired with @marksmithtnlcf and @mo-durvesh on these changes.

- Update eligibility step to make it clear you have to spend the money within 6 months in England
- Updated confirmation page with new COVID-19 text
- Updated process map on start page with new COVID-19 text