### PR TITLE
tnlcf-lightning sandbox configuration

### DIFF
--- a/common/locals.js
+++ b/common/locals.js
@@ -254,7 +254,7 @@ module.exports = function (req, res, next) {
     /**
      * Check the domain to point to the correct Salesforce Endpint (sandbox)
      * */
-    if (get(req, 'host') === SANDBOX_DOMAIN) {
+    if (get(req, 'hostname') === SANDBOX_DOMAIN) {
         res.locals.USE_GMS_SANDBOX = true;
     }
 

--- a/common/locals.js
+++ b/common/locals.js
@@ -5,6 +5,7 @@ const config = require('config');
 const moment = require('moment-timezone');
 const isString = require('lodash/isString');
 const get = require('lodash/get');
+const { SANDBOX_DOMAIN } = require('../common/secrets');
 
 const appData = require('./appData');
 const { getAbsoluteUrl, getCurrentUrl, isWelsh, localify } = require('./urls');
@@ -248,6 +249,13 @@ module.exports = function (req, res, next) {
     res.locals.cmsFlags = {};
     if (get(req, 'user.userData.is_sandbox')) {
         res.locals.cmsFlags.sandboxMode = true;
+    }
+
+    /**
+     * Check the domain to point to the correct Salesforce Endpint (sandbox)
+     * */
+    if (get(req, 'host') === SANDBOX_DOMAIN) {
+        res.locals.USE_GMS_SANDBOX = true;
     }
 
     next();

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -83,6 +83,12 @@ const SALESFORCE_AUTH = {
     instanceId:
         process.env.SALESFORCE_INSTANCE_ID ||
         getParameter('salesforce.instanceId'),
+    sandboxApiUrl:
+        process.env.SANDBOX_SALESFORCE_API_URL ||
+        getParameter('sandbox.salesforce.apiUrl'),
+    sandboxUsername:
+        process.env.SANDBOX_SALESFORCE_USERNAME ||
+        getParameter('sandbox.salesforce.username'),
 };
 
 // These expire in July 2021
@@ -129,6 +135,14 @@ const DOTDIGITAL_API = {
         process.env.DOTDIGITAL_PASS || getParameter('dotdigital.api.password'),
 };
 
+/**
+ * Sandbox domain
+ * Used to specify the requested salesforce endpoint
+ * */
+
+const SANDBOX_DOMAIN =
+    process.env.SANDBOX_DOMAIN || getParameter('sandbox.test.domain');
+
 module.exports = {
     AZURE_AUTH,
     BANK_API,
@@ -143,6 +157,7 @@ module.exports = {
     MATERIAL_SUPPLIER,
     PAST_GRANTS_API_URI,
     POSTCODES_API_KEY,
+    SANDBOX_DOMAIN,
     S3_KMS_KEY_ID,
     SALESFORCE_AUTH,
     SENTRY_DSN,

--- a/common/secrets.js
+++ b/common/secrets.js
@@ -83,12 +83,18 @@ const SALESFORCE_AUTH = {
     instanceId:
         process.env.SALESFORCE_INSTANCE_ID ||
         getParameter('salesforce.instanceId'),
-    sandboxApiUrl:
-        process.env.SANDBOX_SALESFORCE_API_URL ||
-        getParameter('sandbox.salesforce.apiUrl'),
+    sandboxConsumerKey:
+        process.env.SANDBOX_SALESFORCE_CONSUMER_KEY ||
+        getParameter('sandbox.salesforce.consumerKey'),
+    sandboxConsumerSecret:
+        process.env.SANDBOX_SALESFORCE_CONSUMER_SECRET ||
+        getParameter('sandbox.salesforce.consumerSecret'),
     sandboxUsername:
         process.env.SANDBOX_SALESFORCE_USERNAME ||
         getParameter('sandbox.salesforce.username'),
+    sandboxToken:
+        process.env.SANDBOX_SALESFORCE_TOKEN ||
+        getParameter('sandbox.salesforce.token'),
 };
 
 // These expire in July 2021

--- a/controllers/apply/form-router/lib/salesforce.js
+++ b/controllers/apply/form-router/lib/salesforce.js
@@ -67,6 +67,23 @@ async function authorise() {
     return new Salesforce(resultJson.instance_url, resultJson.access_token);
 }
 
+async function sandboxAuthorise() {
+    const AUTH_URL = `https://${SALESFORCE_AUTH.sandboxApiUrl}/services/oauth2/token`;
+    const resultJson = await request.post({
+        url: AUTH_URL,
+        json: true,
+        form: {
+            grant_type: 'password',
+            client_id: SALESFORCE_AUTH.consumerKey,
+            client_secret: SALESFORCE_AUTH.consumerSecret,
+            username: SALESFORCE_AUTH.sandboxUsername,
+            password: `${SALESFORCE_AUTH.password}${SALESFORCE_AUTH.token}`,
+        },
+    });
+
+    return new Salesforce(resultJson.instance_url, resultJson.access_token);
+}
+
 function checkStatus() {
     return request({
         url: `https://api.status.salesforce.com/v1/instances/${SALESFORCE_AUTH.instanceId}/status`,
@@ -77,5 +94,6 @@ function checkStatus() {
 
 module.exports = {
     authorise,
+    sandboxAuthorise,
     checkStatus,
 };

--- a/controllers/apply/form-router/lib/salesforce.js
+++ b/controllers/apply/form-router/lib/salesforce.js
@@ -68,16 +68,16 @@ async function authorise() {
 }
 
 async function sandboxAuthorise() {
-    const AUTH_URL = `https://${SALESFORCE_AUTH.sandboxApiUrl}/services/oauth2/token`;
+    const AUTH_URL = `https://${SALESFORCE_AUTH.apiUrl}/services/oauth2/token`;
     const resultJson = await request.post({
         url: AUTH_URL,
         json: true,
         form: {
             grant_type: 'password',
-            client_id: SALESFORCE_AUTH.consumerKey,
-            client_secret: SALESFORCE_AUTH.consumerSecret,
+            client_id: SALESFORCE_AUTH.sandboxConsumerKey,
+            client_secret: SALESFORCE_AUTH.sandboxConsumerSecret,
             username: SALESFORCE_AUTH.sandboxUsername,
-            password: `${SALESFORCE_AUTH.password}${SALESFORCE_AUTH.token}`,
+            password: `${SALESFORCE_AUTH.password}${SALESFORCE_AUTH.sandboxToken}`,
         },
     });
 

--- a/controllers/apply/form-router/submission.js
+++ b/controllers/apply/form-router/submission.js
@@ -133,7 +133,12 @@ module.exports = function (
                 config.get('features.enableSalesforceConnector') === true &&
                 !appData.isTestServer
             ) {
-                const salesforce = await salesforceService.authorise();
+                let salesforce = {};
+                if (res.locals.USE_GMS_SANDBOX) {
+                    salesforce = await salesforceService.sandboxAuthorise();
+                } else {
+                    salesforce = await salesforceService.authorise();
+                }
                 salesforceRecordId = await salesforce.submitFormData(
                     salesforceFormData
                 );


### PR DESCRIPTION
Config to handle requests from the test.sandbox domain and point to the salesforce sandbox (tnlcf-lightning).

Parameters added to /Web/Test to avoid creating a new environment and additional repeated params (e.g. db connection)

Salesforce class updated to have an alternative function when gms sandbox enabled. 