### PR TITLE
Remove redeclared const

### DIFF
--- a/views/includes/metaFooterJS.njk
+++ b/views/includes/metaFooterJS.njk
@@ -4,7 +4,6 @@
 {% if hotjarId %}
     <script id="script-hotjar">
         var hotjarId = "{{ hotjarId }}";
-        var isDoNotTrack = (window.doNotTrack === '1' || window.navigator.doNotTrack === '1' || window.navigator.msDoNotTrack === '1') || localStorage.getItem('tnlcommunityfund:cookie-consent') != 'all';
 
         if (hotjarId && isDoNotTrack === false) {
             // Pre-init Hotjar so we can tag pages before its library loads


### PR DESCRIPTION
Now defined in header for GA4 so not needed in footer. 