### PR TITLE
WEB-92 Language buttons in footer have language attribute

### DIFF
--- a/views/components/language/macros.njk
+++ b/views/components/language/macros.njk
@@ -17,7 +17,7 @@
                 {{ iconTick() }} {{ item.label }}
             </span>
         {% else %}
-            <a href="{{ getCurrentUrl(item.id) }}"
+            <a lang="{{ item.id }}"href="{{ getCurrentUrl(item.id) }}"
                 class="language-control">
                 {{ item.label }}
             </a>


### PR DESCRIPTION
WEB-92 Language buttons in footer have language attribute. Language attribute is defined by item.id which will either be cy for welsh or en for english. 