### PR TITLE
Disable non-flexible content in About, BBO and Customer Service sections

### DIFF
--- a/controllers/about/index.js
+++ b/controllers/about/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const express = require('express');
 
-const { basicContent, flexibleContentPage } = require('../common');
+const { flexibleContentPage } = require('../common');
 const { isNotProduction } = require('../../common/appData');
 
 const router = express.Router();
@@ -14,6 +14,6 @@ if (isNotProduction) {
     router.use('/newsletter', require('../newsletter'));
 }
 
-router.use('/*', basicContent());
+router.use('/*', flexibleContentPage());
 
 module.exports = router;

--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -6114,5 +6114,21 @@ Array [
     "from": "/welsh/about/covid-19-how-we-are-supporting-our-grant-holders-at-this-difficult-time",
     "to": "/welsh/funding/covid-19/support-for-our-grantholders-during-covid-19",
   },
+  Object {
+    "from": "/jobs",
+    "to": "/about/jobs",
+  },
+  Object {
+    "from": "/welsh/jobs",
+    "to": "/welsh/about/jobs",
+  },
+  Object {
+    "from": "/jobs/benefits",
+    "to": "/about/jobs/benefits",
+  },
+  Object {
+    "from": "/welsh/jobs/benefits",
+    "to": "/welsh/about/jobs/benefits",
+  },
 ]
 `;

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -712,4 +712,12 @@ module.exports = createAliases([
             '/about/covid-19-how-we-are-supporting-our-grant-holders-at-this-difficult-time',
         to: '/funding/covid-19/support-for-our-grantholders-during-covid-19',
     },
+    {
+        from: '/jobs',
+        to: '/about/jobs',
+    },
+    {
+        from: '/jobs/benefits',
+        to: '/about/jobs/benefits',
+    },
 ]);

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -45,8 +45,6 @@ router.use('/publications', require('./publications'));
  */
 router.use('/grants', require('./grants'));
 
-router.use('/the-big-lunch', basicContent());
-
 router.use('/funding-guidance/*', basicContent());
 
 /**

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -13,7 +13,10 @@ const { buildArchiveUrl, localify } = require('../../../common/urls');
 const { sMaxAge } = require('../../../common/cached');
 const contentApi = require('../../../common/content-api');
 
-const { basicContent, renderFlexibleContentChild } = require('../../common');
+const {
+    renderFlexibleContentChild,
+    flexibleContentPage,
+} = require('../../common');
 
 const getValidLocation = require('./lib/get-valid-location');
 const programmeFilters = require('./lib/programme-filters');
@@ -262,7 +265,7 @@ router.use(
         });
         next();
     },
-    basicContent()
+    flexibleContentPage()
 );
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -202,10 +202,6 @@ const sections = {
         path: '/news',
         router: require('./controllers/updates'),
     },
-    jobs: {
-        path: '/jobs*',
-        router: basicContent(),
-    },
     data: {
         path: '/data',
         router: require('./controllers/data'),


### PR DESCRIPTION
This removes some old legacy calls to `basicContent()` for the About section, as well as BBO and Customer Services. These sections now have flexible content versions of their content, which we can enable when this change is deployed. This simplifies the CMS meaning most pages will now use flexible content. 

See https://github.com/biglotteryfund/blf-alpha/issues/3361 for more.