### PR TITLE
WEB-93 ensure valid phone number before parse

### DIFF
--- a/controllers/apply/lib/field-types/phone.js
+++ b/controllers/apply/lib/field-types/phone.js
@@ -49,13 +49,17 @@ class PhoneField extends Field {
 
     get displayValue() {
         if (this.value) {
-            const parsedValue = phoneUtil.parse(this.value, 'GB');
-            if (phoneUtil.isValidNumber(parsedValue)) {
-                return phoneUtil.format(
-                    parsedValue,
-                    PhoneNumberFormat.NATIONAL
-                );
-            } else {
+            try {
+                const parsedValue = phoneUtil.parse(this.value, 'GB');
+                if (phoneUtil.isValidNumber(parsedValue)) {
+                    return phoneUtil.format(
+                        parsedValue,
+                        PhoneNumberFormat.NATIONAL
+                    );
+                } else {
+                    return this.value;
+                }
+            } catch {
                 return this.value;
             }
         } else {


### PR DESCRIPTION
To ensure any values that cannot be parsed into a phone number will not throw an error and instead, return the display value as is.