### PR TITLE
Change image size of updates card

### DIFF
--- a/views/components/blog/macro.njk
+++ b/views/components/blog/macro.njk
@@ -6,7 +6,7 @@
         "subtitle": formatDate(entry.postDate.date),
         "summary": entry.summary or entry.trailText,
         "image": {
-            "url": entry.thumbnail.large or entry.hero.image.default,
+            "url": entry.thumbnail.medium or entry.hero.image.default,
             "alt": entry.title
         },
         "link": {


### PR DESCRIPTION
Small change to the chosen image size that is pulled through onto news pages from updates section on the CMS