### PR TITLE
rectangle focus for arrows on search grants page

### DIFF
--- a/assets/sass/components/_facet-filters.scss
+++ b/assets/sass/components/_facet-filters.scss
@@ -223,7 +223,7 @@ $filterSpacing: 10px;
 
         &:active,
         &:focus {
-            outline: none;
+            outline: 1px auto -webkit-focus-ring-color;
 
             .icon {
                 fill: black;


### PR DESCRIPTION
- when focused, the arrows do not have anything visible to indicate its focus. Now uses a visible rectangle.