### PR TITLE
Add CMS sandbox mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,12 @@ MS_REDIRECT_URL=http://localhost:3000/user/staff/auth/openid/return
 # you may want to point your app to a local API url.
 # CONTENT_API_URL=
 
+# Content API Sandbox url (optional)
+# This is for staff training - if a logged-in staff user visits
+# /tools/sandbox-mode/toggle then they will use this URL for API calls
+# (eg. used to point at the TEST CMS instance for staff training)
+# CONTENT_API_SANDBOX_URL=
+
 # Past grants API url (optional)
 # This defaults to the production endpoint so that
 # all environments have the most accurate data.

--- a/common/content-api.js
+++ b/common/content-api.js
@@ -14,423 +14,446 @@ const querystring = require('querystring');
 
 const logger = require('./logger');
 const { sanitiseUrlPath, stripTrailingSlashes } = require('./urls');
-const { CONTENT_API_URL } = require('./secrets');
+const { CONTENT_API_URL, CONTENT_API_SANDBOX_URL } = require('./secrets');
 
 const getAttrs = (response) => get('data.attributes')(response);
 const mapAttrs = (response) => map('attributes')(response.data);
 
-const queryContentApi = got.extend({
-    prefixUrl: CONTENT_API_URL,
-    headers: { 'user-agent': 'tnlcf-www' },
-    hooks: {
-        beforeRequest: [
-            function (options) {
-                logger.debug(`Fetching ${options.url.href}`);
-            },
-        ],
-    },
-});
+module.exports = function ({ flags = {} }) {
+    const API_ENDPOINT =
+        get('sandboxMode')(flags) === true
+            ? CONTENT_API_SANDBOX_URL
+            : CONTENT_API_URL;
 
-/**
- * Adds the preview parameters to the request
- * (if accessed via the preview domain)
- */
-function withPreviewParams(rawSearchParams = {}, extraSearchParams = {}) {
-    const globalParams = pick(rawSearchParams, [
-        'social',
-        'x-craft-live-preview',
-        'x-craft-preview',
-        'token',
-    ]);
-    return Object.assign({}, globalParams, extraSearchParams);
-}
+    const queryContentApi = got.extend({
+        prefixUrl: API_ENDPOINT,
+        headers: { 'user-agent': 'tnlcf-www' },
+        hooks: {
+            beforeRequest: [
+                function (options) {
+                    logger.debug(`Fetching ${options.url.href}`);
+                },
+            ],
+        },
+    });
 
-/**
- * Merge welsh by property name
- * Merge welsh results where available matched by a given property
- * Usage:
- * ```
- * mergeWelshBy('slug')(currentLocale, enResults, cyResults)
- * ```
- */
-function mergeWelshBy(propName) {
-    return function (currentLocale, enResults, cyResults) {
-        if (currentLocale === 'en') {
-            return enResults;
-        } else {
-            return map((enItem) => {
-                const findCy = find(
-                    (cyItem) => cyItem[propName] === enItem[propName]
-                );
-                return findCy(cyResults) || enItem;
-            })(enResults);
-        }
-    };
-}
+    /**
+     * Adds the preview parameters to the request
+     * (if accessed via the preview domain)
+     */
+    function withPreviewParams(rawSearchParams = {}, extraSearchParams = {}) {
+        const globalParams = pick(rawSearchParams, [
+            'social',
+            'x-craft-live-preview',
+            'x-craft-preview',
+            'token',
+        ]);
+        return Object.assign({}, globalParams, extraSearchParams);
+    }
 
-/**
- * Build pagination
- * Translate content API pagination into an object for use in views
- */
-function _buildPagination(paginationMeta, currentQuery = {}) {
-    if (paginationMeta && paginationMeta.total_pages > 1) {
-        const currentPage = paginationMeta.current_page;
-        const totalPages = paginationMeta.total_pages;
-        const prevLink = `?${querystring.stringify({
-            ...currentQuery,
-            ...{ page: currentPage - 1 },
-        })}`;
-        const nextLink = `?${querystring.stringify({
-            ...currentQuery,
-            ...{ page: currentPage + 1 },
-        })}`;
-
-        return {
-            count: paginationMeta.count,
-            total: paginationMeta.total,
-            perPage: paginationMeta.per_page,
-            currentPage: currentPage,
-            totalPages: totalPages,
-            prevLink: currentPage > 1 ? prevLink : null,
-            nextLink: currentPage < totalPages ? nextLink : null,
+    /**
+     * Merge welsh by property name
+     * Merge welsh results where available matched by a given property
+     * Usage:
+     * ```
+     * mergeWelshBy('slug')(currentLocale, enResults, cyResults)
+     * ```
+     */
+    function mergeWelshBy(propName) {
+        return function (currentLocale, enResults, cyResults) {
+            if (currentLocale === 'en') {
+                return enResults;
+            } else {
+                return map((enItem) => {
+                    const findCy = find(
+                        (cyItem) => cyItem[propName] === enItem[propName]
+                    );
+                    return findCy(cyResults) || enItem;
+                })(enResults);
+            }
         };
     }
-}
 
-/***********************************************
- * API Methods
- ***********************************************/
+    /**
+     * Build pagination
+     * Translate content API pagination into an object for use in views
+     */
+    function _buildPagination(paginationMeta, currentQuery = {}) {
+        if (paginationMeta && paginationMeta.total_pages > 1) {
+            const currentPage = paginationMeta.current_page;
+            const totalPages = paginationMeta.total_pages;
+            const prevLink = `?${querystring.stringify({
+                ...currentQuery,
+                ...{ page: currentPage - 1 },
+            })}`;
+            const nextLink = `?${querystring.stringify({
+                ...currentQuery,
+                ...{ page: currentPage + 1 },
+            })}`;
 
-function getRoutes() {
-    return queryContentApi('v1/list-routes').json().then(mapAttrs);
-}
-
-function getAliasForLocale(locale, urlPath) {
-    return queryContentApi(`v1/${locale}/aliases`)
-        .json()
-        .then(mapAttrs)
-        .then((matches) => {
-            return find(function (alias) {
-                return alias.from.toLowerCase() === urlPath.toLowerCase();
-            })(matches);
-        });
-}
-
-function getAlias(urlPath) {
-    const getOrHomepage = getOr('/', 'to');
-    return getAliasForLocale('en', urlPath).then((enMatch) => {
-        if (enMatch) {
-            return getOrHomepage(enMatch);
-        } else {
-            return getAliasForLocale('cy', urlPath).then((cyMatch) =>
-                cyMatch ? getOrHomepage(cyMatch) : null
-            );
+            return {
+                count: paginationMeta.count,
+                total: paginationMeta.total,
+                perPage: paginationMeta.per_page,
+                currentPage: currentPage,
+                totalPages: totalPages,
+                prevLink: currentPage > 1 ? prevLink : null,
+                nextLink: currentPage < totalPages ? nextLink : null,
+            };
         }
-    });
-}
+    }
 
-function getHeroImage({ locale, slug }) {
-    return queryContentApi(`v1/${locale}/hero-image/${slug}`)
-        .json()
-        .then(getAttrs);
-}
+    /***********************************************
+     * API Methods
+     ***********************************************/
 
-function getHomepage(locale, searchParams = {}) {
-    return queryContentApi(`v1/${locale}/homepage`, {
-        searchParams: withPreviewParams(searchParams),
-    })
-        .json()
-        .then(getAttrs);
-}
+    function getRoutes() {
+        return queryContentApi('v1/list-routes').json().then(mapAttrs);
+    }
 
-/**
- * Get updates
- * @param options
- * @property {string} options.locale
- * @property {string} [options.type]
- * @property {string} [options.date]
- * @property {string} [options.slug]
- * @property {object} [options.query]
- * @property {object} [options.requestParams]
- */
-function getUpdates({
-    locale,
-    type = null,
-    date = null,
-    slug = null,
-    query = {},
-    requestParams = {},
-}) {
-    if (slug) {
-        return queryContentApi(`v1/${locale}/updates/${type}/${date}/${slug}`, {
-            searchParams: withPreviewParams(requestParams, { ...query }),
+    function getAliasForLocale(locale, urlPath) {
+        return queryContentApi(`v1/${locale}/aliases`)
+            .json()
+            .then(mapAttrs)
+            .then((matches) => {
+                return find(function (alias) {
+                    return alias.from.toLowerCase() === urlPath.toLowerCase();
+                })(matches);
+            });
+    }
+
+    function getAlias(urlPath) {
+        const getOrHomepage = getOr('/', 'to');
+        return getAliasForLocale('en', urlPath).then((enMatch) => {
+            if (enMatch) {
+                return getOrHomepage(enMatch);
+            } else {
+                return getAliasForLocale('cy', urlPath).then((cyMatch) =>
+                    cyMatch ? getOrHomepage(cyMatch) : null
+                );
+            }
+        });
+    }
+
+    function getHeroImage({ locale, slug }) {
+        return queryContentApi(`v1/${locale}/hero-image/${slug}`)
+            .json()
+            .then(getAttrs);
+    }
+
+    function getHomepage(locale, searchParams = {}) {
+        return queryContentApi(`v1/${locale}/homepage`, {
+            searchParams: withPreviewParams(searchParams),
         })
             .json()
-            .then((response) => {
-                return {
-                    meta: response.meta,
-                    result: response.data.attributes,
-                };
+            .then(getAttrs);
+    }
+
+    /**
+     * Get updates
+     * @param options
+     * @property {string} options.locale
+     * @property {string} [options.type]
+     * @property {string} [options.date]
+     * @property {string} [options.slug]
+     * @property {object} [options.query]
+     * @property {object} [options.requestParams]
+     */
+    function getUpdates({
+        locale,
+        type = null,
+        date = null,
+        slug = null,
+        query = {},
+        requestParams = {},
+    }) {
+        if (slug) {
+            return queryContentApi(
+                `v1/${locale}/updates/${type}/${date}/${slug}`,
+                {
+                    searchParams: withPreviewParams(requestParams, {
+                        ...query,
+                    }),
+                }
+            )
+                .json()
+                .then((response) => {
+                    return {
+                        meta: response.meta,
+                        result: response.data.attributes,
+                    };
+                });
+        } else {
+            return queryContentApi(`v1/${locale}/updates/${type || ''}`, {
+                searchParams: withPreviewParams(requestParams, {
+                    ...query,
+                    ...{ 'page-limit': 10 },
+                }),
+            })
+                .json()
+                .then((response) => {
+                    return {
+                        meta: response.meta,
+                        result: mapAttrs(response),
+                        pagination: _buildPagination(
+                            response.meta.pagination,
+                            query
+                        ),
+                    };
+                });
+        }
+    }
+
+    function getFundingProgrammes({
+        locale,
+        page = 1,
+        pageLimit = 100,
+        showAll = false,
+    }) {
+        const requestOptions = {
+            searchParams: {
+                'page': page,
+                'page-limit': pageLimit,
+                'all': showAll === true,
+            },
+        };
+
+        return Promise.all([
+            queryContentApi
+                .get('v2/en/funding-programmes', requestOptions)
+                .json(),
+            queryContentApi
+                .get('v2/cy/funding-programmes', requestOptions)
+                .json(),
+        ]).then((responses) => {
+            const [enResponse, cyResponse] = responses;
+            return {
+                meta: locale === 'en' ? enResponse.meta : cyResponse.meta,
+                result: mergeWelshBy('slug')(
+                    locale,
+                    mapAttrs(enResponse),
+                    mapAttrs(cyResponse)
+                ),
+            };
+        });
+    }
+
+    function getRecentFundingProgrammes(locale) {
+        return queryContentApi
+            .get(`v2/${locale}/funding-programmes`, {
+                searchParams: { 'page': 1, 'page-limit': 3, 'newest': true },
+            })
+            .json()
+            .then(mapAttrs);
+    }
+
+    function getFundingProgramme({ locale, slug, searchParams = {} }) {
+        return queryContentApi
+            .get(`v2/${locale}/funding-programmes/${slug}`, {
+                searchParams: withPreviewParams(searchParams),
+            })
+            .json()
+            .then(getAttrs);
+    }
+
+    function getResearch({
+        locale,
+        slug = null,
+        query = {},
+        requestParams = {},
+        type = null,
+    }) {
+        if (slug) {
+            return queryContentApi(`v1/${locale}/research/${slug}`, {
+                searchParams: withPreviewParams(requestParams, { ...query }),
+            })
+                .json()
+                .then(getAttrs);
+        } else {
+            let path = `v1/${locale}/research`;
+            if (type) {
+                path += `/${type}`;
+            }
+            return queryContentApi(path, {
+                searchParams: withPreviewParams(requestParams, { ...query }),
+            })
+                .json()
+                .then((response) => {
+                    return {
+                        meta: response.meta,
+                        result: mapAttrs(response),
+                        pagination: _buildPagination(
+                            response.meta.pagination,
+                            query
+                        ),
+                    };
+                });
+        }
+    }
+
+    function getPublications({
+        locale,
+        programme,
+        slug = null,
+        searchParams = {},
+    }) {
+        const customSearchParams = {
+            // Override default page-limit
+            ...{ 'page-limit': 10 },
+            ...pick(searchParams, ['page', 'tag', 'q', 'sort']),
+        };
+
+        const combinedSearchParams = withPreviewParams(searchParams, {
+            ...customSearchParams,
+        });
+
+        if (slug) {
+            return queryContentApi(
+                `v1/${locale}/funding/publications/${programme}/${slug}`,
+                { searchParams: combinedSearchParams }
+            )
+                .json()
+                .then((response) => {
+                    return {
+                        meta: response.meta,
+                        entry: getAttrs(response),
+                    };
+                });
+        } else {
+            return queryContentApi(
+                `v1/${locale}/funding/publications/${programme}`,
+                { searchParams: combinedSearchParams }
+            )
+                .json()
+                .then((response) => {
+                    return {
+                        meta: response.meta,
+                        result: mapAttrs(response),
+                        pagination: _buildPagination(
+                            response.meta.pagination,
+                            customSearchParams
+                        ),
+                    };
+                });
+        }
+    }
+
+    function getPublicationTags({ locale, programme }) {
+        return queryContentApi(
+            `v1/${locale}/funding/publications/${programme}/tags`
+        )
+            .json()
+            .then(function (response) {
+                const attrs = mapAttrs(response);
+                // Strip entries to just their tags
+                const allTags = flatten(attrs.map((_) => _.tags));
+                // Count the occurrences of each tag
+                const counts = countBy(allTags, 'id');
+                // Merge these counts into the tag list after de-duping
+                const tags = uniqBy(allTags, 'id').map((tag) => {
+                    tag.count = counts[tag.id];
+                    return tag;
+                });
+                return sortBy('count')(tags).reverse();
             });
-    } else {
-        return queryContentApi(`v1/${locale}/updates/${type || ''}`, {
+    }
+
+    function getStrategicProgrammes({
+        locale,
+        slug = null,
+        query = {},
+        requestParams = {},
+    }) {
+        if (slug) {
+            return queryContentApi
+                .get(`v1/${locale}/strategic-programmes/${slug}`, {
+                    searchParams: withPreviewParams(requestParams, {
+                        ...query,
+                    }),
+                })
+                .json()
+                .then((response) => get('data.attributes')(response));
+        } else {
+            return Promise.all([
+                queryContentApi.get('v1/en/strategic-programmes').json(),
+                queryContentApi.get('v1/cy/strategic-programmes').json(),
+            ]).then((responses) => {
+                const [enResults, cyResults] = responses.map(mapAttrs);
+                return mergeWelshBy('urlPath')(locale, enResults, cyResults);
+            });
+        }
+    }
+
+    function getListingPage({ locale, path, query = {}, requestParams = {} }) {
+        const sanitisedPath = sanitiseUrlPath(path);
+        return queryContentApi(`v1/${locale}/listing`, {
             searchParams: withPreviewParams(requestParams, {
                 ...query,
-                ...{ 'page-limit': 10 },
+                ...{ path: sanitisedPath },
             }),
         })
             .json()
             .then((response) => {
-                return {
-                    meta: response.meta,
-                    result: mapAttrs(response),
-                    pagination: _buildPagination(
-                        response.meta.pagination,
-                        query
-                    ),
-                };
+                const attributes = response.data.map((item) => item.attributes);
+                return attributes.find((attr) => {
+                    return attr.linkUrl === stripTrailingSlashes(path);
+                });
             });
     }
-}
 
-function getFundingProgrammes({
-    locale,
-    page = 1,
-    pageLimit = 100,
-    showAll = false,
-}) {
-    const requestOptions = {
-        searchParams: {
-            'page': page,
-            'page-limit': pageLimit,
-            'all': showAll === true,
-        },
-    };
-
-    return Promise.all([
-        queryContentApi.get('v2/en/funding-programmes', requestOptions).json(),
-        queryContentApi.get('v2/cy/funding-programmes', requestOptions).json(),
-    ]).then((responses) => {
-        const [enResponse, cyResponse] = responses;
-        return {
-            meta: locale === 'en' ? enResponse.meta : cyResponse.meta,
-            result: mergeWelshBy('slug')(
-                locale,
-                mapAttrs(enResponse),
-                mapAttrs(cyResponse)
-            ),
-        };
-    });
-}
-
-function getRecentFundingProgrammes(locale) {
-    return queryContentApi
-        .get(`v2/${locale}/funding-programmes`, {
-            searchParams: { 'page': 1, 'page-limit': 3, 'newest': true },
-        })
-        .json()
-        .then(mapAttrs);
-}
-
-function getFundingProgramme({ locale, slug, searchParams = {} }) {
-    return queryContentApi
-        .get(`v2/${locale}/funding-programmes/${slug}`, {
-            searchParams: withPreviewParams(searchParams),
-        })
-        .json()
-        .then(getAttrs);
-}
-
-function getResearch({
-    locale,
-    slug = null,
-    query = {},
-    requestParams = {},
-    type = null,
-}) {
-    if (slug) {
-        return queryContentApi(`v1/${locale}/research/${slug}`, {
+    function getProjectStory({
+        locale,
+        grantId,
+        query = {},
+        requestParams = {},
+    }) {
+        return queryContentApi(`v1/${locale}/project-stories/${grantId}`, {
             searchParams: withPreviewParams(requestParams, { ...query }),
         })
             .json()
             .then(getAttrs);
-    } else {
-        let path = `v1/${locale}/research`;
-        if (type) {
-            path += `/${type}`;
-        }
-        return queryContentApi(path, {
-            searchParams: withPreviewParams(requestParams, { ...query }),
+    }
+
+    function getDataStats(locale, searchParams = {}) {
+        return queryContentApi(`v1/${locale}/data`, {
+            searchParams: withPreviewParams(searchParams),
         })
             .json()
-            .then((response) => {
-                return {
-                    meta: response.meta,
-                    result: mapAttrs(response),
-                    pagination: _buildPagination(
-                        response.meta.pagination,
-                        query
-                    ),
-                };
-            });
+            .then(getAttrs);
     }
-}
 
-function getPublications({
-    locale,
-    programme,
-    slug = null,
-    searchParams = {},
-}) {
-    const customSearchParams = {
-        // Override default page-limit
-        ...{ 'page-limit': 10 },
-        ...pick(searchParams, ['page', 'tag', 'q', 'sort']),
+    function getMerchandise({ locale, showAll = false } = {}) {
+        let searchParams = {};
+        if (showAll) {
+            searchParams.all = 'true';
+        }
+
+        return queryContentApi(`v1/${locale}/merchandise`, {
+            searchParams: searchParams,
+        })
+            .json()
+            .then(mapAttrs);
+    }
+
+    return {
+        // Exported for tests
+        _buildPagination,
+        // API methods
+        getAlias,
+        getProjectStory,
+        getDataStats,
+        getFundingProgramme,
+        getFundingProgrammes,
+        getRecentFundingProgrammes,
+        getHeroImage,
+        getHomepage,
+        getListingPage,
+        getMerchandise,
+        getPublications,
+        getPublicationTags,
+        getResearch,
+        getRoutes,
+        getStrategicProgrammes,
+        getUpdates,
     };
-
-    const combinedSearchParams = withPreviewParams(searchParams, {
-        ...customSearchParams,
-    });
-
-    if (slug) {
-        return queryContentApi(
-            `v1/${locale}/funding/publications/${programme}/${slug}`,
-            { searchParams: combinedSearchParams }
-        )
-            .json()
-            .then((response) => {
-                return {
-                    meta: response.meta,
-                    entry: getAttrs(response),
-                };
-            });
-    } else {
-        return queryContentApi(
-            `v1/${locale}/funding/publications/${programme}`,
-            { searchParams: combinedSearchParams }
-        )
-            .json()
-            .then((response) => {
-                return {
-                    meta: response.meta,
-                    result: mapAttrs(response),
-                    pagination: _buildPagination(
-                        response.meta.pagination,
-                        customSearchParams
-                    ),
-                };
-            });
-    }
-}
-
-function getPublicationTags({ locale, programme }) {
-    return queryContentApi(
-        `v1/${locale}/funding/publications/${programme}/tags`
-    )
-        .json()
-        .then(function (response) {
-            const attrs = mapAttrs(response);
-            // Strip entries to just their tags
-            const allTags = flatten(attrs.map((_) => _.tags));
-            // Count the occurrences of each tag
-            const counts = countBy(allTags, 'id');
-            // Merge these counts into the tag list after de-duping
-            const tags = uniqBy(allTags, 'id').map((tag) => {
-                tag.count = counts[tag.id];
-                return tag;
-            });
-            return sortBy('count')(tags).reverse();
-        });
-}
-
-function getStrategicProgrammes({
-    locale,
-    slug = null,
-    query = {},
-    requestParams = {},
-}) {
-    if (slug) {
-        return queryContentApi
-            .get(`v1/${locale}/strategic-programmes/${slug}`, {
-                searchParams: withPreviewParams(requestParams, { ...query }),
-            })
-            .json()
-            .then((response) => get('data.attributes')(response));
-    } else {
-        return Promise.all([
-            queryContentApi.get('v1/en/strategic-programmes').json(),
-            queryContentApi.get('v1/cy/strategic-programmes').json(),
-        ]).then((responses) => {
-            const [enResults, cyResults] = responses.map(mapAttrs);
-            return mergeWelshBy('urlPath')(locale, enResults, cyResults);
-        });
-    }
-}
-
-function getListingPage({ locale, path, query = {}, requestParams = {} }) {
-    const sanitisedPath = sanitiseUrlPath(path);
-    return queryContentApi(`v1/${locale}/listing`, {
-        searchParams: withPreviewParams(requestParams, {
-            ...query,
-            ...{ path: sanitisedPath },
-        }),
-    })
-        .json()
-        .then((response) => {
-            const attributes = response.data.map((item) => item.attributes);
-            return attributes.find((attr) => {
-                return attr.linkUrl === stripTrailingSlashes(path);
-            });
-        });
-}
-
-function getProjectStory({ locale, grantId, query = {}, requestParams = {} }) {
-    return queryContentApi(`v1/${locale}/project-stories/${grantId}`, {
-        searchParams: withPreviewParams(requestParams, { ...query }),
-    })
-        .json()
-        .then(getAttrs);
-}
-
-function getDataStats(locale, searchParams = {}) {
-    return queryContentApi(`v1/${locale}/data`, {
-        searchParams: withPreviewParams(searchParams),
-    })
-        .json()
-        .then(getAttrs);
-}
-
-function getMerchandise({ locale, showAll = false } = {}) {
-    let searchParams = {};
-    if (showAll) {
-        searchParams.all = 'true';
-    }
-
-    return queryContentApi(`v1/${locale}/merchandise`, {
-        searchParams: searchParams,
-    })
-        .json()
-        .then(mapAttrs);
-}
-
-module.exports = {
-    // Exported for tests
-    _buildPagination,
-    // API methods
-    getAlias,
-    getProjectStory,
-    getDataStats,
-    getFundingProgramme,
-    getFundingProgrammes,
-    getRecentFundingProgrammes,
-    getHeroImage,
-    getHomepage,
-    getListingPage,
-    getMerchandise,
-    getPublications,
-    getPublicationTags,
-    getResearch,
-    getRoutes,
-    getStrategicProgrammes,
-    getUpdates,
 };

--- a/common/content-api.test.js
+++ b/common/content-api.test.js
@@ -1,7 +1,9 @@
 /* eslint-env jest */
 'use strict';
 
-const { _buildPagination } = require('./content-api');
+const contentApi = require('./content-api');
+
+const _buildPagination = contentApi({ flags: {} })._buildPagination;
 
 it('should transform API pagination meta into object for views', () => {
     expect(

--- a/common/content-api.test.js
+++ b/common/content-api.test.js
@@ -1,9 +1,10 @@
 /* eslint-env jest */
 'use strict';
 
-const contentApi = require('./content-api');
+const { ContentApiClient } = require('./content-api');
+const ContentApi = new ContentApiClient();
 
-const _buildPagination = contentApi({ flags: {} })._buildPagination;
+const _buildPagination = ContentApi._buildPagination;
 
 it('should transform API pagination meta into object for views', () => {
     expect(

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -62,7 +62,7 @@ function injectHeroImage(heroSlug) {
 
             try {
                 const image = await ContentApi.init({
-                    flags: res.locals,
+                    flags: res.locals.cmsFlags,
                 }).getHeroImage({
                     locale: req.i18n.getLocale(),
                     slug: heroSlug,
@@ -84,7 +84,7 @@ function injectHeroImage(heroSlug) {
 async function injectListingContent(req, res, next) {
     try {
         const entry = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getListingPage({
             locale: req.i18n.getLocale(),
             path: req.baseUrl + req.path,

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -4,8 +4,10 @@ const Sentry = require('@sentry/node');
 const get = require('lodash/fp/get');
 const getOr = require('lodash/fp/getOr');
 
-const contentApi = require('./content-api');
+const { ContentApiClient } = require('./content-api');
 const checkPreviewMode = require('./check-preview-mode');
+
+const ContentApi = new ContentApiClient();
 
 /*
  * Populate hero image (with social image URLs too)
@@ -59,7 +61,7 @@ function injectHeroImage(heroSlug) {
             res.locals.socialImage = fallbackHeroImage;
 
             try {
-                const image = await contentApi({
+                const image = await ContentApi.init({
                     flags: res.locals,
                 }).getHeroImage({
                     locale: req.i18n.getLocale(),
@@ -81,7 +83,9 @@ function injectHeroImage(heroSlug) {
 
 async function injectListingContent(req, res, next) {
     try {
-        const entry = await contentApi({ flags: res.locals }).getListingPage({
+        const entry = await ContentApi.init({
+            flags: res.locals,
+        }).getListingPage({
             locale: req.i18n.getLocale(),
             path: req.baseUrl + req.path,
             requestParams: req.query,

--- a/common/inject-content.js
+++ b/common/inject-content.js
@@ -59,7 +59,9 @@ function injectHeroImage(heroSlug) {
             res.locals.socialImage = fallbackHeroImage;
 
             try {
-                const image = await contentApi.getHeroImage({
+                const image = await contentApi({
+                    flags: res.locals,
+                }).getHeroImage({
                     locale: req.i18n.getLocale(),
                     slug: heroSlug,
                 });
@@ -79,7 +81,7 @@ function injectHeroImage(heroSlug) {
 
 async function injectListingContent(req, res, next) {
     try {
-        const entry = await contentApi.getListingPage({
+        const entry = await contentApi({ flags: res.locals }).getListingPage({
             locale: req.i18n.getLocale(),
             path: req.baseUrl + req.path,
             requestParams: req.query,

--- a/common/locals.js
+++ b/common/locals.js
@@ -245,8 +245,9 @@ module.exports = function (req, res, next) {
      * Mark the request as a sandbox user if accessed by staff with this option enabled
      * (eg. to use the Sandbox CMS for staff training)
      */
+    res.locals.cmsFlags = {};
     if (get(req, 'user.userData.is_sandbox')) {
-        res.locals.sandboxMode = true;
+        res.locals.cmsFlags.sandboxMode = true;
     }
 
     next();

--- a/common/locals.js
+++ b/common/locals.js
@@ -6,7 +6,13 @@ const moment = require('moment-timezone');
 const isString = require('lodash/isString');
 
 const appData = require('./appData');
-const { getAbsoluteUrl, getCurrentUrl, isWelsh, localify } = require('./urls');
+const {
+    getAbsoluteUrl,
+    getCurrentUrl,
+    isWelsh,
+    localify,
+    isSandboxUrl,
+} = require('./urls');
 
 let assets = {};
 try {
@@ -239,6 +245,14 @@ module.exports = function (req, res, next) {
     res.locals.clearAuthCookie = function () {
         res.clearCookie(config.get('session.cookieLogin'), authCookieOptions);
     };
+
+    /**
+     * Mark the request as a sandbox domain if accessed via that host
+     * (eg. to use the Sandbox CMS for staff training)
+     */
+    if (isSandboxUrl(req.hostname)) {
+        res.locals.sandboxMode = true;
+    }
 
     next();
 };

--- a/common/locals.js
+++ b/common/locals.js
@@ -4,15 +4,10 @@ const path = require('path');
 const config = require('config');
 const moment = require('moment-timezone');
 const isString = require('lodash/isString');
+const { get } = require('lodash');
 
 const appData = require('./appData');
-const {
-    getAbsoluteUrl,
-    getCurrentUrl,
-    isWelsh,
-    localify,
-    isSandboxUrl,
-} = require('./urls');
+const { getAbsoluteUrl, getCurrentUrl, isWelsh, localify } = require('./urls');
 
 let assets = {};
 try {
@@ -247,10 +242,10 @@ module.exports = function (req, res, next) {
     };
 
     /**
-     * Mark the request as a sandbox domain if accessed via that host
+     * Mark the request as a sandbox user if accessed by staff with this option enabled
      * (eg. to use the Sandbox CMS for staff training)
      */
-    if (isSandboxUrl(req.hostname)) {
+    if (get(req, 'user.userData.is_sandbox')) {
         res.locals.sandboxMode = true;
     }
 

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -25,12 +25,10 @@ const CONTENT_API_URL =
     process.env.CONTENT_API_URL || getParameter('content-api.url', true);
 
 /**
- * Sandbox domains
- * When the site is accessed via this domain (pointing to the Test instance)
- * we use the Test instance of the CMS (eg. for staff training) as defined below
+ * Content API Sandbox url
+ * When the site is accessed by Staff using the TEST instance, they can switch on
+ * Sandbox Mode, which means we use the Test instance of the CMS (eg. for staff training)
  */
-const SANDBOX_DOMAIN =
-    process.env.SANDBOX_DOMAIN || getParameter('sandbox.domain');
 const CONTENT_API_SANDBOX_URL =
     process.env.CONTENT_API_SANDBOX_URL ||
     getParameter('content-api.sandbox.url');
@@ -145,7 +143,6 @@ module.exports = {
     MATERIAL_SUPPLIER,
     PAST_GRANTS_API_URI,
     POSTCODES_API_KEY,
-    SANDBOX_DOMAIN,
     S3_KMS_KEY_ID,
     SALESFORCE_AUTH,
     SENTRY_DSN,

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -25,6 +25,17 @@ const CONTENT_API_URL =
     process.env.CONTENT_API_URL || getParameter('content-api.url', true);
 
 /**
+ * Sandbox domains
+ * When the site is accessed via this domain (pointing to the Test instance)
+ * we use the Test instance of the CMS (eg. for staff training) as defined below
+ */
+const SANDBOX_DOMAIN =
+    process.env.SANDBOX_DOMAIN || getParameter('sandbox.domain');
+const CONTENT_API_SANDBOX_URL =
+    process.env.CONTENT_API_SANDBOX_URL ||
+    getParameter('content-api.sandbox.url');
+
+/**
  * Past grants API
  * We allow overriding through an environment variable for CI and to allow
  * switching to a local instance of the API in development
@@ -76,7 +87,7 @@ const SALESFORCE_AUTH = {
         getParameter('salesforce.instanceId'),
 };
 
-// These expire in July 2020
+// These expire in July 2021
 const BANK_API = {
     KEY: process.env.BANK_API_TOKEN || getParameter('bank.api.key'),
     PASSWORD:
@@ -124,6 +135,7 @@ module.exports = {
     AZURE_AUTH,
     BANK_API,
     CONTENT_API_URL,
+    CONTENT_API_SANDBOX_URL,
     DATA_STUDIO_UNDER10K_URL,
     DB_CONNECTION_URI,
     DOTDIGITAL_API,
@@ -133,6 +145,7 @@ module.exports = {
     MATERIAL_SUPPLIER,
     PAST_GRANTS_API_URI,
     POSTCODES_API_KEY,
+    SANDBOX_DOMAIN,
     S3_KMS_KEY_ID,
     SALESFORCE_AUTH,
     SENTRY_DSN,

--- a/common/urls.js
+++ b/common/urls.js
@@ -2,8 +2,6 @@
 const { URL } = require('url');
 const querystring = require('querystring');
 
-const { SANDBOX_DOMAIN } = require('./secrets');
-
 const WELSH_REGEX = /^\/welsh(\/|$)/;
 
 const isAbsoluteUrl = (str) => str.indexOf('://') !== -1;
@@ -159,16 +157,11 @@ function buildArchiveUrl(urlPath, crawlDate = '20171011152352') {
     return `http://webarchive.nationalarchives.gov.uk/${crawlDate}/${fullUrl}`;
 }
 
-function isSandboxUrl(hostname) {
-    return hostname === SANDBOX_DOMAIN;
-}
-
 module.exports = {
     getAbsoluteUrl,
     getBaseUrl,
     getCurrentUrl,
     hasTrailingSlash,
-    isSandboxUrl,
     isWelsh,
     localify,
     makeWelsh,

--- a/common/urls.js
+++ b/common/urls.js
@@ -2,6 +2,8 @@
 const { URL } = require('url');
 const querystring = require('querystring');
 
+const { SANDBOX_DOMAIN } = require('./secrets');
+
 const WELSH_REGEX = /^\/welsh(\/|$)/;
 
 const isAbsoluteUrl = (str) => str.indexOf('://') !== -1;
@@ -157,11 +159,16 @@ function buildArchiveUrl(urlPath, crawlDate = '20171011152352') {
     return `http://webarchive.nationalarchives.gov.uk/${crawlDate}/${fullUrl}`;
 }
 
+function isSandboxUrl(hostname) {
+    return hostname === SANDBOX_DOMAIN;
+}
+
 module.exports = {
     getAbsoluteUrl,
     getBaseUrl,
     getCurrentUrl,
     hasTrailingSlash,
+    isSandboxUrl,
     isWelsh,
     localify,
     makeWelsh,

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -12,7 +12,7 @@ const ContentApi = new ContentApiClient();
 router.get('/', injectHeroImage('fsn-new'), async function (req, res, next) {
     try {
         const dataStats = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getDataStats(req.i18n.getLocale(), req.query);
 
         res.render(path.resolve(__dirname, './views/data'), {

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -3,17 +3,17 @@ const path = require('path');
 const express = require('express');
 const get = require('lodash/get');
 
-const contentApi = require('../../common/content-api');
+const { ContentApiClient } = require('../../common/content-api');
 const { injectHeroImage } = require('../../common/inject-content');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 router.get('/', injectHeroImage('fsn-new'), async function (req, res, next) {
     try {
-        const dataStats = await contentApi({ flags: res.locals }).getDataStats(
-            req.i18n.getLocale(),
-            req.query
-        );
+        const dataStats = await ContentApi.init({
+            flags: res.locals,
+        }).getDataStats(req.i18n.getLocale(), req.query);
 
         res.render(path.resolve(__dirname, './views/data'), {
             title: dataStats.title,

--- a/controllers/data/index.js
+++ b/controllers/data/index.js
@@ -10,7 +10,7 @@ const router = express.Router();
 
 router.get('/', injectHeroImage('fsn-new'), async function (req, res, next) {
     try {
-        const dataStats = await contentApi.getDataStats(
+        const dataStats = await contentApi({ flags: res.locals }).getDataStats(
             req.i18n.getLocale(),
             req.query
         );

--- a/controllers/funding/grants/index.js
+++ b/controllers/funding/grants/index.js
@@ -280,7 +280,9 @@ router.get('/:id', async function (req, res, next) {
 
         let projectStory;
         try {
-            projectStory = await contentApi.getProjectStory({
+            projectStory = await contentApi({
+                flags: res.locals,
+            }).getProjectStory({
                 locale: req.i18n.getLocale(),
                 grantId: req.params.id,
                 requestParams: req.query,
@@ -299,7 +301,9 @@ router.get('/:id', async function (req, res, next) {
                 grantProgramme.url.indexOf('/') === -1
             ) {
                 try {
-                    fundingProgramme = await contentApi.getFundingProgramme({
+                    fundingProgramme = await contentApi({
+                        flags: res.locals,
+                    }).getFundingProgramme({
                         slug: grantProgramme.url,
                         locale: req.i18n.getLocale(),
                     });

--- a/controllers/funding/grants/index.js
+++ b/controllers/funding/grants/index.js
@@ -15,11 +15,12 @@ const {
     setHeroLocals,
 } = require('../../../common/inject-content');
 const { sMaxAge } = require('../../../common/cached');
-const contentApi = require('../../../common/content-api');
+const { ContentApiClient } = require('../../../common/content-api');
 
 const grantsService = require('./grants-service');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 router.use(sMaxAge(604800 /* 7 days in seconds */), function (req, res, next) {
     res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
@@ -280,7 +281,7 @@ router.get('/:id', async function (req, res, next) {
 
         let projectStory;
         try {
-            projectStory = await contentApi({
+            projectStory = await ContentApi.init({
                 flags: res.locals,
             }).getProjectStory({
                 locale: req.i18n.getLocale(),
@@ -301,7 +302,7 @@ router.get('/:id', async function (req, res, next) {
                 grantProgramme.url.indexOf('/') === -1
             ) {
                 try {
-                    fundingProgramme = await contentApi({
+                    fundingProgramme = await ContentApi.init({
                         flags: res.locals,
                     }).getFundingProgramme({
                         slug: grantProgramme.url,

--- a/controllers/funding/grants/index.js
+++ b/controllers/funding/grants/index.js
@@ -282,7 +282,7 @@ router.get('/:id', async function (req, res, next) {
         let projectStory;
         try {
             projectStory = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getProjectStory({
                 locale: req.i18n.getLocale(),
                 grantId: req.params.id,
@@ -303,7 +303,7 @@ router.get('/:id', async function (req, res, next) {
             ) {
                 try {
                     fundingProgramme = await ContentApi.init({
-                        flags: res.locals,
+                        flags: res.locals.cmsFlags,
                     }).getFundingProgramme({
                         slug: grantProgramme.url,
                         locale: req.i18n.getLocale(),

--- a/controllers/funding/materials/index.js
+++ b/controllers/funding/materials/index.js
@@ -153,7 +153,7 @@ router
     .all(csrfProtection, injectListingContent, async function (req, res, next) {
         try {
             res.locals.availableItems = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getMerchandise({
                 locale: req.i18n.getLocale(),
             });

--- a/controllers/funding/materials/index.js
+++ b/controllers/funding/materials/index.js
@@ -8,7 +8,7 @@ const Sentry = require('@sentry/node');
 const { oneLine } = require('common-tags');
 
 const { Order } = require('../../../db/models');
-const contentApi = require('../../../common/content-api');
+const { ContentApiClient } = require('../../../common/content-api');
 const { isNotProduction } = require('../../../common/appData');
 const { csrfProtection, noStore } = require('../../../common/cached');
 const { generateHtmlEmail, sendEmail } = require('../../../common/mail');
@@ -21,6 +21,7 @@ const makeOrderText = require('./lib/make-order-text');
 const normaliseUserInput = require('./lib/normalise-user-input');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 const FORM_STATES = {
     NOT_SUBMITTED: 'NOT_SUBMITTED',
@@ -151,7 +152,7 @@ router
     .route('/')
     .all(csrfProtection, injectListingContent, async function (req, res, next) {
         try {
-            res.locals.availableItems = await contentApi({
+            res.locals.availableItems = await ContentApi.init({
                 flags: res.locals,
             }).getMerchandise({
                 locale: req.i18n.getLocale(),

--- a/controllers/funding/materials/index.js
+++ b/controllers/funding/materials/index.js
@@ -151,7 +151,9 @@ router
     .route('/')
     .all(csrfProtection, injectListingContent, async function (req, res, next) {
         try {
-            res.locals.availableItems = await contentApi.getMerchandise({
+            res.locals.availableItems = await contentApi({
+                flags: res.locals,
+            }).getMerchandise({
                 locale: req.i18n.getLocale(),
             });
             next();

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -40,7 +40,9 @@ router.get('/', injectHeroImage('rosemount-1-letterbox-new'), async function (
     next
 ) {
     try {
-        const response = await contentApi.getFundingProgrammes({
+        const response = await contentApi({
+            flags: res.locals,
+        }).getFundingProgrammes({
             locale: req.i18n.getLocale(),
         });
 
@@ -136,7 +138,9 @@ router.get(
     injectHeroImage('cbsa-2-letterbox-new'),
     async function (req, res, next) {
         try {
-            const response = await contentApi.getFundingProgrammes({
+            const response = await contentApi({
+                flags: res.locals,
+            }).getFundingProgrammes({
                 locale: req.i18n.getLocale(),
                 showAll: true,
                 page: req.query.page || 1,
@@ -211,7 +215,9 @@ router.get(
  */
 router.get('/:slug/:child_slug?', async (req, res, next) => {
     try {
-        const entry = await contentApi.getFundingProgramme({
+        const entry = await contentApi({
+            flags: res.locals,
+        }).getFundingProgramme({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),
             searchParams: req.query,

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -11,7 +11,7 @@ const {
 } = require('../../../common/inject-content');
 const { buildArchiveUrl, localify } = require('../../../common/urls');
 const { sMaxAge } = require('../../../common/cached');
-const contentApi = require('../../../common/content-api');
+const { ContentApiClient } = require('../../../common/content-api');
 
 const {
     renderFlexibleContentChild,
@@ -22,6 +22,7 @@ const getValidLocation = require('./lib/get-valid-location');
 const programmeFilters = require('./lib/programme-filters');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 router.use(function (req, res, next) {
     res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
@@ -40,7 +41,7 @@ router.get('/', injectHeroImage('rosemount-1-letterbox-new'), async function (
     next
 ) {
     try {
-        const response = await contentApi({
+        const response = await ContentApi.init({
             flags: res.locals,
         }).getFundingProgrammes({
             locale: req.i18n.getLocale(),
@@ -138,7 +139,7 @@ router.get(
     injectHeroImage('cbsa-2-letterbox-new'),
     async function (req, res, next) {
         try {
-            const response = await contentApi({
+            const response = await ContentApi.init({
                 flags: res.locals,
             }).getFundingProgrammes({
                 locale: req.i18n.getLocale(),
@@ -215,7 +216,7 @@ router.get(
  */
 router.get('/:slug/:child_slug?', async (req, res, next) => {
     try {
-        const entry = await contentApi({
+        const entry = await ContentApi.init({
             flags: res.locals,
         }).getFundingProgramme({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),

--- a/controllers/funding/programmes/index.js
+++ b/controllers/funding/programmes/index.js
@@ -42,7 +42,7 @@ router.get('/', injectHeroImage('rosemount-1-letterbox-new'), async function (
 ) {
     try {
         const response = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getFundingProgrammes({
             locale: req.i18n.getLocale(),
         });
@@ -140,7 +140,7 @@ router.get(
     async function (req, res, next) {
         try {
             const response = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getFundingProgrammes({
                 locale: req.i18n.getLocale(),
                 showAll: true,
@@ -217,7 +217,7 @@ router.get(
 router.get('/:slug/:child_slug?', async (req, res, next) => {
     try {
         const entry = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getFundingProgramme({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),

--- a/controllers/funding/publications/index.js
+++ b/controllers/funding/publications/index.js
@@ -7,9 +7,10 @@ const {
     setCommonLocals,
 } = require('../../../common/inject-content');
 const { renderFlexibleContentChild } = require('../../common');
-const contentApi = require('../../../common/content-api');
+const { ContentApiClient } = require('../../../common/content-api');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 function checkProgramme(req, res, next) {
     const programme = req.params.programme;
@@ -28,11 +29,11 @@ router.get(
     async function (req, res, next) {
         try {
             const [publicationTags, publications] = await Promise.all([
-                contentApi({ flags: res.locals }).getPublicationTags({
+                ContentApi.init({ flags: res.locals }).getPublicationTags({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
                 }),
-                contentApi({ flags: res.locals }).getPublications({
+                ContentApi.init({ flags: res.locals }).getPublications({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
                     searchParams: req.query,
@@ -66,7 +67,7 @@ router.get('/:programme/:slug', checkProgramme, async function (
     next
 ) {
     try {
-        const publication = await contentApi({
+        const publication = await ContentApi.init({
             flags: res.locals,
         }).getPublications({
             locale: req.i18n.getLocale(),

--- a/controllers/funding/publications/index.js
+++ b/controllers/funding/publications/index.js
@@ -28,11 +28,11 @@ router.get(
     async function (req, res, next) {
         try {
             const [publicationTags, publications] = await Promise.all([
-                contentApi.getPublicationTags({
+                contentApi({ flags: res.locals }).getPublicationTags({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
                 }),
-                contentApi.getPublications({
+                contentApi({ flags: res.locals }).getPublications({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
                     searchParams: req.query,
@@ -66,7 +66,9 @@ router.get('/:programme/:slug', checkProgramme, async function (
     next
 ) {
     try {
-        const publication = await contentApi.getPublications({
+        const publication = await contentApi({
+            flags: res.locals,
+        }).getPublications({
             locale: req.i18n.getLocale(),
             programme: req.params.programme,
             slug: req.params.slug,

--- a/controllers/funding/publications/index.js
+++ b/controllers/funding/publications/index.js
@@ -29,15 +29,19 @@ router.get(
     async function (req, res, next) {
         try {
             const [publicationTags, publications] = await Promise.all([
-                ContentApi.init({ flags: res.locals }).getPublicationTags({
+                ContentApi.init({
+                    flags: res.locals.cmsFlags,
+                }).getPublicationTags({
                     locale: req.i18n.getLocale(),
                     programme: req.params.programme,
                 }),
-                ContentApi.init({ flags: res.locals }).getPublications({
-                    locale: req.i18n.getLocale(),
-                    programme: req.params.programme,
-                    searchParams: req.query,
-                }),
+                ContentApi.init({ flags: res.locals.cmsFlags }).getPublications(
+                    {
+                        locale: req.i18n.getLocale(),
+                        programme: req.params.programme,
+                        searchParams: req.query,
+                    }
+                ),
             ]);
 
             if (req.params.programme === 'a-better-start') {
@@ -68,7 +72,7 @@ router.get('/:programme/:slug', checkProgramme, async function (
 ) {
     try {
         const publication = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getPublications({
             locale: req.i18n.getLocale(),
             programme: req.params.programme,

--- a/controllers/funding/strategic-investments/index.js
+++ b/controllers/funding/strategic-investments/index.js
@@ -7,11 +7,12 @@ const {
     injectListingContent,
     setCommonLocals,
 } = require('../../../common/inject-content');
-const contentApi = require('../../../common/content-api');
+const { ContentApiClient } = require('../../../common/content-api');
 
 const { renderFlexibleContentChild } = require('../../common');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 router.use(function (req, res, next) {
     res.locals.breadcrumbs = res.locals.breadcrumbs.concat({
@@ -24,7 +25,7 @@ router.use(function (req, res, next) {
 router.get('/', injectListingContent, async function (req, res, next) {
     try {
         res.render(path.resolve(__dirname, './views/strategic-investments'), {
-            strategicProgrammes: await contentApi({
+            strategicProgrammes: await ContentApi.init({
                 flags: res.locals,
             }).getStrategicProgrammes({
                 locale: req.i18n.getLocale(),
@@ -42,7 +43,7 @@ router.get('/', injectListingContent, async function (req, res, next) {
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
-        const entry = await contentApi({
+        const entry = await ContentApi.init({
             flags: res.locals,
         }).getStrategicProgrammes({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),

--- a/controllers/funding/strategic-investments/index.js
+++ b/controllers/funding/strategic-investments/index.js
@@ -24,7 +24,9 @@ router.use(function (req, res, next) {
 router.get('/', injectListingContent, async function (req, res, next) {
     try {
         res.render(path.resolve(__dirname, './views/strategic-investments'), {
-            strategicProgrammes: await contentApi.getStrategicProgrammes({
+            strategicProgrammes: await contentApi({
+                flags: res.locals,
+            }).getStrategicProgrammes({
                 locale: req.i18n.getLocale(),
                 requestParams: req.query,
             }),
@@ -40,7 +42,9 @@ router.get('/', injectListingContent, async function (req, res, next) {
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
-        const entry = await contentApi.getStrategicProgrammes({
+        const entry = await contentApi({
+            flags: res.locals,
+        }).getStrategicProgrammes({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),
             requestParams: req.query,

--- a/controllers/funding/strategic-investments/index.js
+++ b/controllers/funding/strategic-investments/index.js
@@ -26,7 +26,7 @@ router.get('/', injectListingContent, async function (req, res, next) {
     try {
         res.render(path.resolve(__dirname, './views/strategic-investments'), {
             strategicProgrammes: await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getStrategicProgrammes({
                 locale: req.i18n.getLocale(),
                 requestParams: req.query,
@@ -44,7 +44,7 @@ router.get('/', injectListingContent, async function (req, res, next) {
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
         const entry = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getStrategicProgrammes({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -1,11 +1,12 @@
 'use strict';
 const path = require('path');
 
-const contentApi = require('../../common/content-api');
+const { ContentApiClient } = require('../../common/content-api');
+const ContentApi = new ContentApiClient();
 
 module.exports = async function (req, res, next) {
     try {
-        const entry = await contentApi({ flags: res.locals }).getHomepage(
+        const entry = await ContentApi.init({ flags: res.locals }).getHomepage(
             req.i18n.getLocale(),
             req.query
         );

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -5,7 +5,7 @@ const contentApi = require('../../common/content-api');
 
 module.exports = async function (req, res, next) {
     try {
-        const entry = await contentApi.getHomepage(
+        const entry = await contentApi({ flags: res.locals }).getHomepage(
             req.i18n.getLocale(),
             req.query
         );

--- a/controllers/home/index.js
+++ b/controllers/home/index.js
@@ -6,10 +6,9 @@ const ContentApi = new ContentApiClient();
 
 module.exports = async function (req, res, next) {
     try {
-        const entry = await ContentApi.init({ flags: res.locals }).getHomepage(
-            req.i18n.getLocale(),
-            req.query
-        );
+        const entry = await ContentApi.init({
+            flags: res.locals.cmsFlags,
+        }).getHomepage(req.i18n.getLocale(), req.query);
 
         res.render(path.resolve(__dirname, './views/home'), {
             content: entry.content,

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -21,7 +21,7 @@ router.use(injectHeroImage('insights-letterbox-new'));
 router.get('/', async (req, res, next) => {
     try {
         const research = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getResearch({
             locale: req.i18n.getLocale(),
             requestParams: req.query,
@@ -59,7 +59,7 @@ router.get('/documents/:slug?', async function (req, res, next) {
 
     try {
         const research = await ContentApi.init({
-            flags: res.locals,
+            flags: res.locals.cmsFlags,
         }).getResearch({
             locale: req.i18n.getLocale(),
             type: 'documents',
@@ -87,7 +87,9 @@ router.use('/covid-19-resources/:slug/:child_slug?', flexibleContentPage());
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
-        const entry = await ContentApi.init({ flags: res.locals }).getResearch({
+        const entry = await ContentApi.init({
+            flags: res.locals.cmsFlags,
+        }).getResearch({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),
             requestParams: req.query,

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -19,7 +19,7 @@ router.use(injectHeroImage('insights-letterbox-new'));
 
 router.get('/', async (req, res, next) => {
     try {
-        const research = await contentApi.getResearch({
+        const research = await contentApi({ flags: res.locals }).getResearch({
             locale: req.i18n.getLocale(),
             requestParams: req.query,
         });
@@ -55,7 +55,7 @@ router.get('/documents/:slug?', async function (req, res, next) {
     }
 
     try {
-        const research = await contentApi.getResearch({
+        const research = await contentApi({ flags: res.locals }).getResearch({
             locale: req.i18n.getLocale(),
             type: 'documents',
             query: query,
@@ -82,7 +82,7 @@ router.use('/covid-19-resources/:slug/:child_slug?', flexibleContentPage());
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
-        const entry = await contentApi.getResearch({
+        const entry = await contentApi({ flags: res.locals }).getResearch({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),
             requestParams: req.query,

--- a/controllers/insights/index.js
+++ b/controllers/insights/index.js
@@ -5,7 +5,7 @@ const clone = require('lodash/clone');
 const compact = require('lodash/compact');
 const pick = require('lodash/pick');
 
-const contentApi = require('../../common/content-api');
+const { ContentApiClient } = require('../../common/content-api');
 const {
     injectHeroImage,
     setCommonLocals,
@@ -14,12 +14,15 @@ const { buildArchiveUrl, localify } = require('../../common/urls');
 const { flexibleContentPage } = require('../common');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 router.use(injectHeroImage('insights-letterbox-new'));
 
 router.get('/', async (req, res, next) => {
     try {
-        const research = await contentApi({ flags: res.locals }).getResearch({
+        const research = await ContentApi.init({
+            flags: res.locals,
+        }).getResearch({
             locale: req.i18n.getLocale(),
             requestParams: req.query,
         });
@@ -55,7 +58,9 @@ router.get('/documents/:slug?', async function (req, res, next) {
     }
 
     try {
-        const research = await contentApi({ flags: res.locals }).getResearch({
+        const research = await ContentApi.init({
+            flags: res.locals,
+        }).getResearch({
             locale: req.i18n.getLocale(),
             type: 'documents',
             query: query,
@@ -82,7 +87,7 @@ router.use('/covid-19-resources/:slug/:child_slug?', flexibleContentPage());
 
 router.get('/:slug/:child_slug?', async function (req, res, next) {
     try {
-        const entry = await contentApi({ flags: res.locals }).getResearch({
+        const entry = await ContentApi.init({ flags: res.locals }).getResearch({
             slug: compact([req.params.slug, req.params.child_slug]).join('/'),
             locale: req.i18n.getLocale(),
             requestParams: req.query,

--- a/controllers/sitemap.js
+++ b/controllers/sitemap.js
@@ -6,7 +6,7 @@ const concat = require('lodash/fp/concat');
 const sortBy = require('lodash/fp/sortBy');
 const uniqBy = require('lodash/fp/uniqBy');
 
-const contentApi = require('../common/content-api');
+const { ContentApiClient } = require('../common/content-api');
 const { getBaseUrl } = require('../common/urls');
 
 /**
@@ -42,7 +42,7 @@ async function getCanonicalRoutes(res) {
         };
     });
 
-    const cmsCanonicalUrls = await contentApi({
+    const cmsCanonicalUrls = await ContentApi.init({
         flags: res.locals,
     }).getRoutes();
     const combined = concat(staticRoutes, cmsCanonicalUrls);

--- a/controllers/sitemap.js
+++ b/controllers/sitemap.js
@@ -45,7 +45,7 @@ async function getCanonicalRoutes(res) {
     });
 
     const cmsCanonicalUrls = await ContentApi.init({
-        flags: res.locals,
+        flags: res.locals.cmsFlags,
     }).getRoutes();
     const combined = concat(staticRoutes, cmsCanonicalUrls);
     const filtered = combined.filter((route) => route.live);

--- a/controllers/sitemap.js
+++ b/controllers/sitemap.js
@@ -9,6 +9,8 @@ const uniqBy = require('lodash/fp/uniqBy');
 const { ContentApiClient } = require('../common/content-api');
 const { getBaseUrl } = require('../common/urls');
 
+const ContentApi = new ContentApiClient();
+
 /**
  * Build a flat list of all canonical routes
  * Combines application routes and routes defined by the CMS

--- a/controllers/sitemap.js
+++ b/controllers/sitemap.js
@@ -13,7 +13,7 @@ const { getBaseUrl } = require('../common/urls');
  * Build a flat list of all canonical routes
  * Combines application routes and routes defined by the CMS
  */
-async function getCanonicalRoutes() {
+async function getCanonicalRoutes(res) {
     /**
      * Static routes
      *
@@ -42,7 +42,9 @@ async function getCanonicalRoutes() {
         };
     });
 
-    const cmsCanonicalUrls = await contentApi.getRoutes();
+    const cmsCanonicalUrls = await contentApi({
+        flags: res.locals,
+    }).getRoutes();
     const combined = concat(staticRoutes, cmsCanonicalUrls);
     const filtered = combined.filter((route) => route.live);
     return compose(sortBy('path'), uniqBy('path'))(filtered);
@@ -50,7 +52,7 @@ async function getCanonicalRoutes() {
 
 module.exports = async function (req, res, next) {
     try {
-        const canonicalRoutes = await getCanonicalRoutes();
+        const canonicalRoutes = await getCanonicalRoutes(res);
 
         const smStream = new SitemapStream({
             hostname: getBaseUrl(req),

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -67,9 +67,12 @@ router.use('/applications', require('./applications'));
 router.use('/order-stats', require('./orders'));
 router.use('/users', require('./users'));
 
-router.get('/sandbox-mode/toggle', async (req, res) => {
-    await Staff.toggleSandboxStatus(req.user.userData.id);
-    return res.redirect('/tools');
-});
+// Only enable sandbox mode toggle in non-live environments
+if (!isNotProduction) {
+    router.get('/sandbox-mode/toggle', async (req, res) => {
+        await Staff.toggleSandboxStatus(req.user.userData.id);
+        return res.redirect('/tools');
+    });
+}
 
 module.exports = router;

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -68,7 +68,7 @@ router.use('/order-stats', require('./orders'));
 router.use('/users', require('./users'));
 
 // Only enable sandbox mode toggle in non-live environments
-if (!isNotProduction) {
+if (isNotProduction) {
     router.get('/sandbox-mode/toggle', async (req, res) => {
         await Staff.toggleSandboxStatus(req.user.userData.id);
         return res.redirect('/tools');

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -67,7 +67,7 @@ router.use('/applications', require('./applications'));
 router.use('/order-stats', require('./orders'));
 router.use('/users', require('./users'));
 
-router.get('/sandbox-mode/toggle', async (req, res, next) => {
+router.get('/sandbox-mode/toggle', async (req, res) => {
     await Staff.toggleSandboxStatus(req.user.userData.id);
     return res.redirect('/tools');
 });

--- a/controllers/tools/index.js
+++ b/controllers/tools/index.js
@@ -4,6 +4,8 @@ const express = require('express');
 
 const { requireStaffAuth } = require('../../common/authed');
 const { noStore } = require('../../common/cached');
+const { isNotProduction } = require('../../common/appData');
+const { Staff } = require('../../db/models');
 
 const router = express.Router();
 
@@ -18,34 +20,44 @@ router.use(noStore, requireStaffAuth, function (req, res, next) {
 });
 
 router.route('/').get((req, res) => {
+    let staffLinks = [
+        {
+            href: '/tools/users',
+            label: 'User accounts summary',
+        },
+        {
+            href: '/tools/applications/awards-for-all',
+            label: 'Awards for All application statistics',
+        },
+        {
+            href: '/tools/applications/standard-enquiry',
+            label: 'Your funding proposal application statistics',
+        },
+        {
+            href: '/tools/survey-results',
+            label: 'Site satisfaction survey results',
+        },
+        {
+            href: '/tools/feedback-results',
+            label: 'Page feedback survey responses',
+        },
+        {
+            href: '/tools/order-stats',
+            label: 'Statistics on recent material orders',
+        },
+    ];
+
+    if (isNotProduction) {
+        const toggleStatus = req.user.userData.is_sandbox ? 'OFF' : 'ON';
+        staffLinks.push({
+            href: '/tools/sandbox-mode/toggle',
+            label: `Toggle Sandbox mode ${toggleStatus}`,
+        });
+    }
+
     res.render(path.resolve(__dirname, './views/index'), {
         title: 'Staff tools',
-        links: [
-            {
-                href: '/tools/users',
-                label: 'User accounts summary',
-            },
-            {
-                href: '/tools/applications/awards-for-all',
-                label: 'Awards for All application statistics',
-            },
-            {
-                href: '/tools/applications/standard-enquiry',
-                label: 'Your funding proposal application statistics',
-            },
-            {
-                href: '/tools/survey-results',
-                label: 'Site satisfaction survey results',
-            },
-            {
-                href: '/tools/feedback-results',
-                label: 'Page feedback survey responses',
-            },
-            {
-                href: '/tools/order-stats',
-                label: 'Statistics on recent material orders',
-            },
-        ],
+        links: staffLinks,
     });
 });
 
@@ -54,5 +66,10 @@ router.use('/survey-results', require('./surveys'));
 router.use('/applications', require('./applications'));
 router.use('/order-stats', require('./orders'));
 router.use('/users', require('./users'));
+
+router.get('/sandbox-mode/toggle', async (req, res, next) => {
+    await Staff.toggleSandboxStatus(req.user.userData.id);
+    return res.redirect('/tools');
+});
 
 module.exports = router;

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -12,11 +12,12 @@ const sortBy = require('lodash/sortBy');
 const take = require('lodash/take');
 
 const { Order } = require('../../db/models');
-const contentApi = require('../../common/content-api');
+const { ContentApiClient } = require('../../common/content-api');
 
 const { getDateRangeWithDefault } = require('./lib/date-helpers');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 function summariseOrders(orders) {
     const normalisedDateFormat = 'YYYY-MM-DD';
@@ -103,7 +104,7 @@ router.get('/', async function (req, res, next) {
         );
 
         const [materials, oldestOrder, orderData] = await Promise.all([
-            contentApi({ flags: res.locals }).getMerchandise({
+            ContentApi.init({ flags: res.locals }).getMerchandise({
                 locale: 'en',
                 showAll: true,
             }),

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -104,7 +104,7 @@ router.get('/', async function (req, res, next) {
         );
 
         const [materials, oldestOrder, orderData] = await Promise.all([
-            ContentApi.init({ flags: res.locals }).getMerchandise({
+            ContentApi.init({ flags: res.locals.cmsFlags }).getMerchandise({
                 locale: 'en',
                 showAll: true,
             }),

--- a/controllers/tools/orders.js
+++ b/controllers/tools/orders.js
@@ -103,7 +103,10 @@ router.get('/', async function (req, res, next) {
         );
 
         const [materials, oldestOrder, orderData] = await Promise.all([
-            contentApi.getMerchandise({ locale: 'en', showAll: true }),
+            contentApi({ flags: res.locals }).getMerchandise({
+                locale: 'en',
+                showAll: true,
+            }),
             Order.getOldestOrder(),
             Order.getAllOrders(dateRange).then(summariseOrders),
         ]);

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -7,10 +7,11 @@ const pick = require('lodash/pick');
 
 const { buildArchiveUrl, localify } = require('../../common/urls');
 const { injectHeroImage } = require('../../common/inject-content');
-const contentApi = require('../../common/content-api');
+const { ContentApiClient } = require('../../common/content-api');
 const checkPreviewMode = require('../../common/check-preview-mode');
 
 const router = express.Router();
+const ContentApi = new ContentApiClient();
 
 const heroSlug = 'pawzitive-letterbox-new';
 
@@ -26,11 +27,11 @@ router.get('/', injectHeroImage(heroSlug), async function (req, res, next) {
          * depending on frequency of posting of the other kind.
          */
         const [blogposts, peopleStories] = await Promise.all([
-            await contentApi({ flags: res.locals }).getUpdates({
+            await ContentApi.init({ flags: res.locals }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'blog',
             }),
-            await contentApi({ flags: res.locals }).getUpdates({
+            await ContentApi.init({ flags: res.locals }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'people-stories',
             }),
@@ -98,7 +99,7 @@ router.get(
     injectHeroImage(heroSlug),
     async function (req, res, next) {
         try {
-            const updatesResponse = await contentApi({
+            const updatesResponse = await ContentApi.init({
                 flags: res.locals,
             }).getUpdates({
                 locale: req.i18n.getLocale(),
@@ -216,7 +217,7 @@ router.get(
     injectHeroImage(heroSlug),
     async (req, res, next) => {
         try {
-            const updatesResponse = await contentApi({
+            const updatesResponse = await ContentApi.init({
                 flags: res.locals,
             }).getUpdates({
                 locale: req.i18n.getLocale(),

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -27,11 +27,11 @@ router.get('/', injectHeroImage(heroSlug), async function (req, res, next) {
          * depending on frequency of posting of the other kind.
          */
         const [blogposts, peopleStories] = await Promise.all([
-            await ContentApi.init({ flags: res.locals }).getUpdates({
+            await ContentApi.init({ flags: res.locals.cmsFlags }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'blog',
             }),
-            await ContentApi.init({ flags: res.locals }).getUpdates({
+            await ContentApi.init({ flags: res.locals.cmsFlags }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'people-stories',
             }),
@@ -100,7 +100,7 @@ router.get(
     async function (req, res, next) {
         try {
             const updatesResponse = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'press-releases',
@@ -218,7 +218,7 @@ router.get(
     async (req, res, next) => {
         try {
             const updatesResponse = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: req.params.updateType,

--- a/controllers/updates/index.js
+++ b/controllers/updates/index.js
@@ -26,11 +26,11 @@ router.get('/', injectHeroImage(heroSlug), async function (req, res, next) {
          * depending on frequency of posting of the other kind.
          */
         const [blogposts, peopleStories] = await Promise.all([
-            await contentApi.getUpdates({
+            await contentApi({ flags: res.locals }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'blog',
             }),
-            await contentApi.getUpdates({
+            await contentApi({ flags: res.locals }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'people-stories',
             }),
@@ -98,7 +98,9 @@ router.get(
     injectHeroImage(heroSlug),
     async function (req, res, next) {
         try {
-            const updatesResponse = await contentApi.getUpdates({
+            const updatesResponse = await contentApi({
+                flags: res.locals,
+            }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: 'press-releases',
                 date: req.params.date,
@@ -214,7 +216,9 @@ router.get(
     injectHeroImage(heroSlug),
     async (req, res, next) => {
         try {
-            const updatesResponse = await contentApi.getUpdates({
+            const updatesResponse = await contentApi({
+                flags: res.locals,
+            }).getUpdates({
                 locale: req.i18n.getLocale(),
                 type: req.params.updateType,
                 date: req.params.date,

--- a/controllers/vanity-redirects.js
+++ b/controllers/vanity-redirects.js
@@ -11,7 +11,7 @@ module.exports = async function (req, res, next) {
     if (pathCouldBeAlias(req.path)) {
         try {
             const urlMatch = await ContentApi.init({
-                flags: res.locals,
+                flags: res.locals.cmsFlags,
             }).getAlias(req.path);
             if (urlMatch) {
                 res.redirect(301, urlMatch);

--- a/controllers/vanity-redirects.js
+++ b/controllers/vanity-redirects.js
@@ -8,7 +8,9 @@ const contentApi = require('../common/content-api');
 module.exports = async function (req, res, next) {
     if (pathCouldBeAlias(req.path)) {
         try {
-            const urlMatch = await contentApi.getAlias(req.path);
+            const urlMatch = await contentApi({ flags: res.locals }).getAlias(
+                req.path
+            );
             if (urlMatch) {
                 res.redirect(301, urlMatch);
             } else {

--- a/controllers/vanity-redirects.js
+++ b/controllers/vanity-redirects.js
@@ -1,6 +1,8 @@
 'use strict';
 const { pathCouldBeAlias } = require('../common/urls');
-const contentApi = require('../common/content-api');
+const { ContentApiClient } = require('../common/content-api');
+
+const ContentApi = new ContentApiClient();
 
 /**
  * Lookup vanity URL and redirect if we have a match
@@ -8,9 +10,9 @@ const contentApi = require('../common/content-api');
 module.exports = async function (req, res, next) {
     if (pathCouldBeAlias(req.path)) {
         try {
-            const urlMatch = await contentApi({ flags: res.locals }).getAlias(
-                req.path
-            );
+            const urlMatch = await ContentApi.init({
+                flags: res.locals,
+            }).getAlias(req.path);
             if (urlMatch) {
                 res.redirect(301, urlMatch);
             } else {

--- a/db/models/staff.js
+++ b/db/models/staff.js
@@ -1,5 +1,5 @@
 'use strict';
-const { Model, Op } = require('sequelize');
+const { Model, Op, literal } = require('sequelize');
 
 class Staff extends Model {
     static init(sequelize, DataTypes) {
@@ -19,6 +19,13 @@ class Staff extends Model {
             family_name: {
                 type: DataTypes.STRING,
                 allowNull: true,
+            },
+            // Only available on TEST environment – switches the Content API endpoint
+            // to the TEST CMS to allow for staff training
+            is_sandbox: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
             },
         };
 
@@ -53,6 +60,13 @@ class Staff extends Model {
 
     get fullName() {
         return `${this.given_name} ${this.family_name}`;
+    }
+
+    static toggleSandboxStatus(id) {
+        return this.update(
+            { is_sandbox: literal('NOT is_sandbox') },
+            { where: { id: { [Op.eq]: id } } }
+        );
     }
 }
 

--- a/views/components/staff-status/macro.njk
+++ b/views/components/staff-status/macro.njk
@@ -3,6 +3,9 @@
         <div class="user-status">
             <div class="user-status__current">
                 <span class="o-badge o-badge--primary u-margin-right-s">Staff</span>
+                {% if user.userData.is_sandbox %}
+                    <span class="o-badge u-margin-right-s">Sandbox mode enabled</span>
+                {% endif %}
                 {{ __('user.common.loggedInAs') }} <strong>{{ user.userData.fullName }}</strong>
             </div>
             <div class="user-status__actions">


### PR DESCRIPTION
(Have just re-worked this so if you read the description yesterday, re-read this!)

Staff need a way to demo changes to the CMS without breaking things in production. We have a TEST CMS instance but it's not hooked up to any of the web environments.

This change adds a new staff-only link to the `/tools` dashboard:

![image](https://user-images.githubusercontent.com/394376/86249958-dd99d400-bba7-11ea-9889-d8d4be65383c.png)

(there's a corresponding new column in the database for this field)

Clicking that link toggles the staff user's `is_sandbox` status, eg:

![image](https://user-images.githubusercontent.com/394376/86250007-f0aca400-bba7-11ea-9068-714cee4130b6.png)

When this is enabled, we set `res.locals.sandboxMode`. This in turn is passed to every Content API request (as a `flags` object so we can extend this approach in future). The API will switch to the TEST CMS endpoint (which I've added to the AWS Parameter Store config) meaning that staff users can now see the content they've created on the TEST CMS using the TEST website (this is only enabled on non-prod environments).

This means you get something like this:

![image](https://user-images.githubusercontent.com/394376/86250438-7a5c7180-bba8-11ea-8a05-e7f8e0aab3b9.png)




There's a mild tradeoff here that each Content API request now needs to pass through the flags, but I think it's worth it to enable this sort of behaviour.

Comments encouraged!