### PR TITLE
Upgrade Joi for form components

### DIFF
--- a/controllers/apply/lib/field-types/address-history.js
+++ b/controllers/apply/lib/field-types/address-history.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const compact = require('lodash/compact');
 
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 
@@ -30,7 +30,7 @@ class AddressHistoryField extends Field {
     defaultSchema() {
         return Joi.object({
             currentAddressMeetsMinimum: Joi.string()
-                .valid(['yes', 'no'])
+                .valid('yes', 'no')
                 .required(),
             previousAddress: Joi.when(Joi.ref('currentAddressMeetsMinimum'), {
                 is: 'no',

--- a/controllers/apply/lib/field-types/address-history.test.js
+++ b/controllers/apply/lib/field-types/address-history.test.js
@@ -21,7 +21,7 @@ test('valid field', function () {
         currentAddressMeetsMinimum: 'yes',
         previousAddress: null,
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toStrictEqual({
         currentAddressMeetsMinimum: 'yes',
     });
@@ -37,7 +37,7 @@ test('valid field', function () {
             postcode: 'B15 1TR',
         },
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toStrictEqual({
         currentAddressMeetsMinimum: 'no',
         previousAddress: {
@@ -78,7 +78,7 @@ test('invalid field', function () {
     });
     expect(field.validate().error.message).toEqual(
         expect.stringContaining(
-            '"townCity" length must be less than or equal to 40 characters long'
+            '"previousAddress.townCity" length must be less than or equal to 40 characters long'
         )
     );
 
@@ -87,8 +87,6 @@ test('invalid field', function () {
         previousAddress: {},
     });
     expect(field.validate().error.message).toEqual(
-        expect.stringContaining(
-            'child "previousAddress" fails because [child "line1" fails because ["line1" is required]]'
-        )
+        expect.stringContaining('"previousAddress.line1" is required')
     );
 });

--- a/controllers/apply/lib/field-types/address.js
+++ b/controllers/apply/lib/field-types/address.js
@@ -1,6 +1,6 @@
 'use strict';
 const compact = require('lodash/compact');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/address.test.js
+++ b/controllers/apply/lib/field-types/address.test.js
@@ -30,6 +30,7 @@ test('address field', function () {
         postcode: 'B15 1TR',
     });
 
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe(
         '1234 example street,\nEdgbaston,\nBirmingham,\nWest Midlands,\nB15 1TR'
     );

--- a/controllers/apply/lib/field-types/budget.js
+++ b/controllers/apply/lib/field-types/budget.js
@@ -4,7 +4,7 @@ const has = require('lodash/has');
 const sumBy = require('lodash/sumBy');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/budget.test.js
+++ b/controllers/apply/lib/field-types/budget.test.js
@@ -29,7 +29,7 @@ test('valid field', function () {
     expect(field.displayValue).toBe(
         'New boiler – £400\nPosters – £20\nTotal: £420'
     );
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });
 
 test('field under budget', function () {

--- a/controllers/apply/lib/field-types/checkbox.js
+++ b/controllers/apply/lib/field-types/checkbox.js
@@ -1,7 +1,7 @@
 'use strict';
 const castArray = require('lodash/castArray');
 const uniq = require('lodash/uniq');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 
@@ -54,7 +54,7 @@ class CheckboxField extends Field {
         const baseSchema = Joi.array()
             .items(
                 Joi.string().valid(
-                    this.normalisedOptions.map((option) => option.value)
+                    ...this.normalisedOptions.map((option) => option.value)
                 )
             )
             .single();

--- a/controllers/apply/lib/field-types/checkbox.test.js
+++ b/controllers/apply/lib/field-types/checkbox.test.js
@@ -20,7 +20,7 @@ test('valid field', function () {
 
     field.withValue(['option-1', 'option-2']);
     expect(field.displayValue).toBe('Option 1,\nOption 2');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue(['bad-option']);
     expect(field.validate().error.message).toEqual(
@@ -74,7 +74,7 @@ test('valid field with optgroups', function () {
 
     field.withValue(['west-midlands', 'south-london']);
     expect(field.displayValue).toBe('West Midlands,\nSouth London');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue(['bad-option']);
     expect(field.validate().error.message).toEqual(
@@ -95,7 +95,7 @@ test('optional field', function () {
         ],
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });
 
 test('must provide options', function () {

--- a/controllers/apply/lib/field-types/currency.js
+++ b/controllers/apply/lib/field-types/currency.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/currency.test.js
+++ b/controllers/apply/lib/field-types/currency.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
 
     field.withValue('120,000');
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toBe(120000);
     expect(field.displayValue).toBe('£120,000');
 });
@@ -28,5 +28,5 @@ test('optional field', function () {
         isRequired: false,
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/date.js
+++ b/controllers/apply/lib/field-types/date.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 const fromDateParts = require('../from-date-parts');
 
 const Field = require('./field');

--- a/controllers/apply/lib/field-types/date.test.js
+++ b/controllers/apply/lib/field-types/date.test.js
@@ -17,7 +17,7 @@ test('DateField', function () {
     const badInput = { day: 82, month: 3, year: 2100 };
 
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('1 March, 2100');
 
     field.withValue(badInput);

--- a/controllers/apply/lib/field-types/day-month.js
+++ b/controllers/apply/lib/field-types/day-month.js
@@ -1,6 +1,6 @@
 'use strict';
 const moment = require('moment');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/day-month.test.js
+++ b/controllers/apply/lib/field-types/day-month.test.js
@@ -14,7 +14,7 @@ test('DayMonthField', function () {
 
     const goodInput = { day: 1, month: 3 };
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('1st March');
 
     const badInput = { day: 82, month: 3 };

--- a/controllers/apply/lib/field-types/email.js
+++ b/controllers/apply/lib/field-types/email.js
@@ -1,6 +1,6 @@
 'use strict';
 const { oneLine } = require('common-tags');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/email.test.js
+++ b/controllers/apply/lib/field-types/email.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
     const badInput = 'not.a.real-email@bad';
 
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe(goodInput);
 
     field.withValue(badInput);
@@ -30,5 +30,5 @@ test('optional field', function () {
         name: 'example',
         isRequired: false,
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/field.js
+++ b/controllers/apply/lib/field-types/field.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 const isFunction = require('lodash/isFunction');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 class Field {
     constructor(props) {

--- a/controllers/apply/lib/field-types/field.test.js
+++ b/controllers/apply/lib/field-types/field.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 'use strict';
 const Field = require('./field');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 test('field base type', function () {
     const field = new Field({
@@ -28,7 +28,7 @@ test('field base type', function () {
 
     field.withValue('something');
     expect(field.displayValue).toBe('something');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });
 
 test('required properties', function () {
@@ -73,7 +73,7 @@ test('optional default field', function () {
     });
 
     expect(optionalField.isRequired).toBeFalsy();
-    expect(optionalField.validate().error).toBeNull();
+    expect(optionalField.validate().error).toBeUndefined();
 });
 
 test('with errors', function () {
@@ -108,7 +108,7 @@ test('override schema', function () {
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM=');
     expect(field.displayValue).toBe('VE9PTUFOWVNFQ1JFVFM=');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM');
     expect(field.validate().error.message).toContain(
@@ -132,7 +132,7 @@ test('extend schema with a function', function () {
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM=');
     expect(field.displayValue).toBe('VE9PTUFOWVNFQ1JFVFM=');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('VE9PTUFOWVNFQ1JFVFM');
     expect(field.validate().error.message).toContain(

--- a/controllers/apply/lib/field-types/file.js
+++ b/controllers/apply/lib/field-types/file.js
@@ -4,7 +4,7 @@ const mime = require('mime-types');
 const fileSize = require('filesize');
 
 const Field = require('./field');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 class FileField extends Field {
     constructor(props) {
@@ -38,7 +38,9 @@ class FileField extends Field {
         this.schema = Joi.object({
             filename: Joi.string().required(),
             size: Joi.number().max(this.maxFileSize.value).required(),
-            type: Joi.string().valid(this.supportedMimeTypes).required(),
+            type: Joi.string()
+                .valid(...this.supportedMimeTypes)
+                .required(),
         }).required();
     }
 

--- a/controllers/apply/lib/field-types/file.test.js
+++ b/controllers/apply/lib/field-types/file.test.js
@@ -18,7 +18,7 @@ test('FileField', function () {
         size: 13264,
         type: 'application/pdf',
     });
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('example.pdf (PDF, 13 KB)');
 
     field.withValue({

--- a/controllers/apply/lib/field-types/month-year.js
+++ b/controllers/apply/lib/field-types/month-year.js
@@ -1,6 +1,6 @@
 'use strict';
 const moment = require('moment');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/month-year.test.js
+++ b/controllers/apply/lib/field-types/month-year.test.js
@@ -14,7 +14,7 @@ test('MonthYearField', function () {
 
     const goodInput = { year: 1986, month: 9 };
     field.withValue(goodInput);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('1st September');
 
     const badInput = { year: 3000, month: 1 };

--- a/controllers/apply/lib/field-types/name.js
+++ b/controllers/apply/lib/field-types/name.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/name.test.js
+++ b/controllers/apply/lib/field-types/name.test.js
@@ -18,5 +18,6 @@ test('NameField', function () {
     );
 
     field.withValue({ firstName: 'Björk', lastName: 'Guðmundsdóttir' });
+    expect(field.validate().error).toBeUndefined();
     expect(field.displayValue).toBe('Björk Guðmundsdóttir');
 });

--- a/controllers/apply/lib/field-types/phone.js
+++ b/controllers/apply/lib/field-types/phone.js
@@ -1,5 +1,5 @@
 'use strict';
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/phone.test.js
+++ b/controllers/apply/lib/field-types/phone.test.js
@@ -15,7 +15,7 @@ test('valid field', function () {
     const badValue = '0345 444';
 
     field.withValue(goodValue);
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
     expect(field.validate().value).toBe('028 9568 0143');
 
     field.withValue(badValue);
@@ -31,8 +31,8 @@ test('optional field', function () {
         isRequired: false,
     });
 
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 });

--- a/controllers/apply/lib/field-types/radio.js
+++ b/controllers/apply/lib/field-types/radio.js
@@ -2,7 +2,7 @@
 const find = require('lodash/fp/find');
 const uniq = require('lodash/uniq');
 const castArray = require('lodash/castArray');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 
@@ -31,7 +31,7 @@ class RadioField extends Field {
     defaultSchema() {
         const options = this.options || [];
         const baseSchema = Joi.string().valid(
-            options.map((option) => option.value)
+            ...options.map((option) => option.value)
         );
 
         return this.isRequired ? baseSchema.required() : baseSchema.optional();

--- a/controllers/apply/lib/field-types/radio.test.js
+++ b/controllers/apply/lib/field-types/radio.test.js
@@ -19,7 +19,7 @@ test('valid field', function () {
 
     field.withValue('option-1');
     expect(field.displayValue).toBe('Option 1');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('bad-option');
     expect(field.validate().error.message).toEqual(

--- a/controllers/apply/lib/field-types/select.js
+++ b/controllers/apply/lib/field-types/select.js
@@ -1,6 +1,6 @@
 'use strict';
 const uniq = require('lodash/uniq');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 
@@ -43,7 +43,7 @@ class SelectField extends Field {
 
     defaultSchema() {
         const baseSchema = Joi.string().valid(
-            this.normalisedOptions.map((option) => option.value)
+            ...this.normalisedOptions.map((option) => option.value)
         );
 
         if (this.isRequired) {

--- a/controllers/apply/lib/field-types/select.test.js
+++ b/controllers/apply/lib/field-types/select.test.js
@@ -20,7 +20,7 @@ test('select field', function () {
 
     field.withValue('option-2');
     expect(field.displayValue).toBe('Option 2');
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue('bad-option');
     expect(field.validate().error.message).toEqual(

--- a/controllers/apply/lib/field-types/textarea.js
+++ b/controllers/apply/lib/field-types/textarea.js
@@ -1,7 +1,7 @@
 'use strict';
 const has = require('lodash/has');
 const countWords = require('../count-words');
-const Joi = require('../joi-extensions');
+const Joi = require('../joi-extensions-next');
 
 const Field = require('./field');
 

--- a/controllers/apply/lib/field-types/textarea.test.js
+++ b/controllers/apply/lib/field-types/textarea.test.js
@@ -26,7 +26,7 @@ test('TextareaField', function () {
     expect(field.displayValue).toEqual(
         `${goodValue}\n\n${minWords + 1}/${maxWords} words`
     );
-    expect(field.validate().error).toBeNull();
+    expect(field.validate().error).toBeUndefined();
 
     field.withValue(faker.lorem.words(minWords - 1));
     expect(field.validate().error.message).toEqual(
@@ -35,7 +35,7 @@ test('TextareaField', function () {
 
     field.withValue(faker.lorem.words(maxWords + 1));
     expect(field.validate().error.message).toEqual(
-        expect.stringContaining(`must have less than ${maxWords} words`)
+        expect.stringContaining(`must have no more than ${maxWords} words`)
     );
 
     const optionalField = new TextareaField({
@@ -48,7 +48,7 @@ test('TextareaField', function () {
         messages: [{ type: 'base', message: 'Enter a value' }],
     });
 
-    expect(optionalField.validate().error).toBeNull();
+    expect(optionalField.validate().error).toBeUndefined();
 });
 
 test('required properties', function () {

--- a/controllers/apply/lib/form-model.js
+++ b/controllers/apply/lib/form-model.js
@@ -8,7 +8,7 @@ const isEmpty = require('lodash/isEmpty');
 const pick = require('lodash/pick');
 const reduce = require('lodash/reduce');
 
-const Joi = require('@hapi/joi');
+const Joi = require('@hapi/joiNext');
 
 const normaliseErrors = require('./normalise-errors');
 
@@ -107,7 +107,8 @@ class FormModel {
          */
         const formIsEmpty = isEmpty(this.validation.value);
         this.progress = {
-            isComplete: formIsEmpty === false && this.validation.error === null,
+            isComplete:
+                formIsEmpty === false && this.validation.error === undefined,
             isPristine: formIsEmpty === true,
             sectionsComplete: this.sections.filter(
                 (section) => section.progress.status === 'complete'
@@ -183,7 +184,7 @@ class FormModel {
         return {
             value: value,
             error: error,
-            isValid: error === null && messages.length === 0,
+            isValid: error === undefined && messages.length === 0,
             messages: messages,
             featuredMessages: this._getFeaturedMessages(messages),
         };

--- a/controllers/apply/standard-proposal/fields.js
+++ b/controllers/apply/standard-proposal/fields.js
@@ -6,7 +6,7 @@ const orderBy = require('lodash/orderBy');
 const { oneLine } = require('common-tags');
 const config = require('config');
 
-const Joi = require('../lib/joi-extensions');
+const Joi = require('../lib/joi-extensions-next');
 
 const {
     Field,
@@ -153,7 +153,9 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
              */
             schema: Joi.array()
                 .items(
-                    Joi.string().valid(options().map((option) => option.value))
+                    Joi.string().valid(
+                        ...options().map((option) => option.value)
+                    )
                 )
                 .single()
                 .required(),
@@ -187,13 +189,13 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
 
         function schema() {
             const isEnglandSelected = Joi.array().items(
-                Joi.string().only('england').required(),
+                Joi.string().valid('england').required(),
                 Joi.any()
             );
 
             const validAllEngland = Joi.array()
                 .items(
-                    Joi.string().only('all-england').required(),
+                    Joi.string().valid('all-england').required(),
                     Joi.any().strip()
                 )
                 .single()
@@ -201,7 +203,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
 
             const validRegionOptions = Joi.array()
                 .items(
-                    Joi.string().valid(options.map((option) => option.value))
+                    Joi.string().valid(...options.map((option) => option.value))
                 )
                 .single()
                 .required();
@@ -257,7 +259,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                 then: Joi.any().strip(),
                 otherwise: Joi.string()
                     .valid(
-                        flatMap(optgroups(), (group) => group.options).map(
+                        ...flatMap(optgroups(), (group) => group.options).map(
                             (option) => option.value
                         )
                     )
@@ -830,7 +832,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             schema: Joi.when('organisationType', {
                 is: 'statutory-body',
                 then: Joi.string()
-                    .valid(options.map((option) => option.value))
+                    .valid(...options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             }),
@@ -898,10 +900,10 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             options: options,
             schema: Joi.when('projectCountries', {
                 is: Joi.array()
-                    .items(Joi.string().only('wales').required(), Joi.any())
+                    .items(Joi.string().valid('wales').required(), Joi.any())
                     .required(),
                 then: Joi.string()
-                    .valid(options.map((option) => option.value))
+                    .valid(...options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             }),

--- a/controllers/apply/standard-proposal/form.test.js
+++ b/controllers/apply/standard-proposal/form.test.js
@@ -17,7 +17,7 @@ test('empty form', () => {
 test('valid form', () => {
     const data = mockResponse();
     const result = formBuilder({ data }).validation;
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 
     expect(result.value).toMatchSnapshot({
         yourIdeaProject: expect.any(String),
@@ -118,7 +118,7 @@ test('organisation sub-type required for statutory-body', function () {
         organisationSubType: 'fire-service',
     });
     const result = formBuilder({ data: validData }).validation;
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 });
 
 test('language preference required in wales', function () {
@@ -139,7 +139,7 @@ test('language preference required in wales', function () {
         }),
     });
 
-    expect(formValid.validation.error).toBeNull();
+    expect(formValid.validation.error).toBeUndefined();
 
     const formStrip = formBuilder({
         data: mockResponse({
@@ -163,5 +163,5 @@ test.each([
 
     const expected = omit(data, fieldName);
     const result = form.validate(expected);
-    expect(result.error).toBeNull();
+    expect(result.error).toBeUndefined();
 });

--- a/controllers/apply/under10k/__snapshots__/form.test.js.snap
+++ b/controllers/apply/under10k/__snapshots__/form.test.js.snap
@@ -23,13 +23,13 @@ Array [
   "organisationType: Select a type of organisation",
   "accountingYearDate: Enter a day and month",
   "totalIncomeYear: Enter a total income for the year (eg. a whole number with no commas or decimal points)",
-  "mainContactName: Enter first and last name",
   "mainContactDateOfBirth: Enter a date of birth",
   "mainContactAddress: Enter a full UK address",
   "mainContactAddressHistory: Enter a full UK address",
   "mainContactPhone: Enter a UK telephone number",
   "seniorContactRole: Choose a role",
   "seniorContactName: Enter first and last name",
+  "mainContactName: Enter first and last name",
   "seniorContactDateOfBirth: Enter a date of birth",
   "seniorContactAddress: Enter a full UK address",
   "seniorContactAddressHistory: Enter a full UK address",
@@ -117,15 +117,13 @@ Array [
   "yourIdeaCommunity: Answer must be no more than 200 words",
   "projectBudget: Costs you would like us to fund must be less than £10,000",
   "projectTotalCosts: Total cost must be the same as or higher than the amount you’re asking us to fund",
-  "mainContactName: Main contact name must be different from the senior contact's name",
   "mainContactDateOfBirth: Must be at least 16 years old",
   "mainContactAddress: Main contact address must be different from the senior contact's address",
   "mainContactAddressHistory: Enter a full UK address",
   "mainContactPhone: Enter a real UK telephone number",
-  "seniorContactRole: Senior contact role is not valid",
-  "seniorContactName: Senior contact name must be different from the main contact's name",
+  "seniorContactRole: Choose a role",
+  "mainContactName: Main contact name must be different from the senior contact's name",
   "seniorContactDateOfBirth: Must be at least 18 years old",
-  "seniorContactAddress: Senior contact address must be different from the main contact's address",
   "seniorContactAddressHistory: Enter a full UK address",
   "mainContactEmail: Main contact email address must be different from the senior contact's email address",
   "seniorContactPhone: Enter a real UK telephone number",
@@ -134,9 +132,8 @@ Array [
 
 exports[`invalid form 2`] = `
 Array [
-  "Main contact name must be different from the senior contact's name",
   "Enter a real UK telephone number",
-  "Senior contact role is not valid",
+  "Main contact name must be different from the senior contact's name",
   "Main contact email address must be different from the senior contact's email address",
 ]
 `;

--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -3,7 +3,7 @@ const get = require('lodash/fp/get');
 const moment = require('moment');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../lib/joi-extensions');
+const Joi = require('../lib/joi-extensions-next');
 
 const {
     Field,
@@ -453,18 +453,6 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                 en: 'This person has to live in the UK.',
                 cy: 'Rhaid i’r person hwn fyw ym Mhrydain',
             }),
-            schema(originalSchema) {
-                return originalSchema.compare(Joi.ref('mainContactName'));
-            },
-            messages: [
-                {
-                    type: 'object.isEqual',
-                    message: localise({
-                        en: `Senior contact name must be different from the main contact's name`,
-                        cy: `Rhaid i enw’r uwch gyswllt fod yn wahanol i enw’r prif gyswllt`,
-                    }),
-                },
-            ],
         }),
         seniorContactDateOfBirth: dateOfBirthField(
             'seniorContactDateOfBirth',
@@ -483,19 +471,8 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
             }),
             schema: stripIfExcludedOrgType(
                 CONTACT_EXCLUDED_TYPES,
-                Joi.ukAddress()
-                    .required()
-                    .compare(Joi.ref('mainContactAddress'))
+                Joi.ukAddress().required()
             ),
-            messages: [
-                {
-                    type: 'object.isEqual',
-                    message: localise({
-                        en: `Senior contact address must be different from the main contact's address`,
-                        cy: `Rhaid i gyfeiriad e-bost yr uwch gyswllt fod yn wahanol i gyfeiriad e-bost y prif gyswllt.`,
-                    }),
-                },
-            ],
         }),
         seniorContactAddressHistory: fieldContactAddressHistory(locale, {
             name: 'seniorContactAddressHistory',

--- a/controllers/apply/under10k/fields/bank-account-name.js
+++ b/controllers/apply/under10k/fields/bank-account-name.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 const Field = require('../../lib/field-types/field');
 

--- a/controllers/apply/under10k/fields/bank-account-number.js
+++ b/controllers/apply/under10k/fields/bank-account-number.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/bank-sort-code.js
+++ b/controllers/apply/under10k/fields/bank-sort-code.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/beneficiaries.js
+++ b/controllers/apply/under10k/fields/beneficiaries.js
@@ -3,13 +3,13 @@ const { oneLine } = require('common-tags');
 const get = require('lodash/fp/get');
 const flatMap = require('lodash/flatMap');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { Field, RadioField, CheckboxField } = require('../../lib/field-types');
 const { BENEFICIARY_GROUPS, FREE_TEXT_MAXLENGTH } = require('../constants');
 
 function multiChoice(options) {
     return Joi.array()
-        .items(Joi.string().valid(options.map((option) => option.value)))
+        .items(Joi.string().valid(...options.map((option) => option.value)))
         .single();
 }
 
@@ -18,7 +18,7 @@ function conditionalBeneficiaryChoice({ match, schema }) {
         is: 'yes',
         then: Joi.when(Joi.ref('beneficiariesGroups'), {
             is: Joi.array()
-                .items(Joi.string().only(match).required(), Joi.any())
+                .items(Joi.string().valid(match).required(), Joi.any())
                 .required(),
             then: schema,
             otherwise: Joi.any().strip(),
@@ -676,7 +676,7 @@ module.exports = {
                 return Joi.when('projectCountry', {
                     is: 'wales',
                     then: Joi.string()
-                        .valid(this.options.map((option) => option.value))
+                        .valid(...this.options.map((option) => option.value))
                         .max(FREE_TEXT_MAXLENGTH.large)
                         .required(),
                     otherwise: Joi.any().strip(),
@@ -737,7 +737,7 @@ module.exports = {
                 return Joi.when('projectCountry', {
                     is: 'northern-ireland',
                     then: Joi.string()
-                        .valid(this.options.map((option) => option.value))
+                        .valid(...this.options.map((option) => option.value))
                         .required(),
                     otherwise: Joi.any().strip(),
                 });

--- a/controllers/apply/under10k/fields/building-society-number.js
+++ b/controllers/apply/under10k/fields/building-society-number.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 const Field = require('../../lib/field-types/field');
 

--- a/controllers/apply/under10k/fields/charity-number.js
+++ b/controllers/apply/under10k/fields/charity-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { CHARITY_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale, data) {
@@ -19,15 +19,15 @@ module.exports = function (locale, data) {
     const excludeRegex = /^[^Oo]+$/;
 
     const baseSchema = Joi.string()
-        .regex(excludeRegex)
+        .pattern(excludeRegex)
         .min(4)
         .max(FREE_TEXT_MAXLENGTH.large);
 
     const schema = Joi.when(Joi.ref('organisationType'), {
-        is: Joi.exist().valid(CHARITY_NUMBER_TYPES.required),
+        is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.required),
         then: baseSchema.required(),
     }).when(Joi.ref('organisationType'), {
-        is: Joi.exist().valid(CHARITY_NUMBER_TYPES.optional),
+        is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.optional),
         then: baseSchema.optional().allow('', null),
         otherwise: Joi.any().strip(),
     });
@@ -53,7 +53,7 @@ module.exports = function (locale, data) {
                 }),
             },
             {
-                type: 'string.regex.base',
+                type: 'string.pattern.base',
                 message: localise({
                     en:
                         'Enter a real charity registration number. And don’t use any spaces. Scottish charity registration numbers must also use the number ‘0’ in ‘SC0’ instead of the letter ‘O’.',

--- a/controllers/apply/under10k/fields/company-number.js
+++ b/controllers/apply/under10k/fields/company-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { COMPANY_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 const { stripUnlessOrgTypes } = require('./organisation-type');

--- a/controllers/apply/under10k/fields/contact-address-history.js
+++ b/controllers/apply/under10k/fields/contact-address-history.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { AddressHistoryField } = require('../../lib/field-types');
 const { CONTACT_EXCLUDED_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
 const { stripIfExcludedOrgType } = require('./organisation-type');
@@ -21,7 +21,7 @@ module.exports = function (locale, props) {
             CONTACT_EXCLUDED_TYPES,
             Joi.object({
                 currentAddressMeetsMinimum: Joi.string()
-                    .valid(['yes', 'no'])
+                    .valid('yes', 'no')
                     .required(),
                 previousAddress: Joi.when(
                     Joi.ref('currentAddressMeetsMinimum'),

--- a/controllers/apply/under10k/fields/contact-communication-needs.js
+++ b/controllers/apply/under10k/fields/contact-communication-needs.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 const Field = require('../../lib/field-types/field');
 

--- a/controllers/apply/under10k/fields/contact-language-preference.js
+++ b/controllers/apply/under10k/fields/contact-language-preference.js
@@ -1,7 +1,7 @@
 'use strict';
 const get = require('lodash/fp/get');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const RadioField = require('../../lib/field-types/radio');
 
 module.exports = function (locale, props) {
@@ -33,7 +33,7 @@ module.exports = function (locale, props) {
             return Joi.when('projectCountry', {
                 is: 'wales',
                 then: Joi.string()
-                    .valid(this.options.map((option) => option.value))
+                    .valid(...this.options.map((option) => option.value))
                     .required(),
                 otherwise: Joi.any().strip(),
             });

--- a/controllers/apply/under10k/fields/covid-19.js
+++ b/controllers/apply/under10k/fields/covid-19.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine, stripIndents } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { RadioField } = require('../../lib/field-types');
 
 module.exports = {

--- a/controllers/apply/under10k/fields/education-number.js
+++ b/controllers/apply/under10k/fields/education-number.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 
 const { EDUCATION_NUMBER_TYPES, FREE_TEXT_MAXLENGTH } = require('../constants');
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 const { stripUnlessOrgTypes } = require('./organisation-type');

--- a/controllers/apply/under10k/fields/organisation-finances.js
+++ b/controllers/apply/under10k/fields/organisation-finances.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { CurrencyField, DayMonthField } = require('../../lib/field-types');
 const isNewOrganisation = require('../lib/new-organisation');
 

--- a/controllers/apply/under10k/fields/organisation-type.js
+++ b/controllers/apply/under10k/fields/organisation-type.js
@@ -3,7 +3,7 @@ const get = require('lodash/fp/get');
 const compact = require('lodash/compact');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { RadioField } = require('../../lib/field-types');
 
 const { ORGANISATION_TYPES, STATUTORY_BODY_TYPES } = require('../constants');
@@ -15,14 +15,14 @@ module.exports = {
      */
     stripIfExcludedOrgType(types, schema) {
         return Joi.when(Joi.ref('organisationType'), {
-            is: Joi.exist().valid(types),
+            is: Joi.exist().valid(...types),
             then: Joi.any().strip(),
             otherwise: schema,
         });
     },
     stripUnlessOrgTypes(types, schema) {
         return Joi.when(Joi.ref('organisationType'), {
-            is: Joi.exist().valid(types),
+            is: Joi.exist().valid(...types),
             then: schema,
             otherwise: Joi.any().strip(),
         });

--- a/controllers/apply/under10k/fields/project-dates.js
+++ b/controllers/apply/under10k/fields/project-dates.js
@@ -4,7 +4,7 @@ const has = require('lodash/fp/has');
 const moment = require('moment');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { DateField, RadioField } = require('../../lib/field-types');
 
 function getLeadTimeWeeks(country) {
@@ -89,7 +89,9 @@ module.exports = {
                     const mapValues = (option) => option.value;
 
                     return Joi.string()
-                        .valid(options().filter(excludeDisabled).map(mapValues))
+                        .valid(
+                            ...options().filter(excludeDisabled).map(mapValues)
+                        )
                         .required();
                 } else {
                     return Joi.any().strip();

--- a/controllers/apply/under10k/fields/project-postcode.js
+++ b/controllers/apply/under10k/fields/project-postcode.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const Field = require('../../lib/field-types/field');
 
 module.exports = function (locale) {

--- a/controllers/apply/under10k/fields/terms.js
+++ b/controllers/apply/under10k/fields/terms.js
@@ -2,7 +2,7 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
+const Joi = require('../../lib/joi-extensions-next');
 const { Field, CheckboxField } = require('../../lib/field-types');
 const { FREE_TEXT_MAXLENGTH } = require('../constants');
 

--- a/controllers/apply/under10k/form.test.js
+++ b/controllers/apply/under10k/form.test.js
@@ -111,7 +111,7 @@ test('valid form for england', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for scotland', () => {
@@ -122,7 +122,7 @@ test('valid form for scotland', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for wales', () => {
@@ -137,7 +137,7 @@ test('valid form for wales', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Test for existence of country specific fields
     expect(form.getCurrentFields().map((field) => field.name)).toEqual(
@@ -159,7 +159,7 @@ test('valid form for northern-ireland', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Test for existence of country specific fields
     expect(form.getCurrentFields().map((field) => field.name)).toEqual(
@@ -185,7 +185,7 @@ test('valid form for unregistered-vco', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for unincorporated-registered-charity', function () {
@@ -197,7 +197,7 @@ test('valid form for unincorporated-registered-charity', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 
@@ -224,7 +224,7 @@ test('valid form for charitable-incorporated-organisation', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 
@@ -262,8 +262,8 @@ test('valid form for not-for-profit-company', function () {
         }),
     });
 
-    expect(form.validation.error).toBeNull();
-    expect(formWithCharityNumber.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
+    expect(formWithCharityNumber.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual([
         'companyNumber',
@@ -295,7 +295,7 @@ test('valid form for community-interest-company', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['companyNumber']);
 
@@ -327,7 +327,7 @@ test('valid form for school', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationType: 'school',
@@ -359,7 +359,7 @@ test('valid form for college-or-university', function () {
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationType: 'college-or-university',
@@ -394,7 +394,7 @@ test('valid form for statutory-body', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test.each(['school', 'college-or-university', 'statutory-body'])(
@@ -437,7 +437,7 @@ test('role can be free text for some statutory bodies', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('valid form for faith-group', function () {
@@ -448,7 +448,7 @@ test('valid form for faith-group', function () {
         }),
     });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const formWithCharityNumber = formBuilder({
         data: mockResponse({
@@ -458,7 +458,7 @@ test('valid form for faith-group', function () {
         }),
     });
 
-    expect(formWithCharityNumber.validation.error).toBeNull();
+    expect(formWithCharityNumber.validation.error).toBeUndefined();
 
     expect(mapRegistrationFieldNames(form)).toEqual(['charityNumber']);
 });
@@ -503,7 +503,7 @@ test('valid form for different trading names', function () {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationLegalName: 'Balloon Rides For Sad Polar Bears',
@@ -535,7 +535,7 @@ test('maintain backwards compatibility for date schema', function () {
         data: omit(mock, 'projectStartDateCheck'),
     });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     // Maintain backwards compatibility with salesforce schema
     const salesforceResult = form.forSalesforce();
@@ -580,7 +580,7 @@ test('start date defaults to current date if specifying as soon as possible', fu
         flags: { enableEnglandAutoEndDate: false },
     });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const salesforceResult = form.forSalesforce();
 
@@ -605,7 +605,7 @@ test('end date pre-filled to 6 months from now if specifying asap in England', f
 
     const form = formBuilder({ data });
 
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 
     const salesforceResult = form.forSalesforce();
 
@@ -659,7 +659,7 @@ test('start date must be at least 12 weeks away outside England when not support
             data: omit(validData, 'projectStartDateCheck'),
         });
 
-        expect(validForm.validation.error).toBeNull();
+        expect(validForm.validation.error).toBeUndefined();
     }
 
     expectStartDateForCountry({
@@ -742,7 +742,7 @@ test('allow only "other" option for beneficiary groups', () => {
     });
 
     const form = formBuilder({ data });
-    expect(form.validation.error).toBeNull();
+    expect(form.validation.error).toBeUndefined();
 });
 
 test('finance details required if organisation is over 15 months old', function () {
@@ -756,7 +756,7 @@ test('finance details required if organisation is over 15 months old', function 
     });
 
     const validForm = formBuilder({ data: validData });
-    expect(validForm.validation.error).toBeNull();
+    expect(validForm.validation.error).toBeUndefined();
 
     const invalidData = mockResponse({
         organisationStartDate: {

--- a/docs/__tests__/schema.test.js
+++ b/docs/__tests__/schema.test.js
@@ -10,7 +10,7 @@ function validateSchemaDocumentation(formBuilder, schemaDocPath) {
     const docContents = fs.readFileSync(schemaDocPath, 'utf8');
 
     describe(`${form.title} schema documentation`, function () {
-        test.each(Object.keys(form.schema.describe().children))(
+        test.each(Object.keys(form.schema.describe().keys))(
             '%s has documentation entry',
             (fieldName) => {
                 const fieldNameRegexp = new RegExp(`### ${fieldName}`);


### PR DESCRIPTION
Finishes off the noble work started here: https://github.com/biglotteryfund/blf-alpha/pull/3246 and fixes https://github.com/biglotteryfund/blf-alpha/issues/3352

Lots of changes but it's mostly boilerplate to allow for new Joi changes, eg:

- `.valid(['a', 'b', 'c'])` now needs arrays to be spread like `.valid(...['a', 'b', 'c'])` or `.valid('a', 'b', 'c')`
- Validation errors now return `undefined` instead of `null`
- Use of `only()` is now deprecated in favour of `valid()`
- `Joi.string.regex()` is now `Joi.string.pattern()`
- `Joi.describe().children` is now `Joi.describe().keys`

The changes are numerous but small, but will need some good testing to ensure nothing unusual has broken. There's also one side effect which is that two-way validations aren't possible any more in extensions, as David noted:

> Validation rules for same name and address now need to be one-way so only associating the error with the second contact.

eg. we used to be able to show an error if a Main and Senior contact had the same name on _both_ ends of the error (eg. both contact pages would show the error) but now we can only show it on one of them – the Main contact (as it's second).
