### PR TITLE
Prevent the min and max values from programme pages from being displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env
 .idea
 .map
+.vs/
 .vscode/
 always_restart.txt
 assets.json

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -16,10 +16,7 @@
         {% if programme.fundingSize.description %}
             <dt>{{ labels.fundingSize }}</dt>
             <dd>{{ programme.fundingSize.description }}</dd>
-        {% elseif programme.fundingSize.minimum and programme.fundingSize.maximum %}
-            <dt>{{ labels.fundingSize }}</dt>
-            <dd>£{{ programme.fundingSize.minimum | numberWithCommas}}{% if programme.fundingSize.maximum %} {{ __('global.misc.to') }} £{{ programme.fundingSize.maximum | numberWithCommas }}{% endif %}</dd>
-        {% endif %}
+       {% endif %}
 
         {% if programme.fundingSize.totalAvailable %}
             <dt>{{ labels.totalAvailable }}</dt>


### PR DESCRIPTION
On the funding programme - When the 'funding size description' has been left empty in the CMS then funding size description is not displayed on the view.

If 'funding size description' has a value then it will show what the minimum/max value is on the funding programme view.

