### PR TITLE
Additional EDI fixes

### DIFF
--- a/controllers/apply/standard-proposal/fields/beneficiaries.js
+++ b/controllers/apply/standard-proposal/fields/beneficiaries.js
@@ -89,9 +89,7 @@ module.exports = {
             locale: locale,
             name: 'beneficiariesPreflightCheck',
             label: localise({
-                en: `<h3>Accessing your application</h3>
-                     <p>This information is being used to inform our own monitoring. We will <strong>not</strong> use your answers in this EDI section to assess your application.</p>
-                     <p><strong>Check this box to show you understand.</strong></p>`,
+                en: `<strong>Check this box to show you understand.</strong>`,
                 cy: ``,
             }),
             options: [
@@ -576,7 +574,7 @@ module.exports = {
                 },
                 {
                     value: 'other-lgbt',
-                    label: localise({ en: 'LGBTQ+ people I\'d describe in another way: ', cy: '' }),
+                    label: localise({ en: 'LGBTQ+ people I\'d describe in another way ', cy: '' }),
                     explanation: localise({
                         en: oneLine`Examples: Other LGBTQ+ People, including queer and intersex people`,
                         cy: oneLine``,
@@ -1775,7 +1773,7 @@ module.exports = {
                 },
                 {
                     value: 'other-lgbt',
-                    label: localise({ en: 'LGBTQ+ people I\'d describe in another way:', cy: '' }),
+                    label: localise({ en: 'LGBTQ+ people I\'d describe in another way', cy: '' }),
                     explanation: localise({
                         en: oneLine`Examples: Other LGBTQ+ People, including queer and intersex people`,
                         cy: oneLine``,

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -249,7 +249,7 @@ module.exports = function ({
                             fully in decision-making processes. While an 'inclusive' group is diverse, a 'diverse' 
                             group may or may not be 'inclusive'.</p>
 
-                            <h3>Accessing your application</h3>
+                            <h3>Assessing your application</h3>
                             <p>This information is being used to inform our own monitoring. 
                             We will <strong>not</strong> use your answers in this EDI section to assess your 
                             application.</p>`,

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -460,10 +460,10 @@ module.exports = function ({
 
     function stepLGBT() {
         return new Step({
-            title: localise({ en: 'LGBT+ people', cy: 'Rhyw' }),
+            title: localise({ en: 'LGBTQ+ people', cy: 'Rhyw' }),
             fieldsets: [
                 {
-                    legend: localise({ en: 'LGBT+ people', cy: 'Rhyw' }),
+                    legend: localise({ en: 'LGBTQ+ people', cy: 'Rhyw' }),
                     fields: conditionalFields(
                         [allFields.beneficiariesGroupsLGBT],
                         includeIfBeneficiaryType(BENEFICIARY_GROUPS.LGBT, [
@@ -800,11 +800,11 @@ module.exports = function ({
 
     function stepLeadershipLGBT() {
         return new Step({
-            title: localise({ en: 'LGBT+ people', cy: '' }),
+            title: localise({ en: 'LGBTQ+ people', cy: '' }),
             fieldsets: [
                 {
                     legend: localise({
-                        en: 'LGBT+ people',
+                        en: 'LGBTQ+ people',
                         cy: '',
                     }),
                     fields: conditionalFields(

--- a/controllers/apply/standard-proposal/form.js
+++ b/controllers/apply/standard-proposal/form.js
@@ -247,7 +247,12 @@ module.exports = function ({
                             <h3>Inclusion</h3>
                             <p>Inclusion refers to the degree to which people feel valued and able to participate 
                             fully in decision-making processes. While an 'inclusive' group is diverse, a 'diverse' 
-                            group may or may not be 'inclusive'.</p>`,
+                            group may or may not be 'inclusive'.</p>
+
+                            <h3>Accessing your application</h3>
+                            <p>This information is being used to inform our own monitoring. 
+                            We will <strong>not</strong> use your answers in this EDI section to assess your 
+                            application.</p>`,
                         cy: `<p>
                             Rydym eisiau clywed mwy am y bobl a fydd yn elwa o’ch prosiect.
                         </p>
@@ -774,11 +779,11 @@ module.exports = function ({
 
     function stepLeadershipAge() {
         return new Step({
-            title: localise({ en: 'Older and younger people', cy: '' }),
+            title: localise({ en: 'Young people', cy: '' }),
             fieldsets: [
                 {
                     legend: localise({
-                        en: 'Older and younger people',
+                        en: 'Young people',
                         cy: '',
                     }),
                     fields: conditionalFields(

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ let { IP_RANGE } = require('./common/secrets');
 
 const app = express();
 if (NODE_ENV === 'dev' && IP_RANGE) {
-    const ipfilter = require('express-ipfilter').IpFilter;git
+    const ipfilter = require('express-ipfilter').IpFilter;
 
     app.use(
         ipfilter(IP_RANGE.split(','), {

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ let { IP_RANGE } = require('./common/secrets');
 
 const app = express();
 if (NODE_ENV === 'dev' && IP_RANGE) {
-    const ipfilter = require('express-ipfilter').IpFilter;
+    const ipfilter = require('express-ipfilter').IpFilter;git
 
     app.use(
         ipfilter(IP_RANGE.split(','), {


### PR DESCRIPTION
- Removed colons from end of LGBTQ+ section
- Moved assessing your application to form rather than field + fixed typo
- Changed title of Older and younger people section in leadership questions to Young people