### PR TITLE
Org start date - display fix

### DIFF
--- a/controllers/apply/lib/field-types/month-year.js
+++ b/controllers/apply/lib/field-types/month-year.js
@@ -54,12 +54,12 @@ class MonthYearField extends Field {
     get displayValue() {
         if (this.value) {
             const dt = moment({
-                year: moment().year(),
+                year: this.value.year,
                 month: this.value.month - 1,
                 day: this.value.day,
             });
 
-            return dt.isValid() ? dt.locale(this.locale).format('Do MMMM') : '';
+            return dt.isValid() ? dt.locale(this.locale).format('MMMM YYYY') : '';
         } else {
             return '';
         }

--- a/controllers/apply/lib/field-types/month-year.js
+++ b/controllers/apply/lib/field-types/month-year.js
@@ -56,7 +56,7 @@ class MonthYearField extends Field {
             const dt = moment({
                 year: this.value.year,
                 month: this.value.month - 1,
-                day: this.value.day,
+                day: 1,
             });
 
             return dt.isValid() ? dt.locale(this.locale).format('MMMM YYYY') : '';

--- a/controllers/apply/lib/field-types/month-year.test.js
+++ b/controllers/apply/lib/field-types/month-year.test.js
@@ -15,7 +15,7 @@ test('MonthYearField', function () {
     const goodInput = { year: 1986, month: 9 };
     field.withValue(goodInput);
     expect(field.validate().error).toBeUndefined();
-    expect(field.displayValue).toBe('1st September');
+    expect(field.displayValue).toBe('September 1986');
 
     const badInput = { year: 3000, month: 1 };
     field.withValue(badInput);

--- a/controllers/apply/under10k/fields/organisation-start-date.js
+++ b/controllers/apply/under10k/fields/organisation-start-date.js
@@ -23,5 +23,6 @@ module.exports = function (locale) {
                  <p><strong>Er enghraifft: 11 ${exampleYear}</strong></p>`,
         }),
         isRequired: true,
+
     });
 };

--- a/controllers/apply/under10k/fields/organisation-start-date.js
+++ b/controllers/apply/under10k/fields/organisation-start-date.js
@@ -23,6 +23,5 @@ module.exports = function (locale) {
                  <p><strong>Er enghraifft: 11 ${exampleYear}</strong></p>`,
         }),
         isRequired: true,
-
     });
 };


### PR DESCRIPTION
"When was your organisation set up?" question using the Month-Year selection was displaying a day and month as view, this was causing some customer confusion.

Updated field to display month and year. 