### PR TITLE
Footer updated to match top nav bar

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -64,7 +64,7 @@ global:
   footerLinks:
     title: Dolenni gwib
     links:
-    - label: "Siarad â ni"
+    - label: "Cysylltwch â ni"
       href: "/welsh/contact"
     - label: Swyddi
       href: "/welsh/jobs"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,7 @@ global:
   footerLinks:
     title: Quick links
     links:
-    - label: Talk to us
+    - label: Contact us
       href: "/contact"
     - label: Jobs
       href: "/jobs"


### PR DESCRIPTION
'Talk to us' has been updated to 'Contact us' to match the change to the top nav bar on the footer. Both English and Welsh have been updated.