### PR TITLE
WEB-12 Added DEV to normalise.

### DIFF
--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -27,7 +27,7 @@ const argv = require('yargs').option('environment', {
 
 function normaliseParameterName(parameter) {
     parameter.OriginalName = parameter.Name;
-    parameter.Name = parameter.Name.replace(/\/Web\/(Global|Test|Prod)\//, '');
+    parameter.Name = parameter.Name.replace(/\/Web\/(Global|Test|Prod|Dev)\//, '');
     return parameter;
 }
 


### PR DESCRIPTION
DEV was missing from normalise function, this was causing the entire parameter name to be used as the name, not the variable part. 