### PR TITLE
Disable "As soon as possible" option for non-COVID-19 applications

### DIFF
--- a/controllers/apply/under10k/fields/project-dates-next.js
+++ b/controllers/apply/under10k/fields/project-dates-next.js
@@ -36,6 +36,10 @@ module.exports = {
                 }),
             };
 
+            if (projectCountry !== 'england' && supportingCOVID19 === 'no') {
+                optionAsap.attributes = { disabled: 'disabled' };
+            }
+
             const optionExactDate = {
                 value: 'exact-date',
                 label: localise({

--- a/controllers/apply/under10k/fields/project-dates-next.test.js
+++ b/controllers/apply/under10k/fields/project-dates-next.test.js
@@ -57,6 +57,25 @@ describe('fieldProjectStartDateCheck', function () {
             },
         ]);
     });
+
+    test('asap disabled outside England when project is not responding to COVID-19', function () {
+        const field = fieldProjectStartDateCheck('en', {
+            projectCountry: 'scotland',
+            supportingCOVID19: 'no',
+        });
+
+        expect(field.options).toStrictEqual([
+            {
+                value: 'asap',
+                label: expect.any(String),
+                attributes: { disabled: 'disabled' },
+            },
+            {
+                value: 'exact-date',
+                label: expect.any(String),
+            },
+        ]);
+    });
 });
 
 describe('fieldProjectEndDate', function () {

--- a/controllers/apply/under10k/form.test.js
+++ b/controllers/apply/under10k/form.test.js
@@ -130,6 +130,7 @@ test('valid form for wales', () => {
         projectCountry: 'wales',
         projectLocation: 'caerphilly',
         supportingCOVID19: 'no',
+        projectStartDateCheck: 'exact-date',
         // Additional questions required in Wales
         beneficiariesWelshLanguage: 'all',
         mainContactLanguagePreference: 'welsh',
@@ -154,6 +155,7 @@ test('valid form for northern-ireland', () => {
         projectCountry: 'northern-ireland',
         projectLocation: 'mid-ulster',
         supportingCOVID19: 'no',
+        projectStartDateCheck: 'exact-date',
         // Additional questions required in Northern-Ireland
         beneficiariesNorthernIrelandCommunity: 'mainly-catholic',
     });


### PR DESCRIPTION
The call has been made to **not** allow "As soon as possible" as an option for non-COVID-19 applications.

![image](https://user-images.githubusercontent.com/123386/81675128-366dab80-9446-11ea-8678-696426faf8c7.png)

Agreed that the simplest change we can make in the short term is to disable the  "As soon as possible" option when selecting "No" to the "Is your project supporting people  affected by the COVID-19 crisis?" shown outside England.

This is an interim change whilst we explore removing this screen completely for non-COVID-19 applications outside England. 