### PR TITLE
Makes past grants filter collapsed by default

### DIFF
--- a/assets/js/vue-apps/components/grants-filters.vue
+++ b/assets/js/vue-apps/components/grants-filters.vue
@@ -16,6 +16,15 @@ export default {
         'handleActiveFilter',
         'trackUi',
     ],
+    data() {
+        return { grantKey: 0,  orgKey: 1};
+    },
+    created() {
+        window.addEventListener("resize", this.forceRerender);
+    },
+    destroyed() {
+        window.removeEventListener("resize", this.forceRerender);
+    },
     methods: {
         isActiveFacet(name) {
             return has(this.filters, name);
@@ -24,6 +33,13 @@ export default {
             // Prevent this from updating the window history, which triggers a search
             event.preventDefault();
             $('#feedback summary').click().get(0).scrollIntoView();
+        },
+        openByDefault(){
+            return window.innerWidth > 640;
+        },
+        forceRerender(){
+            this.grantKey += 1;
+            this.orgKey += 1;
         },
     },
 };
@@ -49,7 +65,8 @@ export default {
         </div>
 
         <FacetGroup
-            :open-by-default="false"
+            :key="this.grantKey"
+            :open-by-default="openByDefault()"
             :legend="copy.filters.grantLegend"
             :toggle-label="copy.filters.toggle"
             :track-ui="trackUi"
@@ -94,7 +111,8 @@ export default {
         </FacetGroup>
 
         <FacetGroup
-            :open-by-default="false"
+            :key="this.orgKey"
+            :open-by-default="openByDefault()"
             :legend="copy.filters.organisationLegend"
             :toggle-label="copy.filters.toggle"
             :track-ui="trackUi"

--- a/assets/js/vue-apps/components/grants-filters.vue
+++ b/assets/js/vue-apps/components/grants-filters.vue
@@ -49,6 +49,7 @@ export default {
         </div>
 
         <FacetGroup
+            :open-by-default="false"
             :legend="copy.filters.grantLegend"
             :toggle-label="copy.filters.toggle"
             :track-ui="trackUi"
@@ -93,6 +94,7 @@ export default {
         </FacetGroup>
 
         <FacetGroup
+            :open-by-default="false"
             :legend="copy.filters.organisationLegend"
             :toggle-label="copy.filters.toggle"
             :track-ui="trackUi"


### PR DESCRIPTION
The past grants filter sections are now collapsed by default.