### PR TITLE
WEB-63 download icon screen reader title change

### DIFF
--- a/views/components/icons.njk
+++ b/views/components/icons.njk
@@ -129,7 +129,7 @@
 {% endmacro %}
 
 {% macro iconDownload() %}
-    {% call icon('download-btn', 'Download symbol', viewbox="0 0 64 64") %}
+    {% call icon('download-btn', 'Download', viewbox="0 0 64 64") %}
         <path d="M55.716 22.372l-7.404-6.952-11.124 10.912V0H26.812v26.332L15.688 15.42l-7.404 6.952 23.714 23.265 23.718-23.265zM8.303 53.083V64h47.394V53.083H8.303z"/>
     {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
WEB-63 download icon now simply says download for screen readers instead of download symbol