### PR TITLE
Only show CCSF expiry date for applications which would expire *after* it

### DIFF
--- a/controllers/apply/standard-proposal/enrich.js
+++ b/controllers/apply/standard-proposal/enrich.js
@@ -1,5 +1,6 @@
 'use strict';
 const get = require('lodash/fp/get');
+const moment = require('moment');
 
 const { formatCurrency } = require('../lib/formatters');
 const { findLocationName } = require('./lib/locations');
@@ -53,6 +54,7 @@ function details(application, data, locale) {
 function enrichPending(application, locale = 'en') {
     const data = application.applicationData || {};
     const form = formBuilder({ locale, data });
+    const applicationDetails = details(application, data, locale);
 
     const defaults = {
         type: 'pending',
@@ -67,7 +69,15 @@ function enrichPending(application, locale = 'en') {
         deleteUrl: `/apply/your-funding-proposal/delete/${application.id}`,
     };
 
-    return Object.assign(defaults, details(application, data, locale));
+    // @TODO remove this logic after August 17th
+    if (applicationDetails.projectCountry === 'england') {
+        const englandCcsfExpiryDate = moment('2020-08-17 12:00');
+        if (moment(defaults.expiresAt).isAfter(englandCcsfExpiryDate)) {
+            defaults.expiresAt = englandCcsfExpiryDate.toISOString();
+        }
+    }
+
+    return Object.assign(defaults, applicationDetails);
 }
 
 function enrichSubmitted(application, locale = 'en') {

--- a/views/components/application-card/macro.njk
+++ b/views/components/application-card/macro.njk
@@ -104,9 +104,7 @@
             {% if props.expiresAt %}
                 <div class="application-card__meta u-text-small">
                     {% if props.projectCountry %}
-                        {# @TODO remove this change after 17th August (eg. use props.expiresAt) #}
-                        {% set expiryDate = '2020-08-17 12:00:00' if props.projectCountry === 'england' else props.expiresAt %}
-                        {{ __(cardCopy.expiresAt, formatDate(expiryDate)) | safe }}
+                        {{ __(cardCopy.expiresAt, formatDate(props.expiresAt)) | safe }}
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
A customer called in to query the expiry dates we're showing them. A change I made last week showed a fixed expiry date of 17th August for England applications. But it didn't take into account applications which expire _before_ this – so the customer was originally told their application would expire today, but the dashboard said 17th. 

This change fixes things so we only show this hard-coded expiry date for England applications which would ordinarily expire *after* this time. 

The code's a bit ugly but we can delete this after the 17th and it's a temporary kludge for a solution I hope we never choose again.