### PR TITLE
Remove funding guidance redirect

### DIFF
--- a/controllers/archived/__snapshots__/aliases.test.js.snap
+++ b/controllers/archived/__snapshots__/aliases.test.js.snap
@@ -2611,46 +2611,6 @@ Array [
     "to": "/welsh/funding/managing-your-grant/under-10k",
   },
   Object {
-    "from": "/funding/funding-guidance",
-    "to": "/funding",
-  },
-  Object {
-    "from": "/welsh/funding/funding-guidance",
-    "to": "/welsh/funding",
-  },
-  Object {
-    "from": "/england/funding/funding-guidance",
-    "to": "/funding",
-  },
-  Object {
-    "from": "/welsh/england/funding/funding-guidance",
-    "to": "/welsh/funding",
-  },
-  Object {
-    "from": "/scotland/funding/funding-guidance",
-    "to": "/funding",
-  },
-  Object {
-    "from": "/welsh/scotland/funding/funding-guidance",
-    "to": "/welsh/funding",
-  },
-  Object {
-    "from": "/northernireland/funding/funding-guidance",
-    "to": "/funding",
-  },
-  Object {
-    "from": "/welsh/northernireland/funding/funding-guidance",
-    "to": "/welsh/funding",
-  },
-  Object {
-    "from": "/wales/funding/funding-guidance",
-    "to": "/funding",
-  },
-  Object {
-    "from": "/welsh/wales/funding/funding-guidance",
-    "to": "/welsh/funding",
-  },
-  Object {
     "from": "/funding/funding-guidance/applying-for-funding",
     "to": "/funding",
   },
@@ -2732,43 +2692,43 @@ Array [
   },
   Object {
     "from": "/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/funding-guidance/help-using-our-application-forms",
+    "to": "/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/welsh/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+    "to": "/welsh/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/england/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/funding-guidance/help-using-our-application-forms",
+    "to": "/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/welsh/england/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+    "to": "/welsh/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/scotland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/funding-guidance/help-using-our-application-forms",
+    "to": "/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/welsh/scotland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+    "to": "/welsh/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/northernireland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/funding-guidance/help-using-our-application-forms",
+    "to": "/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/welsh/northernireland/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+    "to": "/welsh/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/wales/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/funding-guidance/help-using-our-application-forms",
+    "to": "/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/welsh/wales/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms",
-    "to": "/welsh/funding-guidance/help-using-our-application-forms",
+    "to": "/welsh/funding/funding-guidance/help-using-our-application-forms",
   },
   Object {
     "from": "/funding/funding-guidance/applying-for-funding/information-checks",
@@ -3092,43 +3052,43 @@ Array [
   },
   Object {
     "from": "/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/funding/funding-guidance/evaluation",
+    "to": "/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/welsh/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/welsh/funding/funding-guidance/evaluation",
+    "to": "/welsh/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/england/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/funding/funding-guidance/evaluation",
+    "to": "/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/welsh/england/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/welsh/funding/funding-guidance/evaluation",
+    "to": "/welsh/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/scotland/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/funding/funding-guidance/evaluation",
+    "to": "/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/welsh/scotland/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/welsh/funding/funding-guidance/evaluation",
+    "to": "/welsh/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/northernireland/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/funding/funding-guidance/evaluation",
+    "to": "/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/welsh/northernireland/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/welsh/funding/funding-guidance/evaluation",
+    "to": "/welsh/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/wales/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/funding/funding-guidance/evaluation",
+    "to": "/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/welsh/wales/funding/funding-guidance/managing-your-funding/self-evaluation",
-    "to": "/welsh/funding/funding-guidance/evaluation",
+    "to": "/welsh/funding/managing-your-grant/gathering-evidence-and-learning",
   },
   Object {
     "from": "/funding/past-grants",

--- a/controllers/archived/aliases.js
+++ b/controllers/archived/aliases.js
@@ -336,10 +336,6 @@ module.exports = createAliases([
         to: `/funding/managing-your-grant/under-10k`,
     }),
     withRegionPrefixes({
-        from: `/funding/funding-guidance`,
-        to: `/funding`,
-    }),
-    withRegionPrefixes({
         from: `/funding/funding-guidance/applying-for-funding`,
         to: `/funding`,
     }),
@@ -349,7 +345,7 @@ module.exports = createAliases([
     }),
     withRegionPrefixes({
         from: `/funding/funding-guidance/applying-for-funding/help-using-our-electronic-application-forms`,
-        to: `/funding-guidance/help-using-our-application-forms`,
+        to: `/funding/funding-guidance/help-using-our-application-forms`,
     }),
     withRegionPrefixes({
         from: `/funding/funding-guidance/applying-for-funding/information-checks`,
@@ -385,7 +381,7 @@ module.exports = createAliases([
     }),
     withRegionPrefixes({
         from: `/funding/funding-guidance/managing-your-funding/self-evaluation`,
-        to: `/funding/funding-guidance/evaluation`,
+        to: `/funding/managing-your-grant/gathering-evidence-and-learning`,
     }),
     withRegionPrefixes({
         from: `/funding/past-grants`,

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -45,8 +45,6 @@ router.use('/publications', require('./publications'));
  */
 router.use('/grants', require('./grants'));
 
-router.use('/funding-guidance/*', basicContent());
-
 /**
  * Custom override: Free materials
  * Allows us to customise the free materials page with an order form,

--- a/controllers/funding/index.js
+++ b/controllers/funding/index.js
@@ -6,7 +6,7 @@ const {
     injectHeroImage,
     injectListingContent,
 } = require('../../common/inject-content');
-const { basicContent, flexibleContentPage } = require('../common');
+const { flexibleContentPage } = require('../common');
 
 const router = express.Router();
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1376,7 +1376,7 @@ it('should correctly email users with expiring applications', () => {
 
 it('should submit materials order', () => {
     cy.visit(
-        '/funding/funding-guidance/managing-your-funding/ordering-free-materials'
+        '/funding/managing-your-grant/promoting-your-project/order-free-materials'
     );
     cy.get('a[href="#monolingual"]').click();
 


### PR DESCRIPTION
Removes this section now it's been migrated to /funding – see https://github.com/biglotteryfund/blf-alpha/issues/3365.