### PR TITLE
Re-enable England expiry emails

### DIFF
--- a/controllers/apply/expiries/expiry-router.js
+++ b/controllers/apply/expiries/expiry-router.js
@@ -18,7 +18,7 @@ const logger = require('../../../common/logger').child({
     service: 'application-expiry',
 });
 
-const { sendExpiryEmail, getProjectCountry } = require('./send-expiry-email');
+const { sendExpiryEmail } = require('./send-expiry-email');
 
 const router = express.Router();
 

--- a/controllers/apply/expiries/expiry-router.js
+++ b/controllers/apply/expiries/expiry-router.js
@@ -55,59 +55,35 @@ async function sendExpiryEmails(req, emailQueue) {
         emailQueue.map(async (emailToSend) => {
             const { emailType, PendingApplication } = emailToSend;
 
-            // Filter out England expiry reminder emails, which we're no
-            // longer sending until the CCSF fund closes
-            // @TODO remove this change after 17th August (eg.send emails to everyone)
-            const country = getProjectCountry(
-                PendingApplication.applicationData,
-                PendingApplication.formId
-            );
+            const emailStatus = await sendExpiryEmail({
+                emailType: emailType,
+                unsubscribeToken: signUnsubscribeToken(PendingApplication.id),
+                formId: PendingApplication.formId,
+                applicationId: PendingApplication.id,
+                applicationData: PendingApplication.applicationData,
+                expiresAt: PendingApplication.expiresAt,
+                sendTo: appData.isNotProduction
+                    ? EMAIL_EXPIRY_TEST_ADDRESS
+                    : PendingApplication.user.username,
+            });
 
-            if (country === 'england') {
+            if (emailStatus.response || appData.isTestServer) {
                 const queueStatus = await ApplicationEmailQueue.updateStatus(
                     emailToSend.id,
-                    'SKIPPED'
+                    'SENT'
                 );
 
                 return {
                     formId: PendingApplication.formId,
-                    emailSent: false,
+                    emailSent: true,
                     dbUpdated: queueStatus[0] === 1,
                 };
             } else {
-                // Send this email
-                const emailStatus = await sendExpiryEmail({
-                    emailType: emailType,
-                    unsubscribeToken: signUnsubscribeToken(
-                        PendingApplication.id
-                    ),
+                return {
                     formId: PendingApplication.formId,
-                    applicationId: PendingApplication.id,
-                    applicationData: PendingApplication.applicationData,
-                    expiresAt: PendingApplication.expiresAt,
-                    sendTo: appData.isNotProduction
-                        ? EMAIL_EXPIRY_TEST_ADDRESS
-                        : PendingApplication.user.username,
-                });
-
-                if (emailStatus.response || appData.isTestServer) {
-                    const queueStatus = await ApplicationEmailQueue.updateStatus(
-                        emailToSend.id,
-                        'SENT'
-                    );
-
-                    return {
-                        formId: PendingApplication.formId,
-                        emailSent: true,
-                        dbUpdated: queueStatus[0] === 1,
-                    };
-                } else {
-                    return {
-                        formId: PendingApplication.formId,
-                        emailSent: false,
-                        dbUpdated: false,
-                    };
-                }
+                    emailSent: false,
+                    dbUpdated: false,
+                };
             }
         })
     );


### PR DESCRIPTION
This undoes a change from a few weeks ago so expiry email reminders for England customers will now be sent again.