### PR TITLE
Allow Data page to use CMS flexible content and remove hard-coded links

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -213,47 +213,6 @@ toplevel:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau
     disclaimer: Am ystadegau thematig (e.e. amgylcheddol, iechyd a lles, a.y.y.b.), rydym wedi cyfri prosiectau sy’n cynnwys y themâu hyn, ond nid yn gyfan gwbl.
-    openData:
-      title: Data am Grantiau
-      linkPrefix: Data grantiau
-      content:
-        intro: >
-          Ar draws y grantiau a wnawn mae'r Gronfa'n ymroddedig i dryloywder fel bod pobl sydd yn arwain yn derbyn yr wybodaeth sydd ei hangen arnynt. Rydym yn cydweithio â'r fenter 360Giving i gyhoeddi ein data grantiau. Rydym wedi defnyddio'r safon 360Giving i gynhyrchu ffeil o'r holl grantiau rydym wedi eu gwneud o 2004 ymlaen.
-        links:
-          - label: "2004 - 2005 (XLSX, 5.5MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2004_05.xlsx"
-          - label: "2005 - 2006 (XLSX, 6.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2005_06.xlsx"
-          - label: "2006 - 2007 (XLSX, 4.7MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2006_07.xlsx"
-          - label: "2007 - 2008 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2007_08.xlsx"
-          - label: "2008 - 2009 (XLSX, 3.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2008_09.xlsx"
-          - label: "2009 - 2010 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2009_10.xlsx"
-          - label: "2010 - 2011 (XLSX, 2.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2010_11.xlsx"
-          - label: "2011 - 2012 (XLSX, 3.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2011_12.xlsx"
-          - label: "2012 - 2013 (XLSX, 3.2MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2012_13.xlsx"
-          - label: "2013 - 2014 (XLSX, 3.3MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2013_14.xlsx"
-          - label: "2014 - 2015 (XLSX, 2.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2014_15.xlsx"
-          - label: "2015 - 2016 (XLSX, 2.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2015_16.xlsx"
-          - label: "2016 - 2017 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2016_17.xlsx"
-          - label: "2017 - 2018 (XLSX, 2.8MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2017_18.xlsx"
-          - label: "2018 - 2019 (XLSX, 4.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2018_19.xlsx"
-          - label: "2019 - 2020 (XLSX, 3MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2019_2020_v3.xlsx"
-        outro: >
-          Trwyddedir y gwaith hwn o dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">drwydded llywodraeth agored ar gyfer gwybodaeth sector cyhoeddus</a>, gan alluogi chi i ddefnyddio ac ailddefnyddio'r Wybodaeth sydd ar gael o dan y drwydded hon yn rhydd ac yn hyblyg, gyda dim ond ychydig o amodau. Os na allwch ddod o hyd i'r hyn rydych yn chwilio amdano, <a href="/contact">cysylltwch â ni</a>.
   newsletter:
     title: e-fwletin
     standard:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,47 +219,6 @@ toplevel:
     keyStats: Key statistics
     mapTitle: Our Year in Numbers
     disclaimer: For thematic statistics (eg. environmental, health and wellbeing, etc), we've counted projects which include these themes, but not exclusively.
