### PR TITLE
Fix an issue with chained .when() calls for charity number field

### DIFF
--- a/controllers/apply/under10k/fields/charity-number.js
+++ b/controllers/apply/under10k/fields/charity-number.js
@@ -23,13 +23,14 @@ module.exports = function (locale, data) {
         .min(4)
         .max(FREE_TEXT_MAXLENGTH.large);
 
-    const schema = Joi.when(Joi.ref('organisationType'), {
+    const schema = Joi.when('organisationType', {
         is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.required),
         then: baseSchema.required(),
-    }).when(Joi.ref('organisationType'), {
-        is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.optional),
-        then: baseSchema.optional().allow('', null),
-        otherwise: Joi.any().strip(),
+        otherwise: Joi.when('organisationType', {
+            is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.optional),
+            then: baseSchema.optional().allow('', null),
+            otherwise: Joi.any().strip(),
+        }),
     });
 
     return new Field({


### PR DESCRIPTION
There was an issue after merging https://github.com/biglotteryfund/blf-alpha/pull/3535 where a valid charity number was not being accepted. I tracked it down to this code:

        const schema = Joi.when('organisationType', {
            is: Joi.exist().valid(CHARITY_NUMBER_TYPES.required),
            then: baseSchema.required()
        }).when('organisationType', {
            is: Joi.exist().valid(CHARITY_NUMBER_TYPES.optional),
            then: baseSchema.optional().allow('', null),
            otherwise: Joi.any().strip(),
        });

The intention of this rule is: when `organisationType` is one of the `CHARITY_NUMBER_TYPES.required` values, then the charity number is a required field. If `organisationType` is one of the `CHARITY_NUMBER_TYPES.optional` values, then the charity number is optional. If `organisationType` is anything else, then we should strip out the value completely.

The issue was that the value was being stripped every time. I set up a test case where I ran the above code in both the old and new Joi versions – in the old version it worked as intended, but in the new version it just silently stripped the `charityNumber` value.

The reason was the nested `.when()` call. It looks like the new Joi version treats these as separate calls, eg. the first `.when()` block makes the `charityNumber` required, but then the second `.when()` condition is triggered, and the `otherwise` block gets matched (because the `organisationType` isn't one of the optional ones) and the value is stripped.

The fix was to nest the secondary `when` criteria in the first `otherwise` block, like a nested if statement:

        const schema = Joi.when('organisationType', {
            is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.required),
            then: baseSchema.required(),
            otherwise: Joi.when('organisationType', {
                is: Joi.exist().valid(...CHARITY_NUMBER_TYPES.optional),
                then: baseSchema.optional().allow('', null),
                otherwise: Joi.any().strip(),
            })
        });

This fixes the issue. Phew!