### PR TITLE
Using length to check for optgroup

### DIFF
--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -241,7 +241,7 @@
             <option value="">{{ field.defaultOption }}</option>
         {% endif %}
 
-        {% if field.optgroups %}
+        {% if field.optgroups.length > 0 %}
             {% for optgroup in field.optgroups %}
                 <optgroup label="{{ optgroup.label }}">
                     {% for option in optgroup.options %}


### PR DESCRIPTION
optgroup check for if null doesnt work because of the assignment of {}. It needs its length checked to be more than 0