### PR TITLE
Page titles font-size changed to 23px

### DIFF
--- a/assets/sass/scaffolding/_content.scss
+++ b/assets/sass/scaffolding/_content.scss
@@ -8,7 +8,7 @@
 
 .page-title {
     width: 100%;
-    font-size: font-scale('display', 't4');
+    font-size: font-scale('display', 't1');
     margin-bottom: 0;
 
     .page-title__text {


### PR DESCRIPTION
Updated _content.scss file so .page-title uses t1 font scale. Before pushing I built the CSS on the website to confirm that the change is there/works. The CSS file will be updated in the build based on the change in this branch. 