### PR TITLE
Fix to prevent underline on pink h2

### DIFF
--- a/assets/sass/scopes/_prose.scss
+++ b/assets/sass/scopes/_prose.scss
@@ -4,7 +4,7 @@
 /* https://csswizardry.com/2015/03/more-transparent-ui-code-with-namespaces/#scope-namespaces-s- */
 
 .s-prose {
-    h2::after {
+    h2:not(.u-tone-brand-primary):after {
         @include underlined();
     }
 


### PR DESCRIPTION
Excluded h2 headings with u tone class from being underlined with the pink underline. 