### PR TITLE
Refactor ebulletin logic to allow stakeholder signups [WIP]

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -1060,14 +1060,16 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
     font-size: 18px;
 
     .form-field {
-        margin-bottom: 0.5em;
+        margin-bottom: 1em;
     }
 
-    .ff-text {
+    .ff-text,
+    .ff-select {
         display: block;
         width: 100%;
         padding: 0.35em;
         font-size: 16px;
         border: 1px solid rgba(0, 0, 0, 0.2);
     }
+
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,9 +260,16 @@ toplevel:
           This work is licensed under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">open government licence for public sector information</a>, which allows you to use and re-use the Information that is available under this licence freely and flexibly, with only a few conditions. If you can’t find what you’re looking for, please <a href="/contact">contact us</a>.
   ebulletin:
     title: e-bulletin
-    introHeading: Find out about our funding
-    intro: Sign up for our latest news relating to your country
-    location: Location
+    standard:
+      heading: Find out about our funding
+      intro: >
+        <p>Sign up for our latest news relating to your country</p>
+    stakeholder:
+      heading: Policy and insights newsletter
+      intro: >
+        <p>Our policy and insights newsletter will share the valuable evidence, learning and data we collect from the people, projects and communities we support.</p>
+        <p>We'll look at the achievements, successes and challenges of the sector and also share news about our funding and activity across the UK. Sign up today to get it sent direct to your inbox.</p>
+        <p>We will be launching the newsletter over the summer.</p>
     locations:
       england: England
       wales: Wales

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,18 +268,34 @@ toplevel:
       wales: Wales
       scotland: Scotland
       northernIreland: Northern Ireland
+    sectors:
+      armsLengthBody: Arm's length body
+      fundingBody: Funding body
+      civilService: Civil Service
+      localGovernment: Local Government
+      charity: Charity
+      communityGroup: Community group
+      socialEnterprise: Social enterprise
+      nhs: NHS
+      privateSector: Private Sector
+      other: Other
     yourDetails: Your Details
     fields:
       firstName: First name
       lastName: Surname
-      organisation: Organisation
       emailAddress: Email Address
+      location: Location
+      organisation: Organisation
+      jobTitle: Job title
+      sector: Sector
     errors:
       firstName: Please provide your first name
       lastName: Please provide your last name
       emailMissing: Please provide your email address
       emailInvalid: Please provide a valid email address
       location: Please choose a country
+      jobTitleMissing: Please provide a job title
+      sectorMissing: Please provide a sector
     callToAction: Subscribe
     responses:
       success:

--- a/controllers/ebulletin/index.js
+++ b/controllers/ebulletin/index.js
@@ -32,7 +32,7 @@ function renderForm(req, res, data = null, errors = []) {
 }
 
 router
-    .route('/:contactType(stakeholder)?')
+    .route('/:contactType(policy)?')
     .all(noStore, csrfProtection)
     .get(renderForm)
     .post(async function handleEbulletinSignup(req, res) {
@@ -41,7 +41,7 @@ router
         let contactToUse = newContact(req.i18n);
         let addressBookId = 148374;
 
-        if (req.params.contactType === 'stakeholder') {
+        if (req.params.contactType === 'policy') {
             contactToUse = newStakeholder(req.i18n);
             addressBookId = 249380;
         }

--- a/controllers/ebulletin/index.js
+++ b/controllers/ebulletin/index.js
@@ -4,7 +4,12 @@ const express = require('express');
 const Sentry = require('@sentry/node');
 const omit = require('lodash/omit');
 
-const { newContact, buildValidLocations } = require('./lib/contact-schema');
+const {
+    newContact,
+    newStakeholder,
+    buildValidLocations,
+    buildValidSectors,
+} = require('./lib/contact-schema');
 const ebulletinService = require('./lib/ebulletin-service');
 
 const { noStore, csrfProtection } = require('../../common/cached');
@@ -17,30 +22,39 @@ const router = express.Router();
 function renderForm(req, res, data = null, errors = []) {
     res.render(path.resolve(__dirname, './views/ebulletin'), {
         title: req.i18n.__('toplevel.ebulletin.title'),
+        contactType: req.params.contactType,
         csrfToken: req.csrfToken(),
         validLocations: buildValidLocations(req.i18n),
+        validSectors: buildValidSectors(req.i18n),
         formValues: data,
         errors: errors,
     });
 }
 
 router
-    .route('/')
+    .route('/:contactType(stakeholder)?')
     .all(noStore, csrfProtection)
     .get(renderForm)
     .post(async function handleEbulletinSignup(req, res) {
         const sanitisedBody = sanitiseRequestBody(omit(req.body, ['_csrf']));
 
-        const validationResult = validateSchema(
-            newContact(req.i18n),
-            sanitisedBody
-        );
+        let contactToUse = newContact(req.i18n);
+        let addressBookId = 148374;
+
+        if (req.params.contactType === 'stakeholder') {
+            console.log('using this');
+            contactToUse = newStakeholder(req.i18n);
+            addressBookId = 249380;
+        }
+
+        const validationResult = validateSchema(contactToUse, sanitisedBody);
 
         if (validationResult.isValid) {
             try {
                 await ebulletinService.subscribe({
-                    addressBookId: '148374',
+                    addressBookId: addressBookId,
                     subscriptionData: validationResult.value,
+                    contactType: req.params.contactType,
                 });
                 res.locals.status = 'SUCCESS';
                 renderForm(req, res);

--- a/controllers/ebulletin/index.js
+++ b/controllers/ebulletin/index.js
@@ -42,7 +42,6 @@ router
         let addressBookId = 148374;
 
         if (req.params.contactType === 'stakeholder') {
-            console.log('using this');
             contactToUse = newStakeholder(req.i18n);
             addressBookId = 249380;
         }

--- a/controllers/ebulletin/lib/contact-schema.js
+++ b/controllers/ebulletin/lib/contact-schema.js
@@ -7,80 +7,180 @@ function getTranslations(i18n) {
     };
 }
 
+const COUNTRIES = {
+    ENGLAND: 'england',
+    NORTHERN_IRELAND: 'northern-ireland',
+    SCOTLAND: 'scotland',
+    WALES: 'wales',
+};
+
+const SECTORS = {
+    ARMS_LENGTH_BODY: 'arms-length-body',
+    FUNDING_BODY: 'funding-body',
+    CIVIL_SERVICE: 'civil-service',
+    LOCAL_GOV: 'local-government',
+    CHARITY: 'charity',
+    COMMUNITY_GROUP: 'community-group',
+    SOCIAL_ENTERPRISE: 'social-enterprise',
+    NHS: 'nhs',
+    PRIVATE_SECTOR: 'private-sector',
+    OTHER: 'other',
+};
+
 function buildValidLocations(i18n) {
     const labelForLocale = getTranslations(i18n);
     return [
         {
-            value: 'england',
+            value: COUNTRIES.ENGLAND,
             label: labelForLocale('locations.england'),
         },
         {
-            value: 'northern-ireland',
+            value: COUNTRIES.NORTHERN_IRELAND,
             label: labelForLocale('locations.northernIreland'),
         },
         {
-            value: 'scotland',
+            value: COUNTRIES.SCOTLAND,
             label: labelForLocale('locations.scotland'),
         },
         {
-            value: 'wales',
+            value: COUNTRIES.WALES,
             label: labelForLocale('locations.wales'),
         },
     ];
 }
 
+function buildValidSectors(i18n) {
+    const labelForLocale = getTranslations(i18n);
+    return [
+        {
+            value: SECTORS.ARMS_LENGTH_BODY,
+            label: labelForLocale('sectors.armsLengthBody'),
+        },
+        {
+            value: SECTORS.FUNDING_BODY,
+            label: labelForLocale('sectors.fundingBody'),
+        },
+        {
+            value: SECTORS.CIVIL_SERVICE,
+            label: labelForLocale('sectors.civilService'),
+        },
+        {
+            value: SECTORS.LOCAL_GOV,
+            label: labelForLocale('sectors.localGovernment'),
+        },
+        {
+            value: SECTORS.CHARITY,
+            label: labelForLocale('sectors.charity'),
+        },
+        {
+            value: SECTORS.COMMUNITY_GROUP,
+            label: labelForLocale('sectors.communityGroup'),
+        },
+        {
+            value: SECTORS.SOCIAL_ENTERPRISE,
+            label: labelForLocale('sectors.socialEnterprise'),
+        },
+        {
+            value: SECTORS.NHS,
+            label: labelForLocale('sectors.nhs'),
+        },
+        {
+            value: SECTORS.PRIVATE_SECTOR,
+            label: labelForLocale('sectors.privateSector'),
+        },
+        {
+            value: SECTORS.OTHER,
+            label: labelForLocale('sectors.other'),
+        },
+    ];
+}
+
+const baseSchema = {
+    email: Joi.string().email().required(),
+    firstName: Joi.string().required(),
+    lastName: Joi.string().required(),
+    location: Joi.string()
+        .valid(...Object.values(COUNTRIES))
+        .required(),
+    organisation: Joi.string().allow('').optional(),
+};
+
+function getBaseMessages(i18n) {
+    const messageForLocale = getTranslations(i18n);
+    return {
+        email: [
+            {
+                type: 'base',
+                message: messageForLocale('errors.emailMissing'),
+            },
+            {
+                type: 'string.email',
+                message: messageForLocale('errors.emailInvalid'),
+            },
+        ],
+        firstName: [
+            {
+                type: 'base',
+                message: messageForLocale('errors.firstName'),
+            },
+        ],
+        lastName: [
+            {
+                type: 'base',
+                message: messageForLocale('errors.lastName'),
+            },
+        ],
+        location: [
+            {
+                type: 'base',
+                message: messageForLocale('errors.location'),
+            },
+        ],
+    };
+}
+
 module.exports = {
     buildValidLocations,
-    newContact(i18n) {
-        const messageForLocale = getTranslations(i18n);
-        const locations = buildValidLocations(i18n);
+    buildValidSectors,
+    newStakeholder(i18n) {
+        const stakeholderSchema = Object.assign(baseSchema, {
+            jobTitle: Joi.string().required(),
+            sector: Joi.string()
+                .valid(...Object.values(SECTORS))
+                .required(),
+        });
 
-        const email = Joi.string().email().required();
-        const firstName = Joi.string().required();
-        const lastName = Joi.string().required();
-        const location = Joi.string()
-            .valid(...locations.map((_) => _.value))
-            .required();
-        const organisation = Joi.string().allow('').optional();
+        const messageForLocale = getTranslations(i18n);
+
+        const additionalMessages = {
+            jobTitle: [
+                {
+                    type: 'base',
+                    message: messageForLocale('errors.jobTitleMissing'),
+                },
+            ],
+            sector: [
+                {
+                    type: 'base',
+                    message: messageForLocale('errors.sectorMissing'),
+                },
+            ],
+        };
+
+        const messages = Object.assign(
+            getBaseMessages(i18n),
+            additionalMessages
+        );
 
         return {
-            schema: Joi.object({
-                email,
-                firstName,
-                lastName,
-                location,
-                organisation,
-            }),
-            messages: {
-                email: [
-                    {
-                        type: 'base',
-                        message: messageForLocale('errors.emailMissing'),
-                    },
-                    {
-                        type: 'string.email',
-                        message: messageForLocale('errors.emailInvalid'),
-                    },
-                ],
-                firstName: [
-                    {
-                        type: 'base',
-                        message: messageForLocale('errors.firstName'),
-                    },
-                ],
-                lastName: [
-                    {
-                        type: 'base',
-                        message: messageForLocale('errors.lastName'),
-                    },
-                ],
-                location: [
-                    {
-                        type: 'base',
-                        message: messageForLocale('errors.location'),
-                    },
-                ],
-            },
+            schema: Joi.object(stakeholderSchema),
+            messages: messages,
+        };
+    },
+    newContact(i18n) {
+        return {
+            schema: Joi.object(baseSchema),
+            messages: getBaseMessages(i18n),
         };
     },
 };

--- a/controllers/ebulletin/lib/ebulletin-service.js
+++ b/controllers/ebulletin/lib/ebulletin-service.js
@@ -10,7 +10,11 @@ const { DOTDIGITAL_API } = require('../../../common/secrets');
  * @see https://developer.dotmailer.com/docs
  * @see https://developer.dotmailer.com/docs/error-response-types
  */
-function subscribe({ addressBookId, subscriptionData }) {
+function subscribe({
+    addressBookId,
+    subscriptionData,
+    contactType = 'contact',
+}) {
     const ENDPOINT = `https://r1-api.dotmailer.com/v2/address-books/${addressBookId}/contacts`;
 
     const data = {
@@ -21,6 +25,23 @@ function subscribe({ addressBookId, subscriptionData }) {
             { key: 'LastName', value: subscriptionData.lastName },
         ],
     };
+
+    if (contactType === 'stakeholder') {
+        data.dataFields.push(
+            {
+                key: 'COUNTRY',
+                value: subscriptionData.location,
+            },
+            {
+                key: 'JOBTITLE',
+                value: subscriptionData.jobTitle,
+            },
+            {
+                key: 'SECTOR',
+                value: subscriptionData.sector,
+            }
+        );
+    }
 
     // Node bug: URL encoding with an @ sign breaks auth
     // so we construct our own header here

--- a/controllers/ebulletin/lib/ebulletin-service.js
+++ b/controllers/ebulletin/lib/ebulletin-service.js
@@ -26,7 +26,7 @@ function subscribe({
         ],
     };
 
-    if (contactType === 'stakeholder') {
+    if (contactType === 'policy') {
         data.dataFields.push(
             {
                 key: 'COUNTRY',

--- a/controllers/ebulletin/views/ebulletin.njk
+++ b/controllers/ebulletin/views/ebulletin.njk
@@ -25,9 +25,10 @@
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                     {% endif %}
 
-                    <h2 class="t1 t--underline">{{ copy.introHeading }}</h2>
+                    {% set introCopy = copy.stakeholder if contactType === 'stakeholder' else copy.standard  %}
 
-                    <p>{{ copy.intro }}</p>
+                    <h2 class="t1 t--underline">{{ introCopy.heading }}</h2>
+                    {{ introCopy.intro | safe }}
 
                     {{ formErrors(
                         errors = errors,
@@ -39,23 +40,29 @@
                             {{ copy.yourDetails }}
                         </legend>
                         <div class="form-fieldset__fields">
-                            {{ formField({
-                                type: 'text',
-                                name: 'firstName',
-                                autocompleteName: 'given-name',
-                                label: copy.fields.firstName,
-                                value: formValues.firstName,
-                                isRequired: true
-                            }, errors = errors) }}
 
-                            {{ formField({
-                                type: 'text',
-                                name: 'lastName',
-                                autocompleteName: 'family-name',
-                                label: copy.fields.lastName,
-                                value: formValues.lastName,
-                                isRequired: true
-                            }, errors = errors) }}
+                            <div class="flex-grid flex-grid--2up">
+                                <div class="flex-grid__item u-no-margin">
+                                    {{ formField({
+                                        type: 'text',
+                                        name: 'firstName',
+                                        autocompleteName: 'given-name',
+                                        label: copy.fields.firstName,
+                                        value: formValues.firstName,
+                                        isRequired: true
+                                    }, errors = errors) }}
+                                </div>
+                                <div class="flex-grid__item u-no-margin">
+                                    {{ formField({
+                                        type: 'text',
+                                        name: 'lastName',
+                                        autocompleteName: 'family-name',
+                                        label: copy.fields.lastName,
+                                        value: formValues.lastName,
+                                        isRequired: true
+                                    }, errors = errors) }}
+                                </div>
+                            </div>
 
                             {{ formField({
                                 type: 'email',
@@ -67,6 +74,30 @@
                                 isRequired: true
                             }, errors = errors) }}
 
+                            {% if contactType === 'stakeholder' %}
+                                <div class="flex-grid flex-grid--2up">
+                                    <div class="flex-grid__item u-no-margin">
+                                        {{ formField({
+                                            type: 'text',
+                                            name: 'jobTitle',
+                                            autocompleteName: 'job-title',
+                                            label: copy.fields.jobTitle,
+                                            value: formValues.jobTitle,
+                                            isRequired: true
+                                        }, errors = errors) }}
+                                    </div>
+                                    <div class="flex-grid__item u-no-margin">
+                                        {{ formField({
+                                            name: 'sector',
+                                            type: 'select',
+                                            label: copy.fields.sector,
+                                            value: formValues.sector,
+                                            options: validSectors
+                                        }, errors = errors) }}
+                                    </div>
+                                </div>
+                            {% endif %}
+
                             {{ formField({
                                 name: 'location',
                                 type: 'radio',
@@ -75,31 +106,12 @@
                                 options: validLocations
                             }, errors = errors) }}
 
-                            {% if contactType === 'stakeholder' %}
-
-                                {{ formField({
-                                    type: 'text',
-                                    name: 'jobTitle',
-                                    autocompleteName: 'job-title',
-                                    label: copy.fields.jobTitle,
-                                    value: formValues.jobTitle,
-                                    isRequired: true
-                                }, errors = errors) }}
-
-                                {{ formField({
-                                    name: 'sector',
-                                    type: 'select',
-                                    label: copy.fields.sector,
-                                    value: formValues.sector,
-                                    options: validSectors
-                                }, errors = errors) }}
-
-                            {% endif %}
-
                         </div>
                     </fieldset>
 
-                    <input type="submit" value="{{ copy.callToAction }}" class="btn btn--small u-block-full"/>
+                    <input type="submit"
+                           value="{{ copy.callToAction }}"
+                           class="btn btn--small"/>
                 </form>
             {% endif %}
         </div>

--- a/controllers/ebulletin/views/ebulletin.njk
+++ b/controllers/ebulletin/views/ebulletin.njk
@@ -19,7 +19,7 @@
                 <p>{{ copy.responses.error.body | safe }}</p>
             {% else %}
 
-                <form class="form-ebulletin form-theme-slim" method="post" action="{{ localify('/about/ebulletin/' + contactType) }}" novalidate>
+                <form class="form-ebulletin form-theme-slim" method="post" novalidate>
 
                     {% if csrfToken %}
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">

--- a/controllers/ebulletin/views/ebulletin.njk
+++ b/controllers/ebulletin/views/ebulletin.njk
@@ -25,7 +25,7 @@
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                     {% endif %}
 
-                    {% set introCopy = copy.stakeholder if contactType === 'stakeholder' else copy.standard  %}
+                    {% set introCopy = copy.stakeholder if contactType === 'policy' else copy.standard  %}
 
                     <h2 class="t1 t--underline">{{ introCopy.heading }}</h2>
                     {{ introCopy.intro | safe }}
@@ -74,7 +74,7 @@
                                 isRequired: true
                             }, errors = errors) }}
 
-                            {% if contactType === 'stakeholder' %}
+                            {% if contactType === 'policy' %}
                                 <div class="flex-grid flex-grid--2up">
                                     <div class="flex-grid__item u-no-margin">
                                         {{ formField({

--- a/controllers/ebulletin/views/ebulletin.njk
+++ b/controllers/ebulletin/views/ebulletin.njk
@@ -18,7 +18,8 @@
                 <h3>{{ copy.responses.error.title }}</h3>
                 <p>{{ copy.responses.error.body | safe }}</p>
             {% else %}
-                <form class="form-ebulletin form-theme-slim" method="post" action="{{ localify('/about/ebulletin') }}" novalidate>
+
+                <form class="form-ebulletin form-theme-slim" method="post" action="{{ localify('/about/ebulletin/' + contactType) }}" novalidate>
 
                     {% if csrfToken %}
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
@@ -32,14 +33,6 @@
                         errors = errors,
                         title = copy.responses.error.title
                     ) }}
-
-                    {{ formField({
-                        name: 'location',
-                        type: 'radio',
-                        label: copy.location,
-                        value: formValues.location,
-                        options: validLocations
-                    }, errors = errors) }}
 
                     <fieldset class="form-fieldset form-fieldset--details">
                         <legend class="form-fieldset__legend u-visually-hidden">
@@ -65,15 +58,6 @@
                             }, errors = errors) }}
 
                             {{ formField({
-                                type: 'text',
-                                name: 'organisation',
-                                autocompleteName: 'organization',
-                                label: copy.fields.organisation,
-                                value: formValues.organisation,
-                                isRequired: false
-                            }, errors = errors) }}
-
-                            {{ formField({
                                 type: 'email',
                                 name: 'email',
                                 autocompleteName: 'email',
@@ -82,6 +66,36 @@
                                 placeholder: 'yourname@example.com',
                                 isRequired: true
                             }, errors = errors) }}
+
+                            {{ formField({
+                                name: 'location',
+                                type: 'radio',
+                                label: copy.fields.location,
+                                value: formValues.location,
+                                options: validLocations
+                            }, errors = errors) }}
+
+                            {% if contactType === 'stakeholder' %}
+
+                                {{ formField({
+                                    type: 'text',
+                                    name: 'jobTitle',
+                                    autocompleteName: 'job-title',
+                                    label: copy.fields.jobTitle,
+                                    value: formValues.jobTitle,
+                                    isRequired: true
+                                }, errors = errors) }}
+
+                                {{ formField({
+                                    name: 'sector',
+                                    type: 'select',
+                                    label: copy.fields.sector,
+                                    value: formValues.sector,
+                                    options: validSectors
+                                }, errors = errors) }}
+
+                            {% endif %}
+
                         </div>
                     </fieldset>
 


### PR DESCRIPTION
Adds a second ebulletin signup form with additional fields:

![image](https://user-images.githubusercontent.com/394376/81587034-5e113500-93ae-11ea-9ac4-dbf8186215b1.png)

This isn't finished yet – needs translation and confirmation that the fields are right (not sure if "Organisation" will be there too) but the approach is ready for review.