### PR TITLE
Post launch changes

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -194,7 +194,7 @@ toplevel:
     latestTitle: Rhaglenni a phartneriaethau diweddaraf
     sectionLinks:
     - label: Ein hariannu yn ystod COVID-19
-      href: "/welsh/funding/our-funding-during-covid-19"
+      href: "/welsh/funding/covid-19"
     - label: Ymgeisio am grantiau o dan £10,000
       href: "/welsh/funding/under10k"
     - label: Ymgeisio am grantiau dros £10,000

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -193,8 +193,8 @@ toplevel:
     title: Ariannu
     latestTitle: Rhaglenni a phartneriaethau diweddaraf
     sectionLinks:
-    - label: "Meddwl am ymgeisio am arian grant?"
-      href: "/welsh/funding/thinking-of-applying-for-funding"
+    - label: Ein hariannu yn ystod COVID-19
+      href: "/welsh/funding/our-funding-during-covid-19"
     - label: Ymgeisio am grantiau o dan £10,000
       href: "/welsh/funding/under10k"
     - label: Ymgeisio am grantiau dros £10,000
@@ -207,6 +207,8 @@ toplevel:
       href: "/welsh/funding/grants"
     - label: Cymorth rheoli’ch grant
       href: "/welsh/funding/managing-your-grant"
+    - label: "Meddwl am ymgeisio am arian grant?"
+      href: "/welsh/funding/thinking-of-applying-for-funding"
   data:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -101,7 +101,7 @@ global:
       Mae'r wefan hon yn defnyddio cwcis, mae esboniad o'u diben a sut i'w rheoli ar gael yn ein
       <a href="/welsh/about/customer-service/cookies">Polisi Cwcis</a>.
     action: Derbyn cwcis
-  covidMessage: Darllenwch y diweddariadau diwethaf ar ein tudalen COVID-19
+  covidMessage: Ein hariannu yn ystod COVID-19
   forms:
     missingFieldError: Darparwch y maes '%s'
     invalidEmailError: Rhowch gyfeiriad e-bost dilys

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,7 +102,7 @@ global:
       This site uses cookies. For an explanation of their purpose and how to manage them see our
       <a href="/about/customer-service/cookies">cookies policy</a>.
     action: Accept cookies
-  covidMessage: Read the latest updates on our COVID-19 page
+  covidMessage: Our funding during COVID-19
   forms:
     missingFieldError: Please provide the '%s' field
     invalidEmailError: Please provide a valid email address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,8 +197,8 @@ toplevel:
     title: Funding
     latestTitle: Latest Programmes & Partnerships
     sectionLinks:
-    - label: Thinking of applying for funding?
-      href: "/funding/thinking-of-applying-for-funding"
+    - label: Our funding during COVID-19
+      href: "/funding/our-funding-during-covid-19"
     - label: Apply for funding under £10,000
       href: "/funding/under10k"
     - label: Apply for funding above £10,000
@@ -213,6 +213,8 @@ toplevel:
       href: "/funding/grants"
     - label: Help with managing your funding
       href: "/funding/managing-your-grant"
+    - label: Thinking of applying for funding?
+      href: "/funding/thinking-of-applying-for-funding"
   data:
     keyStats: Key statistics
     mapTitle: Our Year in Numbers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,7 +198,7 @@ toplevel:
     latestTitle: Latest Programmes & Partnerships
     sectionLinks:
     - label: Our funding during COVID-19
-      href: "/funding/our-funding-during-covid-19"
+      href: "/funding/covid-19"
     - label: Apply for funding under £10,000
       href: "/funding/under10k"
     - label: Apply for funding above £10,000

--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -6100,11 +6100,11 @@ Array [
   },
   Object {
     "from": "/about/coronavirus-updates",
-    "to": "/funding/our-funding-during-covid-19",
+    "to": "/funding/covid-19",
   },
   Object {
     "from": "/welsh/about/coronavirus-updates",
-    "to": "/welsh/funding/our-funding-during-covid-19",
+    "to": "/welsh/funding/covid-19",
   },
 ]
 `;

--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -6098,5 +6098,13 @@ Array [
     "from": "/welsh/funding/managing-your-grant/under10k",
     "to": "/welsh/funding/managing-your-grant/under-10k",
   },
+  Object {
+    "from": "/about/coronavirus-updates",
+    "to": "/funding/our-funding-during-covid-19",
+  },
+  Object {
+    "from": "/welsh/about/coronavirus-updates",
+    "to": "/welsh/funding/our-funding-during-covid-19",
+  },
 ]
 `;

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -703,4 +703,8 @@ module.exports = createAliases([
         from: '/funding/managing-your-grant/under10k',
         to: '/funding/managing-your-grant/under-10k',
     },
+    {
+        from: '/about/coronavirus-updates',
+        to: '/funding/our-funding-during-covid-19',
+    },
 ]);

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -705,6 +705,6 @@ module.exports = createAliases([
     },
     {
         from: '/about/coronavirus-updates',
-        to: '/funding/our-funding-during-covid-19',
+        to: '/funding/covid-19',
     },
 ]);

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -11,7 +11,6 @@ module.exports = async function (req, res, next) {
         );
 
         res.render(path.resolve(__dirname, './views/home'), {
-            showCOVID19AnnouncementBanner: false,
             content: entry.content,
             featuredLinks: entry.featuredLinks,
             promotedUpdates: entry.promotedUpdates,

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -42,7 +42,7 @@
 
             {% if showCOVID19AnnouncementBanner %}
                 <aside class="announcement-banner announcement-banner--major">
-                    <a href="{{ localify('/about/coronavirus-updates') }}">
+                    <a href="{{ localify('/funding/our-funding-during-covid-19') }}">
                         {{ __('global.covidMessage') }}
                     </a>
                 </aside>

--- a/views/layouts/main.njk
+++ b/views/layouts/main.njk
@@ -42,7 +42,7 @@
 
             {% if showCOVID19AnnouncementBanner %}
                 <aside class="announcement-banner announcement-banner--major">
-                    <a href="{{ localify('/funding/our-funding-during-covid-19') }}">
+                    <a href="{{ localify('/funding/covid-19') }}">
                         {{ __('global.covidMessage') }}
                     </a>
                 </aside>


### PR DESCRIPTION
To be merged after the new changes launch. Final URL for new page still to be confirmed, using the draft URL for now.

- Update funding links with new COVID-19 page
- Update COVID-19 banner w/new label + link
- Add redirect for old coronavirus-updates page
- Show COVID-19 banner on homepage