### PR TITLE
WEB-66 Fix for missing legend warning

### DIFF
--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -447,7 +447,7 @@
             {{ caller() }}
         {% endif %}
 
-        <fieldset class="ff-address{% if isNested %} ff-address--nested{% endif %}" id="field-{{ field.name }}">
+        <div class="ff-address{% if isNested %} ff-address--nested{% endif %}" id="field-{{ field.name }}">
 
             <address-lookup
                 label="{{ field.label }}"
@@ -460,16 +460,15 @@
 
             {# Non-JS version (*not* <noscript> because we still need it if JS fails #}
             {# (this will be removed by our Vue component when mounted) #}
-            <div class="js-fallback-only">
+            <fieldset class="js-fallback-only">
                 <legend class="ff-label ff-address__legend">
                     {{ labelFor(field) }}
                 </legend>
-
                 {{ explanationFor(field) }}
                 {{ fallbackFields | safe }}
-            </div>
+            </fieldset>
 
-        </fieldset>
+        </div>
     </div>
 {% endmacro %}
 


### PR DESCRIPTION
This change fixes the warning that was appearing when running WAVE for the address history field.