### PR TITLE
Remove project duration question for Standard applications in England

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -34,7 +34,8 @@
     "enableEnglandAutoEndDate": false
   },
   "standardFundingProposal": {
-    "allowedCountries": ["england", "northern-ireland"]
+    "allowedCountries": ["england", "northern-ireland"],
+    "enableEnglandAutoProjectDuration": false
   },
   "session": {
     "cookie": "blf-alpha-session",

--- a/config/development.json
+++ b/config/development.json
@@ -6,5 +6,8 @@
   "fundingUnder10k": {
     "enableEnglandAutoEndDate": true,
     "enableGovCOVIDUpdates": true
+  },
+  "standardFundingProposal": {
+    "enableEnglandAutoProjectDuration": true
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -8,5 +8,8 @@
   "fundingUnder10k": {
     "enableEnglandAutoEndDate": true,
     "enableGovCOVIDUpdates": true
+  },
+  "standardFundingProposal": {
+    "enableEnglandAutoProjectDuration": true
   }
 }

--- a/controllers/apply/standard-proposal/__snapshots__/enrich.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/enrich.test.js.snap
@@ -13,7 +13,7 @@ Object {
   "overview": Array [
     Object {
       "label": "Project length",
-      "value": "3 years",
+      "value": "1 years",
     },
     Object {
       "label": "Location",
@@ -40,7 +40,7 @@ Object {
   "overview": Array [
     Object {
       "label": "Project length",
-      "value": "3 years",
+      "value": "1 years",
     },
     Object {
       "label": "Location",

--- a/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
+++ b/controllers/apply/standard-proposal/__snapshots__/form.test.js.snap
@@ -59,7 +59,6 @@ Object {
   "projectCountries": Array [
     "england",
   ],
-  "projectDurationYears": 3,
   "projectLocation": "derbyshire",
   "projectLocationDescription": "description",
   "projectName": "My project",

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -20,7 +20,7 @@ module.exports = function ({
 } = {}) {
     const localise = get(locale);
 
-    const allFields = fieldsFor({ locale, data });
+    const allFields = fieldsFor({ locale, data, flags });
 
     const projectCountries = getOr([], 'projectCountries')(data);
 

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -1,4 +1,5 @@
 'use strict';
+const config = require('config');
 const { oneLine } = require('common-tags');
 const clone = require('lodash/clone');
 const compact = require('lodash/compact');
@@ -11,7 +12,12 @@ const { Step } = require('../lib/step-model');
 
 const fieldsFor = require('./fields');
 
-module.exports = function ({ locale = 'en', data = {}, metadata = {} } = {}) {
+module.exports = function ({
+    locale = 'en',
+    data = {},
+    metadata = {},
+    flags = config.get('standardFundingProposal'),
+} = {}) {
     const localise = get(locale);
 
     const allFields = fieldsFor({ locale, data });
@@ -89,7 +95,12 @@ module.exports = function ({ locale = 'en', data = {}, metadata = {} } = {}) {
 
     function stepProjectDuration() {
         function fields() {
-            if (projectCountries.length < 2) {
+            if (
+                projectCountries.includes('england') &&
+                flags.enableEnglandAutoProjectDuration
+            ) {
+                return [];
+            } else if (projectCountries.length < 2) {
                 return [allFields.projectDurationYears];
             } else {
                 return [];
@@ -301,6 +312,18 @@ module.exports = function ({ locale = 'en', data = {}, metadata = {} } = {}) {
             const enriched = clone(data);
             if (metadata && metadata.programme) {
                 enriched.projectName = `${metadata.programme.title}: ${enriched.projectName}`;
+            }
+
+            /**
+             * If projectCountries contains England
+             * then pre-fill the projectDurationYears to 1 year
+             * as this question is hidden from them
+             */
+            if (
+                enriched.projectCountries.includes('england') &&
+                flags.enableEnglandAutoProjectDuration
+            ) {
+                enriched.projectDurationYears = 1;
             }
             return enriched;
         },

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -94,6 +94,17 @@ test('strip projectDurationYears when applying for more than one country', () =>
     expect(form.validation.value).not.toHaveProperty('projectDurationYears');
 });
 
+test('set projectDurationYears to 1 when applying for England', () => {
+    const form = formBuilder({
+        data: mockResponse({
+            projectCountries: ['england'],
+            projectDurationYears: 5,
+        }),
+    });
+    const salesforceResult = form.forSalesforce();
+    expect(salesforceResult.projectDurationYears).toBe(1);
+});
+
 test('organisation sub-type required for statutory-body', function () {
     const requiredData = mockResponse({ organisationType: 'statutory-body' });
     const requiredResult = formBuilder({ data: requiredData }).validation;

--- a/controllers/apply/standard-proposal/mocks.js
+++ b/controllers/apply/standard-proposal/mocks.js
@@ -10,7 +10,7 @@ function mockResponse(overrides = {}) {
         projectLocation: 'derbyshire',
         projectLocationDescription: 'description',
         projectCosts: '250,000',
-        projectDurationYears: 3,
+        projectDurationYears: 1,
         yourIdeaProject: faker.lorem.words(random(50, 500)),
         yourIdeaCommunity: faker.lorem.words(random(50, 500)),
         yourIdeaActivities: faker.lorem.words(random(50, 350)),

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1212,8 +1212,11 @@ function standardApplication({
         );
         submitStep();
 
-        cy.findByLabelText(mock.projectDurationYears).click();
-        submitStep();
+        // This field only exists for non-England forms
+        if (!mock.projectCountries.includes('England')) {
+            cy.findByLabelText(mock.projectDurationYears).click();
+            submitStep();
+        }
 
         cy.findByLabelText('What would you like to do?')
             .invoke('val', mock.yourIdeaProject)


### PR DESCRIPTION
This does a few things for **Standard** applications **in England only**:

## Users will no longer be asked this question:

![image](https://user-images.githubusercontent.com/394376/83780097-a1488600-a684-11ea-9619-469cddbb48c3.png)

Instead, we'll automatically populate their answer as `1` which is the only valid answer now (because in England, Standard projects must only last for six months now).

## Users will see this new text above the project amount question:

![image](https://user-images.githubusercontent.com/394376/83780580-45cac800-a685-11ea-9f55-2ca8976a179a.png)

Beforehand it just said "This can be an estimate".

## Some users will see this message on their summary screen:

![image](https://user-images.githubusercontent.com/394376/83780296-e4a2f480-a684-11ea-93b1-7ac5a390cf4c.png)

Anyone who created their application before a hard-coded cutoff date (currently set to today, but when we make this live we'll set it to that day's date) will see this text.

Relates to this Trello ticket: https://trello.com/c/Mpy18Jsf/809-project-funding-length-on-standard-customer-journey-cl64
