### PR TITLE
Past grants XSS parameter vulnerability fix

### DIFF
--- a/controllers/apply/under10k/form.test.js
+++ b/controllers/apply/under10k/form.test.js
@@ -501,13 +501,14 @@ test('valid form for different trading names', function () {
     );
 });
 
+// TODO: this needs to be fixed so it doesn't break every 3 months.
 test('maintain backwards compatibility for date schema', function () {
     const mock = mockResponse({
         projectCountry: 'scotland',
         projectLocation: 'fife',
         supportingCOVID19: 'no',
-        projectStartDate: { day: 3, month: 4, year: 2021 },
-        projectEndDate: { day: 3, month: 5, year: 2021 },
+        projectStartDate: { day: 3, month: 7, year: 2021 },
+        projectEndDate: { day: 3, month: 12, year: 2021 },
     });
 
     const form = formBuilder({
@@ -518,11 +519,11 @@ test('maintain backwards compatibility for date schema', function () {
 
     // Maintain backwards compatibility with salesforce schema
     const salesforceResult = form.forSalesforce();
-    expect(salesforceResult.projectStartDate).toBe('2021-04-03');
-    expect(salesforceResult.projectEndDate).toBe('2021-05-03');
+    expect(salesforceResult.projectStartDate).toBe('2021-07-03');
+    expect(salesforceResult.projectEndDate).toBe('2021-12-03');
     expect(salesforceResult.projectDateRange).toEqual({
-        startDate: '2021-04-03',
-        endDate: '2021-05-03',
+        startDate: '2021-07-03',
+        endDate: '2021-12-03',
     });
 });
 

--- a/controllers/funding/grants/index.js
+++ b/controllers/funding/grants/index.js
@@ -9,6 +9,7 @@ const clone = require('lodash/clone');
 const get = require('lodash/get');
 const isEmpty = require('lodash/isEmpty');
 const pick = require('lodash/pick');
+const { check } = require('express-validator');
 
 const {
     injectHeroImage,
@@ -69,8 +70,24 @@ function buildPagination(req, paginationMeta, currentQuery = {}) {
 }
 
 router.get(
-    '/',
-    injectHeroImage('search-all-grants-letterbox-new'),
+    '/', [
+    check([
+        'q',
+        'amount',
+        'postcode',
+        'programme',
+        'year',
+        'orgType',
+        'sort',
+        'country',
+        'awardDate',
+        'localAuthority',
+        'westminsterConstituency',
+        'recipient',
+        'exclude',
+        'limit',
+    ]).escape(),
+    injectHeroImage('search-all-grants-letterbox-new')],
     async function (req, res, next) {
         try {
             const locale = req.i18n.getLocale();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10111,6 +10111,22 @@
         }
       }
     },
+    "express-validator": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.9.2.tgz",
+      "integrity": "sha512-Yqlsw2/uBobtBVkP+gnds8OMmVAEb3uTI4uXC93l0Ym5JGHgr8Vd4ws7oSo7GGYpWn5YCq4UePMEppKchURXrw==",
+      "requires": {
+        "lodash": "^4.17.20",
+        "validator": "^13.5.2"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "13.5.2",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.5.2.tgz",
+          "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
+        }
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "ext": "js,json,yml"
   },
   "dependencies": {
-    "joi": "17.2.1",
     "@ideal-postcodes/core-node": "2.1.0",
     "@sentry/browser": "5.21.1",
     "@sentry/integrations": "5.24.2",
@@ -100,6 +99,7 @@
     "express": "4.17.1",
     "express-cache-controller": "^1.0.1",
     "express-session": "1.17.1",
+    "express-validator": "6.9.2",
     "faker": "4.1.0",
     "filesize": "6.1.0",
     "fitvids": "^2.1.1",
@@ -111,6 +111,7 @@
     "helmet": "4.1.0",
     "html-to-text": "5.1.1",
     "i18n-2": "^0.7.3",
+    "joi": "17.2.1",
     "js-yaml": "3.14.0",
     "jsdom": "16.4.0",
     "json2csv": "5.0.1",


### PR DESCRIPTION
An XSS reflection vulnerability was discovered in the past grants search which could be exploited by manipulating the query string provided to the page as the output was set to trust HTML for facets. 

To resolve, the [express-validator](https://express-validator.github.io/docs/) library is included and check([query]).escape() is called on all query params passed to grant-service.
![image](https://user-images.githubusercontent.com/62546081/104312035-f3307480-54cd-11eb-8cf8-3757fa01e68c.png)

This allows the use of facets and linking to continue while ensuring all input is escaped before being presented back to the client. 