-    openData:
-      title: Grant Data
-      linkPrefix: Grants data
-      content:
-        intro: >
-          Across our grant making the Fund is committed to transparency so that people in the lead have the information they need. We work with the 360Giving initiative to publish our grant data. We have used the 360Giving standard to produce a file of all the grants we have made 2004 onwards.
-        links:
-          - label: "2004 - 2005 (XLSX, 5.5MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2004_05.xlsx"
-          - label: "2005 - 2006 (XLSX, 6.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2005_06.xlsx"
-          - label: "2006 - 2007 (XLSX, 4.7MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2006_07.xlsx"
-          - label: "2007 - 2008 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2007_08.xlsx"
-          - label: "2008 - 2009 (XLSX, 3.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2008_09.xlsx"
-          - label: "2009 - 2010 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2009_10.xlsx"
-          - label: "2010 - 2011 (XLSX, 2.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2010_11.xlsx"
-          - label: "2011 - 2012 (XLSX, 3.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2011_12.xlsx"
-          - label: "2012 - 2013 (XLSX, 3.2MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2012_13.xlsx"
-          - label: "2013 - 2014 (XLSX, 3.3MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2013_14.xlsx"
-          - label: "2014 - 2015 (XLSX, 2.1MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2014_15.xlsx"
-          - label: "2015 - 2016 (XLSX, 2.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2015_16.xlsx"
-          - label: "2016 - 2017 (XLSX, 3.4MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2016_17.xlsx"
-          - label: "2017 - 2018 (XLSX, 2.8MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2017_18.xlsx"
-          - label: "2018 - 2019 (XLSX, 4.9MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2018_19.xlsx"
-          - label: "2019 - 2020 (XLSX, 3MB)"
-            href: "https://www.tnlcommunityfund.org.uk/media/data/grants/2019_2020_v3.xlsx"
-        outro: >
-          This work is licensed under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">open government licence for public sector information</a>, which allows you to use and re-use the Information that is available under this licence freely and flexibly, with only a few conditions. If you can’t find what you’re looking for, please <a href="/contact">contact us</a>.
   newsletter:
     title: Newsletters
     standard:

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -18,7 +18,7 @@ router.get('/', injectHeroImage('fsn-new'), async function (req, res, next) {
         res.render(path.resolve(__dirname, './views/data'), {
             title: dataStats.title,
             openGraph: get(dataStats, 'openGraph', false),
-            dataStats: dataStats,
+            content: dataStats,
         });
     } catch (error) {
         next(error);

--- a/controllers/data/views/data.njk
+++ b/controllers/data/views/data.njk
@@ -1,4 +1,5 @@
-{% extends "layouts/main.njk" %}
+{% extends "controllers/common/views/flexible-content-page.njk" %}
+
 {% from "components/data.njk" import statsGrid %}
 {% from "components/hero.njk" import hero with context %}
 
@@ -18,64 +19,53 @@
     </section>
 {% endmacro %}
 
-{% block content %}
-    <main role="main" id="content">
-        {{ hero(title, pageHero.image) }}
+{% block contentPrimary %}
 
-        <div class="nudge-up">
-            <div class="content-box content-box--borderless u-inner-wide-only">
-                <h2 class="t2 t--underline">{{ copy.keyStats }}</h2>
-                {{ statsGrid(dataStats.stats) }}
+    <div class="content-box content-box--borderless u-inner-wide-only">
+        <h2 class="t2 t--underline">{{ copy.keyStats }}</h2>
+        {{ statsGrid(content.stats) }}
 
-                <p class="u-text-x-small u-margin-top">{{ copy.disclaimer }}</p>
+        <p class="u-text-x-small u-margin-top">{{ copy.disclaimer }}</p>
+    </div>
+
+    <aside class="map-holder u-border-top-brand-primary u-margin-bottom">
+        <div class="map-holder__inner u-inner-wide-only u-padded">
+            <h2 class="t2 t--underline">{{ copy.mapTitle }}</h2>
+
+            <div class="map-wrapper" role="tablist">
+                {% include "includes/uk-countries.njk" %}
             </div>
 
-            <aside class="map-holder u-border-top-brand-primary u-margin-bottom">
-                <div class="map-holder__inner u-inner-wide-only u-padded">
-                    <h2 class="t2 t--underline">{{ copy.mapTitle }}</h2>
+            <div id="js-map-panes" class="map-panes js-paneset">
+                {% set regionTitles = __('global.regions') %}
+                {{ mapPane(
+                    id = 'england',
+                    title = regionTitles.england,
+                    stats = content.regions.england,
+                    isActive = true
+                ) }}
+                {{ mapPane(
+                    id = 'northern-ireland',
+                    title = regionTitles.northernIreland,
+                    stats = content.regions.northernIreland
+                ) }}
+                {{ mapPane(
+                    id = 'scotland',
+                    title = regionTitles.scotland,
+                    stats = content.regions.scotland
+                ) }}
+                {{ mapPane(
+                    id = 'wales',
+                    title = regionTitles.wales,
+                    stats = content.regions.wales
+                ) }}
+            </div>
 
-                    <div class="map-wrapper" role="tablist">
-                        {% include "includes/uk-countries.njk" %}
-                    </div>
-
-                    <div id="js-map-panes" class="map-panes js-paneset">
-                        {% set regionTitles = __('global.regions') %}
-                        {{ mapPane(
-                            id = 'england',
-                            title = regionTitles.england,
-                            stats = dataStats.regions.england,
-                            isActive = true
-                        ) }}
-                        {{ mapPane(
-                            id = 'northern-ireland',
-                            title = regionTitles.northernIreland,
-                            stats = dataStats.regions.northernIreland
-                        ) }}
-                        {{ mapPane(
-                            id = 'scotland',
-                            title = regionTitles.scotland,
-                            stats = dataStats.regions.scotland
-                        ) }}
-                        {{ mapPane(
-                            id = 'wales',
-                            title = regionTitles.wales,
-                            stats = dataStats.regions.wales
-                        ) }}
-                    </div>
-
-                </div>
-            </aside>
-
-            <section class="s-prose u-padded u-inner" id="open-data">
-                <h2>{{ copy.openData.title}}</h2>
-                <p>{{ copy.openData.content.intro | safe }}</p>
-                <ul>
-                    {% for link in copy.openData.content.links %}
-                        <li><a href="{{ link.href }}">{{ copy.openData.linkPrefix }} {{ link.label }}</a></li>
-                    {% endfor %}
-                </ul>
-                <p>{{ copy.openData.content.outro | safe }}</p>
-            </section>
         </div>
-    </main>
+    </aside>
+
+    <section id="open-data">
+        {# CMS content #}
+        {{ super() }}
+    </section>
 {% endblock %}


### PR DESCRIPTION
Pairs with https://github.com/biglotteryfund/craft-dev/pull/281 – allows us to remove these links from the app and render them from the CMS instead.

Fixes https://github.com/biglotteryfund/blf-alpha/issues/3432