### PR TITLE
Misc minor fixes

### DIFF
--- a/common/secrets.js
+++ b/common/secrets.js
@@ -105,8 +105,6 @@ const POSTCODES_API_KEY =
 const S3_KMS_KEY_ID =
     process.env.S3_KMS_KEY_ID || getParameter('s3.kms.key.id');
 
-const DATA_STUDIO_UNDER10K_URL = getParameter('dataStudio.url.awardsForAll');
-
 /**
  * Email expiry secret
  * A shared token sent in POST requests to the email API endpoints
@@ -134,7 +132,6 @@ module.exports = {
     BANK_API,
     CONTENT_API_URL,
     CONTENT_API_SANDBOX_URL,
-    DATA_STUDIO_UNDER10K_URL,
     DB_CONNECTION_URI,
     DOTDIGITAL_API,
     EMAIL_EXPIRY_SECRET,

--- a/controllers/tools/applications/index.js
+++ b/controllers/tools/applications/index.js
@@ -2,8 +2,6 @@
 const express = require('express');
 const get = require('lodash/get');
 
-const { DATA_STUDIO_UNDER10K_URL } = require('../../../common/secrets');
-
 const { initApplicationStatsRouter } = require('./router');
 
 const router = express.Router();
@@ -20,7 +18,6 @@ router.use(
             'National Lottery Awards for All',
             'Apply for funding under £10,000',
         ],
-        dataStudioUrl: DATA_STUDIO_UNDER10K_URL,
     })
 );
 

--- a/controllers/tools/applications/router.js
+++ b/controllers/tools/applications/router.js
@@ -136,7 +136,6 @@ function initApplicationStatsRouter({
     title,
     getProjectCountry,
     feedbackDescriptions,
-    dataStudioUrl,
 }) {
     const router = express.Router();
 
@@ -282,7 +281,6 @@ function initApplicationStatsRouter({
                 countryColour: country
                     ? getColourForCountry(titleCase(country))
                     : null,
-                dataStudioUrl: dataStudioUrl,
                 feedback: feedback,
             });
         } catch (error) {

--- a/controllers/tools/applications/views/applications.njk
+++ b/controllers/tools/applications/views/applications.njk
@@ -333,17 +333,6 @@
                 </div>
             {% endif %}
 
-            {% if dataStudioUrl %}
-                <div class="u-margin-bottom-l">
-                    <h3>User analytics for form usage <small>(not using the above date range)</small></h3>
-
-                    <div style="position:relative;padding-top:56.25%;">
-                        <iframe src="{{ dataStudioUrl }}" frameborder="0" allowfullscreen
-                                style="position:absolute;top:0;left:0;width:100%;height:100%;"></iframe>
-                    </div>
-                </div>
-            {% endif %}
-
         </div>
 
     </main>

--- a/db/models/applications.js
+++ b/db/models/applications.js
@@ -470,7 +470,7 @@ class ApplicationEmailQueue extends Model {
             where: {
                 status: { [Op.eq]: 'NOT_SENT' },
                 dateToSend: {
-                    [Op.lte]: moment().toDate(),
+                    [Op.lte]: moment().endOf('day').toDate(),
                 },
             },
             include: [

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,23 +13,27 @@ All requests to www.tnlcommunityfund.org.uk are routed via CloudFront. Requests 
 
 ### NGINX and Passenger
 
-Requests to the origin are handled by [NGINX](https://www.nginx.com/) which is primarily concerned with routing requests to [Passenger](https://www.phusionpassenger.com/) which handles all Node.js processes. We also use NGINX as a rate limiter to avoid overloading user endpoints.
+Requests to the origin are handled by [NGINX](https://www.nginx.com/) which is primarily concerned with routing requests to [Passenger](https://www.phusionpassenger.com/) which handles all Node.js processes. We also use NGINX as a rate limiter to avoid overloading user endpoints. Passenger is configured in [server.conf](deploy/server.conf).
 
 ### EC2 and ELB
 
-The application runs on EC2 behind an ELB. Provisioning of new servers is handled by CodeDeploy. Scripts used to provision servers can be found in the `deploy/` directory. These scripts map to different CodeDeploy lifecyle stages as defined in `appspec.yml`
+The application runs on EC2 behind an ELB. Provisioning of new servers is handled by CodeDeploy. Scripts used to provision servers can be found in the `deploy/` directory. These scripts map to different CodeDeploy lifecyle stages as defined in `appspec.yml`.
 
 ### Lambda
 
-This has a single Lambda function which is run on a schedule and used to trigger periodic application expiry emails.
+This has a single Lambda function which is run on a schedule and used to trigger periodic application expiry emails. The script itself is extremely basic and simply sends an authenticated HTTP POST request to this webapp. Updating this function should not be necessary but if required, it's a copy/paste job (rather than any automated deploy) as it changes so rarely.
+
+The schedule for _calling_ the Lambda function is controlled within AWS. When editing the `applicationExpiryProd` function, there's a Cloudwatch Events config block which shows the frequency to call the function. It's currently defined as a Cron expression: `cron(0 9,16 * * ? *)` – eg. it runs every day at 9am and 4pm. The second run is intended as a backup in case the first one fails to run or doesn't send all of the emails. In practice this rarely happens.
 
 ### RDS
 
-We use MySQL hosted on RDS for our database instance.
+We use MySQL hosted on RDS for our database instance. This is a managed service and has automated backups taken every day, which can be restored easily.
 
 ### Azure Active Directory auth
 
 We have a handful of internal staff tools within the application which are protected behind staff-only log in. This relies on a small Active Directory app which controls access permissions. This app lives in Azure and configured separately there.
+
+Microsoft have recently (June 2020) marked the particular API we use for this service as deprecated, but it will still work indefinitely.
 
 ## Connected services
 
@@ -37,11 +41,11 @@ As well as the main web app there are two other key services that power the webs
 
 ## Content API
 
-The Content API is a headless CMS powered by [Craft](https://craftcms.com/). We use this for managing most frequently changing content on the website. The main exceptions to this are landing pages and any copy related to application forms where we need more control over what is presented to users.
+The Content API is a headless CMS powered by [Craft](https://craftcms.com/). We use this for managing most frequently-changing content on the website. The main exceptions to this are landing pages and any copy related to application forms where we need more control over what is presented to users.
 
 See [https://github.com/biglotteryfund/craft-dev]()
 
-## Past grants API
+## Past Grants API
 
 We run a separate API service for all of our historic past grants data. This is a set of serverless methods which are backed by a Mongo database.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,14 +2,14 @@
 
 ## Test environment
 
-Deployments to the test environment are triggered each time a change is merged to `master`. Once a change is merged Travis will build and deploy it automatically.
+Deployments to the test environment are triggered each time a change is merged to `master`. Once a change is merged, Travis will build and deploy it automatically.
 
 ## Production environment
 
-Deploys to production are manual. Once a deploy has been checked on the test environment it can be advanced to production via AWS CodeDeploy, either by using the web console, or the bundled deploy script within the app:
+**Deploys to production are manual**. Once a deploy has been checked on the test environment it can be advanced to production via AWS CodeDeploy, either by using the web console, or the bundled deploy script within the app:
 
 ```shell script
 ./bin/deploy --live
 ```
 
-This command will begin a deployment by listing the previous 10 releases deployed to the test environment and asking which build you wish to deploy. It will provide you with a GitHub diff link for the changes that are going to be deployed, and will ask you to confirm if you wish to proceed. Progress updates will be posted to Slack, and can be followed in the AWS console, as the deployment proceeds.
+This command will begin a deployment by listing the previous 10 releases deployed to the test environment and asking which build you wish to deploy. It will provide you with a GitHub diff link for the changes that are going to be deployed, and will ask you to confirm if you wish to proceed. Progress updates can be followed in the AWS console, as the deployment proceeds.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,8 @@ You'll need the following tools installed in order to run the project locally:
 -   MySQL v5.7+
 -   [AWS CLI](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) configured on your machine
 
+You will also need a modern, Bash-like terminal app. On Windows, Git Bash is recommended.
+
 Once you have the prerequisites installed on your machine, and have the project checked out locally, run these commands in your terminal of choice:
 
 ## Install dependencies
@@ -24,7 +26,7 @@ Next, you'll need to download the application secrets. These are configuration s
 
 Create a directory called `/etc/blf/` and make sure it is writeable. This is where application secrets will be stored.
 
-Optional: you can override the location of this directory by setting an environment variable like so:
+**Optional**: for Windows users, you can override the location of this directory by setting an environment variable like so:
 
 ```
 SECRET_DIR=C:/Users/Someone/FolderName
@@ -58,10 +60,25 @@ npm run build
 
 ## Start the application
 
-This command runs the app through `nodemon` with debugging enabled.
+This command runs the app through `nodemon` with debugging enabled. Changes to server-side code will be automatically applied when you reload. If you add `SHOW_RESTART_NOTIFICATION=true` to your `.env` file you'll get a native system notification when the app has reloaded (which takes a few seconds).
 
 ```shell script
 npm run start-dev
 ```
 
-The application should now be running. Visit `http://localhost:3000` in your browser to confirm everything is OK.
+## Watch for front-end changes
+
+If you wish for CSS and JavaScript files to be recompiled automatically when working, run the following command in another terminal:
+
+```shell script
+npm run watch
+```
+
+When you reload your web browser, you should see the latest CSS/JS changes.
+
+
+## IDE / text editor configuration
+
+It's recommended that you use [prettier](https://prettier.io/)  and [ESLint](https://eslint.org/) with whatever editor/IDE you use – the settings for both are contained within the app (eg. `package.json` for Prettier and `.eslintrc.js` for ESLint). Ideally you should configure your editor to apply Prettier's rules when saving files locally (so you can never commit anything with non-standard formatting), and to flag ESLint violations within your editor – again, so you can fix them before the build runs and fails.
+
+We also have an `.editorconfig` file to define common things like spacing, newlines, etc. It's recommended to use this too (where your editor supports it) to ensure the team is working to the same code style.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -10,7 +10,7 @@ We monitor the following log sources:
 
 -   EC2 memory usage
 -   Nginx error logs
--   Clamav logs (antivirus)
+-   ClamAV logs (antivirus)
 
 We also use [Winston](https://github.com/winstonjs/winston) to log directly to CloudWatch from within our app. We use these logs to power internal dashboards to show key statistics about the health of the app.
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,46 @@
+# Secrets
+The web app uses AWS Parameter Store to store application secrets such as database credentials, API keys, and other secure data which should not be stored in source control.
+
+This means that adding a new secret or updating one requires logging into the AWS control panel and creating/updating it, and then triggering a deploy. 
+
+The secrets are fetched via the `./bin/get-secrets` script, which passes through a `--environment` argument to define which set to use. This runs during each deploy.
+
+## Adding a secret
+
+Log into the AWS control panel and search for the Parameter Store tool (which lives within Systems Manager). You should see a set of parameters with names like the following:
+
+    /Web/Global/bank.api.key
+    /Web/Prod/pastgrants.api.uri
+    /Web/Test/db.connection-uri
+    
+The naming convention for these secrets is like so:
+
+    /<Platform>/<Environment>/<Key>
+    
+In practice, Platform is always `Web`, and Environment is always `Test`, `Prod` or `Global` – the latter refers to an environment-wide secret. We don't need `Dev` as you can override most secrets using your local `.env` file. Key names themselves should use `.`s to separate names, eg. `bank.api.key`.
+
+Each secret is a `SecureString`, meaning the secret's value is encrypted. When we fetch the application secrets, the script decrypts them before writing them out to disk as JSON.
+
+After adding a new secret, you'll need to edit `common/secrets.js` and add a line similar to this:
+
+    const DB_CONNECTION_URI = 
+        process.env.DB_CONNECTION_URI || getParameter('db.connection-uri', true);
+        
+    ...
+        
+    module.exports = {
+        DB_CONNECTION_URI,
+        ...
+    };
+        
+This will first look in the process's environment (eg. `.env`) for a secret, allowing you to override them locally, and then will fall back to `getParameter()`, which looks up a secret by its `Key` (see above), from the secrets file the app was loaded with (`/etc/blf/parameters.json`, or `$SECRET_DIR/parameters.json` on Windows). The `true` parameter above is for `shouldThrowIfMissing` – eg. if this parameter can't be found, the app should fail to start. This should only be used for hard requirements (eg. which Travis CI should use).
+
+You should then be able to use your secret around the app.
+
+## Other considerations
+
+The above approach is slightly fiddly and we've sometimes run into issues with the Parameter Store API which only fetches 50 secrets at a time – occasionally we've exceeded this number and had to remove (unused) secrets.
+
+Since we implemented the above process, AWS has released Secrets Manager which is specifically designed for this task. It incurs a small fee for each retrieval of secrets, but the key difference is that a secret here can contain multiple values (like a JSON object), so we’re able to keep all of the CMS’s config items in a per-environment secret. This means we only have three secrets for the CMS (rather than 30 or so which we have for the website) – global, test and production. Within the test/production secrets we override some of the global parameters.
+
+It would be worth exploring moving this web app to follow the above approach as used in the CMS. The `get-secrets` script will need to be updated to match the CMS pattern, but the improvements to workflow are worth the change.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-We rely on a number of different tools for testing our code.
+We rely on a number of different tools for testing our code. Please ensure that you write new tests when adding non-trivial new code, update existing tests when modifying functionality, and remove outdated tests which are no longer in use. Our confidence in a quick release cycle is built on top of these tests so if they become outdated and unreliable then our users' experience is likely to become unreliable, too. 
 
 ## Linting
 


### PR DESCRIPTION
A few things in here, just doing some final cleanups 😭 

- Update documentation (added a few missing bits)
- Remove an unused secret (for showing Google Data Studio embeds on application dashboard – this is not used anymore)

And one slightly more interesting change:

David and I pointed out a while ago that the application expiry emails are sent relative to when the application is created. eg:

- I create a new application at 20:23 on the 1st January
- An email is scheduled to be sent at 20:23 on 31st March (eg. one day before expiry)
- On 31st March, the 9am expiry job runs **and doesn't send an email** (because the `dateToSend` value is `2020-31-03 20:23:00`)
- Later that day, the 4pm expiry job runs **and still doesn't send an email** (because 20:23 is still in the future).

The next day at 9am, the expiry job runs again and this time will send the email, but this means the customer only has half a day to finish their application, rather than (at least) 24 hours.

The reason is this query:

    dateToSend: {
        [Op.lte]: moment().toDate(),
    },

This looks up any scheduled email where the `dateToSend` is before/equal to now. My change here makes it:

    dateToSend: {
        [Op.lte]: moment().endOf('day').toDate()
    },

This will look up any scheduled email where the `dateToSend` is before **the end of the current day**, eg. `2020-31-03 23:59:00`. 

This means that in my example above, the 9am job will send the expiry email. It actually means in basically all cases, the 9am job will send all of that day's emails, and the 4pm one will be an "insurance" or backup one, just in case the 9am one fails. Right now, both jobs send a similar number of emails depending on what time applications were created.

Anyway, that explanation was longer than the code change, but hopefully it makes sense!