### PR TITLE
Send bulk emails

### DIFF
--- a/bin/bulk-emailer
+++ b/bin/bulk-emailer
@@ -129,7 +129,7 @@ if (mode !== 'template' && !dbPath) {
 const SENDS_PER_SECOND = 14; // SES limit for our account
 const EMAIL_SOURCE = 'noreply@blf.digital';
 const EMAIL_SUBJECT =
-    'Important update about your The National Lottery Community Fund application';
+    'Important update about your Coronavirus Community Support Fund application';
 
 // Send a pre-templated email to an array of senders (max 50)
 const sendBulkEmail = (emails) => {

--- a/bin/bulk-emailer
+++ b/bin/bulk-emailer
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-
 /*
 * A script to email people in bulk, to be run from local environments.
 *
@@ -69,7 +68,7 @@
 *
 * */
 
-const _ = require('lodash');
+const chunk = require('lodash/chunk');
 const htmlToText = require('html-to-text');
 const AWS = require('aws-sdk');
 const sqlite3 = require('sqlite3').verbose();
@@ -77,7 +76,7 @@ const csv = require('csvtojson');
 
 const SES = new AWS.SES({
     apiVersion: '2010-12-01',
-    region: 'eu-west-1',
+    region: 'eu-west-1'
 });
 
 const { generateHtmlEmail } = require('../common/mail');
@@ -138,24 +137,24 @@ const sendBulkEmail = (emails) => {
         Destinations: [
             {
                 Destination: {
-                    BccAddresses: emails,
-                },
-            },
+                    BccAddresses: emails
+                }
+            }
         ],
         Source: EMAIL_SOURCE,
         Template: emailTemplate,
-        DefaultTemplateData: '{}',
+        DefaultTemplateData: '{}'
     }).promise();
 };
 
 // Send a batch of emails every second
 const processEmailQueue = (emailAddresses) => {
     // Split the list into chunks matching our limit per-second
-    const emailQueue = _.chunk(emailAddresses, SENDS_PER_SECOND);
+    const emailQueue = chunk(emailAddresses, SENDS_PER_SECOND);
 
     // Send a bulk email to $SENDS_PER_SECOND people, every second
     emailQueue.forEach((queue, i) => {
-        setTimeout(function () {
+        setTimeout(function() {
             console.log('Sending batch: ' + i);
             sendBulkEmail(queue)
                 .then((data) => {
@@ -188,14 +187,14 @@ const createHtmlTemplate = async () => {
     // Make HTML version
     const emailHtml = await generateHtmlEmail({
         template: './controllers/apply/expiries/views/ccsf-closure-email.njk',
-        templateData: {},
+        templateData: {}
     });
 
     // Make plain text version from HTML
     const emailText = htmlToText.fromString(emailHtml, {
         wordwrap: 130,
         hideLinkHrefIfSameAsText: true,
-        ignoreImage: true,
+        ignoreImage: true
     });
 
     // Register the new template with SES
@@ -204,8 +203,8 @@ const createHtmlTemplate = async () => {
             TemplateName: emailTemplate,
             SubjectPart: EMAIL_SUBJECT,
             TextPart: emailText,
-            HtmlPart: emailHtml,
-        },
+            HtmlPart: emailHtml
+        }
     }).promise();
 };
 
@@ -225,7 +224,7 @@ if (mode === 'send') {
         .then((data) => {
             console.log(
                 'Template was successfully created with the name ' +
-                    emailTemplate,
+                emailTemplate,
                 data
             );
         })

--- a/bin/bulk-emailer
+++ b/bin/bulk-emailer
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const _ = require('lodash');
+const htmlToText = require('html-to-text');
+const AWS = require('aws-sdk');
+const sqlite3 = require('sqlite3').verbose();
+const csv = require('csvtojson');
+
+const SES = new AWS.SES({
+    apiVersion: '2010-12-01',
+    region: 'eu-west-1',
+});
+
+const { generateHtmlEmail } = require('../common/mail');
+
+const argv = require('yargs')
+    .alias('m', 'mode')
+    .describe(
+        'm',
+        'What mode this script should run in. One of `database`, `send` or `template`.'
+    )
+    .alias('t', 'template')
+    .describe('t', 'Pass the name of a template to use')
+    .alias('d', 'database')
+    .describe('d', 'Pass the filename of a database to use')
+    .alias('c', 'csv')
+    .describe('c', 'Pass the filename of a CSV file with a `username` column of email addresses')
+    .demandOption(['m', 'd'])
+    .help('h')
+    .alias('h', 'help').argv;
+
+const mode = argv.mode;
+const emailTemplate = argv.template;
+const dbPath = argv.database;
+const csvPath = argv.csv;
+
+if (mode === 'send' && !emailTemplate) {
+    throw new Error(
+        'You must provide the name of a template to use for this email'
+    );
+} else if (mode === 'template' && !emailTemplate) {
+    throw new Error('You must provide a template name to create');
+} else if (mode === 'database' && !csvPath) {
+    throw new Error('You must provide a CSV file of email addresses to store');
+}
+
+if (!argv.d) {
+    throw new Error('You must provide the path to a database file (-d or --database)');
+}
+
+const db = new sqlite3.Database(dbPath, (err) => {
+    if (err) {
+        throw new Error(err);
+    }
+    console.log('Connected to the bulk emails database.');
+});
+
+// Email configuration
+const SENDS_PER_SECOND = 14; // SES limit for our account
+const EMAIL_SOURCE = 'noreply@blf.digital';
+const EMAIL_SUBJECT =
+    'Important update about your The National Lottery Community Fund application';
+
+// Send a pre-templated email to an array of senders (max 50)
+const sendBulkEmail = (emails) => {
+    return SES.sendBulkTemplatedEmail({
+        Destinations: [
+            {
+                Destination: {
+                    BccAddresses: emails,
+                },
+            },
+        ],
+        Source: EMAIL_SOURCE,
+        Template: emailTemplate,
+        DefaultTemplateData: '{}',
+    }).promise();
+};
+
+// Send a batch of emails every second
+const processEmailQueue = (emailAddresses) => {
+    // Split the list into chunks matching our limit per-second
+    const emailQueue = _.chunk(emailAddresses, SENDS_PER_SECOND);
+
+    // Send a bulk email to $SENDS_PER_SECOND people, every second
+    emailQueue.forEach((queue, i) => {
+        setTimeout(function () {
+            console.log('Sending batch: ' + i);
+            sendBulkEmail(queue)
+                .then((data) => {
+                    console.log('Email was sent to batch', queue, data);
+
+                    if (data.Status[0].Status === 'Success') {
+                        // Mark these users as sent
+                        db.serialize(() => {
+                            const stmt = db.prepare(
+                                'UPDATE users SET sent = 1 WHERE email = ?'
+                            );
+                            queue.forEach((email) => {
+                                stmt.run(email);
+                            });
+                            stmt.finalize();
+                        });
+                    } else {
+                        console.log('Error with this batch');
+                    }
+                })
+                .catch((err) => {
+                    throw new Error(err);
+                });
+        }, i * 1000);
+    });
+};
+
+// Create an email template in SES for future use based on a Nunjucks template
+const createHtmlTemplate = async () => {
+    // Make HTML version
+    const emailHtml = await generateHtmlEmail({
+        template: './controllers/apply/expiries/views/ccsf-closure-email.njk',
+        templateData: {},
+    });
+
+    // Make plain text version from HTML
+    const emailText = htmlToText.fromString(emailHtml, {
+        wordwrap: 130,
+        hideLinkHrefIfSameAsText: true,
+        ignoreImage: true,
+    });
+
+    // Register the new template with SES
+    return SES.createTemplate({
+        Template: {
+            TemplateName: emailTemplate,
+            SubjectPart: EMAIL_SUBJECT,
+            TextPart: emailText,
+            HtmlPart: emailHtml,
+        },
+    }).promise();
+};
+
+if (mode === 'send') {
+    // Look up users who haven't been emailed yet
+    db.all('SELECT * FROM users WHERE sent = 0', [], (err, rows) => {
+        if (err) {
+            throw new Error(err);
+        }
+        const emailAddresses = rows.map((_) => _.email);
+        // Start sending the emails
+        processEmailQueue(emailAddresses);
+    });
+} else if (mode === 'template') {
+    // Create an HTML email template and store it in AWS SES for future use
+    createHtmlTemplate()
+        .then((data) => {
+            console.log(
+                'Template was successfully created with the name ' +
+                    emailTemplate,
+                data
+            );
+        })
+        .catch((err) => {
+            throw new Error(err);
+        });
+} else if (mode === 'database') {
+    // Convert a CSV file of email addresses into a database
+    csv()
+        .fromFile(csvPath)
+        .then((users) => {
+            // Create a database and insert user records
+            db.serialize(() => {
+                db.run('DROP TABLE IF EXISTS users');
+                db.run('CREATE TABLE users("email" TEXT, "sent" INTEGER)');
+                const stmt = db.prepare('INSERT INTO users VALUES (?, ?)');
+                users.forEach((user) => {
+                    stmt.run(user.username, 0);
+                });
+                stmt.finalize();
+            });
+            console.log(
+                `Database created and populated with ${users.length} email addresses`
+            );
+            db.close();
+        });
+} else {
+    console.log('Unknown command options.');
+}

--- a/bin/bulk-emailer
+++ b/bin/bulk-emailer
@@ -1,7 +1,74 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('path');
+
+/*
+* A script to email people in bulk, to be run from local environments.
+*
+* It has three "modes" – database, template, and send.
+*
+* 1. Database mode
+* ================
+*
+* This will create a SQLite database of email addresses and a "sent" column,
+* to indicate if that user has been emailed before. This allows us to re-run
+* this script (in "send" mode) multiple times and avoid re-sending the email
+* (in case one batch fails to send etc).
+*
+* To run in database mode you'll need to provide a CSV file containing a "username"
+* column, which must be an email address. Example:
+*
+* id,username,date
+* 1,foo@bar.com,2020-07-27 11:32:00
+* 2,baz@quux.xyz,2020-07-27 11:33:00
+*
+* When this CSV file exists, call this script like so:
+*
+* ./bin/bulk-emailer -m database -d <path-to-database-file> -c <path-to-csv-file>
+*
+* This will create a SQLite database from the CSV file, which can then be used
+* to send emails.
+*
+* 2. Template mode
+* ================
+*
+* When sending bulk email via AWS SES, we need to provide an HTML email template.
+* This function will use a Nunjucks template file to output HTML (with our logo
+* and branding) plus a subject line (configured below).
+*
+* To run this command:
+*
+* ./bin/bulk-emailer -m template -t <unique-template-name>
+*
+* This will create a template – keep a record of its name to later send it.
+* Note that templates can contain variables which are supplied when sending,
+* but this script doesn't make use of this.
+*
+* 3. Send mode
+* ================
+*
+* The core of this script is to send emails in bulk. Our AWS SES account has a
+* limit of emails per second (configured below) which we will be blocked from
+* if we exceed it. This function will send emails in bulk at a rate of this
+* limit per second (eg. 14/second currently).
+*
+* The function looks up users in the database (created above) who have not been
+* emailed already, looks up the template (created above) and sends it to each
+* user in a batch. If there are errors (eg. invalid email addresses in the batch),
+* the task will fail. If the batch succeeds then those email addresses are marked
+* as having been sent, so if the script is re-run they won't be emailed again.
+*
+* The script will output the addresses of each batch it sends to.
+*
+* To run this command:
+*
+* ./bin/bulk-emailer -m send -d <path-to-database-file> -t <unique-template-name>
+*
+* Watch for errors in the console, but otherwise this script will tick along and
+* send approx 14 emails/second (or around 840 per minute).
+*
+* */
+
 const _ = require('lodash');
 const htmlToText = require('html-to-text');
 const AWS = require('aws-sdk');
@@ -27,7 +94,7 @@ const argv = require('yargs')
     .describe('d', 'Pass the filename of a database to use')
     .alias('c', 'csv')
     .describe('c', 'Pass the filename of a CSV file with a `username` column of email addresses')
-    .demandOption(['m', 'd'])
+    .demandOption(['m'])
     .help('h')
     .alias('h', 'help').argv;
 
@@ -46,16 +113,18 @@ if (mode === 'send' && !emailTemplate) {
     throw new Error('You must provide a CSV file of email addresses to store');
 }
 
-if (!argv.d) {
+let db;
+if (mode !== 'template' && !dbPath) {
     throw new Error('You must provide the path to a database file (-d or --database)');
+} else if (mode !== 'template') {
+    db = new sqlite3.Database(dbPath, (err) => {
+        if (err) {
+            throw new Error(err);
+        }
+        console.log('Connected to the bulk emails database.');
+    });
 }
 
-const db = new sqlite3.Database(dbPath, (err) => {
-    if (err) {
-        throw new Error(err);
-    }
-    console.log('Connected to the bulk emails database.');
-});
 
 // Email configuration
 const SENDS_PER_SECOND = 14; // SES limit for our account

--- a/controllers/apply/expiries/views/ccsf-closure-email.njk
+++ b/controllers/apply/expiries/views/ccsf-closure-email.njk
@@ -1,0 +1,20 @@
+{% extends "../../../../views/layouts/emails.njk" %}
+
+{% block content %}
+
+    <p>Hello,</p>
+    <p>
+        <strong>Your application will expire soon</strong>
+    </p>
+    <p>
+        This is a test
+    </p>
+    <p>
+        <strong>If you have any questions at all</strong><br/>
+        You can call 0123456. Or email matt.andrews@tnlcommunityfund.org.uk. We’ll be happy to help you.
+    </p>
+    <p>
+        <strong>Best wishes,<br/>
+        The National Lottery Community Fund</strong>
+    </p>
+{% endblock %}

--- a/controllers/apply/expiries/views/ccsf-closure-email.njk
+++ b/controllers/apply/expiries/views/ccsf-closure-email.njk
@@ -3,18 +3,46 @@
 {% block content %}
 
     <p>Hello,</p>
-    <p>
-        <strong>Your application will expire soon</strong>
-    </p>
-    <p>
-        This is a test
-    </p>
-    <p>
-        <strong>If you have any questions at all</strong><br/>
-        You can call 0123456. Or email matt.andrews@tnlcommunityfund.org.uk. We’ll be happy to help you.
-    </p>
-    <p>
-        <strong>Best wishes,<br/>
-        The National Lottery Community Fund</strong>
-    </p>
+
+    <p>Thank you for your interest in applying to the Coronavirus Community Support Fund.</p>
+
+    <h2>The Coronavirus Community Support Fund is closing to applications on Monday 17 August 2020 at 12 noon</h2>
+
+    <p>We opened the Government’s Coronavirus Community Support Fund on 22 May.  So far, we’ve already awarded £55m of the £200 million Government gave us for this fund, to over 2,300 organisations and received applications totalling almost £130 million.</p>
+
+    <p>Because of this record high demand, we will close to applications on <strong>Monday 17 August at 12 noon</strong>.</p>
+
+    <h3>What you need to do now</h3>
+
+    <p><strong>If you’re planning to apply for the Government-funded <a href="https://www.tnlcommunityfund.org.uk/funding/covid-19/learn-about-applying-for-emergency-funding-in-england">Coronavirus Community Support Fund</a></strong></p>
+    <p>You must submit your application by <strong>12 noon on 17 August 2020</strong>. You can <a href="https://www.tnlcommunityfund.org.uk/apply">access your application here</a>. We should finish awarding these funds by the end of October 2020.</p>
+
+    <p><strong>If you no longer plan on applying for this funding</strong></p>
+    <p>We will delete all applications that are still in progress and haven’t been submitted to us by 12 noon on 17 August 2020. So you won’t be able to access unsubmitted applications after this time.</p>
+
+    <p>You can still apply for National Lottery funded grants in England. But we will only be focusing on funding for organisations supporting people and communities who experience disproportionate challenge and difficulty as a result of the COVID-19 crisis, specifically for user-led equality groups supporting:</p>
+
+    <ul>
+        <li>black, Asian, minority ethnic and refugee (BAMER) communities</li>
+        <li>lesbian, gay, bisexual, transgender, queer + (LGBTQ+) communities</li>
+        <li>disabled people.</li>
+    </ul>
+
+    <p>This is for six months’ emergency funding, for small and medium organisations and for between £300 and £100K.</p>
+
+    <p>We are also working with specialist partners to reach specific groups as quickly as we can. You can <a href="https://www.tnlcommunityfund.org.uk/funding/programmes/covid-19-community-led-organisations-recovery-scheme">find out more here</a>.</p>
+
+    <p>Beyond the emergency response, National Lottery funding to support communities in England will be available, and we’ll keep you updated on our funding as it develops.</p>
+
+    <p>Best wishes,</p>
+
+    <p>Julie Galano<br />
+    Head of Funding</p>
+    
+    <small>
+        <p>
+            T: 028 9568 0143 | Text Relay: Text relay 18001 plus 028 9568 0143 (for people with a hearing or speech impairment)<br />
+            Apex House, 3 Embassy Drive, Edgbaston, Birmingham, B15 1TR<br/>
+            <a href="https://www.tnlcommunityfund.org.uk/">Website</a> | <a href="https://www.twitter.com/TNLComFund">Twitter</a> | <a href="http://www.facebook.com/TNLCommunityFund">Facebook</a></p>
+    </small>
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8675,6 +8675,28 @@
         }
       }
     },
+    "csvtojson": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
+      "integrity": "sha512-lUWFxGKyhraKCW8Qghz6Z0f2l/PqB1W3AO0HKJzGIQ5JRSlR651ekJDiGJbBT4sRNNv5ddnSGVEnsxP9XRCVpQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.1",
+        "lodash": "^4.17.3",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        }
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "cross-env": "7.0.2",
     "css-loader": "3.6.0",
     "cssnano": "4.1.10",
+    "csvtojson": "2.0.10",
     "cypress": "4.11.0",
     "cypress-file-upload": "4.0.7",
     "del-cli": "3.0.1",


### PR DESCRIPTION
This change adds a utility script which can be used to send bulk HTML emails, branded like our other messages, to a large number of users via our AWS Simple Email Service.

It requires a bit of configuration to run locally – specifically

- a CSV file of email addresses to send to (which will be converted into a SQLite database)
- a Nunjucks template containing the email message to send (which will be uploaded to SES as a reusable template)

When these things are provided, it will send emails within our sending limits (14/second currently) and report any errors. It will also mark users as having been emailed, so repeat runs of the script won't email the same user again.

Not something we should use very often, but handy to have around in the scenario where we need to contact more people than our Exchange/Outlook systems will allow.