### PR TITLE
Country added to default data fields

### DIFF
--- a/controllers/newsletter/lib/newsletter-service.js
+++ b/controllers/newsletter/lib/newsletter-service.js
@@ -23,15 +23,12 @@ function subscribe({
         dataFields: [
             { key: 'FirstName', value: subscriptionData.firstName },
             { key: 'LastName', value: subscriptionData.lastName },
+            { key: 'COUNTRY', value: subscriptionData.location },
         ],
     };
 
     if (contactType === 'insights') {
         data.dataFields.push(
-            {
-                key: 'COUNTRY',
-                value: subscriptionData.location,
-            },
             {
                 key: 'JOBTITLE',
                 value: subscriptionData.jobTitle,


### PR DESCRIPTION
The country field was set for only the insights(stakeholder) newsletter. Updated it so it is a default value that will be pulled through for both stakeholder and grantholder newsletter signups 