### PR TITLE
Misc Covid-19 fixes

### DIFF
--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -6106,5 +6106,13 @@ Array [
     "from": "/welsh/about/coronavirus-updates",
     "to": "/welsh/funding/covid-19",
   },
+  Object {
+    "from": "/about/covid-19-how-we-are-supporting-our-grant-holders-at-this-difficult-time",
+    "to": "/funding/covid-19/support-for-our-grantholders-during-covid-19",
+  },
+  Object {
+    "from": "/welsh/about/covid-19-how-we-are-supporting-our-grant-holders-at-this-difficult-time",
+    "to": "/welsh/funding/covid-19/support-for-our-grantholders-during-covid-19",
+  },
 ]
 `;

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -707,4 +707,9 @@ module.exports = createAliases([
         from: '/about/coronavirus-updates',
         to: '/funding/covid-19',
     },
+    {
+        from:
+            '/about/covid-19-how-we-are-supporting-our-grant-holders-at-this-difficult-time',
+        to: '/funding/covid-19/support-for-our-grantholders-during-covid-19',
+    },
 ]);

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -72,6 +72,11 @@ router.get(
     }
 );
 
+router.get('/covid-19', (req, res, next) => {
+    res.locals.showCOVID19AnnouncementBanner = false;
+    next();
+});
+
 /**
  * Wildcard handler
  * Remaining pages powered by Funding structure in the CMS

--- a/controllers/funding/programmes/views/programmes-list.njk
+++ b/controllers/funding/programmes/views/programmes-list.njk
@@ -14,8 +14,13 @@
             {% if groupedProgrammes %}
                 {% for region, regionProgrammes in groupedProgrammes %}
                     <h3>{{ region }}</h3>
-                    {% if countryCovidStatus %}
-                        <p>{{ countryCovidStatus.status }}</p>
+                    {#
+                        Hide Covid-19 status message for UK-wide programmes,
+                        which are always shown alongside country-specific ones
+                        and may confuse users if we show two different statuses on one page
+                    #}
+                    {% if countryCovidStatus and region !== 'UK-wide' and region !== 'Ledled y DU' %}
+                        <p>{{ countryCovidStatus.status | nl2br | safe }}</p>
                     {% endif %}
                     <ol class="flex-grid flex-grid--3up">
                         {% for programme in regionProgrammes %}

--- a/controllers/funding/programmes/views/programmes-list.njk
+++ b/controllers/funding/programmes/views/programmes-list.njk
@@ -32,7 +32,7 @@
                 {% endfor %}
             {% elseif programmes.length > 0 %}
                 {% if countryCovidStatus %}
-                    <p>{{ countryCovidStatus.status }}</p>
+                    <p>{{ countryCovidStatus.status | nl2br | safe }}</p>
                 {% endif %}
                 <ol class="flex-grid flex-grid--3up">
                     {% for programme in programmes %}


### PR DESCRIPTION
A few things in here, related to this ticket: https://trello.com/c/uHzllbyu/784-launch-mop-up-dev

- Remove this banner from the page it links to (bit confusing otherwise!):
![image](https://user-images.githubusercontent.com/394376/83260193-41983980-a1b1-11ea-88aa-7c6a92746b85.png)

- Add a linebreak to this message: 
![image](https://user-images.githubusercontent.com/394376/83260241-58d72700-a1b1-11ea-9e8c-be79642d369d.png)

(this required a change to the CMS which has just gone live, so when this PR is merged I'll add the linebreak!)

- Redirect an old Covid-related URL to a new one

- Prevent the UK-wide message above from showing on country-specific pages:
![image](https://user-images.githubusercontent.com/394376/83260339-815f2100-a1b1-11ea-99fc-1e4eb47c775d.png)
