### PR TITLE
Remove reference to terms from start page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1124,14 +1124,7 @@ awardsForAll:
         <p>Dyma <a href="/assets/images/apply/under-10k-bank-statement-example-welsh.jpg">lun defnyddiol o'r math o gyfriflen banc rydym yn chwilio amdano.</a></p>
         <h3>5. Rydym yn gofyn am wybodaeth am ba fath o brosiect hoffech ei wneud</h3>
         <p>A sut fydd eich prosiect yn helpu a chynnwys eich cymuned.</p>
-        <h3>6. Rydym hefyd yn gofyn i chi ddarllen a chytuno i’n amodau a thelerau</h3>
-        <p>
-          Gallwch gymryd
-          <a href="/media/documents/awards-for-all/terms%20and%20conditions/TF19_043_Awards-for-All_Terms-and-Conditions_WALES-WELSH-0.1-1.pdf">
-            golwg ar yr amodau a thelerau yma
-          </a>.
-        </p>
-        <h3>7. Os nad ydych yn siŵr am y mathau o bethau rydym yn gofyn amdano wrth i chi ymgeisio</h3>
+        <h3>6. Os nad ydych yn siŵr am y mathau o bethau rydym yn gofyn amdano wrth i chi ymgeisio</h3>
         <p><a href="/welsh/contact">Cysylltwch â ni</a></p>
     readyToApply:
       title: Barod i ymgeisio?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1126,9 +1126,7 @@ awardsForAll:
         <p>Here’s <a href="/assets/images/apply/under-10k-bank-statement-example.png">a handy picture of the kind of bank statement we’re looking for.</a></p>
         <h3>5. We ask for information about what sort of project you’d like to do</h3>
         <p>And how your project will help and involve your community.</p>
-        <h3>6. We also ask you to read and agree to our terms and conditions</h3>
-        <p>You can have a <a href="/media/documents/awards-for-all/terms%20and%20conditions/TF19_043_Awards-for-All_Terms-and-Conditions_ENGLAND-0.1.pdf">look at the terms and conditions here</a>.</p>
-        <h3>7. If you’re not sure about the sort of things we ask for when you apply</h3>
+        <h3>6. If you’re not sure about the sort of things we ask for when you apply</h3>
         <p><a href="/contact">Contact us</a></p>
     readyToApply:
       title: Ready to apply?


### PR DESCRIPTION
- With the launch of the new fund the terms vary slightly per country, but this page is before any country selection.
- Terms are already linked to from individual programme pages and  included as part of the form so the simplest call we can make is to remove reference to terms from the start page.

**Before**

![image](https://user-images.githubusercontent.com/123386/82557559-d96ba700-9b63-11ea-9b29-3e0975049467.png)


**After**

![image](https://user-images.githubusercontent.com/123386/82557481-b93be800-9b63-11ea-91d4-3e76e11f9c73.png)
