### PR TITLE
Grant length added to summary section on programmes

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -170,6 +170,7 @@ global:
       fundingSize: Maint yr ariannu
       totalAvailable: Cyfanswm ar gael
       applicationDeadline: Terfyn amser ymgeisio
+      grantLength: Hyd y grant
   survey:
     question: A ddaethoch o hyd i'r hyn yr oeddech yn chwilio amdano?
     prompt: Sut gallem fod wedi gwneud y dudalen hon yn well?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -172,6 +172,7 @@ global:
       fundingSize: Funding size
       totalAvailable: Total available
       applicationDeadline: Application deadline
+      grantLength: Grant length
   survey:
     question: Did you find what you were looking for?
     prompt: How could we have made this page better?

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -23,10 +23,17 @@
             <dd>{{ programme.fundingSize.totalAvailable }}</dd>
         {% endif %}
 
+        {% if programme.grantLength %}
+            <dt>{{ labels.grantLength }}</dt>
+            <dd>{{ programme.grantLength }}</dd>
+        {% endif %}
+
+
         {% if programme.applicationDeadline %}
             <dt>{{ labels.applicationDeadline }}</dt>
             <dd>{{ programme.applicationDeadline | safe }}</dd>
         {% endif %}
+
 
     </dl>
 {% endmacro %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -23,9 +23,9 @@
             <dd>{{ programme.fundingSize.totalAvailable }}</dd>
         {% endif %}
 
-        {% if programme.grantLength %}
+        {% if programme.grantLength.description %}
             <dt>{{ labels.grantLength }}</dt>
-            <dd>{{ programme.grantLength }}</dd>
+            <dd>{{ programme.grantLength.description }}</dd>
         {% endif %}
 
         {% if programme.applicationDeadline %}

--- a/views/components/programmes.njk
+++ b/views/components/programmes.njk
@@ -28,12 +28,10 @@
             <dd>{{ programme.grantLength }}</dd>
         {% endif %}
 
-
         {% if programme.applicationDeadline %}
             <dt>{{ labels.applicationDeadline }}</dt>
             <dd>{{ programme.applicationDeadline | safe }}</dd>
         {% endif %}
-
 
     </dl>
 {% endmacro %}


### PR DESCRIPTION
New field was added to the CMS for grant length. This change displays this field on the programme pages in the summary section, if the field is left blank then it will not display. 