### PR TITLE
Newsletter feed is now different depending on page/locale

### DIFF
--- a/controllers/newsletter/views/newsletter.njk
+++ b/controllers/newsletter/views/newsletter.njk
@@ -123,7 +123,13 @@
                     <div class="js-newsletter-preview u-hidden u-tone-background-tint u-padded s-prose"
                          data-dd-uid="5P0C"
                          data-dd-cid="A5KMIFI43"
+                         {% if (locale === 'cy') and (contactType !== 'insights')  %}
+                         data-dd-tagname="grantholderwales"
+                         {% elseif contactType === 'insights' %}
                          data-dd-tagname="insights"
+                         {% else %}
+                         data-dd-tagname="grantholder"
+                         {% endif %}
                          data-dd-count="10"
                          data-dd-showdate="true">
                         <h3>{{ copy.latest }}</h3>


### PR DESCRIPTION
Grantholder newsletter page now shows only grantholder newsletters in the feed. Switching to Welsh displays the Welsh grantholder newsletters and stakeholder now shows the insights newsletter feed. 