### PR TITLE
WEB-91 focus now goes to error message container

### DIFF
--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -3,7 +3,7 @@
 
 {% macro formErrors(title, errors) %}
     {% if errors.length > 0 %}
-        <div class="form-errors" data-testid="form-errors" tabindex="9999" id="error-container">
+        <div class="form-errors" data-testid="form-errors" tabindex="0" id="error-container">
             <h2 class="form-errors__title">{{ title }}</h2>
             <div class="form-errors__body">
                 <ol class="form-errors__list">

--- a/views/components/form-fields/macros.njk
+++ b/views/components/form-fields/macros.njk
@@ -3,7 +3,7 @@
 
 {% macro formErrors(title, errors) %}
     {% if errors.length > 0 %}
-        <div class="form-errors" data-testid="form-errors">
+        <div class="form-errors" data-testid="form-errors" tabindex="9999" id="error-container">
             <h2 class="form-errors__title">{{ title }}</h2>
             <div class="form-errors__body">
                 <ol class="form-errors__list">

--- a/views/includes/errorFocus.njk
+++ b/views/includes/errorFocus.njk
@@ -4,7 +4,12 @@
 
 <script>
     (function() {
+        var elSelector = '.form-errors__list';
+        var el = document.querySelector(elSelector);
 
+        if (!el) {
+            return;
+        }
         document.getElementById("error-container").focus();
 
     }());

--- a/views/includes/errorFocus.njk
+++ b/views/includes/errorFocus.njk
@@ -4,16 +4,8 @@
 
 <script>
     (function() {
-        var elSelector = '.form-errors__list';
-        var el = document.querySelector(elSelector);
 
-        if (!el) {
-            return;
-        }
+        document.getElementById("error-container").focus();
 
-        var listItems = el.getElementsByTagName("a");
-
-        if (listItems.length > 0)
-            listItems[0].focus();
     }());
 </script>


### PR DESCRIPTION
Focus now goes to the error message container: when pressing continue with validation issues, the page title will read out followed by the error message container. This should be tested with the screen reader DAC recommended NVDA screen reader