### PR TITLE
WEB-59 using the header as the legend instead of hidden

### DIFF
--- a/controllers/apply/form-router/views/step.njk
+++ b/controllers/apply/form-router/views/step.njk
@@ -54,13 +54,6 @@
                     </div>
                 </div>
 
-                <div class="form-header">
-                    <h1 class="t2 form-header__title u-tone-brand-primary">{{ section.title }}</h1>
-                    <p class="form-header__suffix">
-                        <strong>{{ step.title }}</strong> ({{ stepCount }})
-                    </p>
-                </div>
-
                 {% if step.introduction %}
                     <div class="form-fieldset__intro s-prose">{{ step.introduction | safe }}</div>
                 {% endif %}
@@ -72,10 +65,12 @@
                     {% set singleFieldset = step.fieldsets.length === 1 %}
                     {% for fieldset in step.fieldsets %}
                         <fieldset class="form-fieldset{% if not singleFieldset %} form-fieldset--multi{% endif %} u-constrained-wide">
-                            <legend
-                                class="form-fieldset__legend t2 t--underline{% if singleFieldset %} u-visually-hidden{% endif %}">
-                                {{ fieldset.legend }}
-                            </legend>
+                            <div class="form-header">
+                                <h1 class="t2 form-header__title u-tone-brand-primary">{{ section.title }}</h1>
+                                <legend class="form-header__suffix">
+                                    <strong>{{ step.title }}</strong><span> ({{ stepCount }})</span>
+                                </legend>
+                            </div>
 
                             {% if fieldset.introduction %}
                                 <div class="form-fieldset__intro s-prose">{{ fieldset.introduction | safe }}</div>


### PR DESCRIPTION
At the minute, there is a legend thats hidden for the overall fieldset of all the form questions. This fix uses the existing form header and places it into that fieldset. The p tag that contains the same text as the legend is then instead used as the legend. 