### PR TITLE
WEB-78 Changed to heading tag

### DIFF
--- a/controllers/updates/views/post/press-release.njk
+++ b/controllers/updates/views/post/press-release.njk
@@ -64,7 +64,7 @@
 
                     {% if content.notesToEditors %}
                         <aside class="u-tone-background-tint u-padded u-text-medium" id="notes">
-                            <p class="u-tone-brand-primary t3">{{ copy.pressRelease.notesToEditors }}</>
+                            <h2 class="u-tone-brand-primary t3">{{ copy.pressRelease.notesToEditors }}</h2>
                             {{ content.notesToEditors | safe }}
                         </aside>
                     {% endif %}


### PR DESCRIPTION
Changed <p> tag to a <h2> tag to fix the 'Possible heading' warning on WAVE.