### PR TITLE
Launch newsletter signup 

### DIFF
--- a/controllers/about/index.js
+++ b/controllers/about/index.js
@@ -2,7 +2,6 @@
 const express = require('express');
 
 const { flexibleContentPage } = require('../common');
-const { isNotProduction } = require('../../common/appData');
 
 const router = express.Router();
 
@@ -14,9 +13,7 @@ router.get('/our-people/*', (req, res, next) => {
     next();
 });
 
-if (isNotProduction) {
-    router.use('/newsletter', require('../newsletter'));
-}
+router.use('/newsletter', require('../newsletter'));
 
 router.use('/*', flexibleContentPage());
 

--- a/controllers/newsletter/index.js
+++ b/controllers/newsletter/index.js
@@ -37,17 +37,6 @@ router
     .all(
         noStore,
         csrfProtection,
-        (req, res, next) => {
-            // Temporarily disable non-insights signup form which will launch later
-            if (
-                !req.params.contactType ||
-                req.params.contactType !== 'insights'
-            ) {
-                res.redirect('/');
-            } else {
-                next();
-            }
-        },
         injectHeroImage('the-bike-project-2-new-letterbox')
     )
     .get(renderForm)
@@ -55,7 +44,7 @@ router
         const sanitisedBody = sanitiseRequestBody(omit(req.body, ['_csrf']));
 
         let contactToUse = newContact(req.i18n);
-        let addressBookId = 148374;
+        let addressBookId = 249381;
 
         if (req.params.contactType === 'insights') {
             contactToUse = newStakeholder(req.i18n);


### PR DESCRIPTION
This is dependent on the Brand team deciding we're ready to go live, but for when we do, this change shows how to launch the signup forms.

You'll be able to access them at the following endpoints:

- `/about/newsletter/insights` (stakeholder signup, goes to contact address book `249380`)
- `/about/newsletter` (regular grantholder signup, goes to contact address book `249381`)
- `/about/newsletter/success` (the page new subscribers are sent to after confirming subscription via email)

It's worth double checking the address books are what the Brand team expect before launching this.

There's also an idea about building mini signup forms to embed around the site. You could create a self-contained version of just the form fields (in `controllers/newsletter/views/newsletter.njk`) and have them post to the newsletter endpoint (eg. `/about/newsletter` or `/about/newsletter/insights`), which would then show any validation errors on the standalone page (rather than having to display them on the homepage or whereever this form gets displayed).