### PR TITLE
Over10k Organisation finances fix

### DIFF
--- a/controllers/apply/lib/field-types/currency.js
+++ b/controllers/apply/lib/field-types/currency.js
@@ -17,15 +17,14 @@ class CurrencyField extends Field {
     defaultSchema() {
         const minAmount = this.minAmount || 0;
         const maxAmount = this.maxAmount || 999999999;
-        const baseSchema = Joi.friendlyNumber()
-            .integer()
+        const baseSchema = Joi.number().integer()
             .min(minAmount)
             .max(maxAmount);
 
         if (this.isRequired) {
             return baseSchema.required();
         } else {
-            return baseSchema.optional();
+            return baseSchema.allow('').optional();
         }
     }
 

--- a/controllers/apply/lib/field-types/currency.js
+++ b/controllers/apply/lib/field-types/currency.js
@@ -17,14 +17,14 @@ class CurrencyField extends Field {
     defaultSchema() {
         const minAmount = this.minAmount || 0;
         const maxAmount = this.maxAmount || 999999999;
-        const baseSchema = Joi.number().integer()
+        const baseSchema = Joi.friendlyNumber().integer()
             .min(minAmount)
             .max(maxAmount);
 
         if (this.isRequired) {
             return baseSchema.required();
         } else {
-            return baseSchema.allow('').optional();
+            return Joi.optional();
         }
     }
 

--- a/controllers/apply/standard-proposal/fields/organisation-finances.js
+++ b/controllers/apply/standard-proposal/fields/organisation-finances.js
@@ -2,7 +2,6 @@
 const get = require('lodash/fp/get');
 const { oneLine } = require('common-tags');
 
-const Joi = require('../../lib/joi-extensions');
 const { CurrencyField, DayMonthField } = require('../../lib/field-types');
 const isNewOrganisation = require('../lib/new-organisation');
 
@@ -41,11 +40,7 @@ module.exports = {
                     'This should be based on your most recent accounts, or a 12-month projection (if you’ve been up and running for less than 15 months). Use whole numbers only - for example, 12,345 and not 12,345.67.',
                 cy: '',
             }),
-            schema(originalSchema) {
-                return isNewOrganisation(get('organisationStartDate')(data))
-                    ? Joi.any().strip()
-                    : originalSchema;
-            },
+            isRequired: !isNewOrganisation(get('organisationStartDate')(data)),
             messages: [
                 {
                     type: 'base',

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1452,7 +1452,7 @@ function standardApplication({
                     fillDayMonthParts(mock.accountingYearDate);
                 });
 
-            cy.findByLabelText('What is your total income for the year? (optional)').type(
+            cy.findByLabelText('What is your total income for the year? (Optional)').type(
                 mock.totalIncomeYear
             );
 

--- a/cypress/integration/integration_spec.js
+++ b/cypress/integration/integration_spec.js
@@ -1452,7 +1452,7 @@ function standardApplication({
                     fillDayMonthParts(mock.accountingYearDate);
                 });
 
-            cy.findByLabelText('What is your total income for the year?').type(
+            cy.findByLabelText('What is your total income for the year? (optional)').type(
                 mock.totalIncomeYear
             );
 


### PR DESCRIPTION
The "totalIncomeYear" field was stripping  the value when an organisation is under 15 months old while the help text asked for a projection.

Updated to make the field optional only when an org is under 15 months. 