### PR TITLE
Windows alternative scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "node ./bin/www",
     "start-dev": "nodemon --inspect ./bin/www",
-    "start-test": "DB_CONNECTION_URI=sqlite://:memory PORT=8090 TEST_SERVER=true npm run start",
+    "start-test": "cross-env DB_CONNECTION_URI=sqlite://:memory PORT=8090 TEST_SERVER=true npm run start",
     "lint": "eslint . bin/* --ext .js,.vue && stylelint assets/sass",
     "format": "prettier --write . bin/*",
     "test-unit": "jest --maxWorkers=4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build-autotrack": "npx autotrack -o public/autotrack/autotrack.js -p outboundLinkTracker,eventTracker",
     "watch-tests": "jest --watch --notify",
     "watch-js": "webpack --watch",
-    "watch-css": "sane 'npm run build-css' assets/sass --glob='**/*.scss'",
+    "watch-css": "sane \"npm run build-css\" assets/sass --glob=\"**/*.scss\"",
     "watch": "concurrently --kill-others npm:watch-js npm:watch-css"
   },
   "jest": {


### PR DESCRIPTION
Updating the package.json to feature commands that have support for windows. The following were updated:
- npm watch - now uses /" instead of ' as single quotation marks are not supported in double quotation marks e.g.  /"example/" instead of 'example'
- npm start-test - now uses cross-env before the command so it can be properly executed on a windows machine.