### PR TITLE
Add notification banners to Funding Programme pages and Flexible Content

### DIFF
--- a/controllers/common/views/flexible-content-page.njk
+++ b/controllers/common/views/flexible-content-page.njk
@@ -46,7 +46,8 @@
                 flexibleContent(
                     content.flexibleContent,
                     children = content.children,
-                    breadcrumbs = breadcrumbTrail(breadcrumbs)
+                    breadcrumbs = breadcrumbTrail(breadcrumbs),
+                    notificationBanner = content.notificationBanner
                 )
             %}
         {% endif %}

--- a/controllers/funding/programmes/views/programme.njk
+++ b/controllers/funding/programmes/views/programme.njk
@@ -5,6 +5,7 @@
 {% from "components/hero.njk" import hero with context %}
 {% from "components/page-title/macro.njk" import pageTitle %}
 {% from "components/programmes.njk" import programmeStats with context %}
+{% from "components/message/macro.njk" import message with context %}
 
 {% if not pageHero %}{% set bodyClass = 'has-static-header' %}{% endif %}
 
@@ -28,6 +29,11 @@
         {% endcall %}
 
         <div class="u-inner-wide-only">
+
+            {% if entry.notificationBanner %}
+                {{ message(entry.notificationBanner.title, entry.notificationBanner.content) }}
+            {% endif %}
+
             {% if entry.contentSections.length > 1 %}
                 {% set tabItems = [] %}
                 {% for section in entry.contentSections -%}

--- a/views/components/flexible-content/macro.njk
+++ b/views/components/flexible-content/macro.njk
@@ -7,10 +7,11 @@
 {% from "components/programmes.njk" import programmeCard with context %}
 {% from "components/promo-card/macro.njk" import promoCard with context %}
 {% from "components/table-of-contents/macro.njk" import tableOfContents %}
+{% from "components/message/macro.njk" import message with context %}
 
 {% set flexAnchor = 'item' %}
 
-{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null, distinguishBlocks = true) %}
+{% macro flexibleContent(flexibleContent, children = null, breadcrumbs = null, distinguishBlocks = true, notificationBanner = null) %}
     {% if flexibleContent.length > 0 %}
         {% set mediaAsideCycler = cycler(true, false) %}
 
@@ -90,6 +91,13 @@
                 <section class="{% if distinguishBlocks %}content-box u-inner-wide-only{% endif %}" id="{{ flexAnchor + '-' + loop.index }}">
                     {% if (breadcrumbs and loop.first) %}
                         {{ breadcrumbs | safe }}
+                    {% endif %}
+
+                    {% if (notificationBanner and loop.first) %}
+                        {{ message(
+                            notificationBanner.title,
+                            notificationBanner.content
+                        ) }}
                     {% endif %}
 
                     {% if part.title %}

--- a/views/components/message/macro.njk
+++ b/views/components/message/macro.njk
@@ -1,0 +1,6 @@
+{% macro message(title, body) %}
+    <div class="message message--info" role="alert">
+        <h2 class="t4 u-no-margin">{{ title }}</h2>
+        {{ body | safe }}
+    </div>
+{% endmacro %}


### PR DESCRIPTION
Allows us to add banners via the CMS to notify users about announcements. Pairs with this CMS change: https://github.com/biglotteryfund/craft-dev/pull/311

Supported on the following page types:

### Flexible Content
![image](https://user-images.githubusercontent.com/394376/88662082-5de12580-d0d1-11ea-9444-379fa0f73456.png)
(currently only enabled in the CMS for the Funding section)

### Funding Programmes
![image](https://user-images.githubusercontent.com/394376/88662124-6a657e00-d0d1-11ea-87a7-f94c760ddd55.png)
