### PR TITLE
Changed summary dropdown from show/show to show/hide.

### DIFF
--- a/assets/sass/scaffolding/_details.scss
+++ b/assets/sass/scaffolding/_details.scss
@@ -50,12 +50,15 @@
 
     &[open] .o-details__summary {
         background-image: $iconChevronDown;
+    }
+
+    &[open] .summary__toggle {
         &:after{
             content: attr(data-open);
         }
     }
 
-    &:not([open]) .o-details__summary {
+    &:not([open]) .summary__toggle {
         &:after{
             content: attr(data-hide);
         }

--- a/assets/sass/scaffolding/_details.scss
+++ b/assets/sass/scaffolding/_details.scss
@@ -50,5 +50,14 @@
 
     &[open] .o-details__summary {
         background-image: $iconChevronDown;
+        &:after{
+            content: attr(data-open);
+        }
+    }
+
+    &:not([open]) .o-details__summary {
+        &:after{
+            content: attr(data-hide);
+        }
     }
 }

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -885,6 +885,7 @@ apply:
     expandAll: Ehangu pob adran
     collapseAll: Cau pob adran
     showQuestions: Dangos cwestiynau
+    hideQuestions: Cuddio cwestiynau
     notRequired: Nid oes angen i chi lenwi’r rhan yma oherwydd yr hyn rydych wedi ei ddweud wrthym am eich prosiect hyd yn hyn.
     errorSummaryTitle: Mae’r meysydd hyn angen eich sylw cyn ichi allu ei anfon.
     featuredErrorsTitle: Mae rhai manylion yn eich ffurflen angen sylw ychwanegol.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -897,6 +897,7 @@ apply:
     expandAll: Expand all sections
     collapseAll: Collapse all sections
     showQuestions: Show questions
+    hideQuestions: Hide questions
     notRequired: You don't need to fill this bit in because of what you've told us about your project so far.
     errorSummaryTitle: These fields need attention before you can submit
     featuredErrorsTitle: Some details in your application need extra attention

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -8,7 +8,7 @@
 
 {% macro details(showQuestionsTitle, hideQuestionsTitle, isOpen = false, showInfoIcon = true, extraClasses, assistiveText = false, dataName = false) %}
     <details class="o-details u-margin-bottom-s {% if extraClasses %}{{ extraClasses }}{% endif %}"{% if isOpen %} open{% endif %}>
-        <summary class="o-details__summary"{% if dataName %} data-name="{{ dataName }}"{% endif %} data-open="{{ hideQuestionsTitle }}" data-hide="{{ showQuestionsTitle }}">
+        <summary class="o-details__summary summary__toggle"{% if dataName %} data-name="{{ dataName }}"{% endif %} data-open="{{ hideQuestionsTitle }}" data-hide="{{ showQuestionsTitle }}">
             {% if showInfoIcon %}{{ iconInfo() }}{% endif %}
             {% if assistiveText %}<span class="u-visually-hidden">{{ assistiveText }}</span>{% endif %}
         </summary>

--- a/controllers/apply/form-router/views/summary.njk
+++ b/controllers/apply/form-router/views/summary.njk
@@ -1,11 +1,20 @@
 {% extends "layouts/main.njk" %}
-{% from "components/details/macro.njk" import details %}
 {% from "components/form-header/macro.njk" import formHeaderWithData with context %}
 {% from "components/icons.njk" import iconTick %}
 {% from "components/user-navigation/macro.njk" import userNavigation with context %}
 {% from "./expiry-warnings.njk" import expiryLoggedOut with context %}
 
 {% block title %}{{ title }} | {{ formTitle }} | {% endblock %}
+
+{% macro details(showQuestionsTitle, hideQuestionsTitle, isOpen = false, showInfoIcon = true, extraClasses, assistiveText = false, dataName = false) %}
+    <details class="o-details u-margin-bottom-s {% if extraClasses %}{{ extraClasses }}{% endif %}"{% if isOpen %} open{% endif %}>
+        <summary class="o-details__summary"{% if dataName %} data-name="{{ dataName }}"{% endif %} data-open="{{ hideQuestionsTitle }}" data-hide="{{ showQuestionsTitle }}">
+            {% if showInfoIcon %}{{ iconInfo() }}{% endif %}
+            {% if assistiveText %}<span class="u-visually-hidden">{{ assistiveText }}</span>{% endif %}
+        </summary>
+        <div class="o-details__content">{{ caller() }}</div>
+    </details>
+{% endmacro %}
 
 {% macro summariseErrors() %}
     {% if showErrors and errorsByStep.length > 0 %}
@@ -157,7 +166,8 @@
                 {% endfor %}
             {% else %}
                 {% call details(
-                    title = copy.summary.showQuestions,
+                    showQuestionsTitle = copy.summary.showQuestions,
+                    hideQuestionsTitle = copy.summary.hideQuestions,
                     assistiveText = 'for "' + secTitle + '" section',
                     extraClasses = 'js-toggleable',
                     isOpen = form.progress.isComplete or section.hasFeaturedErrors,


### PR DESCRIPTION
On the summary page when you click 'Show questions', it would still say 'Show questions'. This change makes it say 'Hide Questions' after the section has been opened.