### PR TITLE
Add a separate success screen for ebulletin signups

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -302,10 +302,15 @@ toplevel:
     callToAction: Tanysgrifio
     responses:
       success:
-        title: Diolch am danysgrifio i dderbyn diweddariadau a newyddion Cronfa Gymunedol y Loteri Genedlaethol
-        body: Mae'ch data personol yn bwysig i ni ac ni fyddwn yn ei rannu gyda
-          thrydydd partïon. Rydym yn siŵr y byddwch yn mwynhau clywed oddi wrthym,
-          ond gallwch dad-danysgrifio unrhyw bryd os mynnwch.
+        title: Diolch am gadarnhau eich tanysgrifiad i’n cylchlythyr. Byddwn mewn cysylltiad yn fuan
+        body: Mae eich data personol yn bwysig i ni ac ni fyddwn yn ei rannu gyda thrydydd partïon. Rydym yn siŵr y gwnewch fwynhau clywed gennym, ond gallwch ddad-danysgrifio ar unrhyw bryd.
+        whereNext:
+          title: Lle nesaf?
+          body: >
+            <ul>
+              <li><a href="/welsh/news/blog">Darllenwch y diweddaraf o'n blog</a></li>
+              <li><a href="/welsh/insights">Mynd i'r mewnwelediadau diweddaraf o'n hariannu</a></li>
+            </ul>
       error:
         title: Cafwyd gwall wrth gofrestru chi i'r e-fwletin.
         body: Mae'n edrych fel ein bod yn cael trafferth gyda'n teclyn e-fwletin.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,10 +308,17 @@ toplevel:
     callToAction: Subscribe
     responses:
       success:
-        title: Thank you for subscribing to receive updates and news from The National Lottery Community Fund
+        title: Thanks for confirming your subscription to the newsletter. We'll be in touch soon
         body: Your personal data is important to us and we will not share it with
           third parties. We are sure you will enjoy hearing from us, but you can
           unsubscribe at any time if you wish.
+        whereNext:
+          title: Where next?
+          body: >
+            <ul>
+              <li><a href="/news/blog">Read the latest from our blog</a></li>
+              <li><a href="/insights">Get the latest insights from our funding</a></li>
+            </ul>
       error:
         title: There was an error signing you up to the e-bulletin.
         body: It looks like we're experiencing an error with our e-bulletin tool.

--- a/controllers/ebulletin/index.js
+++ b/controllers/ebulletin/index.js
@@ -36,9 +36,10 @@ router
     .all(noStore, csrfProtection, (req, res, next) => {
         // Temporarily disable non-policy signup form which will launch later
         if (!req.params.contactType || req.params.contactType !== 'policy') {
-            return res.redirect('/');
+            res.redirect('/');
+        } else {
+            next();
         }
-        next();
     })
     .get(renderForm)
     .post(async function handleEbulletinSignup(req, res) {

--- a/controllers/ebulletin/views/success.njk
+++ b/controllers/ebulletin/views/success.njk
@@ -1,0 +1,18 @@
+{% extends "layouts/main.njk" %}
+
+{% set bodyClass = 'has-static-header' %}
+{% set copy = __('toplevel.ebulletin') %}
+
+{% block content %}
+    <main role="main" id="content">
+        <div class="content-box u-inner-wide-only">
+            <div class="s-prose">
+                <h1>{{ copy.responses.success.title }}</h1>
+                <p>{{ copy.responses.success.body | safe }}</p>
+
+                <h2>{{ copy.responses.success.whereNext.title }}</h2>
+                {{ copy.responses.success.whereNext.body | safe }}
+            </div>
+        </div>
+    </main>
+{% endblock %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/394376/82215368-3a4e7180-990f-11ea-867f-4a48da3777ab.png)

This is to allow us to use a generic signup success URL within DotDigital, as well as on the site.

Also disables the plain signup form (in favour of the pending "policy" one) for now, until that one is ready to go.