### PR TITLE
WEB-71 Screen size fixes

### DIFF
--- a/assets/sass/components/_forms.scss
+++ b/assets/sass/components/_forms.scss
@@ -810,6 +810,10 @@ $inputOutline: $inputOutlineWidth solid $inputOutlineColour;
             outline: $inputOutline;
             outline-offset: 0;
         }
+
+        @media all and (max-width: 320px){
+            width: 5px;
+        }
     }
 
     .form-field-addon__action {

--- a/assets/sass/components/_global-header.scss
+++ b/assets/sass/components/_global-header.scss
@@ -442,4 +442,8 @@ $breakpointLarge: 840px;
         height: auto;
         background: none;
     }
+
+    @media all and (max-width: 320px) {
+        background-size: 130px 32px;
+    }
 }


### PR DESCRIPTION
- Logo size change at 400%
- Search bar for grants and insights size change at 400%

Test with 1280 by 1024 resolution at 100%. 