### PR TITLE
WEB-88 Reset filters and clear filters are accessible now

### DIFF
--- a/assets/js/vue-apps/components/grants-filters.vue
+++ b/assets/js/vue-apps/components/grants-filters.vue
@@ -38,12 +38,14 @@ export default {
             <legend class="search-filters__title">
                 {{ copy.filters.title }}
             </legend>
-            <a
-                class="search-filters__clear-all"
+            <button
+                tabindex="0"
+                role="link"
+                class="search-filters__clear-all btn-link"
                 @click="$emit('clear-filters')"
             >
                 {{ copy.filters.reset }}
-            </a>
+            </button>
         </div>
 
         <FacetGroup

--- a/controllers/insights/views/insights-documents.njk
+++ b/controllers/insights/views/insights-documents.njk
@@ -150,9 +150,9 @@
                         <fieldset class="search-filters">
                             <div class="search-filters__header">
                                 <legend class="search-filters__title">{{ copy.search.filters.filterBy }}</legend>
-                                <a class="search-filters__clear-all btn-link" href="{{ basePageUrl }}">
+                                <button tabindex="0" role="link" class="search-filters__clear-all btn-link" href="{{ basePageUrl }}">
                                     {{ copy.search.filters.clearAll }}
-                                </a>
+                                </button>
                             </div>
 
                             <div class="facet-group is-open">

--- a/controllers/insights/views/insights-documents.njk
+++ b/controllers/insights/views/insights-documents.njk
@@ -237,9 +237,9 @@
                         <fieldset class="search-filters">
                             <div class="search-filters__header">
                                 <legend class="search-filters__title">{{ copy.search.filters.filterBy }}</legend>
-                                <a class="search-filters__clear-all btn-link" href="{{ basePageUrl }}">
+                                <button  role="link" tabindex="0" class="search-filters__clear-all btn-link" href="{{ basePageUrl }}">
                                     {{ copy.search.filters.clearAll }}
-                                </a>
+                                </button>
                             </div>
 
                             <div class="facet-group is-open">


### PR DESCRIPTION
Reset and clear filters: 

- Added role="link"
- Instead of being a link it is now a button
- Added tabindex so it can be navigated to through a keyboard