### PR TITLE
Launch new form changes

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -30,7 +30,7 @@
     "expiryPeriod": [3, "months"]
   },
   "fundingUnder10k": {
-    "enableGovCOVIDUpdates": false
+    "enableGovCOVIDUpdates": true
   },
   "standardFundingProposal": {
     "allowedCountries": ["england", "northern-ireland"]


### PR DESCRIPTION
This launches the following changes:

- Revised priorities text
- Removes statutory groups as options in England along with notices for people with pending applications from these groups
- Enables additional Ts&Cs in England