### PR TITLE
Build cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,8 @@ script:
   - shellcheck deploy/*.sh
   - npm audit --production --audit-level=moderate
   - npm run lint
-  - npm run test-unit
   - npm run build-production
+  - npm run test-unit
   - npm run test-integration
 
 # Prepare artefact for deployment

--- a/assets/js/vue-apps/components/__tests__/facet-group.test.js
+++ b/assets/js/vue-apps/components/__tests__/facet-group.test.js
@@ -22,12 +22,8 @@ describe('FacetGroup', () => {
         });
 
         const div = wrapper.find('.facet-group');
-
-        expect(wrapper.isVueInstance()).toBeTruthy();
         expect(div.exists()).toBeTruthy();
-
         wrapper.setData({ isOpen: true });
-
         expect(div.classes()).toContain('is-open');
     });
 });

--- a/assets/js/vue-apps/form-components/budget-input.test.js
+++ b/assets/js/vue-apps/form-components/budget-input.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 /* eslint-env jest */
-import { mount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import { setupI18n } from '../vue-helpers';
 import BudgetInput from './budget-input.vue';
 import times from 'lodash/times';
@@ -19,8 +19,7 @@ test('should be able to add items up to max limit', async function () {
     const maxItems = 10;
     const maxBudget = 10000;
     const minBudget = 300;
-    const wrapper = mount(BudgetInput, {
-        attachToDocument: true,
+    const wrapper = shallowMount(BudgetInput, {
         localVue,
         i18n,
         propsData: {
@@ -88,8 +87,7 @@ test('should not add new rows when loading a completed budget', () => {
         cost: 123,
     }));
 
-    const wrapper = mount(BudgetInput, {
-        attachToDocument: true,
+    const wrapper = shallowMount(BudgetInput, {
         localVue,
         i18n,
         propsData: {


### PR DESCRIPTION
- Run build before unit tests: Mailer code inlines CSS using juicer so it needs the CSS
files to be there to avoid warnings in unit tests.
- Fix deprecation warnings in vue tests: introduced in https://github.com/biglotteryfund/blf-alpha/pull/3317