### PR TITLE
Removed underline from h2

### DIFF
--- a/assets/sass/base/_base.scss
+++ b/assets/sass/base/_base.scss
@@ -61,7 +61,6 @@ h1 {
 }
 h2 {
     font-size: font-scale('display', 't2');
-    text-decoration: underline;
 }
 h3 {
     font-size: font-scale('display', 't3');


### PR DESCRIPTION
Removed the underline from the h2 in the base css file as h2 has it's own pink underline.