### PR TITLE
Hide sensitive field data that was showing on hotjar

### DIFF
--- a/controllers/apply/under10k/fields.js
+++ b/controllers/apply/under10k/fields.js
@@ -271,7 +271,7 @@ module.exports = function fieldsFor({ locale, data = {}, flags = {} }) {
                     data
                 );
                 const nameMessage = organisationLegalName
-                    ? `, <strong>${organisationLegalName}</strong>`
+                    ? `, <strong data-hj-suppress>${organisationLegalName}</strong>`
                     : '';
                 return localise({
                     en: `<p>This must be different from your organisation's legal name${nameMessage}.</p>`,


### PR DESCRIPTION
Data from one field could be seen in hotjar, hj suppress added to prevent this.