### PR TITLE
Update to links on funding home page

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -226,12 +226,12 @@ toplevel:
     title: Ariannu
     latestTitle: Rhaglenni a phartneriaethau diweddaraf
     sectionLinks:
-    - label: Ariannu yn ystod COVID-19
-      href: "/welsh/funding/covid-19"
-    - label: Ymgeisio am grantiau o dan £10,000
-      href: "/welsh/funding/under10k"
+    - label: Meddwl am ymgeisio am arian grant?
+      href: "/welsh/funding/thinking-of-applying-for-funding"
     - label: Ymgeisio am grantiau dros £10,000
       href: "/welsh/funding/over10k"
+    - label: Ymgeisio am grantiau o dan £10,000
+      href: "/welsh/funding/under10k"
     - label: Gweld pob rhaglen grantiau agored
       href: "/welsh/funding/programmes"
     - label: Gweld pob rhaglen grantiau sydd ar gau
@@ -240,8 +240,6 @@ toplevel:
       href: "/welsh/funding/grants"
     - label: Cymorth rheoli’ch grant
       href: "/welsh/funding/managing-your-grant"
-    - label: "Meddwl am ymgeisio am arian grant?"
-      href: "/welsh/funding/thinking-of-applying-for-funding"
   data:
     keyStats: Ystadegau allweddol
     mapTitle: Ein blwyddyn mewn Rhifau

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,12 +230,12 @@ toplevel:
     title: Funding
     latestTitle: Latest Programmes & Partnerships
     sectionLinks:
-    - label: Funding during COVID-19
-      href: "/funding/covid-19"
-    - label: Apply for funding under £10,000
-      href: "/funding/under10k"
+    - label: Thinking of applying for funding?
+      href: "/funding/thinking-of-applying-for-funding"
     - label: Apply for funding above £10,000
       href: "/funding/over10k"
+    - label: Apply for funding under £10,000
+      href: "/funding/under10k"
     - label: View all open funding programmes
       href: "/funding/programmes"
     - label: View all closed funding programmes
@@ -246,8 +246,6 @@ toplevel:
       href: "/funding/grants"
     - label: Help with managing your funding
       href: "/funding/managing-your-grant"
-    - label: Thinking of applying for funding?
-      href: "/funding/thinking-of-applying-for-funding"
   data:
     keyStats: Key statistics
     mapTitle: Our Year in Numbers


### PR DESCRIPTION
Funding homepage based on the following information:

- Remove link to 'Funding during covid-19'
- The /funding page links follow the order 

1. Thinking of applying
2. Over 10k
3. Under 10k
4. Open
5. Closed
6. Strategics in England
7. Past grants
8. MYG

Welsh site excludes "Strategics in England" as there is no welsh alternative to this