### PR TITLE
Content review of error messages

### DIFF
--- a/controllers/apply/standard-proposal-v2/fields.js
+++ b/controllers/apply/standard-proposal-v2/fields.js
@@ -914,14 +914,14 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Please tell us your organisation trading name.',
+                        en: 'Enter your organisation's day-to-day name',
                         cy: '',
                     }),
                 },
                 {
                     type: 'any.invalid',
                     message: localise({
-                        en: 'Trading name must not be the same as legal name',
+                        en: 'Organisation's day-to-day name must not be the same as its legal name',
                         cy: '',
                     }),
                 },
@@ -1016,7 +1016,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Please enter a valid whole number.',
+                        en: 'Enter a number.',
                         cy: '',
                     }),
                 },
@@ -1042,7 +1042,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Please enter a valid whole number.',
+                        en: 'Enter a number.',
                         cy: '',
                     }),
                 },
@@ -1069,7 +1069,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Please enter a valid number.',
+                        en: 'Enter a number.',
                         cy: '',
                     }),
                 },
@@ -1103,21 +1103,21 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: `Please enter a valid whole number.`,
+                        en: `Enter a number.`,
                         cy: ``,
                     }),
                 },
                 {
                     type: 'number.max',
                     message: localise({
-                        en: 'Please enter a valid percentage.',
+                        en: 'Number must be between 0 and 100.',
                         cy: '',
                     }),
                 },
                 {
                     type: 'number.min',
                     message: localise({
-                        en: 'Please enter a valid percentage.',
+                        en: 'Number must be between 0 and 100.',
                         cy: '',
                     }),
                 },
@@ -1481,8 +1481,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'dateParts.minDate',
                     message: localise({
-                        en: oneLine`Their birth date is not valid—please
-                            use four digits, eg. 1986`,
+                        en: oneLine`Birth year must be four digits, for example 1986`,
                         cy: oneLine`Nid yw’r dyddiad geni yn ddilys—defnyddiwch
                             bedwar digid, e.e. 1986`,
                     }),

--- a/controllers/apply/standard-proposal-v2/fields.js
+++ b/controllers/apply/standard-proposal-v2/fields.js
@@ -332,7 +332,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: `Tell us all of the locations that you'll be running your project in`,
+                        en: `Tell us all the locations that you'll be running your project in`,
                         cy: '',
                     }),
                 },
@@ -373,8 +373,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: oneLine`Tell us the total cost of your project — Total cost 
-                        must be the same as or higher than the amount you’re asking us to fund.`,
+                        en: oneLine`Enter the total cost of your project`,
                         cy: '',
                     }),
                 },
@@ -388,8 +387,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'number.min',
                     message: localise({
-                        en: oneLine`Tell us the total cost of your project — Total cost 
-                        must be the same as or higher than the amount you’re asking us to fund.`,
+                        en: oneLine`Total cost must be the same as or higher than the amount you’re asking us to fund.`,
                         cy: ``,
                     }),
                 },
@@ -457,7 +455,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'number.max',
                     message: localise({
-                        en: oneLine`The amount you ask for cannot exceed the total cost.`,
+                        en: oneLine`The amount you ask us for cannot be more than the total cost of the project.`,
                         cy: ``,
                     }),
                 },
@@ -561,7 +559,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'dateParts.minDate',
                     message: localise({
-                        en: oneLine`Date you start the project must be on
+                        en: oneLine`The date you start the project must be on
                             or after ${minDateExample}`,
                         cy: oneLine`Mae’n rhaid i ddyddiad dechrau eich
                             prosiect fod ar neu ar ôl ${minDateExample}`,
@@ -570,9 +568,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'dateParts.maxDate',
                     message: localise({
-                        en: oneLine`The estimated start date for the project 
-                        should not be more than 10 years in the future of 
-                        the current date.`,
+                        en: oneLine`The date you start the project must be less than 10 years in the future.`,
                         cy: oneLine``,
                     }),
                 },
@@ -613,7 +609,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'base',
                     message: localise({
-                        en: 'Select a project duration',
+                        en: 'Select a project length',
                         cy: '',
                     }),
                 },
@@ -842,7 +838,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                 {
                     type: 'string.max',
                     message: localise({
-                        en: `Full legal name of organisation must be ${maxLength} characters or less`,
+                        en: `The full legal name of organisation must be ${maxLength} characters or less`,
                         cy: `Rhaid i’r enw cyfreithiol llawn fod yn llai na ${maxLength} nod`,
                     }),
                 },
@@ -871,7 +867,7 @@ module.exports = function fieldsFor({ locale, data = {} }) {
                     type: 'base',
                     message: localise({
                         en:
-                            'Tell us if your organisation uses a different name in your day-to-day work.',
+                            'Select yes or no.',
                         cy: '',
                     }),
                 },

--- a/controllers/apply/standard-proposal-v2/fields/project-postcode.js
+++ b/controllers/apply/standard-proposal-v2/fields/project-postcode.js
@@ -28,7 +28,7 @@ module.exports = function (locale) {
             {
                 type: 'base',
                 message: localise({
-                    en: 'Enter a real postcode',
+                    en: 'Enter a postcode',
                     cy: 'Rhowch gôd post go iawn',
                 }),
             },


### PR DESCRIPTION
I've used the [GOV.UK design system component on error messages](https://design-system.service.gov.uk/components/error-message/) to review the error messages - and make them consistent with existing messages designed the same way.

Here's extra rationale for some specific changes: 
- For `fieldOrganisationSupport` I've changed to error message to `Enter a number`  - this should be if they leave the field blank. If they add a number but it's not a whole number, can we have a separate error message to resolve that? It should be `Number of people supported by your organisation must be a whole number (for example, no decimal point)`. This means the customer gets more specific guidance based on the mistake they've made and are more likely to be able to resolve it themselves without calling us
- same as `fieldOrganisationSupport` for `fieldOrganisationVolunteers`, except second error message should be `Number of volunteers at your organisation must be a whole number (for example, no decimal point)`