### PR TITLE
change to make publication-search no longer use insight document copy

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -333,6 +333,37 @@ insights:
     region: Rhanbarth
     partner: Partner
     tags: Tagiau
+publication:
+  search:
+    cta: Chwiliwch ein dogfennau
+    submit: Chwilio
+    download: Lawrlwytho
+    explanation: 'Chwiliwch am allweddair fel "unigrwydd" neu enw mudiad'
+    totals:
+      one: 'Canfuwyd %s dogfen'
+      other: 'Canfuwyd %s ddogfen'
+    noResultsTotal: Canfuwyd 0 dogfen
+    sortBy:
+      orderedBy: "Wedi'u trefnu fesul"
+      relevancy: Mwyaf perthnasol
+      newest: Diweddaraf yn gyntaf
+      oldest: Hynaf yn gyntaf
+    filters:
+      clearAll: Clirio popeth
+      clearAllFilters: Clirio pob hidlydd
+      filterBy: Hidlwch fesul
+      applyFilters: Cymhwyso hidlyddion
+      programme:
+        title: Rhaglen ariannu
+        label: Dewis rhaglen
+      region:
+        title: Rhanbarth
+        label: Dewis rhanbarth
+      docType:
+        title: Math o ddogfen
+        label: Pob math o ddogfen
+    noResults: Ni chanfuwyd canlyniadau ar gyfer y chwiliad hwn - rhowch gynnig ar ddileu hidlyddion neu nodwch ymholiad gwahanol.
+  tags: Tagiau
 news:
   title: Newyddion
   allNews: Holl newyddion

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -342,6 +342,37 @@ insights:
     region: Region
     partner: Partner
     tags: Tags
+publications:
+  search:
+    cta: Search our documents
+    submit: Search
+    download: Download
+    explanation: 'Search for a keyword such as "loneliness" or an organisation name'
+    totals:
+      one: '%s document found'
+      other: '%s documents found'
+    noResultsTotal: 0 documents found
+    sortBy:
+      orderedBy: Ordered by
+      relevancy: Most relevant
+      newest: Newest first
+      oldest: Oldest first
+    filters:
+      clearAll: Clear all
+      clearAllFilters: Clear all filters
+      filterBy: Filter by
+      applyFilters: Apply filters
+      programme:
+        title: Funding programme
+        label: Choose programme
+      region:
+        title: Region
+        label: Choose region
+      docType:
+        title: Document type
+        label: All document types
+    noResults: No results were found for this search – please try removing filters or entering a different query.
+  tags: Tags
 news:
   title: News
   allNews: All news

--- a/controllers/funding/publications/views/publication-search.njk
+++ b/controllers/funding/publications/views/publication-search.njk
@@ -6,7 +6,7 @@
 {% from "components/split-nav/macro.njk" import splitNav %}
 {% from "components/icons.njk" import iconClose, iconTickPlain %}
 
-{% set copy = __('insights.documents') %}
+{% set copy = __('publications') %}
 {% set basePageUrl = localify(baseUrl) %}
 
 {% block content %}
@@ -58,7 +58,7 @@
                 <div class="search__meta">
                     <h2 class="search__total t--underline" role="alert">
                         {% if entriesMeta.pagination.total > 0 %}
-                            {{ __n('insights.documents.search.totals', entriesMeta.pagination.total) }}
+                            {{ __n('publications.search.totals', entriesMeta.pagination.total) }}
                         {% else %}
                             {{ copy.search.noResultsTotal }}
                         {% endif %}


### PR DESCRIPTION
Duplicated the bits of the copy that were needed for the publication search so it is no longer using the insight.document.