### PR TITLE
Add fallback page title to flexible content page

### DIFF
--- a/controllers/common/views/flexible-content-page.njk
+++ b/controllers/common/views/flexible-content-page.njk
@@ -1,7 +1,8 @@
 {% extends "layouts/main.njk" %}
-{% from "components/hero.njk" import hero with context %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/flexible-content-next/macro.njk" import flexibleContent with context %}
+{% from "components/hero.njk" import hero with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
 
 {% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
 
@@ -12,6 +13,10 @@
         {% endif %}
 
         {% if pageHero.image %}<div class="nudge-up">{% endif %}
+
+        {% if not pageHero %}
+            {{ pageTitle(title) }}
+        {% endif %}
 
         {% block contentPrimary %}
             {% if content.flexibleContent %}


### PR DESCRIPTION
If a flexible content page didn't have a hero image then no title was shown. Adds the same pageTitle fallback from other templates.