### PR TITLE
Add Covid-19 funding info

### DIFF
--- a/common/content-api.js
+++ b/common/content-api.js
@@ -214,7 +214,7 @@ function getFundingProgrammes({
     ]).then((responses) => {
         const [enResults, cyResults] = responses.map(mapAttrs);
         return {
-            meta: head(responses).meta,
+            meta: locale === 'en' ? head(responses).meta : responses[1].meta,
             result: mergeWelshBy('slug')(locale, enResults, cyResults),
         };
     });

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -4,7 +4,6 @@ const find = require('lodash/fp/find');
 const flatten = require('lodash/flatten');
 const get = require('lodash/fp/get');
 const getOr = require('lodash/fp/getOr');
-const head = require('lodash/fp/head');
 const map = require('lodash/fp/map');
 const pick = require('lodash/pick');
 const sortBy = require('lodash/fp/sortBy');

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -212,10 +212,14 @@ function getFundingProgrammes({
         queryContentApi.get('v2/en/funding-programmes', requestOptions).json(),
         queryContentApi.get('v2/cy/funding-programmes', requestOptions).json(),
     ]).then((responses) => {
-        const [enResults, cyResults] = responses.map(mapAttrs);
+        const [enResponse, cyResponse] = responses;
         return {
-            meta: locale === 'en' ? head(responses).meta : responses[1].meta,
-            result: mergeWelshBy('slug')(locale, enResults, cyResults),
+            meta: locale === 'en' ? enResponse.meta : cyResponse.meta,
+            result: mergeWelshBy('slug')(
+                locale,
+                mapAttrs(enResponse),
+                mapAttrs(cyResponse)
+            ),
         };
     });
 }

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -50,17 +50,14 @@ router.get('/', injectHeroImage('rosemount-1-letterbox-new'), async function (
 
         const covidStatuses = get(response.meta, 'covid19Statuses');
         if (covidStatuses) {
-            let countryCovidStatus;
-            countryCovidStatus = covidStatuses.find(
-                (status) => status.country === locationParam
-            );
-            // Fall back to the UK-wide statement
-            if (!countryCovidStatus) {
-                countryCovidStatus = covidStatuses.find(
-                    (status) => status.country === 'ukWide'
+            res.locals.countryCovidStatus = covidStatuses.find(function (
+                status
+            ) {
+                return (
+                    status.country === locationParam ||
+                    status.country === 'ukWide'
                 );
-            }
-            res.locals.countryCovidStatus = countryCovidStatus;
+            });
         }
 
         const programmesFilteredByAmount = allFundingProgrammes

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -48,6 +48,21 @@ router.get('/', injectHeroImage('rosemount-1-letterbox-new'), async function (
             req.query.location
         );
 
+        const covidStatuses = get(response.meta, 'covid19Statuses');
+        if (covidStatuses) {
+            let countryCovidStatus;
+            countryCovidStatus = covidStatuses.find(
+                (status) => status.country === locationParam
+            );
+            // Fall back to the UK-wide statement
+            if (!countryCovidStatus) {
+                countryCovidStatus = covidStatuses.find(
+                    (status) => status.country === 'ukWide'
+                );
+            }
+            res.locals.countryCovidStatus = countryCovidStatus;
+        }
+
         const programmesFilteredByAmount = allFundingProgrammes
             .filter(programmeFilters.filterByMinAmount(req.query.min))
             .filter(programmeFilters.filterByMaxAmount(req.query.max));

--- a/controllers/funding/programmes/views/programmes-list.njk
+++ b/controllers/funding/programmes/views/programmes-list.njk
@@ -14,6 +14,9 @@
             {% if groupedProgrammes %}
                 {% for region, regionProgrammes in groupedProgrammes %}
                     <h3>{{ region }}</h3>
+                    {% if countryCovidStatus %}
+                        <p>{{ countryCovidStatus.status }}</p>
+                    {% endif %}
                     <ol class="flex-grid flex-grid--3up">
                         {% for programme in regionProgrammes %}
                             <li class="flex-grid__item">
@@ -23,6 +26,9 @@
                     </ol>
                 {% endfor %}
             {% elseif programmes.length > 0 %}
+                {% if countryCovidStatus %}
+                    <p>{{ countryCovidStatus.status }}</p>
+                {% endif %}
                 <ol class="flex-grid flex-grid--3up">
                     {% for programme in programmes %}
                         <li class="flex-grid__item">

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -35,6 +35,9 @@
 
 {% macro programmeCard(programme) %}
     {% set description %}
+        {% if programme.trailText %}
+            <p>{{ programme.trailText }}</p>
+        {% endif %}
         {{ programmeStats(programme) }}
     {% endset %}
     {{ promoCard({


### PR DESCRIPTION
This adds two things (and pairs with [these CMS changes](https://github.com/biglotteryfund/craft-dev/pull/268)):

- A new paragraph showing a specific country's funding status for Covid-19:

![image](https://user-images.githubusercontent.com/394376/81181810-e2297e00-8fa4-11ea-9c50-9e0debb94acd.png)
![image](https://user-images.githubusercontent.com/394376/81181834-e8b7f580-8fa4-11ea-9764-e14a85556cbd.png)
![image](https://user-images.githubusercontent.com/394376/81181842-ece41300-8fa4-11ea-845f-e0dce831f9af.png)

- A new "trail text" field for funding programmes which replaces their (longer) intro/description text as it used to be:

![image](https://user-images.githubusercontent.com/394376/81181907-04230080-8fa5-11ea-8994-ebe9a42ea2a7.png)

(this will need to be populated in the CMS)