### PR TITLE
Additional notice about eligibility in England

### DIFF
--- a/controllers/apply/dashboard/views/dashboard-all.njk
+++ b/controllers/apply/dashboard/views/dashboard-all.njk
@@ -46,7 +46,7 @@
                     {% if notices.length > 0 %}
                         <div class="message message--info message--minor" role="alert">
                             {% for notice in notices  %}
-                                <h2 class="t4 u-margin-bottom-s">{{ notice.title }}</h2>
+                                <h2 class="t4 u-no-margin">{{ notice.title }}</h2>
                                 <p>{{ notice.body }}</p>
                             {% endfor %}
                         </div>

--- a/controllers/apply/dashboard/views/dashboard.njk
+++ b/controllers/apply/dashboard/views/dashboard.njk
@@ -16,7 +16,7 @@
                 {% if notices.length > 0 %}
                     <div class="message message--info message--minor" role="alert">
                         {% for notice in notices  %}
-                            <h2 class="t4 u-margin-bottom-s">{{ notice.title }}</h2>
+                            <h2 class="t4 u-no-margin">{{ notice.title }}</h2>
                             <p>{{ notice.body }}</p>
                         {% endfor %}
                     </div>

--- a/controllers/apply/lib/__snapshots__/notices.test.js.snap
+++ b/controllers/apply/lib/__snapshots__/notices.test.js.snap
@@ -30,8 +30,12 @@ Array [
 exports[`show for pending under £10,000 application in England 1`] = `
 Array [
   Object {
-    "body": "If you've started an application already, and it's not related to supporting your community or organisation through the pandemic, we won't be able to accept it. But you could decide to start a new one that focuses on COVID-19 instead.",
+    "body": "If you've started an application already, and it's not related to supporting your community or organisation through the pandemic, we won't be able to fund it. But you could decide to start a new one that focuses on COVID-19 instead.",
     "title": "For funding under £10,000 in England, we're now only accepting COVID-19 related applications",
+  },
+  Object {
+    "body": "So in England we're only funding voluntary and community organisations for the time being.",
+    "title": "We've also changed our eligibility criteria to help communities through the pandemic",
   },
 ]
 `;
@@ -41,6 +45,10 @@ Array [
   Object {
     "body": "Os ydych chi wedi cychwyn cais yn barod, ac nad yw'n gysylltiedig â chefnogi'ch cymuned neu sefydliad trwy'r pandemig, ni fyddwn yn gallu ei dderbyn. Ond fe allech chi benderfynu cychwyn un newydd sy'n canolbwyntio ar COVID-19 yn lle.",
     "title": "Ar gyfer ariannu o dan £10,000 yn Lloegr, dim ond ceisiadau cysylltiedig â COVID-19 yr ydym yn eu derbyn",
+  },
+  Object {
+    "body": "So in England we're only funding voluntary and community organisations for the time being.",
+    "title": "We've also changed our eligibility criteria to help communities through the pandemic",
   },
 ]
 `;

--- a/controllers/apply/lib/notices.js
+++ b/controllers/apply/lib/notices.js
@@ -38,7 +38,7 @@ module.exports = {
                     en: oneLine`If you've started an application already,
                     and it's not related to supporting your community
                     or organisation through the pandemic, we won't be
-                    able to accept it. But you could decide to start
+                    able to fund it. But you could decide to start
                     a new one that focuses on COVID-19 instead.`,
                     cy: oneLine`Os ydych chi wedi cychwyn cais yn barod,
                     ac nad yw'n gysylltiedig â chefnogi'ch cymuned
@@ -47,6 +47,15 @@ module.exports = {
                     un newydd sy'n canolbwyntio ar COVID-19 yn lle.`,
                 }),
             });
+
+            if (enableGovCOVIDUpdates) {
+                notices.push({
+                    title: oneLine`We've also changed our eligibility
+                        criteria to help communities through the pandemic`,
+                    body: oneLine`So in England we're only funding voluntary
+                        and community organisations for the time being.`,
+                });
+            }
         }
 
         return notices;


### PR DESCRIPTION
Change is to add the second line to mention changed organisation type eligibility. We already have a stronger message in place on the summary screen if you have an actual application in flight for a statutory groups. This is to cover things more generally for anyone with a pending application, who may not have selected organisation type yet.

![image](https://user-images.githubusercontent.com/123386/81919407-bb380100-95cf-11ea-82ba-d94380d1a0ec.png)
