### PR TITLE
use dev over development to avoid conflict with local

### DIFF
--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -56,7 +56,7 @@ function getParametersForEnvironment(environment) {
     return new Promise((resolve) => {
         let envVars = {
             Path: environment === 'production'
-                ? '/Web/Prod' : environment === 'development'
+                ? '/Web/Prod' : environment === 'dev'
                     ? '/Web/Dev' : '/Web/Test',
             WithDecryption: true
         };

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -24,6 +24,9 @@ LIVE_IN_PLACE="Live_In_Place";
 
 # Check if the deployment group name contains one of the above strings
 APP_ENV="development"
+if [[ $DEPLOYMENT_GROUP_NAME =~ $DEV_FLEET ]];
+then
+    APP_ENV="dev"
 if [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_FLEET ]] ||
    [[ $DEPLOYMENT_GROUP_NAME =~ $TEST_IN_PLACE ]];
 then


### PR DESCRIPTION
The current environment name for local versions is development and so the dev site should be renamed to avoid conflict.