### PR TITLE
Add datepicker to remaining staff tools

### DIFF
--- a/controllers/tools/applications/views/applications.njk
+++ b/controllers/tools/applications/views/applications.njk
@@ -46,7 +46,7 @@
             </h1>
 
             <p>
-                <strong>Date range</strong>: {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
+                {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
                 (<a href="?">Reset dates</a>)
             </p>
 

--- a/controllers/tools/feedback.js
+++ b/controllers/tools/feedback.js
@@ -2,21 +2,26 @@
 const path = require('path');
 const express = require('express');
 const moment = require('moment-timezone');
+const { parse } = require('json2csv');
 
 const { Feedback } = require('../../db/models');
 const { sanitise } = require('../../common/sanitise');
-const { parse } = require('json2csv');
+
+const { getDateRangeWithDefault } = require('./lib/date-helpers');
 
 const router = express.Router();
 
 async function render(req, res) {
+    const dateRange = getDateRangeWithDefault(req.query.start, req.query.end);
+
     const title = 'Feedback results';
-    const feedback = await Feedback.findAllGroupedByDescription();
+    const feedback = await Feedback.findAllGroupedByDescription(dateRange);
 
     res.render(path.resolve(__dirname, './views/feedback'), {
-        title: title,
+        title,
         breadcrumbs: res.locals.breadcrumbs.concat({ label: title }),
         feedback,
+        dateRange,
     });
 }
 

--- a/controllers/tools/surveys/index.js
+++ b/controllers/tools/surveys/index.js
@@ -11,22 +11,25 @@ const pageCountsFor = require('./lib/page-counts');
 const percentagesFor = require('./lib/percentages');
 const voteDataFor = require('./lib/vote-data');
 
+const { getDateRangeWithDefault } = require('../lib/date-helpers');
+
 const router = express.Router();
 
 router.get('/', async function (req, res, next) {
     try {
+        const dateRange = getDateRangeWithDefault(
+            req.query.start,
+            req.query.end
+        );
+
         const responses = await SurveyAnswer.findAllByPath(
-            sanitise(req.query.path)
+            sanitise(req.query.path),
+            dateRange
         );
 
         if (req.query.download && req.query.path && responses.length > 0) {
             res.attachment(`surveyResponses.csv`).send(csvSummary(responses));
         } else {
-            const recentResponses = responses.filter(function (response) {
-                const startDt = moment().subtract('30', 'days');
-                return moment(response.createdAt).isSameOrAfter(startDt, 'day');
-            });
-
             const title = 'Surveys';
             res.render(path.resolve(__dirname, './views/survey'), {
                 title: title,
@@ -34,7 +37,7 @@ router.get('/', async function (req, res, next) {
                 survey: {
                     totalResponses: responses.length,
                     voteData: voteDataFor(responses),
-                    recentStats: percentagesFor(recentResponses),
+                    recentStats: percentagesFor(responses),
                     pageCounts: pageCountsFor(responses),
                     pageCountsWithResponses: pageCountsFor(
                         responses.filter((response) => response.message)
@@ -44,6 +47,7 @@ router.get('/', async function (req, res, next) {
                     ),
                 },
                 pathQuery: req.query.path,
+                dateRange,
             });
         }
     } catch (error) {

--- a/controllers/tools/surveys/index.js
+++ b/controllers/tools/surveys/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const path = require('path');
 const express = require('express');
-const moment = require('moment');
 
 const { SurveyAnswer } = require('../../../db/models');
 const { sanitise } = require('../../../common/sanitise');

--- a/controllers/tools/surveys/lib/percentages.js
+++ b/controllers/tools/surveys/lib/percentages.js
@@ -3,10 +3,9 @@ const partition = require('lodash/partition');
 
 module.exports = function percentagesFor(responses) {
     const [yes, no] = partition(responses, ['choice', 'yes']);
-
     return {
         yesCount: yes.length,
         noCount: no.length,
-        percentageYes: Math.round((yes.length / responses.length) * 100),
+        percentageYes: ((yes.length / responses.length) * 100).toFixed(1),
     };
 };

--- a/controllers/tools/surveys/lib/percentages.test.js
+++ b/controllers/tools/surveys/lib/percentages.test.js
@@ -9,7 +9,7 @@ test('percentagesFor', function () {
     ];
 
     expect(percentagesFor(responses)).toEqual({
-        percentageYes: 91,
+        percentageYes: '90.9',
         yesCount: 500,
         noCount: 50,
     });

--- a/controllers/tools/surveys/views/survey.njk
+++ b/controllers/tools/surveys/views/survey.njk
@@ -17,15 +17,46 @@
 
             <h1 class="t--underline">“Did you find what you were looking for?”</h1>
 
-            {% if pathQuery %}
+            {% if pathQuery or dateRange %}
                 <p>
-                    Showing results for <code>{{ pathQuery }}</code>,
+                    {% if pathQuery %}
+                        Showing results for <code>{{ pathQuery }}</code>,
+                    {% endif %}
+                    {% if dateRange %}
+                        {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
+                    {% endif %}
                     <a href="?">clear selection?</a>
                 </p>
             {% endif %}
 
+            <form action="" method="get" class="tools-filter-form">
+                <div class="tools-filter-form__item">
+                    <label for="start" class="ff-label">Start date</label>
+                    <input class="ff-text"
+                           type="date"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
+                           name="start"
+                           id="start"
+                    >
+                </div>
+                <div class="tools-filter-form__item">
+                    <label for="end" class="ff-label">End date</label>
+                    <input class="ff-text"
+                           type="date"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
+                           name="end"
+                           id="end"
+                    >
+                </div>
+                <div class="tools-filter-form__item tools-filter-form__actions">
+                    <input class="btn btn--small" type="submit" value="Filter by date"/>
+                </div>
+            </form>
+
             <div class="u-margin-bottom-l">
-                <h2 class="u-no-margin">In the last 30 days:</h2>
+                <h2 class="u-no-margin">Overall totals</h2>
                 {{ statsGrid([{
                     value: survey.recentStats.percentageYes + '%',
                     title: 'of respondents said “yes”',
@@ -42,12 +73,12 @@
             </div>
 
             <div class="u-margin-bottom-l">
-                <h2>In the last 3 months:</h2>
+                <h2>Responses over time</h2>
 
-                <p><small>Percentage who said “yes” based on <strong>{{ survey.totalResponses | numberWithCommas }} responses</strong> in the last 3 months.</small></p>
+                <p><small>Percentage who said “yes” based on <strong>{{ survey.totalResponses | numberWithCommas }} responses</strong> between {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}</small></p>
 
                 <div class="u-margin-bottom">
-                    <canvas id="js-chart" height="150"></canvas>
+                    <canvas id="js-chart" height="220"></canvas>
                 </div>
 
                 {% if not pathQuery %}
@@ -55,8 +86,12 @@
                     <div class="s-prose">
                         <ol>
                             {% for item in survey.pageCounts | take(10) %}
-                                <li><a href="?path={{ item.path }}">{{ item.path }}
-                                with {{ item.count | numberWithCommas }} responses</a></li>
+                                <li>
+                                    <a href="?path={{ item.path }}">
+                                        {{ item.path }}
+                                        ({{ item.count | numberWithCommas }} responses)
+                                    </a>
+                                </li>
                             {% endfor %}
                         </ol>
                     </div>
@@ -65,8 +100,12 @@
                     <div class="s-prose">
                         <ol>
                             {% for item in survey.pageCountsWithResponses | take(10) %}
-                                <li><a href="?path={{ item.path }}">{{ item.path }}
-                                with {{ item.count | numberWithCommas }} responses</a></li>
+                                <li>
+                                    <a href="?path={{ item.path }}">
+                                        {{ item.path }}
+                                        ({{ item.count | numberWithCommas }} responses)
+                                    </a>
+                                </li>
                             {% endfor %}
                         </ol>
                     </div>
@@ -146,16 +185,16 @@
                         },
                         time: {
                             round: 'day',
-                            unit: 'month'
+                            unit: 'day'
                         },
                         gridLines: {
-                            display: false
+                            display: true
                         }
                     }],
                     yAxes: [{
                         display: true,
                         ticks: {
-                            stepSize: 25,
+                            stepSize: 10,
                             min: 0,
                             max: 100,
                             callback: function(value) {

--- a/controllers/tools/views/feedback.njk
+++ b/controllers/tools/views/feedback.njk
@@ -10,6 +10,37 @@
 
             <h1 class="t--underline">{{ title }}</h1>
 
+            <p>
+                {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}
+                (<a href="?">Reset dates</a>)
+            </p>
+
+            <form action="" method="get" class="tools-filter-form">
+                <div class="tools-filter-form__item">
+                    <label for="start" class="ff-label">Start date</label>
+                    <input class="ff-text"
+                           type="date"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.start, "YYYY-MM-DD") }}"
+                           name="start"
+                           id="start"
+                    >
+                </div>
+                <div class="tools-filter-form__item">
+                    <label for="end" class="ff-label">End date</label>
+                    <input class="ff-text"
+                           type="date"
+                           max="{{ formatDate(now, "YYYY-MM-DD") }}"
+                           value="{{ formatDate(dateRange.end, "YYYY-MM-DD") }}"
+                           name="end"
+                           id="end"
+                    >
+                </div>
+                <div class="tools-filter-form__item tools-filter-form__actions">
+                    <input class="btn btn--small" type="submit" value="Filter by date"/>
+                </div>
+            </form>
+
             {% for description, items in feedback  %}
                 <h2>{{ description }} <small>({{ items.length }} responses)</small></h2>
                 <p><a class="btn btn--outline btn--small" href="?download={{ description }}">Download as CSV</a></p>

--- a/controllers/tools/views/users.njk
+++ b/controllers/tools/views/users.njk
@@ -13,7 +13,7 @@
             {{ breadcrumbTrail(breadcrumbs) }}
             {{ staffStatus(user) }}
 
-            <h1 class="u-margin-bottom-s">{{ title }}</h1>
+            <h1 class="t--underline">{{ title }}</h1>
 
             <p>
                 {{ formatDate(dateRange.start) }}–{{ formatDate(dateRange.end) }}

--- a/db/models/feedback.js
+++ b/db/models/feedback.js
@@ -38,12 +38,19 @@ class Feedback extends Model {
         ]);
     }
 
-    static findAllGroupedByDescription() {
+    static findAllGroupedByDescription(dateRange) {
+        let whereClause = {};
+        if (dateRange) {
+            whereClause = {
+                createdAt: { [Op.between]: [dateRange.start, dateRange.end] },
+            };
+        }
         return this.findAll({
             order: [
                 ['description', 'ASC'],
                 ['updatedAt', 'DESC'],
             ],
+            where: whereClause,
         }).then(groupBy((result) => result.description.toLowerCase()));
     }
 

--- a/db/models/survey.js
+++ b/db/models/survey.js
@@ -40,10 +40,21 @@ class SurveyAnswer extends Model {
             }),
         ]);
     }
-    static findAllByPath(urlPath) {
-        const query = { order: [['updatedAt', 'DESC']] };
+    static findAllByPath(urlPath, dateRange) {
+        const query = {
+            order: [['updatedAt', 'DESC']],
+            where: {},
+        };
+
         if (urlPath) {
             query.where = { path: { [Op.eq]: urlPath } };
+        }
+
+        if (dateRange) {
+            const dateClause = {
+                createdAt: { [Op.between]: [dateRange.start, dateRange.end] },
+            };
+            query.where = { ...query.where, ...dateClause };
         }
 
         return this.findAll(query);


### PR DESCRIPTION
A few of the staff tools didn't have a datepicker (which is helpful for the ones that get used in monthly reporting, like the website satisfaction survey) so I've added it to those ones and made the others a bit more consistent.

Adds this to Surveys and Feedback pages:

![image](https://user-images.githubusercontent.com/394376/89162495-11cc3000-d56c-11ea-877a-793198030b74.png)
