### PR TITLE
Remove legacy flexible content

### DIFF
--- a/controllers/common/index.js
+++ b/controllers/common/index.js
@@ -90,7 +90,9 @@ function renderFlexibleContentChild(req, res, entry) {
 
     res.render(path.resolve(__dirname, './views/flexible-content-page'), {
         breadcrumbs: res.locals.breadcrumbs.concat({ label: res.locals.title }),
-        content: { flexibleContent: entry.content },
+        content: {
+            flexibleContent: entry.flexibleContent,
+        },
     });
 }
 

--- a/controllers/common/views/information-page.njk
+++ b/controllers/common/views/information-page.njk
@@ -1,3 +1,5 @@
+{% extends "layouts/main.njk" %}
+
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/flexible-content/macro.njk" import flexibleContentPart %}
@@ -5,7 +7,6 @@
 {% from "components/segment/macro.njk" import segment %}
 {% from "components/table-of-contents/macro.njk" import tableOfContents %}
 
-{% extends "layouts/main.njk" %}
 {% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
 
 {% set flexAnchor = 'item' %}

--- a/controllers/common/views/listing-page.njk
+++ b/controllers/common/views/listing-page.njk
@@ -1,3 +1,5 @@
+{% extends "layouts/main.njk" %}
+
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/content-box/macro.njk" import contentBox %}
 {% from "components/hero.njk" import hero with context %}
@@ -5,7 +7,6 @@
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/section-links/macro.njk" import sectionLinks %}
 
-{% extends "layouts/main.njk" %}
 {% if not pageHero.image %}{% set bodyClass = 'has-static-header' %}{% endif %}
 
 {% block content %}

--- a/controllers/funding/grants/index.js
+++ b/controllers/funding/grants/index.js
@@ -309,7 +309,7 @@ router.get('/:id', async function (req, res, next) {
             res.render(path.resolve(__dirname, './views/grant-detail'), {
                 title: data.result.title,
                 grant: grant,
-                projectStory: projectStory,
+                content: projectStory,
                 fundingProgramme: fundingProgramme,
                 breadcrumbs: res.locals.breadcrumbs.concat({
                     label: data.result.title,

--- a/controllers/funding/grants/views/grant-detail.njk
+++ b/controllers/funding/grants/views/grant-detail.njk
@@ -1,174 +1,189 @@
-{% extends "controllers/common/views/flexible-content-page.njk" %}
-
+{% extends "layouts/main.njk" %}
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/promo-card/macro.njk" import promoCard %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/content-box/macro.njk" import contentBox %}
-{% from "components/flexible-content/macro.njk" import flexibleContent %}
+{% from "components/flexible-content-next/macro.njk" import flexibleContent with context %}
 
 {% from './helpers.njk' import badgeActiveProject, badgeProjectStory, buildLocationList, buildOrgTypeList, pgLink with context %}
 
+{% if not pageHero %}
+    {% set bodyClass = 'has-static-header' %}
+{% endif %}
 
-{% block contentPrimary %}
-
+{% block content %}
     {% set mainProgramme = grant.grantProgramme[0] %}
 
-    <div class="u-inner-wide-only js-past-grants-detail">
+    <main role="main" id="content" class="js-past-grants-detail">
+        {% if pageHero %}
+            {{ hero(title, pageHero.image) }}
+        {% endif %}
 
-        <div class="content-sidebar">
-            <div class="content-sidebar__primary">
-                {% if content %}
-                    {# CMS content #}
-                    {{ super() }}
+        <div class="content-box u-inner-wide-only{% if pageHero %} nudge-up{% endif %}">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-                    {% if content.outro %}
-                        <div class="content-box content-box--frameless">
-                            <aside class="u-tone-background-tint u-padded u-text-medium">
-                                <h2 class="t3 u-tone-brand-primary">{{ __('global.misc.moreInformation') }}</h2>
-                                <div class="s-prose">
-                                    {{ content.outro | safe }}
-                                </div>
-                            </aside>
-                        </div>
-                    {% endif %}
-                {% elseif grant.description !== grant.title %}
-                    <div class="content-box">
-                        {{ breadcrumbTrail(breadcrumbs) }}
-                        <h2 class="t3 t--underline">{{ copy.grantDetail.projectOverview }}</h2>
-                        <p class="u-wrap-words">{{ grant.description }}</p>
-                    </div>
-                {% endif %}
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    <div class="u-constrained-wide">
+                        <h1>{{ title }}</h1>
 
-                <grants-back-to-search
-                    label="{{ copy.backToSearch }}"
-                    :storage-key="STORAGE_KEY"
-                    prefix="./" />
-            </div>
+                        {% if content %}
+                            <div class="s-prose">
+                                {# CMS content #}
+                                {{
+                                    flexibleContent(
+                                        flexibleContent = content.flexibleContent,
+                                        distinguishBlocks = false
+                                    )
+                                }}
+                            </div>
 
-            <div class="content-sidebar__secondary">
-                {% call card(aboutTitle) %}
-                    <aside class="grant-summary">
-                        <p class="grant-summary__amount">£{{ grant.amountAwarded | numberWithCommas }}</p>
-                        <p class="grant-summary__title">{{ grant.title }}</p>
-                        <p class="grant-summary__date">{{ formatDate(grant.awardDate) }}</p>
-                    </aside>
-
-                    <dl class="o-definition-list o-definition-list--compact u-text-small">
-                        {% if grant.plannedDates %}
-                            <dt>{{ copy.grantDetail.fields.duration }}</dt>
-                            {% for dates in grant.plannedDates %}
-                                <dd>
-                                    {{ fields.area.label }}
-                                    {{ formatDate(dates.startDate) }}{% if dates.endDate -%}
-                                        &ndash;{{ formatDate(dates.endDate) }}
-                                    {%- endif %}
-                                </dd>
-                            {% endfor %}
+                            {% if content.outro %}
+                                <aside class="u-tone-background-tint u-padded u-text-medium">
+                                    <h2 class="t3 u-tone-brand-primary">{{ __('global.misc.moreInformation') }}</h2>
+                                    <div class="s-prose">
+                                        {{ content.outro | safe }}
+                                    </div>
+                                </aside>
+                            {% endif %}
+                        {% elseif grant.description !== grant.title %}
+                            <h2 class="t3 t--underline">{{ copy.grantDetail.projectOverview }}</h2>
+                            <p class="u-wrap-words">{{ grant.description }}</p>
                         {% endif %}
-                    </dl>
 
-                    {% if grant.isActive %}
-                        {{ badgeActiveProject()}}
-                    {% endif %}
+                        <grants-back-to-search
+                            label="{{ copy.backToSearch }}"
+                            :storage-key="STORAGE_KEY"
+                            prefix="./" />
+                    </div>
+                </div>
 
-                    {% if content %}
-                        {{ badgeProjectStory()}}
-                    {% endif %}
-                {% endcall %}
+                <div class="content-sidebar__secondary">
+                    {% call card(aboutTitle) %}
+                        <aside class="grant-summary">
+                            <p class="grant-summary__amount">£{{ grant.amountAwarded | numberWithCommas }}</p>
+                            <p class="grant-summary__title">{{ grant.title }}</p>
+                            <p class="grant-summary__date">{{ formatDate(grant.awardDate) }}</p>
+                        </aside>
 
-            </div>
-        </div>
-    </div>
-
-    <div class="u-inner-wide-only{% if content%} u-padded{% endif %}">
-        <div class="flex-grid">
-            <div class="flex-grid__item">
-                {% call contentBox(isConstrained = false) %}
-                    <h2>{{ copy.grantDetail.fields.recipientOrg }}</h2>
-                    {% for org in grant.recipientOrganization %}
                         <dl class="o-definition-list o-definition-list--compact u-text-small">
-                            <dt>{{ copy.grantDetail.fields.orgName }}</dt>
-                            <dd><a href="./recipients/{{ org.id }}">{{ org.name }}</a></dd>
-
-                            {% if org.organisationType %}
-                                <dt>{{ copy.grantDetail.fields.type }}</dt>
-                                <dd>{{ buildOrgTypeList(org) }}</dd>
-                            {% endif %}
-
-                            {% if org.charityNumber %}
-                                <dt>{{ copy.grantDetail.fields.charityNumber }}</dt>
-                                <dd>{{ org.charityNumber }}</dd>
-                            {% endif %}
-
-                            {% if org.companyNumber %}
-                                <dt>{{ copy.grantDetail.fields.companyNumber }}</dt>
-                                <dd>{{ org.companyNumber }}</dd>
-                            {% endif %}
-
-                            {% if grant.beneficiaryLocation %}
-                                <dt>{{ copy.grantDetail.fields.location }}</dt>
-                                <dd>{{ buildLocationList(grant.beneficiaryLocation) }}</dd>
+                            {% if grant.plannedDates %}
+                                <dt>{{ copy.grantDetail.fields.duration }}</dt>
+                                {% for dates in grant.plannedDates %}
+                                    <dd>
+                                        {{ fields.area.label }}
+                                        {{ formatDate(dates.startDate) }}{% if dates.endDate -%}
+                                            &ndash;{{ formatDate(dates.endDate) }}
+                                        {%- endif %}
+                                    </dd>
+                                {% endfor %}
                             {% endif %}
                         </dl>
 
-                        <p>
-                            <a class="btn btn--small btn--outline" href="./recipients/{{ org.id }}">
-                                {{ copy.grantDetail.viewAllForRecipient }}
-                            </a>
-                        </p>
-                    {% endfor %}
-                {% endcall %}
+                        {% if grant.isActive %}
+                            {{ badgeActiveProject()}}
+                        {% endif %}
+
+                        {% if content %}
+                            {{ badgeProjectStory()}}
+                        {% endif %}
+                    {% endcall %}
+
+                </div>
+
             </div>
-            <div class="flex-grid__item">
-                {% if fundingProgramme %}
-                    {% set link = localify(fundingProgramme.linkUrl) %}
-                {% elseif mainProgramme.url %}
-                    {% set link = localify(mainProgramme.url) %}
-                {% else %}
-                    {% set link = localify('/funding/programmes') %}
-                {% endif %}
+        </div>
 
-                {% set image = {
-                    "url": fallbackHeroImage.large,
-                    "alt": mainProgramme.title
-                } %}
+        <div class="u-inner-wide-only">
+            <div class="flex-grid">
+                <div class="flex-grid__item">
+                    {% call contentBox(isConstrained = false) %}
+                        <h2>{{ copy.grantDetail.fields.recipientOrg }}</h2>
+                        {% for org in grant.recipientOrganization %}
+                            <dl class="o-definition-list o-definition-list--compact u-text-small">
+                                <dt>{{ copy.grantDetail.fields.orgName }}</dt>
+                                <dd><a href="./recipients/{{ org.id }}">{{ org.name }}</a></dd>
 
-                {% if fundingProgramme and fundingProgramme.hero %}
+                                {% if org.organisationType %}
+                                    <dt>{{ copy.grantDetail.fields.type }}</dt>
+                                    <dd>{{ buildOrgTypeList(org) }}</dd>
+                                {% endif %}
+
+                                {% if org.charityNumber %}
+                                    <dt>{{ copy.grantDetail.fields.charityNumber }}</dt>
+                                    <dd>{{ org.charityNumber }}</dd>
+                                {% endif %}
+
+                                {% if org.companyNumber %}
+                                    <dt>{{ copy.grantDetail.fields.companyNumber }}</dt>
+                                    <dd>{{ org.companyNumber }}</dd>
+                                {% endif %}
+
+                                {% if grant.beneficiaryLocation %}
+                                    <dt>{{ copy.grantDetail.fields.location }}</dt>
+                                    <dd>{{ buildLocationList(grant.beneficiaryLocation) }}</dd>
+                                {% endif %}
+                            </dl>
+
+                            <p>
+                                <a class="btn btn--small btn--outline" href="./recipients/{{ org.id }}">
+                                    {{ copy.grantDetail.viewAllForRecipient }}
+                                </a>
+                            </p>
+                        {% endfor %}
+                    {% endcall %}
+                </div>
+                <div class="flex-grid__item">
+                    {% if fundingProgramme %}
+                        {% set link = localify(fundingProgramme.linkUrl) %}
+                    {% elseif mainProgramme.url %}
+                        {% set link = localify(mainProgramme.url) %}
+                    {% else %}
+                        {% set link = localify('/funding/programmes') %}
+                    {% endif %}
+
                     {% set image = {
-                        "url": fundingProgramme.hero.image.large,
+                        "url": fallbackHeroImage.large,
                         "alt": mainProgramme.title
                     } %}
-                {% endif %}
 
-                {% call promoCard({
-                    "title": copy.grantDetail.fundedBy + ' ' + mainProgramme.title,
-                    "summary": fundingProgramme.trailText,
-                    "image": image,
-                    "link": {
-                        "label": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
-                        "labelAria": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
-                        "url": link
-                    }
-                }) %}
-                    {% if fundingProgramme.hero.caption %}
-                        <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
+                    {% if fundingProgramme and fundingProgramme.hero %}
+                        {% set image = {
+                            "url": fundingProgramme.hero.image.large,
+                            "alt": mainProgramme.title
+                        } %}
                     {% endif %}
-                {% endcall %}
+
+                    {% call promoCard({
+                        "title": copy.grantDetail.fundedBy + ' ' + mainProgramme.title,
+                        "summary": fundingProgramme.trailText,
+                        "image": image,
+                        "link": {
+                            "label": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
+                            "labelAria": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
+                            "url": link
+                        }
+                    }) %}
+                        {% if fundingProgramme.hero.caption %}
+                            <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
+                        {% endif %}
+                    {% endcall %}
+                </div>
             </div>
         </div>
-    </div>
 
-    {# Related projects widget #}
-    {% if appData.config.get('features.enableRelatedGrants') %}
-        {# This wrapper div must exist or the related component swallows the following component #}
-        <div>
-            <grants-related
-                limit="3"
-                exclude-id="{{ grant.id }}"
-                programme="{{ mainProgramme.title }}"
-                beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
-            />
-        </div>
-    {% endif %}
+        {# Related projects widget #}
+        {% if appData.config.get('features.enableRelatedGrants') %}
+            {# This wrapper div must exist or the related component swallows the following component #}
+            <div>
+                <grants-related
+                    limit="3"
+                    exclude-id="{{ grant.id }}"
+                    programme="{{ mainProgramme.title }}"
+                    beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
+                />
+            </div>
+        {% endif %}
+    </main>
 {% endblock %}

--- a/controllers/funding/grants/views/grant-detail.njk
+++ b/controllers/funding/grants/views/grant-detail.njk
@@ -1,4 +1,5 @@
-{% extends "layouts/main.njk" %}
+{% extends "controllers/common/views/flexible-content-page.njk" %}
+
 {% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/hero.njk" import hero with context %}
 {% from "components/promo-card/macro.njk" import promoCard %}
@@ -8,176 +9,166 @@
 
 {% from './helpers.njk' import badgeActiveProject, badgeProjectStory, buildLocationList, buildOrgTypeList, pgLink with context %}
 
-{% if not pageHero %}
-    {% set bodyClass = 'has-static-header' %}
-{% endif %}
 
-{% block content %}
+{% block contentPrimary %}
+
     {% set mainProgramme = grant.grantProgramme[0] %}
 
-    <main role="main" id="content" class="js-past-grants-detail">
-        {% if pageHero %}
-            {{ hero(title, pageHero.image) }}
-        {% endif %}
+    <div class="u-inner-wide-only js-past-grants-detail">
 
-        <div class="content-box u-inner-wide-only{% if pageHero %} nudge-up{% endif %}">
-            {{ breadcrumbTrail(breadcrumbs) }}
+        <div class="content-sidebar">
+            <div class="content-sidebar__primary">
+                {% if content %}
+                    {# CMS content #}
+                    {{ super() }}
 
-            <div class="content-sidebar">
-                <div class="content-sidebar__primary">
-                    <div class="u-constrained-wide">
-                        <h1>{{ title }}</h1>
-
-                        {% if projectStory %}
-                            <div class="s-prose">
-                                {{ flexibleContent(projectStory.flexibleContent) }}
-                            </div>
-
-                            {% if projectStory.outro %}
-                                <aside class="u-tone-background-tint u-padded u-text-medium">
-                                    <h2 class="t3 u-tone-brand-primary">{{ __('global.misc.moreInformation') }}</h2>
-                                    <div class="s-prose">
-                                        {{ projectStory.outro | safe }}
-                                    </div>
-                                </aside>
-                            {% endif %}
-                        {% elseif grant.description !== grant.title %}
-                            <h2 class="t3 t--underline">{{ copy.grantDetail.projectOverview }}</h2>
-                            <p class="u-wrap-words">{{ grant.description }}</p>
-                        {% endif %}
-
-                        <grants-back-to-search
-                            label="{{ copy.backToSearch }}"
-                            :storage-key="STORAGE_KEY"
-                            prefix="./" />
+                    {% if content.outro %}
+                        <div class="content-box content-box--frameless">
+                            <aside class="u-tone-background-tint u-padded u-text-medium">
+                                <h2 class="t3 u-tone-brand-primary">{{ __('global.misc.moreInformation') }}</h2>
+                                <div class="s-prose">
+                                    {{ content.outro | safe }}
+                                </div>
+                            </aside>
+                        </div>
+                    {% endif %}
+                {% elseif grant.description !== grant.title %}
+                    <div class="content-box">
+                        {{ breadcrumbTrail(breadcrumbs) }}
+                        <h2 class="t3 t--underline">{{ copy.grantDetail.projectOverview }}</h2>
+                        <p class="u-wrap-words">{{ grant.description }}</p>
                     </div>
-                </div>
+                {% endif %}
 
-                <div class="content-sidebar__secondary">
-                    {% call card(aboutTitle) %}
-                        <aside class="grant-summary">
-                            <p class="grant-summary__amount">£{{ grant.amountAwarded | numberWithCommas }}</p>
-                            <p class="grant-summary__title">{{ grant.title }}</p>
-                            <p class="grant-summary__date">{{ formatDate(grant.awardDate) }}</p>
-                        </aside>
+                <grants-back-to-search
+                    label="{{ copy.backToSearch }}"
+                    :storage-key="STORAGE_KEY"
+                    prefix="./" />
+            </div>
 
+            <div class="content-sidebar__secondary">
+                {% call card(aboutTitle) %}
+                    <aside class="grant-summary">
+                        <p class="grant-summary__amount">£{{ grant.amountAwarded | numberWithCommas }}</p>
+                        <p class="grant-summary__title">{{ grant.title }}</p>
+                        <p class="grant-summary__date">{{ formatDate(grant.awardDate) }}</p>
+                    </aside>
+
+                    <dl class="o-definition-list o-definition-list--compact u-text-small">
+                        {% if grant.plannedDates %}
+                            <dt>{{ copy.grantDetail.fields.duration }}</dt>
+                            {% for dates in grant.plannedDates %}
+                                <dd>
+                                    {{ fields.area.label }}
+                                    {{ formatDate(dates.startDate) }}{% if dates.endDate -%}
+                                        &ndash;{{ formatDate(dates.endDate) }}
+                                    {%- endif %}
+                                </dd>
+                            {% endfor %}
+                        {% endif %}
+                    </dl>
+
+                    {% if grant.isActive %}
+                        {{ badgeActiveProject()}}
+                    {% endif %}
+
+                    {% if content %}
+                        {{ badgeProjectStory()}}
+                    {% endif %}
+                {% endcall %}
+
+            </div>
+        </div>
+    </div>
+
+    <div class="u-inner-wide-only{% if content%} u-padded{% endif %}">
+        <div class="flex-grid">
+            <div class="flex-grid__item">
+                {% call contentBox(isConstrained = false) %}
+                    <h2>{{ copy.grantDetail.fields.recipientOrg }}</h2>
+                    {% for org in grant.recipientOrganization %}
                         <dl class="o-definition-list o-definition-list--compact u-text-small">
-                            {% if grant.plannedDates %}
-                                <dt>{{ copy.grantDetail.fields.duration }}</dt>
-                                {% for dates in grant.plannedDates %}
-                                    <dd>
-                                        {{ fields.area.label }}
-                                        {{ formatDate(dates.startDate) }}{% if dates.endDate -%}
-                                            &ndash;{{ formatDate(dates.endDate) }}
-                                        {%- endif %}
-                                    </dd>
-                                {% endfor %}
+                            <dt>{{ copy.grantDetail.fields.orgName }}</dt>
+                            <dd><a href="./recipients/{{ org.id }}">{{ org.name }}</a></dd>
+
+                            {% if org.organisationType %}
+                                <dt>{{ copy.grantDetail.fields.type }}</dt>
+                                <dd>{{ buildOrgTypeList(org) }}</dd>
+                            {% endif %}
+
+                            {% if org.charityNumber %}
+                                <dt>{{ copy.grantDetail.fields.charityNumber }}</dt>
+                                <dd>{{ org.charityNumber }}</dd>
+                            {% endif %}
+
+                            {% if org.companyNumber %}
+                                <dt>{{ copy.grantDetail.fields.companyNumber }}</dt>
+                                <dd>{{ org.companyNumber }}</dd>
+                            {% endif %}
+
+                            {% if grant.beneficiaryLocation %}
+                                <dt>{{ copy.grantDetail.fields.location }}</dt>
+                                <dd>{{ buildLocationList(grant.beneficiaryLocation) }}</dd>
                             {% endif %}
                         </dl>
 
-                        {% if grant.isActive %}
-                            {{ badgeActiveProject()}}
-                        {% endif %}
-
-                        {% if projectStory %}
-                            {{ badgeProjectStory()}}
-                        {% endif %}
-                    {% endcall %}
-
-                </div>
-
+                        <p>
+                            <a class="btn btn--small btn--outline" href="./recipients/{{ org.id }}">
+                                {{ copy.grantDetail.viewAllForRecipient }}
+                            </a>
+                        </p>
+                    {% endfor %}
+                {% endcall %}
             </div>
-        </div>
+            <div class="flex-grid__item">
+                {% if fundingProgramme %}
+                    {% set link = localify(fundingProgramme.linkUrl) %}
+                {% elseif mainProgramme.url %}
+                    {% set link = localify(mainProgramme.url) %}
+                {% else %}
+                    {% set link = localify('/funding/programmes') %}
+                {% endif %}
 
-        <div class="u-inner-wide-only">
-            <div class="flex-grid">
-                <div class="flex-grid__item">
-                    {% call contentBox(isConstrained = false) %}
-                        <h2>{{ copy.grantDetail.fields.recipientOrg }}</h2>
-                        {% for org in grant.recipientOrganization %}
-                            <dl class="o-definition-list o-definition-list--compact u-text-small">
-                                <dt>{{ copy.grantDetail.fields.orgName }}</dt>
-                                <dd><a href="./recipients/{{ org.id }}">{{ org.name }}</a></dd>
+                {% set image = {
+                    "url": fallbackHeroImage.large,
+                    "alt": mainProgramme.title
+                } %}
 
-                                {% if org.organisationType %}
-                                    <dt>{{ copy.grantDetail.fields.type }}</dt>
-                                    <dd>{{ buildOrgTypeList(org) }}</dd>
-                                {% endif %}
-
-                                {% if org.charityNumber %}
-                                    <dt>{{ copy.grantDetail.fields.charityNumber }}</dt>
-                                    <dd>{{ org.charityNumber }}</dd>
-                                {% endif %}
-
-                                {% if org.companyNumber %}
-                                    <dt>{{ copy.grantDetail.fields.companyNumber }}</dt>
-                                    <dd>{{ org.companyNumber }}</dd>
-                                {% endif %}
-
-                                {% if grant.beneficiaryLocation %}
-                                    <dt>{{ copy.grantDetail.fields.location }}</dt>
-                                    <dd>{{ buildLocationList(grant.beneficiaryLocation) }}</dd>
-                                {% endif %}
-                            </dl>
-
-                            <p>
-                                <a class="btn btn--small btn--outline" href="./recipients/{{ org.id }}">
-                                    {{ copy.grantDetail.viewAllForRecipient }}
-                                </a>
-                            </p>
-                        {% endfor %}
-                    {% endcall %}
-                </div>
-                <div class="flex-grid__item">
-                    {% if fundingProgramme %}
-                        {% set link = localify(fundingProgramme.linkUrl) %}
-                    {% elseif mainProgramme.url %}
-                        {% set link = localify(mainProgramme.url) %}
-                    {% else %}
-                        {% set link = localify('/funding/programmes') %}
-                    {% endif %}
-
+                {% if fundingProgramme and fundingProgramme.hero %}
                     {% set image = {
-                        "url": fallbackHeroImage.large,
+                        "url": fundingProgramme.hero.image.large,
                         "alt": mainProgramme.title
                     } %}
+                {% endif %}
 
-                    {% if fundingProgramme and fundingProgramme.hero %}
-                        {% set image = {
-                            "url": fundingProgramme.hero.image.large,
-                            "alt": mainProgramme.title
-                        } %}
+                {% call promoCard({
+                    "title": copy.grantDetail.fundedBy + ' ' + mainProgramme.title,
+                    "summary": fundingProgramme.trailText,
+                    "image": image,
+                    "link": {
+                        "label": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
+                        "labelAria": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
+                        "url": link
+                    }
+                }) %}
+                    {% if fundingProgramme.hero.caption %}
+                        <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
                     {% endif %}
-
-                    {% call promoCard({
-                        "title": copy.grantDetail.fundedBy + ' ' + mainProgramme.title,
-                        "summary": fundingProgramme.trailText,
-                        "image": image,
-                        "link": {
-                            "label": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
-                            "labelAria": copy.grantDetail.readMoreAbout + ' ' + mainProgramme.title,
-                            "url": link
-                        }
-                    }) %}
-                        {% if fundingProgramme.hero.caption %}
-                            <p class="project-caption">{{ copy.grantDetail.photoCaption }}: {{ fundingProgramme.hero.caption }}</p>
-                        {% endif %}
-                    {% endcall %}
-                </div>
+                {% endcall %}
             </div>
         </div>
+    </div>
 
-        {# Related projects widget #}
-        {% if appData.config.get('features.enableRelatedGrants') %}
-            {# This wrapper div must exist or the related component swallows the following component #}
-            <div>
-                <grants-related
-                    limit="3"
-                    exclude-id="{{ grant.id }}"
-                    programme="{{ mainProgramme.title }}"
-                    beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
-                />
-            </div>
-        {% endif %}
-    </main>
+    {# Related projects widget #}
+    {% if appData.config.get('features.enableRelatedGrants') %}
+        {# This wrapper div must exist or the related component swallows the following component #}
+        <div>
+            <grants-related
+                limit="3"
+                exclude-id="{{ grant.id }}"
+                programme="{{ mainProgramme.title }}"
+                beneficiary-location="{{ grant.beneficiaryLocation | dump }}"
+            />
+        </div>
+    {% endif %}
 {% endblock %}

--- a/controllers/funding/grants/views/grant-detail.njk
+++ b/controllers/funding/grants/views/grant-detail.njk
@@ -30,7 +30,7 @@
 
                         {% if projectStory %}
                             <div class="s-prose">
-                                {{ flexibleContent(projectStory.content) }}
+                                {{ flexibleContent(projectStory.flexibleContent) }}
                             </div>
 
                             {% if projectStory.outro %}

--- a/controllers/funding/strategic-investments/views/strategic-investments.njk
+++ b/controllers/funding/strategic-investments/views/strategic-investments.njk
@@ -1,8 +1,12 @@
-{% extends "controllers/common/views/information-page.njk" %}
-{% from "components/hero.njk" import hero with context %}
+{% extends "controllers/common/views/flexible-content-page.njk" %}
+
 {% from "components/promo-card/macro.njk" import promoCard %}
 
-{% block customContent %}
+{% block contentPrimary %}
+
+    {# CMS content #}
+    {{ super() }}
+
     {% if strategicProgrammes.length > 0 %}
         <section class="u-inner-wide-only u-margin-bottom">
             <h2 class="t2 t--underline">Our strategic programmes</h2>

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -114,7 +114,7 @@ router.get(
                     res.redirect(entry.linkUrl);
                 } else if (entry.articleLink) {
                     res.redirect(entry.articleLink);
-                } else if (entry.content.length > 0) {
+                } else if (entry.flexibleContent.length > 0) {
                     renderPressDetail(req, res, entry);
                 } else {
                     next();
@@ -232,7 +232,7 @@ router.get(
                 const entry = updatesResponse.result;
                 if (shouldRedirectLinkUrl(req, entry)) {
                     res.redirect(entry.linkUrl);
-                } else if (entry.content.length > 0) {
+                } else if (entry.flexibleContent.length > 0) {
                     renderUpdatesDetail(req, res, entry);
                 } else {
                     next();

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -73,11 +73,14 @@ function renderPressDetail(req, res, entry) {
     res.locals.isBilingual = entry.availableLanguages.length === 2;
     res.locals.openGraph = get(entry, 'openGraph', false);
 
+    // Disable hero images for press releases
+    res.locals.pageHero = null;
+
     return res.render(path.resolve(__dirname, './views/post/press-release'), {
         title: entry.title,
         description: entry.summary,
         socialImage: get(entry, 'thumbnail.large', false),
-        entry: entry,
+        content: entry,
         breadcrumbs: res.locals.breadcrumbs.concat([
             {
                 label: req.i18n.__('news.types.press-releases.plural'),
@@ -184,6 +187,9 @@ function renderUpdatesDetail(req, res, entry) {
         };
     });
 
+    // Disable hero images for blogposts/people stories
+    res.locals.pageHero = null;
+
     res.render(path.resolve(__dirname, './views/post/blogpost'), {
         updateType: req.params.updateType,
         title: entry.title,
@@ -191,7 +197,7 @@ function renderUpdatesDetail(req, res, entry) {
         description: entry.summary,
         openGraph: get(entry, 'openGraph', false),
         socialImage: get(entry, 'thumbnail.large', false),
-        entry: entry,
+        content: entry,
         entryTagList: entryTagList,
         breadcrumbs: res.locals.breadcrumbs.concat({
             label: req.i18n.__(`news.types.${req.params.updateType}.singular`),

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -1,12 +1,16 @@
-{% extends "controllers/common/views/flexible-content-page.njk" %}
+{% extends "layouts/main.njk" %}
 
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
 {% from "components/inline-links/macro.njk" import inlineLinks %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
+{% from "components/flexible-content-next/macro.njk" import flexibleContent with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
 
 {% set copy = __('news') %}
+{% set bodyClass = 'has-static-header' %}
 
 {% macro articleMeta(content) %}
     {% call card(copy.aboutThisContent[updateType]) %}
@@ -61,66 +65,74 @@
     {% endcall %}
 {% endmacro %}
 
-{% block contentPrimary %}
+{% block content %}
+    <main role="main" id="content">
+        {{ pageTitle(title) }}
+        <section class="content-box u-inner-wide-only">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-    <div class="u-inner-wide-only">
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    {# CMS content #}
+                    {{
+                        flexibleContent(
+                            flexibleContent = content.flexibleContent,
+                            distinguishBlocks = false
+                        )
+                    }}
+                </div>
 
-        <div class="content-sidebar">
-            <div class="content-sidebar__primary">
-                {# CMS content #}
-                {{ super() }}
+                <div class="content-sidebar__secondary">
+                    {{ articleMeta(content) }}
+                </div>
             </div>
 
-            <div class="content-sidebar__secondary">
-                {{ articleMeta(content) }}
-            </div>
-        </div>
-
-        {% if entryTagList.length > 0 %}
-            {{ inlineLinks(
-                prefix = __('global.misc.topics') | title,
-                links = entryTagList
-            ) }}
-        {% endif %}
-
-        <div class="o-button-group-flex u-gutter-half u-margin-top">
-            <a class="btn btn--small btn--outline"
-                href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
-                data-ga-on="click"
-                data-ga-event-category="Facebook"
-                data-ga-event-action="Share {{ updateType }}">
-                <span class="btn__icon">{{ iconFacebook() }}</span>
-                {{ __('global.misc.share.facebook') }}
-            </a>
-            <a class="btn btn--small btn--outline"
-                href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ content.title }}&via={{ globalCopy.brand.twitter }}"
-                data-ga-on="click"
-                data-ga-event-category="Twitter"
-                data-ga-event-action="Share {{ updateType }}">
-                <span class="btn__icon">{{ iconTwitter() }}</span>
-                {{ __('global.misc.share.twitter')  }}
-            </a>
-        </div>
-
-        {{ relatedProgrammes(content.relatedFundingProgrammes) }}
-
-        {% if content.siblings.next or content.siblings.prev %}
-            {% set prevLink = {
-                "label": content.siblings.prev.title,
-                "url": content.siblings.prev.linkUrl
-            } if content.siblings.prev else false %}
-            {% set nextLink = {
-                "label": content.siblings.next.title,
-                "url": content.siblings.next.linkUrl
-            } if content.siblings.next else false %}
-
-            <div class="u-margin-top-l">
-                {{ splitNav(
-                    prevLink = prevLink,
-                    nextLink = nextLink
+            {% if entryTagList.length > 0 %}
+                {{ inlineLinks(
+                    prefix = __('global.misc.topics') | title,
+                    links = entryTagList
                 ) }}
-            </div>
-        {% endif %}
+            {% endif %}
 
-    </div>
+            <div class="o-button-group-flex u-gutter-half u-margin-top">
+                <a class="btn btn--small btn--outline"
+                    href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
+                    data-ga-on="click"
+                    data-ga-event-category="Facebook"
+                    data-ga-event-action="Share {{ updateType }}">
+                    <span class="btn__icon">{{ iconFacebook() }}</span>
+                    {{ __('global.misc.share.facebook') }}
+                </a>
+                <a class="btn btn--small btn--outline"
+                    href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ content.title }}&via={{ globalCopy.brand.twitter }}"
+                    data-ga-on="click"
+                    data-ga-event-category="Twitter"
+                    data-ga-event-action="Share {{ updateType }}">
+                    <span class="btn__icon">{{ iconTwitter() }}</span>
+                    {{ __('global.misc.share.twitter')  }}
+                </a>
+            </div>
+
+            {{ relatedProgrammes(content.relatedFundingProgrammes) }}
+
+            {% if content.siblings.next or content.siblings.prev %}
+                {% set prevLink = {
+                    "label": content.siblings.prev.title,
+                    "url": content.siblings.prev.linkUrl
+                } if content.siblings.prev else false %}
+                {% set nextLink = {
+                    "label": content.siblings.next.title,
+                    "url": content.siblings.next.linkUrl
+                } if content.siblings.next else false %}
+
+                <div class="u-margin-top-l">
+                    {{ splitNav(
+                        prevLink = prevLink,
+                        nextLink = nextLink
+                    ) }}
+                </div>
+            {% endif %}
+
+        </section>
+    </main>
 {% endblock %}

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -80,7 +80,7 @@
                             {{ entry.body | safe }}
                         </div>
                     {% else %}
-                        {{ flexibleContent(entry.content) }}
+                        {{ flexibleContent(entry.flexibleContent) }}
                     {% endif %}
                 </div>
 

--- a/controllers/updates/views/post/blogpost.njk
+++ b/controllers/updates/views/post/blogpost.njk
@@ -1,40 +1,42 @@
-{% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% extends "controllers/common/views/flexible-content-page.njk" %}
+
 {% from "components/card/macro.njk" import card %}
-{% from "components/flexible-content/macro.njk" import flexibleContent %}
 {% from "components/icons.njk" import iconFacebook, iconTwitter %}
 {% from "components/inline-links/macro.njk" import inlineLinks %}
-{% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "components/split-nav/macro.njk" import splitNav %}
 
 {% set copy = __('news') %}
-{% set bodyClass = 'has-static-header' %}
 
-{% macro articleMeta(entry) %}
+{% macro articleMeta(content) %}
     {% call card(copy.aboutThisContent[updateType]) %}
+        {% if content.thumbnail %}
+            <img src="{{ content.thumbnail.medium }}"
+                 alt="{{ content.title }}"
+                 class="u-margin-bottom" />
+        {% endif %}
         <div class="s-prose">
-            {% if entry.postDate %}
+            {% if content.postDate %}
                 <p>
                     <strong>{{ copy.datePublished }}</strong>:<br/>
-                    <time datetime="{{ entry.postDate.date }}">
-                        {{ formatDate(entry.postDate.date) }}
+                    <time datetime="{{ content.postDate.date }}">
+                        {{ formatDate(content.postDate.date) }}
                     </time>
 
-                    {% if entry.category %}
+                    {% if content.category %}
                         {{ __('global.misc.in') }}
-                        <a href="{{ localify('/news/' + updateType + '?category=' + entry.category.slug) }}">
-                            {{ entry.category.title }}
+                        <a href="{{ localify('/news/' + updateType + '?category=' + content.category.slug) }}">
+                            {{ content.category.title }}
                         </a>
                     {% endif %}
                 </p>
             {% endif %}
 
             <p><strong>
-                {{ copy.author.plural if entry.authors.length > 1  else copy.author.singular }}
+                {{ copy.author.plural if content.authors.length > 1  else copy.author.singular }}
             </strong></p>
 
-            {% for author in entry.authors -%}
+            {% for author in content.authors -%}
                 <div class="o-media u-margin-bottom-s">
                     {% if author.photo %}
                         <img src="{{ author.photo }}"
@@ -59,82 +61,66 @@
     {% endcall %}
 {% endmacro %}
 
-{% block content %}
-    <main role="main" id="content">
-        {{ pageTitle(title) }}
+{% block contentPrimary %}
 
-        <section class="content-box u-inner-wide-only">
-            {{ breadcrumbTrail(breadcrumbs) }}
+    <div class="u-inner-wide-only">
 
-            <div class="content-sidebar">
-                <div class="content-sidebar__primary">
-
-                    {% if entry.thumbnail %}
-                        <img src="{{ entry.thumbnail.medium }}"
-                             alt="{{ entry.title }}"
-                             class="u-margin-bottom" />
-                    {% endif %}
-
-                    {% if entry.body %}
-                        <div class="s-prose">
-                            {{ entry.body | safe }}
-                        </div>
-                    {% else %}
-                        {{ flexibleContent(entry.flexibleContent) }}
-                    {% endif %}
-                </div>
-
-                <div class="content-sidebar__secondary">
-                    {{ articleMeta(entry) }}
-                </div>
+        <div class="content-sidebar">
+            <div class="content-sidebar__primary">
+                {# CMS content #}
+                {{ super() }}
             </div>
 
-            {% if entryTagList.length > 0 %}
-                {{ inlineLinks(
-                    prefix = __('global.misc.topics') | title,
-                    links = entryTagList
+            <div class="content-sidebar__secondary">
+                {{ articleMeta(content) }}
+            </div>
+        </div>
+
+        {% if entryTagList.length > 0 %}
+            {{ inlineLinks(
+                prefix = __('global.misc.topics') | title,
+                links = entryTagList
+            ) }}
+        {% endif %}
+
+        <div class="o-button-group-flex u-gutter-half u-margin-top">
+            <a class="btn btn--small btn--outline"
+                href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
+                data-ga-on="click"
+                data-ga-event-category="Facebook"
+                data-ga-event-action="Share {{ updateType }}">
+                <span class="btn__icon">{{ iconFacebook() }}</span>
+                {{ __('global.misc.share.facebook') }}
+            </a>
+            <a class="btn btn--small btn--outline"
+                href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ content.title }}&via={{ globalCopy.brand.twitter }}"
+                data-ga-on="click"
+                data-ga-event-category="Twitter"
+                data-ga-event-action="Share {{ updateType }}">
+                <span class="btn__icon">{{ iconTwitter() }}</span>
+                {{ __('global.misc.share.twitter')  }}
+            </a>
+        </div>
+
+        {{ relatedProgrammes(content.relatedFundingProgrammes) }}
+
+        {% if content.siblings.next or content.siblings.prev %}
+            {% set prevLink = {
+                "label": content.siblings.prev.title,
+                "url": content.siblings.prev.linkUrl
+            } if content.siblings.prev else false %}
+            {% set nextLink = {
+                "label": content.siblings.next.title,
+                "url": content.siblings.next.linkUrl
+            } if content.siblings.next else false %}
+
+            <div class="u-margin-top-l">
+                {{ splitNav(
+                    prevLink = prevLink,
+                    nextLink = nextLink
                 ) }}
-            {% endif %}
-
-            <div class="o-button-group-flex u-gutter-half u-margin-top">
-                <a class="btn btn--small btn--outline"
-                    href="https://www.facebook.com/sharer.php?u={{ getCurrentAbsoluteUrl() }}"
-                    data-ga-on="click"
-                    data-ga-event-category="Facebook"
-                    data-ga-event-action="Share {{ updateType }}">
-                    <span class="btn__icon">{{ iconFacebook() }}</span>
-                    {{ __('global.misc.share.facebook') }}
-                </a>
-                <a class="btn btn--small btn--outline"
-                    href="https://twitter.com/intent/tweet?url={{ getCurrentAbsoluteUrl() }}&text={{ entry.title }}&via={{ globalCopy.brand.twitter }}"
-                    data-ga-on="click"
-                    data-ga-event-category="Twitter"
-                    data-ga-event-action="Share {{ updateType }}">
-                    <span class="btn__icon">{{ iconTwitter() }}</span>
-                    {{ __('global.misc.share.twitter')  }}
-                </a>
             </div>
+        {% endif %}
 
-            {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
-
-            {% if entry.siblings.next or entry.siblings.prev %}
-                {% set prevLink = {
-                    "label": entry.siblings.prev.title,
-                    "url": entry.siblings.prev.linkUrl
-                } if entry.siblings.prev else false %}
-                {% set nextLink = {
-                    "label": entry.siblings.next.title,
-                    "url": entry.siblings.next.linkUrl
-                } if entry.siblings.next else false %}
-
-                <div class="u-margin-top-l">
-                    {{ splitNav(
-                        prevLink = prevLink,
-                        nextLink = nextLink
-                    ) }}
-                </div>
-            {% endif %}
-
-        </section>
-    </main>
+    </div>
 {% endblock %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -1,50 +1,44 @@
-{% extends "layouts/main.njk" %}
-{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
+{% extends "controllers/common/views/flexible-content-page.njk" %}
+
 {% from "components/card/macro.njk" import card %}
 {% from "components/document-list/macro.njk" import documentList %}
-{% from "components/flexible-content/macro.njk" import flexibleContent %}
-{% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "../view-helpers.njk" import entryRegions with context %}
 
 {% set copy = __('news') %}
 {% set bodyClass = 'has-static-header' %}
 
-{% macro entryMeta(entry) %}
+{% macro entryMeta(content) %}
     <dl class="o-definition-list o-definition-list--compact">
-        {% if entry.postDate %}
+        {% if content.postDate %}
             <dt>{{ copy.datePublished }}</dt>
             <dd>
-                <time datetime="{{ entry.postDate.date }}">
-                    {{ formatDate(entry.postDate.date) }}
+                <time datetime="{{ content.postDate.date }}">
+                    {{ formatDate(content.postDate.date) }}
                 </time>
             </dd>
         {% endif %}
-        {% if entry.regions.length > 0 %}
+        {% if content.regions.length > 0 %}
             <dt>{{ copy.pressRelease.region }}</dt>
-            <dd>{{ entryRegions(entry.regions, '../') }}</dd>
+            <dd>{{ entryRegions(content.regions, '../') }}</dd>
         {% endif %}
     </dl>
 {% endmacro %}
 
-{% block content %}
-    <main role="main" id="content">
-        {{ pageTitle(title) }}
+{% block contentPrimary %}
 
-        <section class="content-box u-inner-wide-only">
-            {{ breadcrumbTrail(breadcrumbs) }}
+    <div class="u-inner-wide-only">
 
-            <div class="content-sidebar">
-                <div class="content-sidebar__primary s-prose">
-                    {% if entry.body %}
-                        {{ entry.body | safe }}
-                    {% else %}
-                        {{ flexibleContent(entry.flexibleContent) }}
-                    {% endif %}
+        <div class="content-sidebar">
+            <div class="content-sidebar__primary">
+                {# CMS content #}
+                {{ super() }}
 
-                    {% if entry.documentGroups.length > 0 %}
+                <div class="content-box content-box--frameless">
+
+                    {% if content.documentGroups.length > 0 %}
                         <section class="content-box">
-                            {% for group in entry.documentGroups  %}
+                            {% for group in content.documentGroups  %}
                                 <h3 class="t2 t--underline">{{ group.title }}</h3>
                                 {{ documentList(group.files) }}
                                 <div class="s-prose">
@@ -55,38 +49,40 @@
                     {% endif %}
 
                     <div class="content-meta">
-                        {{ entryMeta(entry) }}
+                        {{ entryMeta(content) }}
                     </div>
 
-                    {% if entry.notesToEditors %}
+                    {% if content.notesToEditors %}
                         <aside class="u-tone-background-tint u-padded u-text-medium" id="notes">
                             <h3 class="u-tone-brand-primary">{{ copy.pressRelease.notesToEditors }}</h3>
-                            {{ entry.notesToEditors | safe }}
+                            {{ content.notesToEditors | safe }}
                         </aside>
                     {% endif %}
 
-                    {{ relatedProgrammes(entry.relatedFundingProgrammes) }}
+                    {{ relatedProgrammes(content.relatedFundingProgrammes) }}
                 </div>
 
-                <div class="content-sidebar__secondary">
-                    {% call card(copy.pressRelease.aboutThisPressRelease) %}
+            </div>
+
+            <div class="content-sidebar__secondary">
+                {% call card(copy.pressRelease.aboutThisPressRelease) %}
+                    <div class="s-prose u-text-small u-wrap-links">
+                        {{ entryMeta(content) }}
+                        {% if content.notesToEditors %}
+                            <p><a href="#notes">{{ copy.pressRelease.notesToEditors }}</a></p>
+                        {% endif %}
+                    </div>
+                {% endcall %}
+
+                {% if content.contacts %}
+                    {% call card(copy.pressRelease.contacts) %}
                         <div class="s-prose u-text-small u-wrap-links">
-                            {{ entryMeta(entry) }}
-                            {% if entry.notesToEditors %}
-                                <p><a href="#notes">{{ copy.pressRelease.notesToEditors }}</a></p>
-                            {% endif %}
+                            {{ content.contacts | safe }}
                         </div>
                     {% endcall %}
-
-                    {% if entry.contacts %}
-                        {% call card(copy.pressRelease.contacts) %}
-                            <div class="s-prose u-text-small u-wrap-links">
-                                {{ entry.contacts | safe }}
-                            </div>
-                        {% endcall %}
-                    {% endif %}
-                </div>
+                {% endif %}
             </div>
-        </section>
-    </main>
+        </div>
+
+    </div>
 {% endblock %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -39,7 +39,7 @@
                     {% if entry.body %}
                         {{ entry.body | safe }}
                     {% else %}
-                        {{ flexibleContent(entry.content) }}
+                        {{ flexibleContent(entry.flexibleContent) }}
                     {% endif %}
 
                     {% if entry.documentGroups.length > 0 %}

--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -1,9 +1,12 @@
-{% extends "controllers/common/views/flexible-content-page.njk" %}
+{% extends "layouts/main.njk" %}
 
+{% from "components/breadcrumb-trail/macro.njk" import breadcrumbTrail %}
 {% from "components/card/macro.njk" import card %}
 {% from "components/document-list/macro.njk" import documentList %}
 {% from "components/programmes.njk" import relatedProgrammes with context %}
 {% from "../view-helpers.njk" import entryRegions with context %}
+{% from "components/page-title/macro.njk" import pageTitle %}
+{% from "components/flexible-content-next/macro.njk" import flexibleContent with context %}
 
 {% set copy = __('news') %}
 {% set bodyClass = 'has-static-header' %}
@@ -25,16 +28,23 @@
     </dl>
 {% endmacro %}
 
-{% block contentPrimary %}
+{% block content %}
+    <main role="main" id="content">
+        {{ pageTitle(title) }}
 
-    <div class="u-inner-wide-only">
+        <section class="content-box u-inner-wide-only">
+            {{ breadcrumbTrail(breadcrumbs) }}
 
-        <div class="content-sidebar">
-            <div class="content-sidebar__primary">
-                {# CMS content #}
-                {{ super() }}
+            <div class="content-sidebar">
+                <div class="content-sidebar__primary">
+                    {# CMS content #}
+                    {{
+                        flexibleContent(
+                            flexibleContent = content.flexibleContent,
+                            distinguishBlocks = false
+                        )
+                    }}
 
-                <div class="content-box content-box--frameless">
 
                     {% if content.documentGroups.length > 0 %}
                         <section class="content-box">
@@ -60,29 +70,29 @@
                     {% endif %}
 
                     {{ relatedProgrammes(content.relatedFundingProgrammes) }}
+
                 </div>
 
-            </div>
-
-            <div class="content-sidebar__secondary">
-                {% call card(copy.pressRelease.aboutThisPressRelease) %}
-                    <div class="s-prose u-text-small u-wrap-links">
-                        {{ entryMeta(content) }}
-                        {% if content.notesToEditors %}
-                            <p><a href="#notes">{{ copy.pressRelease.notesToEditors }}</a></p>
-                        {% endif %}
-                    </div>
-                {% endcall %}
-
-                {% if content.contacts %}
-                    {% call card(copy.pressRelease.contacts) %}
+                <div class="content-sidebar__secondary">
+                    {% call card(copy.pressRelease.aboutThisPressRelease) %}
                         <div class="s-prose u-text-small u-wrap-links">
-                            {{ content.contacts | safe }}
+                            {{ entryMeta(content) }}
+                            {% if content.notesToEditors %}
+                                <p><a href="#notes">{{ copy.pressRelease.notesToEditors }}</a></p>
+                            {% endif %}
                         </div>
                     {% endcall %}
-                {% endif %}
-            </div>
-        </div>
 
-    </div>
+                    {% if content.contacts %}
+                        {% call card(copy.pressRelease.contacts) %}
+                            <div class="s-prose u-text-small u-wrap-links">
+                                {{ content.contacts | safe }}
+                            </div>
+                        {% endcall %}
+                    {% endif %}
+                </div>
+            </div>
+
+        </section>
+    </main>
 {% endblock %}

--- a/views/components/flexible-content-next/macro.njk
+++ b/views/components/flexible-content-next/macro.njk
@@ -10,7 +10,7 @@
 
 {% set flexAnchor = 'item' %}
 
-{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null) %}
+{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null, distinguishBlocks = true) %}
     {% if flexibleContent.length > 0 %}
         {% set mediaAsideCycler = cycler(true, false) %}
 
@@ -87,7 +87,7 @@
                     </ul>
                 </section>
             {% else %}
-                <section class="content-box u-inner-wide-only" id="{{ flexAnchor + '-' + loop.index }}">
+                <section class="{% if distinguishBlocks %}content-box u-inner-wide-only{% endif %}" id="{{ flexAnchor + '-' + loop.index }}">
                     {% if (breadcrumbs and loop.first) %}
                         {{ breadcrumbs | safe }}
                     {% endif %}


### PR DESCRIPTION
This removes the old flexible content macro usage (which didn't support most of the new block types) in favour of the new one (which a future PR will rename so it's no longer `flexible-content-next`). 

Only the following page types used it:

- [blogposts](https://www.tnlcommunityfund.org.uk/news/blog/2020-06-18/food-for-thought-supporting-sustainable-community-food-projects-through-coronavirus-and-beyond)
- [press releases](https://www.tnlcommunityfund.org.uk/news/press-releases/2020-06-24/1-8million-national-lottery-funding-supports-health-and-well-being-across-our-communities) 
- [project stories](https://www.tnlcommunityfund.org.uk/funding/grants/0031059849) 

This mainly involved renaming some variables for consistency (which pairs with [the CMS change here](https://github.com/biglotteryfund/craft-dev/pull/289) and [fixes this issue](https://github.com/biglotteryfund/blf-alpha/issues/3363)), and updating the flexible content macro to allow for rendering the blocks without `content-box` frames, eg:

### With frames
![image](https://user-images.githubusercontent.com/394376/85591947-a2465500-b63d-11ea-83e8-47644701067e.png)

### Without frames
![image](https://user-images.githubusercontent.com/394376/85591977-aa9e9000-b63d-11ea-8c6b-666df1b80996.png)

These page types (blogposts, press releases and project stories) should all be rendered in a single container to improve their readability/flow from a UX perspective, as they're considered a single piece of content rather than multiple separate pieces (like the Funding page example above).

Also, the Strategic Programmes landing page used the old `information-page.njk` template which we're deleting (see https://github.com/biglotteryfund/blf-alpha/issues/3367) so I've migrated it to use flexible content, too.