### PR TITLE
WEB-96 Added aria-hidden to check icon.

### DIFF
--- a/views/components/icons.njk
+++ b/views/components/icons.njk
@@ -51,7 +51,7 @@
 
 {# tick by miza bin from the Noun Project #}
 {% macro iconTick(variant = 'small') %}
-    {% call icon('tick', 'Check mark complete', viewbox="0 0 100 96", variant = variant, selected = true) %}
+    {% call icon('tick', 'Check mark complete', viewbox="0 0 100 96", variant = variant, ariaHidden = true) %}
         <path d="M50 6.6C26 6.6 6.6 26 6.6 50S26 93.4 50 93.4 93.4 74 93.4 50 74 6.6 50 6.6zM71 41L45.3 66.6c-.8.8-1.8 1.2-2.8 1.2s-2.1-.4-2.8-1.2L27 54c-1.6-1.6-1.6-4.1 0-5.7 1.6-1.6 4.1-1.6 5.7 0l9.8 9.8 22.8-22.8c1.6-1.6 4.1-1.6 5.7 0 1.5 1.6 1.5 4.2 0 5.7z"></path>
    {% endcall %}
 {% endmacro %}


### PR DESCRIPTION
Check icon SVG was being read to screen readers even though it is decorative. 
Added aria-hidden as recommended solution.