### PR TITLE
Rename ebulletin form

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -1054,7 +1054,7 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
 /* =========================================================================
    Slim form theme
    ========================================================================= */
-/* e.g. ebulletin form */
+/* e.g. newsletter form */
 
 .form-theme-slim {
     font-size: 18px;

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -254,14 +254,14 @@ toplevel:
             href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2020_YTD.xlsx"
         outro: >
           Trwyddedir y gwaith hwn o dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">drwydded llywodraeth agored ar gyfer gwybodaeth sector cyhoeddus</a>, gan alluogi chi i ddefnyddio ac ailddefnyddio'r Wybodaeth sydd ar gael o dan y drwydded hon yn rhydd ac yn hyblyg, gyda dim ond ychydig o amodau. Os na allwch ddod o hyd i'r hyn rydych yn chwilio amdano, <a href="/contact">cysylltwch â ni</a>.
-  ebulletin:
+  newsletter:
     title: e-fwletin
     standard:
       heading: Mwy o wybodaeth am ein grantiau
       intro: >
         <p>Cofrestrwch am y newyddion diweddaraf yn eich gwlad</p>
     stakeholder:
-      heading: Cylchlythyr Polisi a Mewnwelediadau
+      heading: Cylchlythyr Mewnwelediadau
       intro: >
         <p>Bydd ein cylchlythyr polisi a mewnwelediadau yn rhannu'r dystiolaeth, y dysgu a'r data gwerthfawr a gasglwn gan y bobl, y prosiectau a'r cymunedau yr ydym yn eu cefnogi.</p>
         <p>Byddwn yn edrych ar gyflawniadau, llwyddiannau a heriau'r sector a hefyd yn rhannu newyddion am ein hariannu a'n gweithgaredd ledled y DU. Cofrestrwch heddiw i'w anfon yn uniongyrchol i'ch mewnflwch.<p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,16 +260,16 @@ toplevel:
             href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2020_YTD.xlsx"
         outro: >
           This work is licensed under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">open government licence for public sector information</a>, which allows you to use and re-use the Information that is available under this licence freely and flexibly, with only a few conditions. If you can’t find what you’re looking for, please <a href="/contact">contact us</a>.
-  ebulletin:
-    title: e-bulletin
+  newsletter:
+    title: Newsletters
     standard:
       heading: Find out about our funding
       intro: >
         <p>Sign up for our latest news relating to your country</p>
     stakeholder:
-      heading: Policy and insights newsletter
+      heading: Insights newsletter
       intro: >
-        <p>Our policy and insights newsletter will share the valuable evidence, learning and data we collect from the people, projects and communities we support.</p>
+        <p>Our Insights newsletter will share the valuable evidence, learning and data we collect from the people, projects and communities we support.</p>
         <p>We'll look at the achievements, successes and challenges of the sector and also share news about our funding and activity across the UK. Sign up today to get the newsletter sent direct to your inbox.</p>
         <p>We will be launching the newsletter over the summer.</p>
     locations:

--- a/controllers/about/index.js
+++ b/controllers/about/index.js
@@ -11,7 +11,7 @@ router.get('/', flexibleContentPage());
 router.use('/our-people', require('./our-people'));
 
 if (isNotProduction) {
-    router.use('/ebulletin', require('../ebulletin'));
+    router.use('/newsletter', require('../newsletter'));
 }
 
 router.use('/*', basicContent());

--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -692,83 +692,83 @@ Array [
   },
   Object {
     "from": "/about-big/ebulletin-subscription",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/about-big/ebulletin-subscription",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/england/about-big/ebulletin-subscription",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/england/about-big/ebulletin-subscription",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/scotland/about-big/ebulletin-subscription",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/scotland/about-big/ebulletin-subscription",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/northernireland/about-big/ebulletin-subscription",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/northernireland/about-big/ebulletin-subscription",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/wales/about-big/ebulletin-subscription",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/wales/about-big/ebulletin-subscription",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/about-big/ebulletin",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/about-big/ebulletin",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/england/about-big/ebulletin",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/england/about-big/ebulletin",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/scotland/about-big/ebulletin",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/scotland/about-big/ebulletin",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/northernireland/about-big/ebulletin",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/northernireland/about-big/ebulletin",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/wales/about-big/ebulletin",
-    "to": "/about/ebulletin",
+    "to": "/about/newsletter",
   },
   Object {
     "from": "/welsh/wales/about-big/ebulletin",
-    "to": "/welsh/about/ebulletin",
+    "to": "/welsh/about/newsletter",
   },
   Object {
     "from": "/about-big/helping-millions-change-their-lives",

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -113,11 +113,11 @@ module.exports = createAliases([
     }),
     withRegionPrefixes({
         from: `/about-big/ebulletin-subscription`,
-        to: `/about/ebulletin`,
+        to: `/about/newsletter`,
     }),
     withRegionPrefixes({
         from: `/about-big/ebulletin`,
-        to: `/about/ebulletin`,
+        to: `/about/newsletter`,
     }),
     withRegionPrefixes({
         from: `/about-big/helping-millions-change-their-lives`,

--- a/controllers/newsletter/index.js
+++ b/controllers/newsletter/index.js
@@ -10,18 +10,19 @@ const {
     buildValidLocations,
     buildValidSectors,
 } = require('./lib/contact-schema');
-const ebulletinService = require('./lib/ebulletin-service');
+const newsletterService = require('./lib/newsletter-service');
 
+const { injectHeroImage } = require('../../common/inject-content');
 const { noStore, csrfProtection } = require('../../common/cached');
 const { sanitiseRequestBody } = require('../../common/sanitise');
 const validateSchema = require('../../common/validate-schema');
-const logger = require('../../common/logger').child({ service: 'ebulletin' });
+const logger = require('../../common/logger').child({ service: 'newsletter' });
 
 const router = express.Router();
 
 function renderForm(req, res, data = null, errors = []) {
-    res.render(path.resolve(__dirname, './views/ebulletin'), {
-        title: req.i18n.__('toplevel.ebulletin.title'),
+    res.render(path.resolve(__dirname, './views/newsletter'), {
+        title: req.i18n.__('toplevel.newsletter.title'),
         contactType: req.params.contactType,
         csrfToken: req.csrfToken(),
         validLocations: buildValidLocations(req.i18n),
@@ -32,15 +33,23 @@ function renderForm(req, res, data = null, errors = []) {
 }
 
 router
-    .route('/:contactType(policy)?')
-    .all(noStore, csrfProtection, (req, res, next) => {
-        // Temporarily disable non-policy signup form which will launch later
-        if (!req.params.contactType || req.params.contactType !== 'policy') {
-            res.redirect('/');
-        } else {
-            next();
-        }
-    })
+    .route('/:contactType(insights)?')
+    .all(
+        noStore,
+        csrfProtection,
+        (req, res, next) => {
+            // Temporarily disable non-insights signup form which will launch later
+            if (
+                !req.params.contactType ||
+                req.params.contactType !== 'insights'
+            ) {
+                res.redirect('/');
+            } else {
+                next();
+            }
+        },
+        injectHeroImage('the-bike-project-2-new-letterbox')
+    )
     .get(renderForm)
     .post(async function handleEbulletinSignup(req, res) {
         const sanitisedBody = sanitiseRequestBody(omit(req.body, ['_csrf']));
@@ -48,7 +57,7 @@ router
         let contactToUse = newContact(req.i18n);
         let addressBookId = 148374;
 
-        if (req.params.contactType === 'policy') {
+        if (req.params.contactType === 'insights') {
             contactToUse = newStakeholder(req.i18n);
             addressBookId = 249380;
         }
@@ -57,7 +66,7 @@ router
 
         if (validationResult.isValid) {
             try {
-                await ebulletinService.subscribe({
+                await newsletterService.subscribe({
                     addressBookId: addressBookId,
                     subscriptionData: validationResult.value,
                     contactType: req.params.contactType,
@@ -81,7 +90,7 @@ router
 
 router.get('/success', function (req, res) {
     res.render(path.resolve(__dirname, './views/success'), {
-        title: req.i18n.__('toplevel.ebulletin.title'),
+        title: req.i18n.__('toplevel.newsletter.title'),
     });
 });
 

--- a/controllers/newsletter/index.js
+++ b/controllers/newsletter/index.js
@@ -51,7 +51,7 @@ router
         injectHeroImage('the-bike-project-2-new-letterbox')
     )
     .get(renderForm)
-    .post(async function handleEbulletinSignup(req, res) {
+    .post(async function handleNewsletterSignup(req, res) {
         const sanitisedBody = sanitiseRequestBody(omit(req.body, ['_csrf']));
 
         let contactToUse = newContact(req.i18n);

--- a/controllers/newsletter/lib/contact-schema.js
+++ b/controllers/newsletter/lib/contact-schema.js
@@ -3,7 +3,7 @@ const Joi = require('@hapi/joiNext');
 
 function getTranslations(i18n) {
     return function (path, ...params) {
-        return i18n && i18n.__(`toplevel.ebulletin.${path}`, ...params);
+        return i18n && i18n.__(`toplevel.newsletter.${path}`, ...params);
     };
 }
 

--- a/controllers/newsletter/lib/contact-schema.test.js
+++ b/controllers/newsletter/lib/contact-schema.test.js
@@ -3,7 +3,7 @@
 const { newContact } = require('./contact-schema');
 const validateSchema = require('../../../common/validate-schema');
 
-describe('ebulletin contact schema', () => {
+describe('newsletter contact schema', () => {
     test('new contact', () => {
         expect(
             validateSchema(newContact(), {

--- a/controllers/newsletter/lib/newsletter-service.js
+++ b/controllers/newsletter/lib/newsletter-service.js
@@ -26,7 +26,7 @@ function subscribe({
         ],
     };
 
-    if (contactType === 'policy') {
+    if (contactType === 'insights') {
         data.dataFields.push(
             {
                 key: 'COUNTRY',

--- a/controllers/newsletter/views/newsletter.njk
+++ b/controllers/newsletter/views/newsletter.njk
@@ -1,14 +1,17 @@
 {% extends "layouts/main.njk" %}
 
+{% from "components/hero.njk" import hero with context %}
 {% from "components/form-fields/macros.njk" import formErrors, formField with context %}
 
-{% set bodyClass = 'has-static-header' %}
-{% set copy = __('toplevel.ebulletin') %}
+{% set copy = __('toplevel.newsletter') %}
 
 {% block content %}
 
     <main role="main" id="content">
-        <div class="content-box u-inner-wide-only">
+
+        {{ hero(title, pageHero.image) }}
+
+        <div class="content-box u-inner-wide-only nudge-up">
             {% if status === 'SUCCESS' %}
                 <div class="s-prose">
                     <h3>{{ copy.responses.success.title }}</h3>
@@ -19,13 +22,13 @@
                 <p>{{ copy.responses.error.body | safe }}</p>
             {% else %}
 
-                <form class="form-ebulletin form-theme-slim" method="post" novalidate>
+                <form class="form-theme-slim" method="post" novalidate>
 
                     {% if csrfToken %}
                         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                     {% endif %}
 
-                    {% set introCopy = copy.stakeholder if contactType === 'policy' else copy.standard  %}
+                    {% set introCopy = copy.stakeholder if contactType === 'insights' else copy.standard  %}
 
                     <h2 class="t1 t--underline">{{ introCopy.heading }}</h2>
                     {{ introCopy.intro | safe }}
@@ -74,7 +77,7 @@
                                 isRequired: true
                             }, errors = errors) }}
 
-                            {% if contactType === 'policy' %}
+                            {% if contactType === 'insights' %}
                                 <div class="flex-grid flex-grid--2up">
                                     <div class="flex-grid__item u-no-margin">
                                         {{ formField({

--- a/controllers/newsletter/views/success.njk
+++ b/controllers/newsletter/views/success.njk
@@ -1,7 +1,7 @@
 {% extends "layouts/main.njk" %}
 
 {% set bodyClass = 'has-static-header' %}
-{% set copy = __('toplevel.ebulletin') %}
+{% set copy = __('toplevel.newsletter') %}
 
 {% block content %}
     <main role="main" id="content">


### PR DESCRIPTION
We've been asked to change the term "ebulletin" (as used in URLs and some copy) to "newsletter", so that's the bulk of this change.

Also modifies the soon-to-launch "policy" newsletter to now be "insights" (again in URLs and copy). Adds a hero image too:

![image](https://user-images.githubusercontent.com/394376/82349990-ae157a80-99f2-11ea-9969-6675850f9697.png)
