### PR TITLE
News accessibility fixes

### DIFF
--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -125,4 +125,3 @@
         </section>
     </main>
 {% endblock %}
-

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -106,7 +106,7 @@
                     {% call card(pressCopy.title) %}
                         <div class="s-prose u-text-small">
                             {% for region in pressCopy.regions %}
-                                <h4 class="t5">{{ region.title }}</h4>
+                                <h3 class="t5">{{ region.title }}</h3>
                                 <dl class="o-definition-list o-definition-list--wrapped u-margin-bottom-s">
                                     {% if region.phone %}
                                         <dt class="u-weight-normal">{{ __('global.misc.phone') | capitalize }}:</dt>

--- a/controllers/updates/views/listing/press-releases.njk
+++ b/controllers/updates/views/listing/press-releases.njk
@@ -125,3 +125,4 @@
         </section>
     </main>
 {% endblock %}
+

--- a/views/components/article-teaser/macro.njk
+++ b/views/components/article-teaser/macro.njk
@@ -1,9 +1,9 @@
 {% macro articleTeaser(props) %}
     <article class="article-teaser s-prose">
         <header class="article-teaser__header">
-            <h2 class="article-teaser__title t3">
+            <p class="article-teaser__title t3">
                 <a class="u-link-minimal" href="{{ props.linkUrl }}">{{ props.title }}</a>
-            </h2>
+            </p>
             {% if props.subtitle %}
                 <p class="article-teaser__subtitle">
                     {{ props.subtitle }}


### PR DESCRIPTION
Updated article-teaser macro to use p tags rather than h2 due to style constraints inside s-prose class.
This would cause the press-releases page to no longer have incremental headings, fixed by incrementing existing h4 to h3. 