### PR TITLE
Input field sizes update

### DIFF
--- a/controllers/user/views/forgotten-password.njk
+++ b/controllers/user/views/forgotten-password.njk
@@ -36,7 +36,8 @@
                         label: __('user.common.emailAddress'),
                         explanation: copy.emailExplanation,
                         isRequired: true,
-                        value: formValues['username']
+                        value: formValues['username'],
+                        attributes: { 'size' : 40 }
                     }, errors = errors) }}
 
                     <div class="form-actions">

--- a/controllers/user/views/login.njk
+++ b/controllers/user/views/login.njk
@@ -36,14 +36,16 @@
                             name: 'username',
                             label: __('user.common.emailAddress'),
                             isRequired: true,
-                            value: formValues['username']
+                            value: formValues['username'],
+                            attributes: { 'size' : 40 }
                         }, errors = errors) }}
 
                         {{ formField({
                             type: 'password',
                             name: 'password',
                             label: __('user.common.password'),
-                            isRequired: true
+                            isRequired: true,
+                            attributes: { 'size' : 40 }
                         }, errors = errors) }}
 
                         <p>

--- a/controllers/user/views/register.njk
+++ b/controllers/user/views/register.njk
@@ -25,7 +25,8 @@
                             name: 'username',
                             label: __('user.common.emailAddress'),
                             isRequired: true,
-                            value: formValues['username']
+                            value: formValues['username'],
+                            attributes: { 'size': 40 }
                         }, errors = errors) }}
 
                         {{ formField({
@@ -33,7 +34,8 @@
                             name: 'password',
                             label: __('user.common.password'),
                             explanation: __('user.common.passwordRequirements'),
-                            isRequired: true
+                            isRequired: true,
+                            attributes: { 'size': 40 }
                         }, errors = errors) }}
 
                         {{ formField({
@@ -41,7 +43,8 @@
                             name: 'passwordConfirmation',
                             label: __('user.common.passwordConfirmation.label'),
                             explanation: __('user.common.passwordConfirmation.explanation'),
-                            isRequired: true
+                            isRequired: true,
+                            attributes: { 'size': 40 }
                         }, errors = errors) }}
 
                         <div class="form-actions">


### PR DESCRIPTION
@LynseyJReynolds noticed field sizes for login were incorrect in test environment - investigation found all fields were like this in login/register/forgot password. 
![LoginFields_prior](https://user-images.githubusercontent.com/62546081/103789162-9a795b80-5037-11eb-9e3a-d8ce0ba1eff8.PNG)

Added missing size attribute to all fields to match live environment.
![LoginFIelds_new](https://user-images.githubusercontent.com/62546081/103789229-acf39500-5037-11eb-9ca2-de83f112ee6d.PNG)
